### PR TITLE
docs: record first external tester

### DIFF
--- a/.github/ISSUE_TEMPLATE/beta_feedback.md
+++ b/.github/ISSUE_TEMPLATE/beta_feedback.md
@@ -27,18 +27,25 @@ Fill this in if you ran the tester loop from the preview post.
 
 - **Distribution**: (Fedora 44, Ubuntu 26.04 LTS, Arch Linux, or other)
 - **Kernel version**: (output of `uname -r`)
-- **Conary version or commit**: (output of `conary --version`, release tag, or commit SHA)
+- **Architecture**: (output of `uname -m`)
+- **Conary version or commit**: (output of `conary --version` or commit SHA)
+- **Release tag and package**: (for example, `v0.11.3` and the exact RPM/DEB/Arch package name)
+- **Package checksum verified**: yes/no
 - **VM/snapshot/non-critical host**: yes/no
 
 ## Commands Run
 
 ```bash
-# Paste the exact commands you ran.
+# List the exact commands and their exit statuses.
+# Include only short output excerpts needed to explain a failure or surprise.
 ```
 
 ## What Happened
 
 Describe the result, including anything confusing, slow, surprising, or good.
+Keep the public report concise: do not paste a full installed-package inventory,
+the complete local transcript, or broad environment output. Strip terminal
+color/control sequences and include only output needed to understand the result.
 
 ## Support Bundle
 

--- a/docs/guides/agent-assisted-tester-loop.md
+++ b/docs/guides/agent-assisted-tester-loop.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-18
-revision: 7
+last_updated: 2026-07-19
+revision: 8
 summary: Agent-supervised instructions for the first external Conary tester loop
 ---
 
@@ -43,7 +43,8 @@ Safety rules:
 - Run dry-run commands before live commands when the loop provides both.
 - Ask me before every non-dry-run command that mutates system state.
 - If a command output is ambiguous, surprising, or scary, stop and ask.
-- Keep a transcript of commands, exit statuses, and notable output.
+- Keep a local transcript of commands, exit statuses, and notable output. The
+  public feedback issue should summarize this transcript, not reproduce it.
 - Do not upload logs, bundles, private keys, tokens, shell history, raw
   environment dumps, or Conary databases.
 - At the end, draft a GitHub beta feedback issue using
@@ -233,6 +234,11 @@ Fill in:
 - **VM/snapshot/non-critical host:** `yes` or `no`;
 - **Commands Run:** exact commands from the transcript;
 - **What Happened:** short notes about results and friction.
+
+Keep the public issue concise. Include exit statuses and only the output needed
+to explain a failure, surprise, or useful result. Do not paste the complete
+local transcript, a full installed-package inventory, or broad environment
+output. Strip terminal color and control sequences before including excerpts.
 
 Only attach a support bundle if it would help explain a failure and you are
 running from a checkout. Review it first:

--- a/docs/operations/external-tester-outreach.md
+++ b/docs/operations/external-tester-outreach.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-07-18
+last_updated: 2026-07-19
 status: scheduled
 summary: Multi-venue launch packet for the first external tester loop
 ---
@@ -18,7 +18,9 @@ summary: Multi-venue launch packet for the first external tester loop
 > verified. Do not publish automatically or until GitHub Support has
 > dereferenced the cached pull-request and commit views that still expose
 > pre-rewrite history and the venue-specific eligibility checks pass. No listed
-> external venue post has been published; the milestone tracker remains 0/10.
+> external venue post has been published. Organic prelaunch testing has one
+> unique qualifying tester across Ubuntu 26.04 LTS and Fedora 44, so the
+> milestone tracker is 1/10; this does not start the broad-outreach stall clock.
 
 The maintainer posts this manually and remains available to answer comments.
 After submission, record the actual HN URL and timestamp in the milestone

--- a/docs/roadmaps/development-roadmap.md
+++ b/docs/roadmaps/development-roadmap.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-07-18
+last_updated: 2026-07-19
 proof_baseline: "v0.11.3 at 0fc31c33b42a84bb00c9c8d9bdfc574ebe960ae0; release proof complete"
 current_milestone: first external tester loop
 active_workstream: W3 First External Tester Loop
@@ -49,7 +49,8 @@ the affected attempts and a chosen remediation or explicit scope change.
 
 Launching outreach, publishing a release, receiving partial reports, or seeing
 ordinary outreach difficulty does not satisfy the milestone. The active
-[milestone tracker](external-tester-milestone.md) currently records 0/10.
+[milestone tracker](external-tester-milestone.md) currently records 1/10 from
+one external tester who completed the full flow on two supported hosts.
 
 ## Principles and Safety Boundaries
 
@@ -70,7 +71,7 @@ ordinary outreach difficulty does not satisfy the milestone. The active
 
 ## Subsystem Maturity
 
