### PR TITLE
fix(remi): make scriptlet evidence queue triageable

### DIFF
--- a/apps/remi/src/server/handlers/admin/scriptlet_evidence.rs
+++ b/apps/remi/src/server/handlers/admin/scriptlet_evidence.rs
@@ -18,12 +18,20 @@ pub struct BackfillRequest {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct UnknownCommandReconciliationRequest {
+    pub dry_run: Option<bool>,
+    pub limit: Option<usize>,
+    pub after_cluster_key: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct ClusterListQuery {
     pub state: Option<String>,
     pub distro: Option<String>,
     pub blocked_class: Option<String>,
     pub command: Option<String>,
     pub package: Option<String>,
+    pub include_superseded: Option<bool>,
     pub limit: Option<i64>,
     pub offset: Option<i64>,
 }
@@ -53,6 +61,7 @@ struct ClusterListResponse {
 struct ClusterSummaryResponse {
     cluster_key: String,
     schema_version: i64,
+    normalization_version: i64,
     distro: String,
     target_profile: String,
     blocked_class: String,
@@ -64,6 +73,9 @@ struct ClusterSummaryResponse {
     first_seen: String,
     last_seen: String,
     updated_at: String,
+    superseded_at: Option<String>,
+    superseded_reason: Option<String>,
+    superseded_by_cluster_key: Option<String>,
     attempt_count: i64,
     unique_package_count: i64,
     architectures: Vec<String>,
@@ -172,6 +184,65 @@ pub async fn scriptlet_evidence_backfill(
             500,
             &format!("Scriptlet evidence backfill task failed: {error}"),
             "SCRIPTLET_EVIDENCE_BACKFILL_TASK_FAILED",
+        ),
+    }
+}
+
+pub async fn reconcile_scriptlet_evidence_unknown_commands(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    scopes: Option<Extension<TokenScopes>>,
+    request: Option<Json<UnknownCommandReconciliationRequest>>,
+) -> Response {
+    if let Some(err) = check_scope(&scopes, Scope::Admin) {
+        return err;
+    }
+
+    let request = request.map(|Json(request)| request);
+    let dry_run = request
+        .as_ref()
+        .and_then(|request| request.dry_run)
+        .unwrap_or(true);
+    let limit = request
+        .as_ref()
+        .and_then(|request| request.limit)
+        .unwrap_or(500)
+        .clamp(1, 5000);
+    let after_cluster_key = request.and_then(|request| request.after_cluster_key);
+    if after_cluster_key
+        .as_ref()
+        .is_some_and(|cluster_key| cluster_key.len() > 256)
+    {
+        return json_error(
+            400,
+            "after_cluster_key must be at most 256 bytes",
+            "INVALID_PARAMETER",
+        );
+    }
+    let db_path = {
+        let state = state.read().await;
+        state.config.db_path.clone()
+    };
+
+    match tokio::task::spawn_blocking(move || {
+        crate::server::scriptlet_evidence_queue::reconciliation::reconcile_unknown_command_batch(
+            &db_path,
+            dry_run,
+            limit,
+            after_cluster_key.as_deref(),
+        )
+    })
+    .await
+    {
+        Ok(Ok(result)) => Json(result).into_response(),
+        Ok(Err(error)) => json_error(
+            500,
+            &format!("Scriptlet evidence reconciliation failed: {error}"),
+            "SCRIPTLET_EVIDENCE_RECONCILIATION_FAILED",
+        ),
+        Err(error) => json_error(
+            500,
+            &format!("Scriptlet evidence reconciliation task failed: {error}"),
+            "SCRIPTLET_EVIDENCE_RECONCILIATION_TASK_FAILED",
         ),
     }
 }
@@ -446,6 +517,7 @@ fn cluster_filter(
             blocked_class: query.blocked_class,
             command: query.command,
             package: query.package,
+            include_superseded: query.include_superseded.unwrap_or(false),
             limit: Some(query.limit.unwrap_or(100).clamp(1, 1000)),
             offset: Some(query.offset.unwrap_or(0).max(0)),
         },
@@ -486,6 +558,7 @@ impl From<conary_core::db::models::ScriptletEvidenceClusterSummary> for ClusterS
         Self {
             cluster_key: cluster.cluster_key,
             schema_version: cluster.schema_version,
+            normalization_version: cluster.normalization_version,
             distro: cluster.distro,
             target_profile: cluster.target_profile,
             blocked_class: cluster.blocked_class,
@@ -497,6 +570,9 @@ impl From<conary_core::db::models::ScriptletEvidenceClusterSummary> for ClusterS
             first_seen: cluster.first_seen,
             last_seen: cluster.last_seen,
             updated_at: cluster.updated_at,
+            superseded_at: cluster.superseded_at,
+            superseded_reason: cluster.superseded_reason,
+            superseded_by_cluster_key: cluster.superseded_by_cluster_key,
             attempt_count: value.attempt_count,
             unique_package_count: value.unique_package_count,
             architectures: value.architectures,
@@ -736,6 +812,7 @@ mod tests {
         let cluster = NewScriptletEvidenceCluster {
             cluster_key: "s1-test".to_string(),
             schema_version: 1,
+            normalization_version: 2,
             distro: "fedora".to_string(),
             target_profile: "fedora-44".to_string(),
             blocked_class: "initramfs".to_string(),
@@ -771,11 +848,127 @@ mod tests {
         .unwrap();
     }
 
+    fn seed_unknown_command_cluster(db_path: &std::path::Path, cluster_key: &str, command: &str) {
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        ScriptletEvidenceCluster::upsert(
+            &conn,
+            &NewScriptletEvidenceCluster {
+                cluster_key: cluster_key.to_string(),
+                schema_version: 1,
+                normalization_version: 1,
+                distro: "ubuntu".to_string(),
+                target_profile: "ubuntu-26.04".to_string(),
+                blocked_class: "unknown-command".to_string(),
+                command: command.to_string(),
+                normalized_command_shape: command.to_string(),
+                normalized_command_shape_hash: format!("hash-{cluster_key}"),
+                lifecycle_phase: "unknown".to_string(),
+            },
+        )
+        .unwrap();
+        ScriptletEvidenceSample::upsert(
+            &conn,
+            &NewScriptletEvidenceSample {
+                cluster_key: cluster_key.to_string(),
+                converted_package_id: None,
+                original_checksum: format!("sha256:{cluster_key}"),
+                distro: "ubuntu".to_string(),
+                package_name: format!("pkg-{cluster_key}"),
+                package_version: "1.0.0".to_string(),
+                package_architecture: Some("amd64".to_string()),
+                publication_status: "private-review".to_string(),
+                scriptlet_fidelity: "legacy".to_string(),
+                target_compatibility: "private-review".to_string(),
+                reason_codes_json: r#"["unknown-command"]"#.to_string(),
+                blocked_classes_json: "[]".to_string(),
+                boot_security_intents_json: "[]".to_string(),
+                security_policy_intents_json: "[]".to_string(),
+                review_artifact_path: None,
+                review_artifact_stale: false,
+                evidence_digest: Some(format!("sha256:evidence-{cluster_key}")),
+                curation_evidence_digest: None,
+            },
+        )
+        .unwrap();
+    }
+
     async fn response_body(response: axum::response::Response) -> String {
         let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
             .await
             .unwrap();
         String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn unknown_command_reconciliation_defaults_to_dry_run_and_preserves_history() {
+        let (app, db_path) = test_app().await;
+        seed_unknown_command_cluster(&db_path, "s1-set-noise", "set");
+
+        let dry_run = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/admin/scriptlet-evidence/reconcile-unknown-commands")
+                    .header("authorization", "Bearer test-admin-token-12345")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(dry_run.status(), StatusCode::OK);
+        let body = response_body(dry_run).await;
+        assert!(body.contains("\"dry_run\":true"));
+        assert!(body.contains("\"superseded_noise_cluster_count\":1"));
+
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let before = ScriptletEvidenceCluster::find(&conn, "s1-set-noise")
+            .unwrap()
+            .unwrap();
+        assert!(before.superseded_at.is_none());
+
+        let app = rebuild_app(&db_path);
+        let apply = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/admin/scriptlet-evidence/reconcile-unknown-commands")
+                    .header("authorization", "Bearer test-admin-token-12345")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"dry_run":false,"limit":1}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(apply.status(), StatusCode::OK);
+
+        let app = rebuild_app(&db_path);
+        let active = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/admin/scriptlet-evidence/clusters")
+                    .header("authorization", "Bearer test-admin-token-12345")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(active.status(), StatusCode::OK);
+        assert!(!response_body(active).await.contains("s1-set-noise"));
+
+        let app = rebuild_app(&db_path);
+        let historical = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/admin/scriptlet-evidence/clusters?include_superseded=true")
+                    .header("authorization", "Bearer test-admin-token-12345")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = response_body(historical).await;
+        assert!(body.contains("s1-set-noise"));
+        assert!(body.contains("normalization-v2:shell-builtin"));
     }
 
     #[tokio::test]

--- a/apps/remi/src/server/handlers/openapi.rs
+++ b/apps/remi/src/server/handlers/openapi.rs
@@ -176,6 +176,27 @@ pub async fn openapi_spec() -> Response {
                     "responses": { "200": { "description": "Backfill batch result" }, "401": { "description": "Invalid or missing token" }, "403": { "description": "Insufficient scope" } }
                 }
             },
+            "/v1/admin/scriptlet-evidence/reconcile-unknown-commands": {
+                "post": {
+                    "operationId": "reconcileScriptletEvidenceUnknownCommands",
+                    "summary": "Reconcile unknown-command queue noise",
+                    "description": "Classifies one bounded batch of legacy unknown-command clusters under the current queue-only normalization contract. Dry-run is the default. Applied batches retain real command signals and supersede provable shell or maintainer-dispatch noise without deleting samples, notes, state events, or changing converted-package publication state.",
+                    "tags": ["scriptlet-evidence"],
+                    "security": [{ "bearerAuth": [] }],
+                    "requestBody": {
+                        "required": false,
+                        "content": { "application/json": { "schema": {
+                            "type": "object",
+                            "properties": {
+                                "dry_run": { "type": "boolean", "default": true },
+                                "limit": { "type": "integer", "minimum": 1, "maximum": 5000, "default": 500 },
+                                "after_cluster_key": { "type": "string", "maxLength": 256 }
+                            }
+                        }}}
+                    },
+                    "responses": { "200": { "description": "Unknown-command reconciliation batch result" }, "400": { "description": "Invalid cursor" }, "401": { "description": "Invalid or missing token" }, "403": { "description": "Insufficient scope" } }
+                }
+            },
             "/v1/admin/scriptlet-evidence/clusters": {
                 "get": {
                     "operationId": "listScriptletEvidenceClusters",
@@ -189,6 +210,7 @@ pub async fn openapi_spec() -> Response {
                         { "name": "blocked_class", "in": "query", "required": false, "schema": { "type": "string" } },
                         { "name": "command", "in": "query", "required": false, "schema": { "type": "string" } },
                         { "name": "package", "in": "query", "required": false, "schema": { "type": "string" } },
+                        { "name": "include_superseded", "in": "query", "required": false, "schema": { "type": "boolean", "default": false } },
                         { "name": "limit", "in": "query", "required": false, "schema": { "type": "integer", "maximum": 1000 } },
                         { "name": "offset", "in": "query", "required": false, "schema": { "type": "integer", "minimum": 0 } }
                     ],
@@ -713,6 +735,10 @@ mod tests {
                 &["get"][..],
             ),
             ("/v1/admin/scriptlet-evidence/backfill", &["post"][..]),
+            (
+                "/v1/admin/scriptlet-evidence/reconcile-unknown-commands",
+                &["post"][..],
+            ),
             ("/v1/admin/scriptlet-evidence/clusters", &["get"][..]),
             (
                 "/v1/admin/scriptlet-evidence/clusters/{cluster_key}",

--- a/apps/remi/src/server/routes/admin.rs
+++ b/apps/remi/src/server/routes/admin.rs
@@ -108,6 +108,10 @@ pub fn create_external_admin_router(
             post(admin_handlers::scriptlet_evidence_backfill),
         )
         .route(
+            "/v1/admin/scriptlet-evidence/reconcile-unknown-commands",
+            post(admin_handlers::reconcile_scriptlet_evidence_unknown_commands),
+        )
+        .route(
             "/v1/admin/scriptlet-evidence/clusters",
             get(admin_handlers::list_scriptlet_evidence_clusters),
         )

--- a/apps/remi/src/server/scriptlet_evidence_queue/aggregation.rs
+++ b/apps/remi/src/server/scriptlet_evidence_queue/aggregation.rs
@@ -11,6 +11,9 @@ use conary_core::db::models::{
 
 use crate::server::publication;
 
+use super::classification::{
+    UNKNOWN_COMMAND_NORMALIZATION_VERSION, UnknownCommandDisposition, classify_unknown_command,
+};
 use super::normalization::{
     normalize_command_shape, sanitize_boot_security_intents, sanitize_security_policy_intents,
     stable_cluster_key, target_profile_for_distro,
@@ -49,7 +52,13 @@ pub fn evidence_samples_from_converted(
 
     let unknown_commands = sorted_unique(summary.unknown_commands.iter().map(String::as_str));
     if !unknown_commands.is_empty() {
-        for command in unknown_commands {
+        let signal_commands = unknown_commands.into_iter().filter(|command| {
+            matches!(
+                classify_unknown_command(command),
+                UnknownCommandDisposition::Signal
+            )
+        });
+        for command in signal_commands {
             samples.push(build_pending_sample(
                 converted,
                 cache_dir,
@@ -60,7 +69,9 @@ pub fn evidence_samples_from_converted(
                 "unknown",
             )?);
         }
-        return Ok(samples);
+        if !samples.is_empty() {
+            return Ok(samples);
+        }
     }
 
     let blocked_classes = sorted_unique(summary.blocked_classes.iter().map(String::as_str));
@@ -129,6 +140,7 @@ fn build_pending_sample(
         cluster: NewScriptletEvidenceCluster {
             cluster_key: stable.cluster_key.clone(),
             schema_version: i64::from(CLUSTER_SCHEMA_VERSION),
+            normalization_version: UNKNOWN_COMMAND_NORMALIZATION_VERSION,
             distro: distro.clone(),
             target_profile,
             blocked_class: blocked_class.to_string(),
@@ -385,6 +397,101 @@ mod tests {
         assert!(!intents.contains("/tmp/foo.pp"));
         assert!(!intents.contains("/home/remi"));
         assert!(!intents.contains("SECRET=/home"));
+    }
+
+    #[test]
+    fn queue_filters_rpm_shell_structure_but_keeps_real_unknown_commands() {
+        let summary = ScriptletBundleSummary {
+            scriptlet_fidelity: "legacy".to_string(),
+            target_compatibility: "private-review".to_string(),
+            publication_status: "private-review".to_string(),
+            unknown_commands: vec![
+                "set".to_string(),
+                "$1".to_string(),
+                "{".to_string(),
+                "custom-rpm-helper".to_string(),
+            ],
+            ..ScriptletBundleSummary::default()
+        };
+        let converted = converted_package_with_summary(summary);
+
+        let samples = evidence_samples_from_converted(&converted, Path::new("/tmp/cache")).unwrap();
+
+        assert_eq!(samples.len(), 1);
+        assert_eq!(samples[0].cluster.command, "custom-rpm-helper");
+        assert_eq!(
+            samples[0].cluster.normalization_version,
+            UNKNOWN_COMMAND_NORMALIZATION_VERSION
+        );
+    }
+
+    #[test]
+    fn queue_filters_deb_dispatch_structure_but_keeps_real_unknown_commands() {
+        let summary = ScriptletBundleSummary {
+            scriptlet_fidelity: "legacy".to_string(),
+            target_compatibility: "private-review".to_string(),
+            publication_status: "private-review".to_string(),
+            unknown_commands: vec![
+                "true".to_string(),
+                "configure)".to_string(),
+                "postinst".to_string(),
+                "custom-deb-helper".to_string(),
+            ],
+            ..ScriptletBundleSummary::default()
+        };
+        let mut converted = converted_package_with_summary(summary);
+        converted.distro = Some("ubuntu".to_string());
+
+        let samples = evidence_samples_from_converted(&converted, Path::new("/tmp/cache")).unwrap();
+
+        assert_eq!(samples.len(), 1);
+        assert_eq!(samples[0].cluster.command, "custom-deb-helper");
+        assert_eq!(samples[0].cluster.target_profile, "ubuntu-26.04");
+    }
+
+    #[test]
+    fn queue_filters_arch_function_structure_but_keeps_real_unknown_commands() {
+        let summary = ScriptletBundleSummary {
+            scriptlet_fidelity: "legacy".to_string(),
+            target_compatibility: "private-review".to_string(),
+            publication_status: "private-review".to_string(),
+            unknown_commands: vec![
+                "post_install".to_string(),
+                "return".to_string(),
+                "custom-arch-helper".to_string(),
+            ],
+            ..ScriptletBundleSummary::default()
+        };
+        let mut converted = converted_package_with_summary(summary);
+        converted.distro = Some("arch".to_string());
+
+        let samples = evidence_samples_from_converted(&converted, Path::new("/tmp/cache")).unwrap();
+
+        assert_eq!(samples.len(), 1);
+        assert_eq!(samples[0].cluster.command, "custom-arch-helper");
+        assert_eq!(samples[0].cluster.target_profile, "arch");
+    }
+
+    #[test]
+    fn all_noise_unknown_commands_fall_through_to_high_signal_blocked_class() {
+        let summary = ScriptletBundleSummary {
+            scriptlet_fidelity: "blocked".to_string(),
+            target_compatibility: "blocked".to_string(),
+            publication_status: "blocked".to_string(),
+            unknown_commands: vec!["set".to_string(), "true".to_string()],
+            blocked_reason_codes: vec!["blocked-class-package-manager-recursion".to_string()],
+            blocked_classes: vec!["package-manager-recursion".to_string()],
+            ..ScriptletBundleSummary::default()
+        };
+        let converted = converted_package_with_summary(summary);
+
+        let samples = evidence_samples_from_converted(&converted, Path::new("/tmp/cache")).unwrap();
+
+        assert_eq!(samples.len(), 1);
+        assert_eq!(
+            samples[0].cluster.blocked_class,
+            "package-manager-recursion"
+        );
     }
 
     #[test]

--- a/apps/remi/src/server/scriptlet_evidence_queue/classification.rs
+++ b/apps/remi/src/server/scriptlet_evidence_queue/classification.rs
@@ -1,0 +1,279 @@
+// apps/remi/src/server/scriptlet_evidence_queue/classification.rs
+
+/// Version of the queue-only unknown-command classification contract.
+///
+/// This does not change CCS conversion, adapter selection, legacy replay, or
+/// publication authority. It only decides whether an already-unknown command
+/// is useful adapter-planning evidence in Remi's admin queue.
+pub const UNKNOWN_COMMAND_NORMALIZATION_VERSION: i64 = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnknownCommandDisposition {
+    Signal,
+    StructuralNoise(&'static str),
+}
+
+impl UnknownCommandDisposition {
+    pub fn noise_reason(self) -> Option<&'static str> {
+        match self {
+            Self::Signal => None,
+            Self::StructuralNoise(reason) => Some(reason),
+        }
+    }
+}
+
+pub fn classify_unknown_command(command: &str) -> UnknownCommandDisposition {
+    let token = command.trim();
+    if token.is_empty() {
+        return UnknownCommandDisposition::StructuralNoise("empty-token");
+    }
+
+    let unquoted = strip_matching_quotes(token);
+    if is_function_definition(unquoted) {
+        return UnknownCommandDisposition::StructuralNoise("function-definition");
+    }
+    if is_variable_reference(unquoted) {
+        return UnknownCommandDisposition::StructuralNoise("variable-reference");
+    }
+    if is_environment_assignment(unquoted) {
+        return UnknownCommandDisposition::StructuralNoise("environment-assignment");
+    }
+    if is_shell_punctuation(unquoted) {
+        return UnknownCommandDisposition::StructuralNoise("shell-punctuation");
+    }
+
+    let dispatch_syntax = unquoted.ends_with(')') || unquoted.ends_with(':');
+    let bare = unquoted.trim_matches(|ch: char| matches!(ch, '(' | ')' | '{' | '}' | ';' | ':'));
+
+    if is_shell_keyword(bare) {
+        return UnknownCommandDisposition::StructuralNoise("shell-keyword");
+    }
+    if is_queue_structural_builtin(bare) {
+        return UnknownCommandDisposition::StructuralNoise("shell-builtin");
+    }
+    if is_unambiguous_maintainer_dispatch_label(bare)
+        || (dispatch_syntax && is_ambiguous_dpkg_dispatch_label(bare))
+    {
+        return UnknownCommandDisposition::StructuralNoise("maintainer-dispatch-label");
+    }
+
+    UnknownCommandDisposition::Signal
+}
+
+fn strip_matching_quotes(value: &str) -> &str {
+    let bytes = value.as_bytes();
+    if bytes.len() < 2 {
+        return value;
+    }
+    match (bytes[0], bytes[bytes.len() - 1]) {
+        (b'\'', b'\'') | (b'"', b'"') => value[1..value.len() - 1].trim(),
+        _ => value,
+    }
+}
+
+fn is_function_definition(token: &str) -> bool {
+    token.strip_suffix("()").is_some_and(is_shell_identifier)
+}
+
+fn is_variable_reference(token: &str) -> bool {
+    let Some(rest) = token.strip_prefix('$') else {
+        return false;
+    };
+    if rest.is_empty() {
+        return false;
+    }
+    if matches!(rest, "@" | "*" | "#" | "?" | "$" | "!" | "-" | "0")
+        || rest.chars().all(|ch| ch.is_ascii_digit())
+    {
+        return true;
+    }
+    if rest.starts_with('{') && rest.ends_with('}') {
+        return true;
+    }
+    if rest.starts_with('(') {
+        return true;
+    }
+    is_shell_identifier(rest)
+}
+
+fn is_environment_assignment(token: &str) -> bool {
+    token
+        .split_once('=')
+        .is_some_and(|(name, _)| is_shell_identifier(name))
+}
+
+fn is_shell_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn is_shell_punctuation(token: &str) -> bool {
+    !token.is_empty()
+        && token.chars().all(|ch| {
+            matches!(
+                ch,
+                '{' | '}' | '(' | ')' | '[' | ']' | ';' | ':' | '|' | '&' | '!'
+            )
+        })
+}
+
+fn is_shell_keyword(token: &str) -> bool {
+    matches!(
+        token,
+        "if" | "then"
+            | "else"
+            | "elif"
+            | "fi"
+            | "do"
+            | "done"
+            | "while"
+            | "until"
+            | "for"
+            | "in"
+            | "case"
+            | "esac"
+            | "select"
+            | "function"
+            | "time"
+            | "coproc"
+    )
+}
+
+fn is_queue_structural_builtin(token: &str) -> bool {
+    matches!(
+        token,
+        ":" | "["
+            | "[["
+            | "break"
+            | "continue"
+            | "declare"
+            | "dirs"
+            | "echo"
+            | "exit"
+            | "export"
+            | "false"
+            | "getopts"
+            | "hash"
+            | "help"
+            | "history"
+            | "jobs"
+            | "let"
+            | "local"
+            | "printf"
+            | "pwd"
+            | "read"
+            | "readonly"
+            | "return"
+            | "set"
+            | "shift"
+            | "test"
+            | "times"
+            | "true"
+            | "type"
+            | "typeset"
+            | "unset"
+            | "wait"
+    )
+}
+
+fn is_unambiguous_maintainer_dispatch_label(token: &str) -> bool {
+    matches!(
+        token,
+        "preinst"
+            | "postinst"
+            | "prerm"
+            | "postrm"
+            | "abort-upgrade"
+            | "abort-remove"
+            | "abort-deconfigure"
+            | "failed-upgrade"
+            | "disappear"
+            | "triggered"
+            | "pre_install"
+            | "post_install"
+            | "pre_upgrade"
+            | "post_upgrade"
+            | "pre_remove"
+            | "post_remove"
+            | "pre_transaction"
+            | "post_transaction"
+            | "%pre"
+            | "%post"
+            | "%preun"
+            | "%postun"
+            | "%trigger"
+            | "%triggerin"
+            | "%triggerun"
+            | "%triggerpostun"
+            | "%pretrans"
+            | "%posttrans"
+    )
+}
+
+fn is_ambiguous_dpkg_dispatch_label(token: &str) -> bool {
+    matches!(
+        token,
+        "configure" | "install" | "upgrade" | "remove" | "purge" | "deconfigure"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_provable_shell_and_package_manager_structure_as_noise() {
+        for (command, reason) in [
+            ("set", "shell-builtin"),
+            ("true", "shell-builtin"),
+            ("exit", "shell-builtin"),
+            ("$1", "variable-reference"),
+            ("${DPKG_MAINTSCRIPT_PACKAGE}", "variable-reference"),
+            ("NAME=value", "environment-assignment"),
+            ("{", "shell-punctuation"),
+            (":", "shell-punctuation"),
+            ("then", "shell-keyword"),
+            ("helper()", "function-definition"),
+            ("configure)", "maintainer-dispatch-label"),
+            ("postinst", "maintainer-dispatch-label"),
+            ("post_install", "maintainer-dispatch-label"),
+            ("%posttrans", "maintainer-dispatch-label"),
+        ] {
+            assert_eq!(
+                classify_unknown_command(command),
+                UnknownCommandDisposition::StructuralNoise(reason),
+                "{command}"
+            );
+        }
+    }
+
+    #[test]
+    fn keeps_ambiguous_effectful_and_security_sensitive_commands_visible() {
+        for command in [
+            "custom-helper",
+            "configure",
+            "install",
+            "eval",
+            "exec",
+            "source",
+            "kill",
+            "umask",
+            "dracut",
+            "semanage",
+            "depmod",
+            "curl",
+            "dnf",
+            "pam-auth-update",
+        ] {
+            assert_eq!(
+                classify_unknown_command(command),
+                UnknownCommandDisposition::Signal,
+                "{command}"
+            );
+        }
+    }
+}

--- a/apps/remi/src/server/scriptlet_evidence_queue/mod.rs
+++ b/apps/remi/src/server/scriptlet_evidence_queue/mod.rs
@@ -2,8 +2,10 @@
 
 pub mod aggregation;
 pub mod backfill;
+pub mod classification;
 pub mod normalization;
 pub mod packet;
+pub mod reconciliation;
 pub mod storage;
 pub mod types;
 

--- a/apps/remi/src/server/scriptlet_evidence_queue/packet.rs
+++ b/apps/remi/src/server/scriptlet_evidence_queue/packet.rs
@@ -54,6 +54,7 @@ pub fn build_packet(detail: ScriptletEvidenceClusterDetail, visibility: PacketVi
         "visibility": visibility.as_str(),
         "cluster": {
             "cluster_key": detail.cluster.cluster_key,
+            "normalization_version": detail.cluster.normalization_version,
             "state": detail.cluster.state.as_str(),
             "distro": detail.cluster.distro,
             "target_profile": detail.cluster.target_profile,
@@ -65,6 +66,9 @@ pub fn build_packet(detail: ScriptletEvidenceClusterDetail, visibility: PacketVi
             "first_seen": detail.cluster.first_seen,
             "last_seen": detail.cluster.last_seen,
             "updated_at": detail.cluster.updated_at,
+            "superseded_at": detail.cluster.superseded_at,
+            "superseded_reason": detail.cluster.superseded_reason,
+            "superseded_by_cluster_key": detail.cluster.superseded_by_cluster_key,
         },
         "impact": {
             "attempt_count": samples.len(),

--- a/apps/remi/src/server/scriptlet_evidence_queue/reconciliation.rs
+++ b/apps/remi/src/server/scriptlet_evidence_queue/reconciliation.rs
@@ -1,0 +1,376 @@
+// apps/remi/src/server/scriptlet_evidence_queue/reconciliation.rs
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use anyhow::Result;
+use rusqlite::{Connection, params};
+use serde::Serialize;
+
+use super::classification::{
+    UNKNOWN_COMMAND_NORMALIZATION_VERSION, UnknownCommandDisposition, classify_unknown_command,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct UnknownCommandReconciliationResult {
+    pub normalization_version: i64,
+    pub dry_run: bool,
+    pub complete: bool,
+    pub next_after_cluster_key: Option<String>,
+    pub scanned_cluster_count: i64,
+    pub retained_signal_cluster_count: i64,
+    pub retained_signal_attempt_count: i64,
+    pub superseded_noise_cluster_count: i64,
+    pub superseded_noise_attempt_count: i64,
+    pub superseded_by_reason: BTreeMap<String, i64>,
+    pub remaining_cluster_count: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ReconciliationCandidate {
+    cluster_key: String,
+    command: String,
+    attempt_count: i64,
+}
+
+pub fn reconcile_unknown_command_batch(
+    db_path: &Path,
+    dry_run: bool,
+    limit: usize,
+    after_cluster_key: Option<&str>,
+) -> Result<UnknownCommandReconciliationResult> {
+    let conn = crate::server::open_runtime_db(db_path)?;
+    reconcile_unknown_command_batch_inner(&conn, dry_run, limit.clamp(1, 5000), after_cluster_key)
+}
+
+fn reconcile_unknown_command_batch_inner(
+    conn: &Connection,
+    dry_run: bool,
+    limit: usize,
+    after_cluster_key: Option<&str>,
+) -> Result<UnknownCommandReconciliationResult> {
+    let candidates = reconciliation_candidates(conn, after_cluster_key.unwrap_or(""), limit)?;
+    let complete = candidates.len() < limit;
+    let next_after_cluster_key = (!complete)
+        .then(|| {
+            candidates
+                .last()
+                .map(|candidate| candidate.cluster_key.clone())
+        })
+        .flatten();
+
+    let mut retained_signal_cluster_count = 0_i64;
+    let mut retained_signal_attempt_count = 0_i64;
+    let mut superseded_noise_cluster_count = 0_i64;
+    let mut superseded_noise_attempt_count = 0_i64;
+    let mut superseded_by_reason = BTreeMap::new();
+
+    for candidate in &candidates {
+        match classify_unknown_command(&candidate.command) {
+            UnknownCommandDisposition::Signal => {
+                retained_signal_cluster_count += 1;
+                retained_signal_attempt_count += candidate.attempt_count;
+            }
+            UnknownCommandDisposition::StructuralNoise(reason) => {
+                superseded_noise_cluster_count += 1;
+                superseded_noise_attempt_count += candidate.attempt_count;
+                *superseded_by_reason.entry(reason.to_string()).or_default() += 1;
+            }
+        }
+    }
+
+    if !dry_run {
+        let tx = conn.unchecked_transaction()?;
+        for candidate in &candidates {
+            match classify_unknown_command(&candidate.command) {
+                UnknownCommandDisposition::Signal => {
+                    tx.execute(
+                        "UPDATE scriptlet_evidence_clusters
+                         SET normalization_version = ?2,
+                             updated_at = (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+                         WHERE cluster_key = ?1
+                           AND normalization_version < ?2
+                           AND superseded_at IS NULL",
+                        params![
+                            &candidate.cluster_key,
+                            UNKNOWN_COMMAND_NORMALIZATION_VERSION
+                        ],
+                    )?;
+                }
+                UnknownCommandDisposition::StructuralNoise(reason) => {
+                    let superseded_reason = format!(
+                        "normalization-v{}:{reason}",
+                        UNKNOWN_COMMAND_NORMALIZATION_VERSION
+                    );
+                    tx.execute(
+                        "UPDATE scriptlet_evidence_clusters
+                         SET normalization_version = ?2,
+                             superseded_at = (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+                             superseded_reason = ?3,
+                             superseded_by_cluster_key = NULL,
+                             updated_at = (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+                         WHERE cluster_key = ?1
+                           AND normalization_version < ?2
+                           AND superseded_at IS NULL",
+                        params![
+                            &candidate.cluster_key,
+                            UNKNOWN_COMMAND_NORMALIZATION_VERSION,
+                            superseded_reason
+                        ],
+                    )?;
+                }
+            }
+        }
+        tx.commit()?;
+    }
+
+    Ok(UnknownCommandReconciliationResult {
+        normalization_version: UNKNOWN_COMMAND_NORMALIZATION_VERSION,
+        dry_run,
+        complete,
+        next_after_cluster_key,
+        scanned_cluster_count: candidates.len() as i64,
+        retained_signal_cluster_count,
+        retained_signal_attempt_count,
+        superseded_noise_cluster_count,
+        superseded_noise_attempt_count,
+        superseded_by_reason,
+        remaining_cluster_count: remaining_cluster_count(conn)?,
+    })
+}
+
+fn reconciliation_candidates(
+    conn: &Connection,
+    after_cluster_key: &str,
+    limit: usize,
+) -> Result<Vec<ReconciliationCandidate>> {
+    let mut stmt = conn.prepare(
+        "SELECT c.cluster_key, c.command, COUNT(s.id)
+         FROM scriptlet_evidence_clusters c
+         LEFT JOIN scriptlet_evidence_cluster_samples s ON s.cluster_key = c.cluster_key
+         WHERE c.blocked_class = 'unknown-command'
+           AND c.normalization_version < ?1
+           AND c.superseded_at IS NULL
+           AND c.cluster_key > ?2
+         GROUP BY c.cluster_key
+         ORDER BY c.cluster_key
+         LIMIT ?3",
+    )?;
+    let rows = stmt
+        .query_map(
+            params![
+                UNKNOWN_COMMAND_NORMALIZATION_VERSION,
+                after_cluster_key,
+                limit as i64
+            ],
+            |row| {
+                Ok(ReconciliationCandidate {
+                    cluster_key: row.get(0)?,
+                    command: row.get(1)?,
+                    attempt_count: row.get(2)?,
+                })
+            },
+        )?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+fn remaining_cluster_count(conn: &Connection) -> Result<i64> {
+    conn.query_row(
+        "SELECT COUNT(*)
+         FROM scriptlet_evidence_clusters
+         WHERE blocked_class = 'unknown-command'
+           AND normalization_version < ?1
+           AND superseded_at IS NULL",
+        [UNKNOWN_COMMAND_NORMALIZATION_VERSION],
+        |row| row.get(0),
+    )
+    .map_err(Into::into)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use conary_core::db::models::{
+        NewScriptletEvidenceCluster, NewScriptletEvidenceSample, ScriptletEvidenceCluster,
+        ScriptletEvidenceClusterListFilter, ScriptletEvidenceNote, ScriptletEvidenceSample,
+        ScriptletEvidenceState,
+    };
+
+    fn test_db() -> (tempfile::TempDir, std::path::PathBuf) {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("test.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conary_core::db::schema::migrate(&conn).unwrap();
+        (temp, db_path)
+    }
+
+    fn seed_cluster(
+        conn: &Connection,
+        cluster_key: &str,
+        blocked_class: &str,
+        command: &str,
+        package_name: &str,
+    ) {
+        ScriptletEvidenceCluster::upsert(
+            conn,
+            &NewScriptletEvidenceCluster {
+                cluster_key: cluster_key.to_string(),
+                schema_version: 1,
+                normalization_version: 1,
+                distro: "fedora".to_string(),
+                target_profile: "fedora-44".to_string(),
+                blocked_class: blocked_class.to_string(),
+                command: command.to_string(),
+                normalized_command_shape: command.to_string(),
+                normalized_command_shape_hash: format!("hash-{cluster_key}"),
+                lifecycle_phase: "unknown".to_string(),
+            },
+        )
+        .unwrap();
+        ScriptletEvidenceSample::upsert(
+            conn,
+            &NewScriptletEvidenceSample {
+                cluster_key: cluster_key.to_string(),
+                converted_package_id: None,
+                original_checksum: format!("sha256:{package_name}"),
+                distro: "fedora".to_string(),
+                package_name: package_name.to_string(),
+                package_version: "1.0.0".to_string(),
+                package_architecture: Some("x86_64".to_string()),
+                publication_status: "private-review".to_string(),
+                scriptlet_fidelity: "legacy".to_string(),
+                target_compatibility: "private-review".to_string(),
+                reason_codes_json: r#"["unknown-command"]"#.to_string(),
+                blocked_classes_json: "[]".to_string(),
+                boot_security_intents_json: "[]".to_string(),
+                security_policy_intents_json: "[]".to_string(),
+                review_artifact_path: None,
+                review_artifact_stale: false,
+                evidence_digest: Some(format!("sha256:evidence-{package_name}")),
+                curation_evidence_digest: None,
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn dry_run_reports_impact_without_changing_queue_state() {
+        let (_temp, db_path) = test_db();
+        let conn = Connection::open(&db_path).unwrap();
+        seed_cluster(
+            &conn,
+            "s1-custom",
+            "unknown-command",
+            "custom-helper",
+            "custom",
+        );
+        seed_cluster(&conn, "s1-set", "unknown-command", "set", "set-noise");
+        seed_cluster(&conn, "s1-true", "unknown-command", "true", "true-noise");
+
+        let result =
+            reconcile_unknown_command_batch(&db_path, true, 100, None).expect("dry run succeeds");
+
+        assert!(result.complete);
+        assert_eq!(result.scanned_cluster_count, 3);
+        assert_eq!(result.retained_signal_cluster_count, 1);
+        assert_eq!(result.superseded_noise_cluster_count, 2);
+        assert_eq!(result.superseded_noise_attempt_count, 2);
+        assert_eq!(result.remaining_cluster_count, 3);
+        assert_eq!(result.superseded_by_reason.get("shell-builtin"), Some(&2));
+        for key in ["s1-custom", "s1-set", "s1-true"] {
+            let cluster = ScriptletEvidenceCluster::find(&conn, key).unwrap().unwrap();
+            assert_eq!(cluster.normalization_version, 1);
+            assert!(cluster.superseded_at.is_none());
+        }
+    }
+
+    #[test]
+    fn reconciliation_is_bounded_resumable_and_preserves_history() {
+        let (_temp, db_path) = test_db();
+        let conn = Connection::open(&db_path).unwrap();
+        seed_cluster(
+            &conn,
+            "s1-custom",
+            "unknown-command",
+            "custom-helper",
+            "custom",
+        );
+        seed_cluster(&conn, "s1-set", "unknown-command", "set", "set-noise");
+        seed_cluster(&conn, "s1-true", "unknown-command", "true", "true-noise");
+        seed_cluster(&conn, "s1-dracut", "initramfs", "dracut", "kernel");
+        ScriptletEvidenceCluster::update_state(
+            &conn,
+            "s1-set",
+            ScriptletEvidenceState::AdapterCandidate,
+            "maintainer",
+            Some("historical disposition"),
+        )
+        .unwrap();
+        ScriptletEvidenceNote::insert(&conn, "s1-set", "maintainer", "keep this private note")
+            .unwrap();
+
+        let first = reconcile_unknown_command_batch(&db_path, false, 2, None).unwrap();
+        assert!(!first.complete);
+        assert_eq!(first.scanned_cluster_count, 2);
+        assert_eq!(first.remaining_cluster_count, 1);
+
+        let second = reconcile_unknown_command_batch(&db_path, false, 2, None).unwrap();
+        assert!(second.complete);
+        assert_eq!(second.scanned_cluster_count, 1);
+        assert_eq!(second.remaining_cluster_count, 0);
+
+        let third = reconcile_unknown_command_batch(&db_path, false, 2, None).unwrap();
+        assert!(third.complete);
+        assert_eq!(third.scanned_cluster_count, 0);
+
+        let custom = ScriptletEvidenceCluster::find(&conn, "s1-custom")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            custom.normalization_version,
+            UNKNOWN_COMMAND_NORMALIZATION_VERSION
+        );
+        assert!(custom.superseded_at.is_none());
+
+        let set = ScriptletEvidenceCluster::detail(&conn, "s1-set")
+            .unwrap()
+            .unwrap();
+        assert_eq!(set.cluster.state, ScriptletEvidenceState::AdapterCandidate);
+        assert_eq!(set.cluster.normalization_version, 2);
+        assert_eq!(
+            set.cluster.superseded_reason.as_deref(),
+            Some("normalization-v2:shell-builtin")
+        );
+        assert_eq!(set.samples.len(), 1);
+        assert_eq!(set.state_events.len(), 1);
+        assert_eq!(set.notes.len(), 1);
+        assert_eq!(set.notes[0].body, "keep this private note");
+        assert_eq!(set.samples[0].publication_status, "private-review");
+
+        let active =
+            ScriptletEvidenceCluster::list(&conn, &ScriptletEvidenceClusterListFilter::default())
+                .unwrap();
+        assert_eq!(active.len(), 2);
+        assert!(
+            active
+                .iter()
+                .any(|row| row.cluster.cluster_key == "s1-custom")
+        );
+        assert!(
+            active
+                .iter()
+                .any(|row| row.cluster.cluster_key == "s1-dracut")
+        );
+
+        let all = ScriptletEvidenceCluster::list(
+            &conn,
+            &ScriptletEvidenceClusterListFilter {
+                include_superseded: true,
+                ..ScriptletEvidenceClusterListFilter::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(all.len(), 4);
+    }
+}

--- a/crates/conary-core/src/db/migrations/v41_current.rs
+++ b/crates/conary-core/src/db/migrations/v41_current.rs
@@ -1360,6 +1360,33 @@ pub fn migrate_v77(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// Version 78: Versioned scriptlet evidence normalization and supersession
+pub fn migrate_v78(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "
+        ALTER TABLE scriptlet_evidence_clusters
+            ADD COLUMN normalization_version INTEGER NOT NULL DEFAULT 1;
+        ALTER TABLE scriptlet_evidence_clusters
+            ADD COLUMN superseded_at TEXT;
+        ALTER TABLE scriptlet_evidence_clusters
+            ADD COLUMN superseded_reason TEXT;
+        ALTER TABLE scriptlet_evidence_clusters
+            ADD COLUMN superseded_by_cluster_key TEXT;
+
+        CREATE INDEX idx_scriptlet_evidence_clusters_active_normalization
+            ON scriptlet_evidence_clusters(
+                superseded_at,
+                blocked_class,
+                normalization_version,
+                cluster_key
+            );
+        ",
+    )?;
+
+    info!("Schema version 78 applied successfully (versioned scriptlet evidence normalization)");
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1538,6 +1565,32 @@ mod tests {
             )
             .unwrap();
         assert_eq!(default_value, "'[]'");
+    }
+
+    #[test]
+    fn test_migrate_v78_versions_queue_normalization_without_dropping_history() {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::db::schema::migrate(&conn).unwrap();
+
+        let columns = table_columns(&conn, "scriptlet_evidence_clusters");
+        for column in [
+            "normalization_version",
+            "superseded_at",
+            "superseded_reason",
+            "superseded_by_cluster_key",
+        ] {
+            assert!(columns.contains(&column.to_string()), "missing {column}");
+        }
+
+        let default_value: String = conn
+            .query_row(
+                "SELECT dflt_value FROM pragma_table_info('scriptlet_evidence_clusters')
+                 WHERE name = 'normalization_version'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(default_value, "1");
     }
 
     #[test]

--- a/crates/conary-core/src/db/models/scriptlet_evidence.rs
+++ b/crates/conary-core/src/db/models/scriptlet_evidence.rs
@@ -55,6 +55,7 @@ impl ScriptletEvidenceState {
 pub struct NewScriptletEvidenceCluster {
     pub cluster_key: String,
     pub schema_version: i64,
+    pub normalization_version: i64,
     pub distro: String,
     pub target_profile: String,
     pub blocked_class: String,
@@ -68,6 +69,7 @@ pub struct NewScriptletEvidenceCluster {
 pub struct ScriptletEvidenceCluster {
     pub cluster_key: String,
     pub schema_version: i64,
+    pub normalization_version: i64,
     pub distro: String,
     pub target_profile: String,
     pub blocked_class: String,
@@ -79,6 +81,9 @@ pub struct ScriptletEvidenceCluster {
     pub first_seen: String,
     pub last_seen: String,
     pub updated_at: String,
+    pub superseded_at: Option<String>,
+    pub superseded_reason: Option<String>,
+    pub superseded_by_cluster_key: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -88,6 +93,7 @@ pub struct ScriptletEvidenceClusterListFilter {
     pub blocked_class: Option<String>,
     pub command: Option<String>,
     pub package: Option<String>,
+    pub include_superseded: bool,
     pub limit: Option<i64>,
     pub offset: Option<i64>,
 }
@@ -110,19 +116,21 @@ pub struct ScriptletEvidenceClusterDetail {
 }
 
 impl ScriptletEvidenceCluster {
-    const COLUMNS: &'static str = "cluster_key, schema_version, distro, target_profile, \
+    const COLUMNS: &'static str = "cluster_key, schema_version, normalization_version, distro, target_profile, \
          blocked_class, command, normalized_command_shape, normalized_command_shape_hash, \
-         lifecycle_phase, state, first_seen, last_seen, updated_at";
+         lifecycle_phase, state, first_seen, last_seen, updated_at, superseded_at, \
+         superseded_reason, superseded_by_cluster_key";
 
     pub fn upsert(conn: &Connection, cluster: &NewScriptletEvidenceCluster) -> Result<Self> {
         conn.execute(
             "INSERT INTO scriptlet_evidence_clusters (
-                cluster_key, schema_version, distro, target_profile, blocked_class,
+                cluster_key, schema_version, normalization_version, distro, target_profile, blocked_class,
                 command, normalized_command_shape, normalized_command_shape_hash,
                 lifecycle_phase
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
             ON CONFLICT(cluster_key) DO UPDATE SET
                 schema_version = excluded.schema_version,
+                normalization_version = excluded.normalization_version,
                 distro = excluded.distro,
                 target_profile = excluded.target_profile,
                 blocked_class = excluded.blocked_class,
@@ -135,6 +143,7 @@ impl ScriptletEvidenceCluster {
             params![
                 &cluster.cluster_key,
                 cluster.schema_version,
+                cluster.normalization_version,
                 &cluster.distro,
                 &cluster.target_profile,
                 &cluster.blocked_class,
@@ -197,6 +206,9 @@ impl ScriptletEvidenceCluster {
         if let Some(package) = filter.package.as_ref() {
             sql.push_str(" AND s.package_name = ?");
             values.push(Box::new(package.clone()));
+        }
+        if !filter.include_superseded {
+            sql.push_str(" AND c.superseded_at IS NULL");
         }
 
         let limit = filter.limit.unwrap_or(100).clamp(1, 1000);
@@ -274,26 +286,30 @@ impl ScriptletEvidenceCluster {
     }
 
     fn from_row(row: &Row<'_>) -> rusqlite::Result<Self> {
-        let state: String = row.get(9)?;
+        let state: String = row.get(10)?;
         Ok(Self {
             cluster_key: row.get(0)?,
             schema_version: row.get(1)?,
-            distro: row.get(2)?,
-            target_profile: row.get(3)?,
-            blocked_class: row.get(4)?,
-            command: row.get(5)?,
-            normalized_command_shape: row.get(6)?,
-            normalized_command_shape_hash: row.get(7)?,
-            lifecycle_phase: row.get(8)?,
-            state: ScriptletEvidenceState::from_db(&state, 9)?,
-            first_seen: row.get(10)?,
-            last_seen: row.get(11)?,
-            updated_at: row.get(12)?,
+            normalization_version: row.get(2)?,
+            distro: row.get(3)?,
+            target_profile: row.get(4)?,
+            blocked_class: row.get(5)?,
+            command: row.get(6)?,
+            normalized_command_shape: row.get(7)?,
+            normalized_command_shape_hash: row.get(8)?,
+            lifecycle_phase: row.get(9)?,
+            state: ScriptletEvidenceState::from_db(&state, 10)?,
+            first_seen: row.get(11)?,
+            last_seen: row.get(12)?,
+            updated_at: row.get(13)?,
+            superseded_at: row.get(14)?,
+            superseded_reason: row.get(15)?,
+            superseded_by_cluster_key: row.get(16)?,
         })
     }
 
     fn summary_from_row(row: &Row<'_>) -> rusqlite::Result<ScriptletEvidenceClusterSummary> {
-        let architectures: String = row.get(15)?;
+        let architectures: String = row.get(19)?;
         let mut architectures = architectures
             .split(',')
             .filter(|value| !value.is_empty())
@@ -303,10 +319,10 @@ impl ScriptletEvidenceCluster {
 
         Ok(ScriptletEvidenceClusterSummary {
             cluster: Self::from_row(row)?,
-            attempt_count: row.get(13)?,
-            unique_package_count: row.get(14)?,
+            attempt_count: row.get(17)?,
+            unique_package_count: row.get(18)?,
             architectures,
-            stale_sample_count: row.get(16)?,
+            stale_sample_count: row.get(20)?,
         })
     }
 }
@@ -773,6 +789,7 @@ mod tests {
         NewScriptletEvidenceCluster {
             cluster_key: "s1-dracut".to_string(),
             schema_version: 1,
+            normalization_version: 2,
             distro: "fedora".to_string(),
             target_profile: "fedora-44".to_string(),
             blocked_class: "initramfs".to_string(),

--- a/crates/conary-core/src/db/schema.rs
+++ b/crates/conary-core/src/db/schema.rs
@@ -11,7 +11,7 @@ use rusqlite::Connection;
 use tracing::info;
 
 /// Current schema version
-pub const SCHEMA_VERSION: i32 = 77;
+pub const SCHEMA_VERSION: i32 = 78;
 
 /// Initialize the schema version tracking table
 fn init_schema_version(conn: &Connection) -> Result<()> {
@@ -201,6 +201,7 @@ fn apply_migration(conn: &Connection, version: i32) -> Result<()> {
         75 => migrations::migrate_v75(conn),
         76 => migrations::migrate_v76(conn),
         77 => migrations::migrate_v77(conn),
+        78 => migrations::migrate_v78(conn),
         _ => Err(crate::error::Error::InitError(format!(
             "Unknown migration version: {}",
             version
@@ -565,7 +566,7 @@ mod tests {
         migrate(&conn).unwrap();
 
         assert_eq!(get_schema_version(&conn).unwrap(), SCHEMA_VERSION);
-        assert_eq!(SCHEMA_VERSION, 77);
+        assert_eq!(SCHEMA_VERSION, 78);
 
         let columns: Vec<(String, String, bool, Option<String>, i32)> = conn
             .prepare("PRAGMA table_info(try_sessions)")
@@ -945,5 +946,45 @@ mod tests {
             .unwrap();
         assert!(indexes.contains(&"idx_installed_file_capabilities_trove".to_string()));
         assert!(indexes.contains(&"idx_installed_file_capabilities_path".to_string()));
+    }
+
+    #[test]
+    fn migration_v78_preserves_existing_scriptlet_evidence_history() {
+        let (_temp, conn) = create_test_db_at_version(77);
+        conn.execute(
+            "INSERT INTO scriptlet_evidence_clusters (
+                cluster_key, schema_version, distro, target_profile, blocked_class,
+                command, normalized_command_shape, normalized_command_shape_hash,
+                lifecycle_phase, state
+             ) VALUES (
+                's1-history', 1, 'ubuntu', 'ubuntu-26.04', 'unknown-command',
+                'set', 'set', 'shape-hash', 'postinstall', 'adapter-candidate'
+             )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO scriptlet_evidence_notes (cluster_key, actor, body)
+             VALUES ('s1-history', 'maintainer', 'keep me')",
+            [],
+        )
+        .unwrap();
+
+        migrate(&conn).unwrap();
+
+        let (normalization_version, state, note_count): (i64, String, i64) = conn
+            .query_row(
+                "SELECT c.normalization_version, c.state, COUNT(n.id)
+                 FROM scriptlet_evidence_clusters c
+                 LEFT JOIN scriptlet_evidence_notes n ON n.cluster_key = c.cluster_key
+                 WHERE c.cluster_key = 's1-history'
+                 GROUP BY c.cluster_key",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(normalization_version, 1);
+        assert_eq!(state, "adapter-candidate");
+        assert_eq!(note_count, 1);
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -93,7 +93,7 @@ crates/conary-core/      Core library crate
     +-- lib.rs           Internal workspace crate surface, not a stable external API
     +-- operations.rs    Shared operation vocabulary across CLI and daemon boundaries
     +-- db/              Database layer
-    |   +-- schema.rs    Schema v77, migration dispatcher
+    |   +-- schema.rs    Schema v78, migration dispatcher
     |   +-- migrations/  Migration functions grouped into v1_v20.rs, v21_v40.rs, v41_current.rs
     |   +-- models/      ORM-style model structs
     |   |   +-- try_session.rs M1b package try session state
@@ -476,7 +476,7 @@ itself.
 Supports x86_64, aarch64, and riscv64 targets. Dry-run mode
 (`--dry-run`) validates the full pipeline without building.
 
-## Database Schema (v77)
+## Database Schema (v78)
 
 All runtime state lives in SQLite, and migrations are dispatched from
 `crates/conary-core/src/db/schema.rs`.
@@ -489,7 +489,7 @@ The stable table families are:
 - Try state: active/kept/rolled-back package try sessions and selected generation metadata
 - Security and provenance: TUF metadata, provenance records, admin tokens, and audit data
 - Service and federation state: conversion/cache/download analytics, federation peers, and test-run persistence
-- Remi review workflow state: admin-only scriptlet evidence clusters, samples, state events, notes, and backfill runs
+- Remi review workflow state: admin-only scriptlet evidence clusters, samples, state events, notes, backfill runs, and versioned normalization/supersession metadata
 
 When exact table names or counts matter, inspect `crates/conary-core/src/db/models/`
 and the active migration functions instead of relying on this overview.

--- a/docs/conaryopedia-v2.md
+++ b/docs/conaryopedia-v2.md
@@ -445,7 +445,7 @@ sudo conary system init --profile fedora-44
 Use `--profile ubuntu-26.04` or `--profile arch` on those supported hosts. This
 creates the SQLite database at `/var/lib/conary/conary.db`, configures Remi and
 only the selected profile's native repositories, and sets up all tables
-(currently schema v77). The database is the single source of truth for all
+(currently schema v78). The database is the single source of truth for all
 package state -- there are no configuration files for runtime state. Recovery
 metadata is SQLite-native: first-wave adoption and unadoption paths write
 checkpoint backups under the runtime root, and generation publication writes a

--- a/docs/modules/ccs.md
+++ b/docs/modules/ccs.md
@@ -278,6 +278,12 @@ Common PAM stack helpers (`authselect`, `authconfig`, `pam-auth-update`, and
 manifest authority or public Remi eligibility without a future native PAM
 policy adapter and target-profile PAM facts.
 
+Remi's unknown-command normalization v2 is an admin queue classification layer,
+not CCS conversion authority. Suppressing provable shell/control-flow noise
+from that queue does not remove unknown commands from the signed conversion
+summary, change entry decisions, grant adapter coverage, enable raw replay, or
+make an artifact public.
+
 Live network fetches and nested package-manager calls remain blocked conversion
 evidence. A scriptlet that fetches content with `curl`, `wget`, `scp`, `ssh`, or
 `git clone`, or that invokes a nested package manager such as `dnf`, `apt`,

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -99,6 +99,25 @@ local review artifact paths. Private packets include sanitized artifact
 references for maintainer follow-up; `public-sanitized` packets omit review
 artifacts and private notes.
 
+Unknown-command queue classification uses normalization contract v2. It drops
+only provable queue noise: shell grammar and punctuation, variable references,
+environment assignments, function-definition syntax, queue-structural command
+builtins, and unambiguous package-manager lifecycle dispatch labels. Ambiguous
+identifiers and builtins whose behavior itself needs adapter review remain
+adapter-planning signal. This classification is queue-only: it does not rewrite
+CCS summaries, adapter decisions, support-matrix outcomes, legacy replay, or
+publication state.
+
+Schema v78 persists each cluster's `normalization_version` and optional
+supersession metadata. New observations use the current version. Operators
+reconcile historical unknown-command clusters with
+`POST /v1/admin/scriptlet-evidence/reconcile-unknown-commands`; the route is
+admin-only, bounded to at most 5,000 clusters per call, resumable, and dry-run
+by default. Applied batches retain real command signals and supersede structural
+noise without deleting samples, triage state, state events, private notes, or
+evidence digests. Normal cluster listings omit superseded rows; operators can
+request `include_superseded=true` to inspect their history and disposition.
+
 The queue is not publication authority. Moving a cluster to
 `covered-public-ready` records maintainer workflow state only; it does not
 rewrite `converted_packages.publication_status`, make blocked rows public, call

--- a/docs/modules/test-fixtures.md
+++ b/docs/modules/test-fixtures.md
@@ -251,6 +251,30 @@ Each fixture family should record:
   Remi publication fixtures; see `remi-scriptlet-publication-gate` for
   server-side gates.
 
+### remi-scriptlet-evidence-queue
+
+- **Owner:** Remi queue normalization and reconciliation under
+  `apps/remi/src/server/scriptlet_evidence_queue/`, with persisted row helpers
+  under `crates/conary-core/src/db/models/scriptlet_evidence.rs`.
+- **Purpose:** Keep admin adapter-planning clusters focused on real unsupported
+  commands while preserving historical queue evidence across versioned
+  normalization.
+- **Fixture sources:**
+  `apps/remi/src/server/scriptlet_evidence_queue/classification.rs`;
+  `apps/remi/src/server/scriptlet_evidence_queue/aggregation.rs`;
+  `apps/remi/src/server/scriptlet_evidence_queue/reconciliation.rs`;
+  `apps/remi/src/server/handlers/admin/scriptlet_evidence.rs`.
+- **Consumes:** RPM, DEB, and Arch unknown-command classification; bounded
+  dry-run/apply reconciliation; active versus superseded cluster listings; and
+  private-history preservation.
+- **Fast proof:** `cargo test -p remi scriptlet_evidence`.
+- **Medium proof:** `cargo test -p remi publication`;
+  `cargo test -p conary --test conversion_integration golden_conversion`.
+- **Regeneration:** Hand-maintained summaries and temporary SQLite databases.
+- **Safety notes:** Ambiguous identifiers stay visible. Reconciliation must not
+  delete samples, notes, or state events, and must not mutate
+  `converted_packages.publication_status`.
+
 ### remi-scriptlet-publication-gate
 
 - **Owner:** Remi server: `apps/remi/src/server/publication.rs`.

--- a/site/src/routes/about/+page.svelte
+++ b/site/src/routes/about/+page.svelte
@@ -151,7 +151,7 @@
 		<dl class="stack-list">
 			<div><dt>Language</dt><dd>Rust, Edition 2024 · 8-member Cargo workspace</dd></div>
 			<div><dt>Filesystem</dt><dd>EROFS · optional composefs and fs-verity integration for generations</dd></div>
-			<div><dt>Database</dt><dd>SQLite · schema version 77 · DB-first runtime state</dd></div>
+			<div><dt>Database</dt><dd>SQLite · schema version 78 · DB-first runtime state</dd></div>
 			<div><dt>Hashing</dt><dd>SHA-256 · XXH128</dd></div>
 			<div><dt>Compression</dt><dd>Zstd · Gzip · XZ</dd></div>
 			<div><dt>Server</dt><dd>Axum · Tantivy full-text search</dd></div>


### PR DESCRIPTION
## Problem

The first production scriptlet-evidence snapshot contains 1,007 `unknown-command` clusters covering 5,949 package-version attempts. Shell grammar, builtins, positional parameters, and maintainer-script dispatch labels dominate the queue and obscure the evidence maintainers actually need for adapter planning.

## Changes

- add a reviewed normalization-v2 classifier for queue-only unknown-command evidence
- suppress provable RPM, DEB, and Arch shell/dispatch structure while retaining ambiguous, effectful, and security-sensitive commands
- add schema v78 normalization and supersession metadata
- add an admin-only, bounded, resumable reconciliation route that defaults to dry-run
- preserve samples, evidence digests, triage state, state events, private notes, and publication status
- hide superseded noise from normal listings while retaining explicit historical access
- document the queue/publication boundary and update OpenAPI, architecture, fixture, and site schema references

This does not change CCS conversion decisions, adapter coverage, support-matrix outcomes, legacy replay, or publication authority.

## Verification

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p remi`
- `cargo test -p conary-core`
- `cargo test -p remi scriptlet_evidence`
- `cargo test -p remi publication`
- `cargo test -p conary --test conversion_integration golden_conversion`
- `cargo test -p conary --test packaging_m4c`
- `npm run check` and `npm run build` in `site/`
- `bash scripts/check-doc-truth.sh`
- `bash scripts/test-doc-truth.sh`
- `bash scripts/agent-context.sh --validate`
- `git diff --check`

## Post-merge production proof

Tracked in #54:

- deploy the exact merged Remi release
- capture reconciliation dry-run impact
- apply bounded batches
- capture the post-reconciliation aggregate
- update #44 and close #45 only after the production evidence is recorded

Refs #45
