### PR TITLE
fix(ci): always rebuild ccs release binary

### DIFF
--- a/packaging/ccs/build.sh
+++ b/packaging/ccs/build.sh
@@ -18,14 +18,10 @@ NAME="conary"
 
 echo "Building $NAME $VERSION CCS package"
 
-# --- Build release binary if needed ---
+# --- Build release binary ---
 RELEASE_BIN="$REPO_ROOT/target/release/$NAME"
-if [ ! -f "$RELEASE_BIN" ]; then
-    echo "[1/4] Building release binary..."
-    cargo build --release --manifest-path "$REPO_ROOT/apps/conary/Cargo.toml"
-else
-    echo "[1/4] Using existing release binary: $RELEASE_BIN"
-fi
+echo "[1/4] Building release binary..."
+cargo build --release --manifest-path "$REPO_ROOT/apps/conary/Cargo.toml"
 
 # --- Stage files in install layout ---
 echo "[2/4] Staging files..."


### PR DESCRIPTION
## Summary
- always rebuild the `conary` release binary inside `packaging/ccs/build.sh`
- avoid reusing a stale cached `target/release/conary` during `release-build`
- preserve the CCS packaging and signing flow while making dry-run packaging deterministic again

## Problem
The new `release-build` workflow can restore `target/` from cache in the `build-ccs` job. When `packaging/ccs/build.sh` reused an existing `target/release/conary`, the job could package the wrong binary or fail against a stale one instead of rebuilding from the current checkout.

## Verification
- `bash -n packaging/ccs/build.sh`
- `git diff --check`
- branch `release-build` dry run for `conary` with `v0.7.0` is running with `build-ccs` green: run `23929681308`