-This is the dated 2026-07-18 baseline. The label describes reliability within
+This is the dated 2026-07-19 baseline. The label describes reliability within
 the stated scope, not whether a workstream happens to be active.
 
 | Subsystem | Maturity | Current limitation or next proof |
@@ -87,7 +88,7 @@ the stated scope, not whether a workstream happens to be active.
 | conaryd package and query service | limited | System routes, authorization policy, restart semantics, dry-run behavior, deployment, and PolicyKit remain incomplete. |
 | Federation | experimental | Coordinator and fetch paths are not wired into serving; TLS identity documentation and enforcement do not yet agree. |
 | Advanced derivation, lock, and reproducibility flows | unfinished | Several interfaces exist without complete persisted inputs or update-path integration. |
-| External product readiness | unfinished | The prepared tester loop has not launched or completed. |
+| External product readiness | unfinished | One organic external tester completed the full flow on Ubuntu 26.04 and Fedora 44 with verified release-package checksums; the unique-person milestone is 1/10 and broad manual outreach remains unlaunched. |
 
 ## Workstreams
 
@@ -271,19 +272,21 @@ and creates no roadmap item.
   workflows, artifact hashes, signature, released package paths, Remi
   synchronization, installed-binary self-update, service, and checked-site
   evidence are complete. Conary remains MIT-only and the GitHub safety
-  settings remain in place. No broad external venue post has been published,
-  and the tracker remains 0/10.
+  settings remain in place. No broad external venue post has been published.
+  One organic external tester completed the full flow on Ubuntu 26.04 LTS and
+  Fedora 44 with verified `v0.11.3` package checksums. The two host reports
+  count once toward the unique-person milestone, so the tracker is 1/10.
 - **Execution status:** active; W3a release and public-readiness proof is
-  complete, while manual outreach and the external tester loop remain
-  unlaunched.
+  complete. The external tester loop has its first organic completion, while
+  the planned manual outreach sequence remains unlaunched.
 - **Dependencies:** GitHub Support must dereference the cached pull-request and
   commit views that still expose pre-rewrite history, and the maintainer must
   re-check each venue's current account/rule eligibility immediately before
   submission.
 - **Next gate:** after GitHub Support confirms the cached history is no longer
   reachable and the venue checks pass, submit the verified Show HN packet,
-  record its actual URL and timestamp, and obtain the first privacy-safe
-  qualifying report.
+  record its actual URL and timestamp, and continue collecting privacy-safe
+  reports toward the second unique qualifying tester.
 - **Proof:** annotated `v0.11.3` tag object
   `a2a12791e695379e9313a210d2fd5eea2a39b352` peels to commit
   `0fc31c33b42a84bb00c9c8d9bdfc574ebe960ae0`; the immutable release was
@@ -309,11 +312,14 @@ and creates no roadmap item.
   preview. The repository Welcome Discussion is live at discussion 36, and
   issue 35 was closed after its released-path proof was recorded; neither
   repository action launches broad outreach or counts as a qualifying external
-  completion. Each later milestone completion belongs to a unique outsider
-  and covers exactly `install -> adopt -> list/search -> update --dry-run ->
-  unadopt` on a supported host with the pinned release. Record failed attempts
-  and triage every report as `fix-now`, `next-slice`, or
-  `declined-with-reason` with an owner.
+  completion. Issues 37 and 38 subsequently recorded full `v0.11.3` loops on
+  x86_64 Ubuntu 26.04 LTS and Fedora 44, with both package checksums confirmed.
+  Because both reports came from the same external tester, they count as one
+  unique completion. Each later milestone completion belongs to a unique
+  outsider and covers exactly `install -> adopt -> list/search -> update
+  --dry-run -> unadopt` on a supported host with the pinned release. Record
+  failed attempts and triage every report as `fix-now`, `next-slice`,
+  `validated-no-action`, or `declined-with-reason` with an owner.
 - **Limitations:** no qualifying completion for three weeks after launch
   triggers a maintainer review of venue reach, onboarding friction, and
   observed failures. A pivot still requires a reproducible systemic blocker;

--- a/docs/roadmaps/external-tester-milestone.md
+++ b/docs/roadmaps/external-tester-milestone.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-07-18
-status: scheduled
-current_result: 0/10
+last_updated: 2026-07-19
+status: active
+current_result: 1/10
 summary: Outcome tracker for Conary's first external tester milestone
 ---
 
@@ -13,7 +13,8 @@ maintainer records an evidence-backed pivot for a reproducible systemic
 blocker. Interest, downloads, partial attempts, and repeated runs by the same
 person do not count as separate completions.
 
-**Current result: 0/10 qualifying completions.**
+**Current result: 1/10 qualifying completions.** Two supported-host reports from
+the same person count as one unique external tester.
 
 ## Qualifying Flow
 
@@ -93,6 +94,15 @@ useful evidence but does not count as a completion.
   live, and [issue #35's released-path proof](https://github.com/ConaryLabs/Conary/issues/35#issuecomment-5009942880)
   was recorded before the issue was closed. These repository actions do not
   count as a qualifying external completion or launch the broad outreach loop.
+- Organic prelaunch tester evidence: [issue #37](https://github.com/ConaryLabs/Conary/issues/37)
+  completed the full `v0.11.3` loop on x86_64 Ubuntu 26.04 LTS and
+  [confirmed the DEB checksum](https://github.com/ConaryLabs/Conary/issues/37#issuecomment-5010174050).
+  [Issue #38](https://github.com/ConaryLabs/Conary/issues/38) completed the same
+  loop on x86_64 Fedora 44 from a never-synced Remi state and
+  [confirmed the RPM checksum](https://github.com/ConaryLabs/Conary/issues/38#issuecomment-5010310461).
+  Both reports came from the same external tester, so they establish two
+  supported-host successes but count once toward the ten-person milestone.
+  They do not start the broad-outreach stall clock.
 - Supported hosts: Fedora 44, Ubuntu 26.04 LTS, and Arch Linux on the release's
   supported architecture and compatibility baseline.
 - Planned launch sequence, using the venue-specific copy in
@@ -122,10 +132,13 @@ dumps out of linked evidence.
 
 | Attempt | Date | Privacy-safe report | Distro and host scope | Pinned release | Full flow completed | Friction or failure | Triage status | Triage owner |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| - | - | - | - | - | - | - | - | - |
+| 1a | 2026-07-18 | [issue #37](https://github.com/ConaryLabs/Conary/issues/37) | Ubuntu 26.04 LTS, x86_64, VM/snapshot/non-critical host confirmed | `v0.11.3` DEB; checksum confirmed | yes, 11/11 steps | No functional failure; public-report verbosity and terminal-control-sequence guidance routed through [issue #39](https://github.com/ConaryLabs/Conary/issues/39) | `validated-no-action` | maintainer |
+| 1b | 2026-07-18 | [issue #38](https://github.com/ConaryLabs/Conary/issues/38) | Fedora 44, x86_64, VM/snapshot/non-critical host confirmed | `v0.11.3` RPM; checksum confirmed | yes, 11/11 steps | No functional failure; clean never-synced Remi start; same reporting-guidance follow-up as 1a | `validated-no-action` | maintainer |
 
-Triage statuses are `fix-now`, `next-slice`, and `declined-with-reason`.
-Qualifying and failed attempts both require an owner and a triage disposition.
+Attempts 1a and 1b came from the same person and therefore contribute one, not
+two, to the unique-tester result. Triage statuses are `fix-now`, `next-slice`,
+`validated-no-action`, and `declined-with-reason`. Qualifying and failed
+attempts both require an owner and a triage disposition.
 
 ## Stall and Pivot Rules
 


### PR DESCRIPTION
## Summary

Record Conary's first qualifying external tester, preserve the distinction between two supported-host runs and one unique person, and clarify what belongs in a public beta-feedback report.

## Changes

- update the external tester milestone and development roadmap from `0/10` to `1/10`
- record the successful Ubuntu 26.04 and Fedora 44 `v0.11.3` runs with checksum confirmations
- keep broad manual outreach and its stall clock explicitly unlaunched
- clarify that full transcripts stay local and public reports should be concise and strip terminal control sequences
- add release-package and checksum fields to the beta-feedback template

## Ownership / Boundary

- Owning subsystem: W3 external tester roadmap and public beta-feedback guidance
- Boundary changed or preserved: preserves the unique-person milestone count and the separate broad-outreach launch clock
- Persisted state or public surface impact: documentation and GitHub issue-template guidance only; no product behavior or persisted package state changes
- [x] Checked `docs/modules/feature-ownership.md` routing through `scripts/agent-context.sh --path`

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated guidance where the external reports exposed ambiguity; no product behavior changed
- [x] No service or daemon code changed
- [x] No subsystem look-here-first path changed
- [x] Planning-doc risk gate satisfied by current issue evidence and the documentation truth suite

```text
bash scripts/check-doc-truth.sh
bash scripts/test-doc-truth.sh
bash scripts/test-agent-context.sh
bash scripts/agent-context.sh --validate
cargo fmt --check
git diff --check
focused stale-state rg sweep
```

## Related Issues / Plans

Records successful evidence from #37 and #38.
Clarifies reporting guidance discussed in #39.
Plan / Roadmap: `docs/roadmaps/external-tester-milestone.md` and `docs/roadmaps/development-roadmap.md`