### PR TITLE
fix(remi): reconcile historical AppArmor evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,10 +48,15 @@ Use standard Rust formatting (`cargo fmt`) and keep Clippy clean. Indentation is
 Recent history uses conventional-style prefixes such as `fix:`, `security:`, and `docs:`. Keep commit subjects short and imperative, e.g. `security(federation): pin https peer identity`. PRs should explain the problem, summarize the fix, list verification commands run, and link the relevant issue/plan entry. Include logs or API examples when behavior changes are not obvious from the diff.
 
 ## Maintainability & Refactor Discipline
-Treat large files as review signals, not automatic failures. When a change adds
-substantial behavior to a Rust file over 1000 lines, or adds or changes
-behavior in a Rust file over 1500 lines, name the ownership boundary you are
-preserving or improving before editing. Files over 2500 lines should get a
+Treat large files as review signals, not automatic failures. Planning has a
+hard gate: when a proposed slice would add behavior to a source file that is
+already over 1000 lines, the issue, design, or plan must include an
+ownership-based refactor or reorganization in that same slice. Put the new
+behavior in the resulting focused module; do not defer the reorganization to a
+follow-up. Thin hub registration, dispatch, and re-export wiring may remain in
+the large file when they do not add business logic. When changing existing
+behavior in a Rust file over 1500 lines, name the ownership boundary being
+preserved or improved before editing. Files over 2500 lines should get a
 reviewed decomposition path before major feature work unless the task is an
 urgent fix.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,6 +175,13 @@ them focused: name the current responsibility, the module or helper that should
 own it, and the focused verification command that proves behavior is preserved
 or intentionally changed.
 
+Before implementation, any planned slice that adds behavior to a source file
+already over 1000 lines must include an ownership-based reorganization in the
+same issue, design, or plan. Add the behavior through the resulting focused
+module instead of deferring the split to later. Thin registration, dispatch,
+and re-export wiring may remain in the large hub when it adds no business
+logic.
+
 Large files are review signals. Use `scripts/line-count-report.sh` to refresh
 the current hotspot list when planning broad maintenance work. Do not split a
 file only to reduce line count; split when a responsibility has a clearer home.

--- a/apps/remi/src/server/handlers/admin/scriptlet_evidence.rs
+++ b/apps/remi/src/server/handlers/admin/scriptlet_evidence.rs
@@ -12,16 +12,13 @@ use super::{check_scope, validate_path_param};
 use crate::server::ServerState;
 use crate::server::auth::{Scope, TokenName, TokenScopes, json_error};
 
+mod reconciliation;
+
+pub use reconciliation::*;
+
 #[derive(Debug, Deserialize)]
 pub struct BackfillRequest {
     pub limit: Option<usize>,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct UnknownCommandReconciliationRequest {
-    pub dry_run: Option<bool>,
-    pub limit: Option<usize>,
-    pub after_cluster_key: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -88,6 +85,8 @@ struct ClusterDetailResponse {
     samples: Vec<SampleSummaryResponse>,
     state_events: Vec<StateEventResponse>,
     notes: Vec<NoteResponse>,
+    outgoing_reconciliation_links: Vec<ReconciliationLinkResponse>,
+    incoming_reconciliation_links: Vec<ReconciliationLinkResponse>,
 }
 
 #[derive(Debug, Serialize)]
@@ -126,6 +125,15 @@ struct NoteResponse {
     body: String,
     created_at: String,
     updated_at: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ReconciliationLinkResponse {
+    source_cluster_key: String,
+    target_cluster_key: String,
+    normalization_version: i64,
+    migrated_sample_count: i64,
+    created_at: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -184,65 +192,6 @@ pub async fn scriptlet_evidence_backfill(
             500,
             &format!("Scriptlet evidence backfill task failed: {error}"),
             "SCRIPTLET_EVIDENCE_BACKFILL_TASK_FAILED",
-        ),
-    }
-}
-
-pub async fn reconcile_scriptlet_evidence_unknown_commands(
-    State(state): State<Arc<RwLock<ServerState>>>,
-    scopes: Option<Extension<TokenScopes>>,
-    request: Option<Json<UnknownCommandReconciliationRequest>>,
-) -> Response {
-    if let Some(err) = check_scope(&scopes, Scope::Admin) {
-        return err;
-    }
-
-    let request = request.map(|Json(request)| request);
-    let dry_run = request
-        .as_ref()
-        .and_then(|request| request.dry_run)
-        .unwrap_or(true);
-    let limit = request
-        .as_ref()
-        .and_then(|request| request.limit)
-        .unwrap_or(500)
-        .clamp(1, 5000);
-    let after_cluster_key = request.and_then(|request| request.after_cluster_key);
-    if after_cluster_key
-        .as_ref()
-        .is_some_and(|cluster_key| cluster_key.len() > 256)
-    {
-        return json_error(
-            400,
-            "after_cluster_key must be at most 256 bytes",
-            "INVALID_PARAMETER",
-        );
-    }
-    let db_path = {
-        let state = state.read().await;
-        state.config.db_path.clone()
-    };
-
-    match tokio::task::spawn_blocking(move || {
-        crate::server::scriptlet_evidence_queue::reconciliation::reconcile_unknown_command_batch(
-            &db_path,
-            dry_run,
-            limit,
-            after_cluster_key.as_deref(),
-        )
-    })
-    .await
-    {
-        Ok(Ok(result)) => Json(result).into_response(),
-        Ok(Err(error)) => json_error(
-            500,
-            &format!("Scriptlet evidence reconciliation failed: {error}"),
-            "SCRIPTLET_EVIDENCE_RECONCILIATION_FAILED",
-        ),
-        Err(error) => json_error(
-            500,
-            &format!("Scriptlet evidence reconciliation task failed: {error}"),
-            "SCRIPTLET_EVIDENCE_RECONCILIATION_TASK_FAILED",
         ),
     }
 }
@@ -631,6 +580,16 @@ impl From<conary_core::db::models::ScriptletEvidenceClusterDetail> for ClusterDe
                 .map(StateEventResponse::from)
                 .collect(),
             notes: value.notes.into_iter().map(NoteResponse::from).collect(),
+            outgoing_reconciliation_links: value
+                .outgoing_reconciliation_links
+                .into_iter()
+                .map(ReconciliationLinkResponse::from)
+                .collect(),
+            incoming_reconciliation_links: value
+                .incoming_reconciliation_links
+                .into_iter()
+                .map(ReconciliationLinkResponse::from)
+                .collect(),
         }
     }
 }
@@ -681,6 +640,20 @@ impl From<conary_core::db::models::ScriptletEvidenceNote> for NoteResponse {
             body: value.body,
             created_at: value.created_at,
             updated_at: value.updated_at,
+        }
+    }
+}
+
+impl From<conary_core::db::models::ScriptletEvidenceClusterReconciliationLink>
+    for ReconciliationLinkResponse
+{
+    fn from(value: conary_core::db::models::ScriptletEvidenceClusterReconciliationLink) -> Self {
+        Self {
+            source_cluster_key: value.source_cluster_key,
+            target_cluster_key: value.target_cluster_key,
+            normalization_version: value.normalization_version,
+            migrated_sample_count: value.migrated_sample_count,
+            created_at: value.created_at,
         }
     }
 }

--- a/apps/remi/src/server/handlers/admin/scriptlet_evidence/reconciliation.rs
+++ b/apps/remi/src/server/handlers/admin/scriptlet_evidence/reconciliation.rs
@@ -1,0 +1,332 @@
+// apps/remi/src/server/handlers/admin/scriptlet_evidence/reconciliation.rs
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::response::{IntoResponse, Response};
+use axum::{Extension, Json};
+use serde::Deserialize;
+use tokio::sync::RwLock;
+
+use super::super::check_scope;
+use crate::server::ServerState;
+use crate::server::auth::{Scope, TokenScopes, json_error};
+
+#[derive(Debug, Deserialize)]
+pub struct ScriptletEvidenceReconciliationRequest {
+    pub dry_run: Option<bool>,
+    pub limit: Option<usize>,
+    pub after_cluster_key: Option<String>,
+}
+
+#[derive(Debug)]
+struct ReconciliationOptions {
+    dry_run: bool,
+    limit: usize,
+    after_cluster_key: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReconciliationParamError {
+    CursorTooLong,
+}
+
+impl ReconciliationParamError {
+    fn into_response(self) -> Response {
+        match self {
+            Self::CursorTooLong => json_error(
+                400,
+                "after_cluster_key must be at most 256 bytes",
+                "INVALID_PARAMETER",
+            ),
+        }
+    }
+}
+
+pub async fn reconcile_scriptlet_evidence_unknown_commands(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    scopes: Option<Extension<TokenScopes>>,
+    request: Option<Json<ScriptletEvidenceReconciliationRequest>>,
+) -> Response {
+    if let Some(err) = check_scope(&scopes, Scope::Admin) {
+        return err;
+    }
+    let options = match reconciliation_options(request) {
+        Ok(options) => options,
+        Err(error) => return error.into_response(),
+    };
+    let db_path = {
+        let state = state.read().await;
+        state.config.db_path.clone()
+    };
+
+    match tokio::task::spawn_blocking(move || {
+        crate::server::scriptlet_evidence_queue::reconciliation::reconcile_unknown_command_batch(
+            &db_path,
+            options.dry_run,
+            options.limit,
+            options.after_cluster_key.as_deref(),
+        )
+    })
+    .await
+    {
+        Ok(Ok(result)) => Json(result).into_response(),
+        Ok(Err(error)) => json_error(
+            500,
+            &format!("Scriptlet evidence reconciliation failed: {error}"),
+            "SCRIPTLET_EVIDENCE_RECONCILIATION_FAILED",
+        ),
+        Err(error) => json_error(
+            500,
+            &format!("Scriptlet evidence reconciliation task failed: {error}"),
+            "SCRIPTLET_EVIDENCE_RECONCILIATION_TASK_FAILED",
+        ),
+    }
+}
+
+pub async fn reconcile_scriptlet_evidence_apparmor(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    scopes: Option<Extension<TokenScopes>>,
+    request: Option<Json<ScriptletEvidenceReconciliationRequest>>,
+) -> Response {
+    if let Some(err) = check_scope(&scopes, Scope::Admin) {
+        return err;
+    }
+    let options = match reconciliation_options(request) {
+        Ok(options) => options,
+        Err(error) => return error.into_response(),
+    };
+    let (db_path, cache_dir) = {
+        let state = state.read().await;
+        (state.config.db_path.clone(), state.config.cache_dir.clone())
+    };
+
+    match tokio::task::spawn_blocking(move || {
+        crate::server::scriptlet_evidence_queue::reconciliation::reconcile_apparmor_batch(
+            &db_path,
+            &cache_dir,
+            options.dry_run,
+            options.limit,
+            options.after_cluster_key.as_deref(),
+        )
+    })
+    .await
+    {
+        Ok(Ok(result)) => Json(result).into_response(),
+        Ok(Err(error)) => json_error(
+            500,
+            &format!("AppArmor evidence reconciliation failed: {error}"),
+            "SCRIPTLET_EVIDENCE_APPARMOR_RECONCILIATION_FAILED",
+        ),
+        Err(error) => json_error(
+            500,
+            &format!("AppArmor evidence reconciliation task failed: {error}"),
+            "SCRIPTLET_EVIDENCE_APPARMOR_RECONCILIATION_TASK_FAILED",
+        ),
+    }
+}
+
+fn reconciliation_options(
+    request: Option<Json<ScriptletEvidenceReconciliationRequest>>,
+) -> Result<ReconciliationOptions, ReconciliationParamError> {
+    let request = request.map(|Json(request)| request);
+    let dry_run = request
+        .as_ref()
+        .and_then(|request| request.dry_run)
+        .unwrap_or(true);
+    let limit = request
+        .as_ref()
+        .and_then(|request| request.limit)
+        .unwrap_or(500)
+        .clamp(1, 5000);
+    let after_cluster_key = request.and_then(|request| request.after_cluster_key);
+    if after_cluster_key
+        .as_ref()
+        .is_some_and(|cluster_key| cluster_key.len() > 256)
+    {
+        return Err(ReconciliationParamError::CursorTooLong);
+    }
+    Ok(ReconciliationOptions {
+        dry_run,
+        limit,
+        after_cluster_key,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::test_helpers::test_app;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use conary_core::db::models::{
+        NewScriptletEvidenceCluster, NewScriptletEvidenceSample, ScriptletEvidenceCluster,
+        ScriptletEvidenceClusterReconciliationLink, ScriptletEvidenceNote, ScriptletEvidenceSample,
+    };
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn apparmor_reconciliation_defaults_to_private_dry_run() {
+        let (app, db_path) = test_app().await;
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        ScriptletEvidenceCluster::upsert(
+            &conn,
+            &NewScriptletEvidenceCluster {
+                cluster_key: "s1-apparmor-legacy".to_string(),
+                schema_version: 1,
+                normalization_version: 1,
+                distro: "ubuntu".to_string(),
+                target_profile: "ubuntu-26.04".to_string(),
+                blocked_class: "apparmor".to_string(),
+                command: "apparmor_parser".to_string(),
+                normalized_command_shape: "apparmor_parser -r <path>".to_string(),
+                normalized_command_shape_hash: "legacy-shape".to_string(),
+                lifecycle_phase: "postinstall".to_string(),
+            },
+        )
+        .unwrap();
+        ScriptletEvidenceSample::upsert(
+            &conn,
+            &NewScriptletEvidenceSample {
+                cluster_key: "s1-apparmor-legacy".to_string(),
+                converted_package_id: None,
+                original_checksum: "sha256:missing".to_string(),
+                distro: "ubuntu".to_string(),
+                package_name: "apparmor-demo".to_string(),
+                package_version: "1.0.0".to_string(),
+                package_architecture: Some("amd64".to_string()),
+                publication_status: "blocked".to_string(),
+                scriptlet_fidelity: "blocked".to_string(),
+                target_compatibility: "blocked".to_string(),
+                reason_codes_json: r#"["blocked-class-apparmor"]"#.to_string(),
+                blocked_classes_json: r#"["apparmor"]"#.to_string(),
+                boot_security_intents_json:
+                    r#"[{"command":"apparmor_parser","argv":["-r","<path>"]}]"#.to_string(),
+                security_policy_intents_json: "[]".to_string(),
+                review_artifact_path: Some("/private/review.json".to_string()),
+                review_artifact_stale: false,
+                evidence_digest: Some("sha256:evidence".to_string()),
+                curation_evidence_digest: None,
+            },
+        )
+        .unwrap();
+        ScriptletEvidenceNote::insert(
+            &conn,
+            "s1-apparmor-legacy",
+            "maintainer",
+            "private rationale",
+        )
+        .unwrap();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/admin/scriptlet-evidence/reconcile-apparmor")
+                    .header("authorization", "Bearer test-admin-token-12345")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(body.contains("\"dry_run\":true"));
+        assert!(body.contains("\"unresolved_cluster_count\":1"));
+        assert!(body.contains("\"converted-package-missing\""));
+        assert!(!body.contains("/private/review.json"));
+        assert!(!body.contains("private rationale"));
+
+        let source = ScriptletEvidenceCluster::find(&conn, "s1-apparmor-legacy")
+            .unwrap()
+            .unwrap();
+        assert!(source.superseded_at.is_none());
+        assert_eq!(source.normalization_version, 1);
+    }
+
+    #[tokio::test]
+    async fn cluster_detail_exposes_reconciliation_links() {
+        let (app, db_path) = test_app().await;
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        for (cluster_key, normalization_version) in
+            [("s1-apparmor-source", 1), ("s1-apparmor-target", 2)]
+        {
+            ScriptletEvidenceCluster::upsert(
+                &conn,
+                &NewScriptletEvidenceCluster {
+                    cluster_key: cluster_key.to_string(),
+                    schema_version: 1,
+                    normalization_version,
+                    distro: "ubuntu".to_string(),
+                    target_profile: "ubuntu-26.04".to_string(),
+                    blocked_class: "apparmor".to_string(),
+                    command: "apparmor_parser".to_string(),
+                    normalized_command_shape: "apparmor_parser -r <path>".to_string(),
+                    normalized_command_shape_hash: format!("hash-{cluster_key}"),
+                    lifecycle_phase: "postinstall".to_string(),
+                },
+            )
+            .unwrap();
+        }
+        ScriptletEvidenceClusterReconciliationLink::record(
+            &conn,
+            "s1-apparmor-source",
+            "s1-apparmor-target",
+            2,
+            4,
+        )
+        .unwrap();
+
+        let source_response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/admin/scriptlet-evidence/clusters/s1-apparmor-source")
+                    .header("authorization", "Bearer test-admin-token-12345")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(source_response.status(), StatusCode::OK);
+        let source_body = axum::body::to_bytes(source_response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let source: serde_json::Value = serde_json::from_slice(&source_body).unwrap();
+        assert_eq!(
+            source["outgoing_reconciliation_links"][0]["target_cluster_key"],
+            "s1-apparmor-target"
+        );
+        assert_eq!(
+            source["outgoing_reconciliation_links"][0]["migrated_sample_count"],
+            4
+        );
+        assert_eq!(
+            source["incoming_reconciliation_links"],
+            serde_json::json!([])
+        );
+
+        let app = super::super::super::test_helpers::rebuild_app(&db_path);
+        let target_response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/admin/scriptlet-evidence/clusters/s1-apparmor-target")
+                    .header("authorization", "Bearer test-admin-token-12345")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(target_response.status(), StatusCode::OK);
+        let target_body = axum::body::to_bytes(target_response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let target: serde_json::Value = serde_json::from_slice(&target_body).unwrap();
+        assert_eq!(
+            target["incoming_reconciliation_links"][0]["source_cluster_key"],
+            "s1-apparmor-source"
+        );
+    }
+}

--- a/apps/remi/src/server/handlers/openapi.rs
+++ b/apps/remi/src/server/handlers/openapi.rs
@@ -197,6 +197,27 @@ pub async fn openapi_spec() -> Response {
                     "responses": { "200": { "description": "Unknown-command reconciliation batch result" }, "400": { "description": "Invalid cursor" }, "401": { "description": "Invalid or missing token" }, "403": { "description": "Insufficient scope" } }
                 }
             },
+            "/v1/admin/scriptlet-evidence/reconcile-apparmor": {
+                "post": {
+                    "operationId": "reconcileScriptletEvidenceAppArmor",
+                    "summary": "Reconcile historical AppArmor queue identity",
+                    "description": "Rematerializes one bounded batch of historical AppArmor observations under the current approved-path normalization contract. Dry-run is the default. Applied batches move observations to current clusters, persist merge/split links, preserve source workflow history, and do not change converted-package publication state.",
+                    "tags": ["scriptlet-evidence"],
+                    "security": [{ "bearerAuth": [] }],
+                    "requestBody": {
+                        "required": false,
+                        "content": { "application/json": { "schema": {
+                            "type": "object",
+                            "properties": {
+                                "dry_run": { "type": "boolean", "default": true },
+                                "limit": { "type": "integer", "minimum": 1, "maximum": 5000, "default": 500 },
+                                "after_cluster_key": { "type": "string", "maxLength": 256 }
+                            }
+                        }}}
+                    },
+                    "responses": { "200": { "description": "AppArmor reconciliation batch result" }, "400": { "description": "Invalid cursor" }, "401": { "description": "Invalid or missing token" }, "403": { "description": "Insufficient scope" } }
+                }
+            },
             "/v1/admin/scriptlet-evidence/clusters": {
                 "get": {
                     "operationId": "listScriptletEvidenceClusters",
@@ -221,7 +242,7 @@ pub async fn openapi_spec() -> Response {
                 "get": {
                     "operationId": "getScriptletEvidenceCluster",
                     "summary": "Get scriptlet evidence cluster detail",
-                    "description": "Returns admin-only cluster detail, sample summaries, state events, and maintainer notes. Sample data exposes review-artifact availability and staleness but never raw local artifact paths.",
+                    "description": "Returns admin-only cluster detail, sample summaries, state events, maintainer notes, and incoming/outgoing normalization reconciliation links. Sample data exposes review-artifact availability and staleness but never raw local artifact paths.",
                     "tags": ["scriptlet-evidence"],
                     "security": [{ "bearerAuth": [] }],
                     "parameters": [{ "name": "cluster_key", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Stable s1-prefixed scriptlet evidence cluster key" }],
@@ -737,6 +758,10 @@ mod tests {
             ("/v1/admin/scriptlet-evidence/backfill", &["post"][..]),
             (
                 "/v1/admin/scriptlet-evidence/reconcile-unknown-commands",
+                &["post"][..],
+            ),
+            (
+                "/v1/admin/scriptlet-evidence/reconcile-apparmor",
                 &["post"][..],
             ),
             ("/v1/admin/scriptlet-evidence/clusters", &["get"][..]),

--- a/apps/remi/src/server/routes/admin.rs
+++ b/apps/remi/src/server/routes/admin.rs
@@ -112,6 +112,10 @@ pub fn create_external_admin_router(
             post(admin_handlers::reconcile_scriptlet_evidence_unknown_commands),
         )
         .route(
+            "/v1/admin/scriptlet-evidence/reconcile-apparmor",
+            post(admin_handlers::reconcile_scriptlet_evidence_apparmor),
+        )
+        .route(
             "/v1/admin/scriptlet-evidence/clusters",
             get(admin_handlers::list_scriptlet_evidence_clusters),
         )

--- a/apps/remi/src/server/scriptlet_evidence_queue/aggregation.rs
+++ b/apps/remi/src/server/scriptlet_evidence_queue/aggregation.rs
@@ -11,9 +11,8 @@ use conary_core::db::models::{
 
 use crate::server::publication;
 
-use super::classification::{
-    UNKNOWN_COMMAND_NORMALIZATION_VERSION, UnknownCommandDisposition, classify_unknown_command,
-};
+use super::SCRIPTLET_EVIDENCE_NORMALIZATION_VERSION;
+use super::classification::{UnknownCommandDisposition, classify_unknown_command};
 use super::normalization::{
     normalize_command_shape, sanitize_boot_security_intents, sanitize_security_policy_intents,
     stable_cluster_key, target_profile_for_distro,
@@ -140,7 +139,7 @@ fn build_pending_sample(
         cluster: NewScriptletEvidenceCluster {
             cluster_key: stable.cluster_key.clone(),
             schema_version: i64::from(CLUSTER_SCHEMA_VERSION),
-            normalization_version: UNKNOWN_COMMAND_NORMALIZATION_VERSION,
+            normalization_version: SCRIPTLET_EVIDENCE_NORMALIZATION_VERSION,
             distro: distro.clone(),
             target_profile,
             blocked_class: blocked_class.to_string(),
@@ -421,7 +420,7 @@ mod tests {
         assert_eq!(samples[0].cluster.command, "custom-rpm-helper");
         assert_eq!(
             samples[0].cluster.normalization_version,
-            UNKNOWN_COMMAND_NORMALIZATION_VERSION
+            SCRIPTLET_EVIDENCE_NORMALIZATION_VERSION
         );
     }
 

--- a/apps/remi/src/server/scriptlet_evidence_queue/classification.rs
+++ b/apps/remi/src/server/scriptlet_evidence_queue/classification.rs
@@ -5,7 +5,8 @@
 /// This does not change CCS conversion, adapter selection, legacy replay, or
 /// publication authority. It only decides whether an already-unknown command
 /// is useful adapter-planning evidence in Remi's admin queue.
-pub const UNKNOWN_COMMAND_NORMALIZATION_VERSION: i64 = 2;
+pub const UNKNOWN_COMMAND_NORMALIZATION_VERSION: i64 =
+    super::SCRIPTLET_EVIDENCE_NORMALIZATION_VERSION;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnknownCommandDisposition {

--- a/apps/remi/src/server/scriptlet_evidence_queue/mod.rs
+++ b/apps/remi/src/server/scriptlet_evidence_queue/mod.rs
@@ -9,4 +9,10 @@ pub mod reconciliation;
 pub mod storage;
 pub mod types;
 
+/// Current queue normalization contract for newly materialized evidence.
+///
+/// Version 2 filters structural unknown-command noise and preserves approved,
+/// traversal-free AppArmor policy paths in normalized cluster identity.
+pub const SCRIPTLET_EVIDENCE_NORMALIZATION_VERSION: i64 = 2;
+
 pub use storage::record_converted_package;

--- a/apps/remi/src/server/scriptlet_evidence_queue/reconciliation.rs
+++ b/apps/remi/src/server/scriptlet_evidence_queue/reconciliation.rs
@@ -11,6 +11,12 @@ use super::classification::{
     UNKNOWN_COMMAND_NORMALIZATION_VERSION, UnknownCommandDisposition, classify_unknown_command,
 };
 
+mod apparmor;
+
+pub use apparmor::{
+    AppArmorReconciliationMapping, AppArmorReconciliationResult, reconcile_apparmor_batch,
+};
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct UnknownCommandReconciliationResult {
     pub normalization_version: i64,

--- a/apps/remi/src/server/scriptlet_evidence_queue/reconciliation/apparmor.rs
+++ b/apps/remi/src/server/scriptlet_evidence_queue/reconciliation/apparmor.rs
@@ -1,0 +1,744 @@
+// apps/remi/src/server/scriptlet_evidence_queue/reconciliation/apparmor.rs
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use anyhow::{Context, Result, ensure};
+use conary_core::db::models::{
+    ConvertedPackage, NewScriptletEvidenceCluster, NewScriptletEvidenceSample,
+    ScriptletEvidenceCluster, ScriptletEvidenceClusterReconciliationLink, ScriptletEvidenceSample,
+};
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::Serialize;
+
+use crate::server::scriptlet_evidence_queue::SCRIPTLET_EVIDENCE_NORMALIZATION_VERSION;
+use crate::server::scriptlet_evidence_queue::aggregation::evidence_samples_from_converted;
+use crate::server::scriptlet_evidence_queue::types::PendingEvidenceSample;
+
+const APPARMOR_BLOCKED_CLASS: &str = "apparmor";
+const APPARMOR_SUPERSEDED_REASON: &str = "normalization-v2:apparmor-path-shape";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AppArmorReconciliationResult {
+    pub normalization_version: i64,
+    pub dry_run: bool,
+    pub complete: bool,
+    pub next_after_cluster_key: Option<String>,
+    pub scanned_cluster_count: i64,
+    pub identity_cluster_count: i64,
+    pub rekeyed_cluster_count: i64,
+    pub split_source_cluster_count: i64,
+    pub merged_target_cluster_count: i64,
+    pub migrated_source_sample_count: i64,
+    pub materialized_target_sample_count: i64,
+    pub unresolved_cluster_count: i64,
+    pub unresolved_by_reason: BTreeMap<String, i64>,
+    pub remaining_cluster_count: i64,
+    pub mappings: Vec<AppArmorReconciliationMapping>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AppArmorReconciliationMapping {
+    pub source_cluster_key: String,
+    pub target_cluster_keys: Vec<String>,
+    pub source_sample_count: i64,
+    pub target_sample_count: i64,
+    pub status: String,
+    pub unresolved_reason: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct AppArmorCandidate {
+    cluster: ScriptletEvidenceCluster,
+    samples: Vec<ScriptletEvidenceSample>,
+}
+
+#[derive(Debug, Clone)]
+struct SampleRematerialization {
+    source: ScriptletEvidenceSample,
+    targets: Vec<PendingEvidenceSample>,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedPlan {
+    candidate: AppArmorCandidate,
+    target_clusters: BTreeMap<String, NewScriptletEvidenceCluster>,
+    samples: Vec<SampleRematerialization>,
+}
+
+#[derive(Debug, Clone)]
+enum CandidatePlan {
+    Resolved(ResolvedPlan),
+    Unresolved {
+        candidate: AppArmorCandidate,
+        reason: String,
+    },
+}
+
+pub fn reconcile_apparmor_batch(
+    db_path: &Path,
+    cache_dir: &Path,
+    dry_run: bool,
+    limit: usize,
+    after_cluster_key: Option<&str>,
+) -> Result<AppArmorReconciliationResult> {
+    let conn = crate::server::open_runtime_db(db_path)?;
+    reconcile_apparmor_batch_inner(
+        &conn,
+        cache_dir,
+        dry_run,
+        limit.clamp(1, 5000),
+        after_cluster_key,
+    )
+}
+
+fn reconcile_apparmor_batch_inner(
+    conn: &Connection,
+    cache_dir: &Path,
+    dry_run: bool,
+    limit: usize,
+    after_cluster_key: Option<&str>,
+) -> Result<AppArmorReconciliationResult> {
+    let candidates = reconciliation_candidates(conn, after_cluster_key.unwrap_or(""), limit)?;
+    let complete = candidates.len() < limit;
+    let next_after_cluster_key = (!complete)
+        .then(|| {
+            candidates
+                .last()
+                .map(|candidate| candidate.cluster.cluster_key.clone())
+        })
+        .flatten();
+    let plans = candidates
+        .into_iter()
+        .map(|candidate| plan_candidate(conn, cache_dir, candidate))
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut identity_cluster_count = 0_i64;
+    let mut rekeyed_cluster_count = 0_i64;
+    let mut split_source_cluster_count = 0_i64;
+    let mut migrated_source_sample_count = 0_i64;
+    let mut materialized_target_sample_count = 0_i64;
+    let mut unresolved_cluster_count = 0_i64;
+    let mut unresolved_by_reason = BTreeMap::new();
+    let mut sources_by_target = BTreeMap::<String, BTreeSet<String>>::new();
+    let mut mappings = Vec::with_capacity(plans.len());
+
+    for plan in &plans {
+        match plan {
+            CandidatePlan::Resolved(plan) => {
+                let target_cluster_keys = plan.target_cluster_keys();
+                let is_identity = target_cluster_keys.len() == 1
+                    && target_cluster_keys[0] == plan.candidate.cluster.cluster_key;
+                if is_identity {
+                    identity_cluster_count += 1;
+                } else {
+                    rekeyed_cluster_count += 1;
+                    migrated_source_sample_count += plan.candidate.samples.len() as i64;
+                    materialized_target_sample_count += plan
+                        .samples
+                        .iter()
+                        .map(|sample| sample.targets.len() as i64)
+                        .sum::<i64>();
+                    if target_cluster_keys.len() > 1 {
+                        split_source_cluster_count += 1;
+                    }
+                    for target_cluster_key in &target_cluster_keys {
+                        sources_by_target
+                            .entry(target_cluster_key.clone())
+                            .or_default()
+                            .insert(plan.candidate.cluster.cluster_key.clone());
+                    }
+                }
+                mappings.push(plan.mapping());
+            }
+            CandidatePlan::Unresolved { candidate, reason } => {
+                unresolved_cluster_count += 1;
+                *unresolved_by_reason.entry(reason.clone()).or_default() += 1;
+                mappings.push(AppArmorReconciliationMapping {
+                    source_cluster_key: candidate.cluster.cluster_key.clone(),
+                    target_cluster_keys: Vec::new(),
+                    source_sample_count: candidate.samples.len() as i64,
+                    target_sample_count: 0,
+                    status: "unresolved".to_string(),
+                    unresolved_reason: Some(reason.clone()),
+                });
+            }
+        }
+    }
+    let merged_target_cluster_count = sources_by_target
+        .values()
+        .filter(|sources| sources.len() > 1)
+        .count() as i64;
+
+    if !dry_run {
+        apply_plans(conn, &plans)?;
+    }
+
+    Ok(AppArmorReconciliationResult {
+        normalization_version: SCRIPTLET_EVIDENCE_NORMALIZATION_VERSION,
+        dry_run,
+        complete,
+        next_after_cluster_key,
+        scanned_cluster_count: plans.len() as i64,
+        identity_cluster_count,
+        rekeyed_cluster_count,
+        split_source_cluster_count,
+        merged_target_cluster_count,
+        migrated_source_sample_count,
+        materialized_target_sample_count,
+        unresolved_cluster_count,
+        unresolved_by_reason,
+        remaining_cluster_count: remaining_cluster_count(conn)?,
+        mappings,
+    })
+}
+
+impl ResolvedPlan {
+    fn target_cluster_keys(&self) -> Vec<String> {
+        self.target_clusters.keys().cloned().collect()
+    }
+
+    fn mapping(&self) -> AppArmorReconciliationMapping {
+        let target_cluster_keys = self.target_cluster_keys();
+        let status = if target_cluster_keys.len() == 1
+            && target_cluster_keys[0] == self.candidate.cluster.cluster_key
+        {
+            "identity"
+        } else if target_cluster_keys.len() > 1 {
+            "split"
+        } else {
+            "rekey"
+        };
+        AppArmorReconciliationMapping {
+            source_cluster_key: self.candidate.cluster.cluster_key.clone(),
+            target_cluster_keys,
+            source_sample_count: self.candidate.samples.len() as i64,
+            target_sample_count: self
+                .samples
+                .iter()
+                .map(|sample| sample.targets.len() as i64)
+                .sum(),
+            status: status.to_string(),
+            unresolved_reason: None,
+        }
+    }
+}
+
+fn reconciliation_candidates(
+    conn: &Connection,
+    after_cluster_key: &str,
+    limit: usize,
+) -> Result<Vec<AppArmorCandidate>> {
+    let mut stmt = conn.prepare(
+        "SELECT cluster_key
+         FROM scriptlet_evidence_clusters
+         WHERE blocked_class = ?1
+           AND normalization_version < ?2
+           AND superseded_at IS NULL
+           AND cluster_key > ?3
+         ORDER BY cluster_key
+         LIMIT ?4",
+    )?;
+    let cluster_keys = stmt
+        .query_map(
+            params![
+                APPARMOR_BLOCKED_CLASS,
+                SCRIPTLET_EVIDENCE_NORMALIZATION_VERSION,
+                after_cluster_key,
+                limit as i64
+            ],
+            |row| row.get::<_, String>(0),
+        )?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    cluster_keys
+        .into_iter()
+        .map(|cluster_key| {
+            let detail = ScriptletEvidenceCluster::detail(conn, &cluster_key)?
+                .with_context(|| format!("load AppArmor queue cluster {cluster_key}"))?;
+            Ok(AppArmorCandidate {
+                cluster: detail.cluster,
+                samples: detail.samples,
+            })
+        })
+        .collect()
+}
+
+fn plan_candidate(
+    conn: &Connection,
+    cache_dir: &Path,
+    candidate: AppArmorCandidate,
+) -> Result<CandidatePlan> {
+    if candidate.samples.is_empty() {
+        return Ok(CandidatePlan::Unresolved {
+            candidate,
+            reason: "source-cluster-has-no-samples".to_string(),
+        });
+    }
+
+    let mut target_clusters = BTreeMap::<String, NewScriptletEvidenceCluster>::new();
+    let mut rematerialized = Vec::with_capacity(candidate.samples.len());
+    for source in &candidate.samples {
+        if source.cluster_key != candidate.cluster.cluster_key
+            || source.distro != candidate.cluster.distro
+        {
+            return Ok(CandidatePlan::Unresolved {
+                candidate,
+                reason: "source-cluster-identity-mismatch".to_string(),
+            });
+        }
+        let Some(converted) = ConvertedPackage::find_by_checksum(conn, &source.original_checksum)?
+        else {
+            return Ok(CandidatePlan::Unresolved {
+                candidate,
+                reason: "converted-package-missing".to_string(),
+            });
+        };
+        if !source_matches_converted(source, &converted) {
+            return Ok(CandidatePlan::Unresolved {
+                candidate,
+                reason: "converted-package-identity-mismatch".to_string(),
+            });
+        }
+
+        let current =
+            evidence_samples_from_converted(&converted, cache_dir).with_context(|| {
+                format!(
+                    "rematerialize AppArmor evidence for converted package checksum {}",
+                    source.original_checksum
+                )
+            })?;
+        let mut seen_target_keys = BTreeSet::new();
+        let targets = current
+            .into_iter()
+            .filter(|pending| pending_matches_candidate(pending, &candidate.cluster, source))
+            .filter(|pending| seen_target_keys.insert(pending.cluster.cluster_key.clone()))
+            .collect::<Vec<_>>();
+        if targets.is_empty() {
+            return Ok(CandidatePlan::Unresolved {
+                candidate,
+                reason: "current-apparmor-observation-missing".to_string(),
+            });
+        }
+        for target in &targets {
+            match target_clusters.get(&target.cluster.cluster_key) {
+                Some(existing) if existing != &target.cluster => {
+                    return Ok(CandidatePlan::Unresolved {
+                        candidate,
+                        reason: "target-cluster-metadata-conflict".to_string(),
+                    });
+                }
+                Some(_) => {}
+                None => {
+                    target_clusters
+                        .insert(target.cluster.cluster_key.clone(), target.cluster.clone());
+                }
+            }
+        }
+        rematerialized.push(SampleRematerialization {
+            source: source.clone(),
+            targets,
+        });
+    }
+
+    Ok(CandidatePlan::Resolved(ResolvedPlan {
+        candidate,
+        target_clusters,
+        samples: rematerialized,
+    }))
+}
+
+fn source_matches_converted(
+    source: &ScriptletEvidenceSample,
+    converted: &ConvertedPackage,
+) -> bool {
+    source
+        .converted_package_id
+        .is_none_or(|id| converted.id == Some(id))
+        && converted.package_name.as_deref() == Some(source.package_name.as_str())
+        && converted.package_version.as_deref() == Some(source.package_version.as_str())
+        && converted.distro.as_deref() == Some(source.distro.as_str())
+        && converted.package_architecture == source.package_architecture
+}
+
+fn pending_matches_candidate(
+    pending: &PendingEvidenceSample,
+    candidate: &ScriptletEvidenceCluster,
+    source: &ScriptletEvidenceSample,
+) -> bool {
+    pending.cluster.blocked_class == APPARMOR_BLOCKED_CLASS
+        && pending.cluster.schema_version == candidate.schema_version
+        && pending.cluster.distro == candidate.distro
+        && pending.cluster.target_profile == candidate.target_profile
+        && pending.cluster.command == candidate.command
+        && pending.cluster.lifecycle_phase == candidate.lifecycle_phase
+        && pending.sample.original_checksum == source.original_checksum
+        && pending.sample.distro == source.distro
+        && pending.sample.package_name == source.package_name
+        && pending.sample.package_version == source.package_version
+        && pending.sample.package_architecture == source.package_architecture
+}
+
+fn apply_plans(conn: &Connection, plans: &[CandidatePlan]) -> Result<()> {
+    let tx = conn.unchecked_transaction()?;
+    for plan in plans {
+        let CandidatePlan::Resolved(plan) = plan else {
+            continue;
+        };
+        apply_resolved_plan(&tx, plan)?;
+    }
+    tx.commit()?;
+    Ok(())
+}
+
+fn apply_resolved_plan(conn: &Connection, plan: &ResolvedPlan) -> Result<()> {
+    let source_cluster_key = &plan.candidate.cluster.cluster_key;
+    let target_cluster_keys = plan.target_cluster_keys();
+    let identity = target_cluster_keys.len() == 1 && target_cluster_keys[0] == *source_cluster_key;
+    let retains_source = target_cluster_keys
+        .iter()
+        .any(|target_cluster_key| target_cluster_key == source_cluster_key);
+
+    if identity {
+        ensure!(
+            cluster_metadata_matches(
+                &plan.candidate.cluster,
+                plan.target_clusters
+                    .get(source_cluster_key)
+                    .context("identity AppArmor target cluster missing")?
+            ),
+            "AppArmor identity reconciliation metadata conflict for {}",
+            source_cluster_key
+        );
+        for sample in &plan.samples {
+            update_sample_row(conn, sample.source.id, &sample.targets[0].sample)?;
+        }
+        conn.execute(
+            "UPDATE scriptlet_evidence_clusters
+             SET normalization_version = ?2,
+                 updated_at = (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+             WHERE cluster_key = ?1
+               AND normalization_version < ?2
+               AND superseded_at IS NULL",
+            params![source_cluster_key, SCRIPTLET_EVIDENCE_NORMALIZATION_VERSION],
+        )?;
+        return Ok(());
+    }
+
+    for target in plan.target_clusters.values() {
+        if let Some(existing) = ScriptletEvidenceCluster::find(conn, &target.cluster_key)? {
+            ensure!(
+                cluster_metadata_matches(&existing, target),
+                "AppArmor reconciliation target cluster metadata conflict for {}",
+                target.cluster_key
+            );
+            conn.execute(
+                "UPDATE scriptlet_evidence_clusters
+                 SET first_seen = MIN(first_seen, ?2),
+                     last_seen = MAX(last_seen, ?3),
+                     updated_at = (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+                 WHERE cluster_key = ?1",
+                params![
+                    &target.cluster_key,
+                    &plan.candidate.cluster.first_seen,
+                    &plan.candidate.cluster.last_seen
+                ],
+            )?;
+        } else {
+            ScriptletEvidenceCluster::upsert(conn, target)?;
+            conn.execute(
+                "UPDATE scriptlet_evidence_clusters
+                 SET first_seen = ?2,
+                     last_seen = ?3,
+                     updated_at = (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+                 WHERE cluster_key = ?1",
+                params![
+                    &target.cluster_key,
+                    &plan.candidate.cluster.first_seen,
+                    &plan.candidate.cluster.last_seen
+                ],
+            )?;
+        }
+    }
+
+    for sample in &plan.samples {
+        if retains_source
+            && sample
+                .targets
+                .iter()
+                .any(|target| target.cluster.cluster_key == *source_cluster_key)
+        {
+            rematerialize_sample_retaining_source(conn, source_cluster_key, sample)?;
+        } else {
+            rematerialize_sample(conn, sample)?;
+        }
+    }
+
+    for target_cluster_key in target_cluster_keys
+        .iter()
+        .filter(|target_cluster_key| *target_cluster_key != source_cluster_key)
+    {
+        let migrated_sample_count = plan
+            .samples
+            .iter()
+            .filter(|sample| {
+                sample
+                    .targets
+                    .iter()
+                    .any(|target| &target.cluster.cluster_key == target_cluster_key)
+            })
+            .count() as i64;
+        ScriptletEvidenceClusterReconciliationLink::record(
+            conn,
+            source_cluster_key,
+            target_cluster_key,
+            SCRIPTLET_EVIDENCE_NORMALIZATION_VERSION,
+            migrated_sample_count,
+        )?;
+    }
+
+    if retains_source {
+        conn.execute(
+            "UPDATE scriptlet_evidence_clusters
+             SET normalization_version = ?2,
+                 updated_at = (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+             WHERE cluster_key = ?1
+               AND normalization_version < ?2
+               AND superseded_at IS NULL",
+            params![source_cluster_key, SCRIPTLET_EVIDENCE_NORMALIZATION_VERSION],
+        )?;
+        return Ok(());
+    }
+
+    let superseded_by_cluster_key =
+        (target_cluster_keys.len() == 1).then(|| target_cluster_keys[0].as_str());
+    conn.execute(
+        "UPDATE scriptlet_evidence_clusters
+         SET normalization_version = ?2,
+             superseded_at = (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+             superseded_reason = ?3,
+             superseded_by_cluster_key = ?4,
+             updated_at = (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+         WHERE cluster_key = ?1
+           AND normalization_version < ?2
+           AND superseded_at IS NULL",
+        params![
+            source_cluster_key,
+            SCRIPTLET_EVIDENCE_NORMALIZATION_VERSION,
+            APPARMOR_SUPERSEDED_REASON,
+            superseded_by_cluster_key
+        ],
+    )?;
+    Ok(())
+}
+
+fn rematerialize_sample_retaining_source(
+    conn: &Connection,
+    source_cluster_key: &str,
+    rematerialized: &SampleRematerialization,
+) -> Result<()> {
+    let source_target = rematerialized
+        .targets
+        .iter()
+        .find(|target| target.cluster.cluster_key == source_cluster_key)
+        .context("retained AppArmor source target missing")?;
+    update_sample_row(conn, rematerialized.source.id, &source_target.sample)?;
+    for target in &rematerialized.targets {
+        if target.cluster.cluster_key != source_cluster_key {
+            insert_or_update_sample_preserving_observed_at(
+                conn,
+                &target.sample,
+                &rematerialized.source.observed_at,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn cluster_metadata_matches(
+    existing: &ScriptletEvidenceCluster,
+    target: &NewScriptletEvidenceCluster,
+) -> bool {
+    existing.schema_version == target.schema_version
+        && existing.distro == target.distro
+        && existing.target_profile == target.target_profile
+        && existing.blocked_class == target.blocked_class
+        && existing.command == target.command
+        && existing.normalized_command_shape == target.normalized_command_shape
+        && existing.normalized_command_shape_hash == target.normalized_command_shape_hash
+        && existing.lifecycle_phase == target.lifecycle_phase
+}
+
+fn rematerialize_sample(conn: &Connection, rematerialized: &SampleRematerialization) -> Result<()> {
+    let mut reusable_target = None;
+    for target in &rematerialized.targets {
+        if observation_id(conn, &target.sample)?.is_none() {
+            reusable_target = Some(target.cluster.cluster_key.clone());
+            break;
+        }
+    }
+
+    let mut source_row_reused = false;
+    for target in &rematerialized.targets {
+        if reusable_target.as_deref() == Some(target.cluster.cluster_key.as_str()) {
+            update_sample_row(conn, rematerialized.source.id, &target.sample)?;
+            source_row_reused = true;
+        } else {
+            insert_or_update_sample_preserving_observed_at(
+                conn,
+                &target.sample,
+                &rematerialized.source.observed_at,
+            )?;
+        }
+    }
+    if !source_row_reused {
+        conn.execute(
+            "DELETE FROM scriptlet_evidence_cluster_samples WHERE id = ?1",
+            [rematerialized.source.id],
+        )?;
+    }
+    Ok(())
+}
+
+fn observation_id(conn: &Connection, sample: &NewScriptletEvidenceSample) -> Result<Option<i64>> {
+    conn.query_row(
+        "SELECT id
+         FROM scriptlet_evidence_cluster_samples
+         WHERE cluster_key = ?1
+           AND original_checksum = ?2
+           AND package_name = ?3
+           AND package_version = ?4
+           AND COALESCE(package_architecture, '') = COALESCE(?5, '')",
+        params![
+            &sample.cluster_key,
+            &sample.original_checksum,
+            &sample.package_name,
+            &sample.package_version,
+            &sample.package_architecture
+        ],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+fn update_sample_row(
+    conn: &Connection,
+    sample_id: i64,
+    sample: &NewScriptletEvidenceSample,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE scriptlet_evidence_cluster_samples
+         SET cluster_key = ?2,
+             converted_package_id = ?3,
+             original_checksum = ?4,
+             distro = ?5,
+             package_name = ?6,
+             package_version = ?7,
+             package_architecture = ?8,
+             publication_status = ?9,
+             scriptlet_fidelity = ?10,
+             target_compatibility = ?11,
+             reason_codes_json = ?12,
+             blocked_classes_json = ?13,
+             boot_security_intents_json = ?14,
+             security_policy_intents_json = ?15,
+             review_artifact_path = ?16,
+             review_artifact_stale = ?17,
+             evidence_digest = ?18,
+             curation_evidence_digest = ?19
+         WHERE id = ?1",
+        params![
+            sample_id,
+            &sample.cluster_key,
+            sample.converted_package_id,
+            &sample.original_checksum,
+            &sample.distro,
+            &sample.package_name,
+            &sample.package_version,
+            &sample.package_architecture,
+            &sample.publication_status,
+            &sample.scriptlet_fidelity,
+            &sample.target_compatibility,
+            &sample.reason_codes_json,
+            &sample.blocked_classes_json,
+            &sample.boot_security_intents_json,
+            &sample.security_policy_intents_json,
+            &sample.review_artifact_path,
+            i64::from(sample.review_artifact_stale),
+            &sample.evidence_digest,
+            &sample.curation_evidence_digest
+        ],
+    )?;
+    Ok(())
+}
+
+fn insert_or_update_sample_preserving_observed_at(
+    conn: &Connection,
+    sample: &NewScriptletEvidenceSample,
+    observed_at: &str,
+) -> Result<()> {
+    conn.execute(
+        "INSERT OR IGNORE INTO scriptlet_evidence_cluster_samples (
+            cluster_key, converted_package_id, original_checksum, distro,
+            package_name, package_version, package_architecture,
+            publication_status, scriptlet_fidelity, target_compatibility,
+            reason_codes_json, blocked_classes_json, boot_security_intents_json,
+            security_policy_intents_json, review_artifact_path,
+            review_artifact_stale, evidence_digest, curation_evidence_digest,
+            observed_at
+         ) VALUES (
+            ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
+            ?15, ?16, ?17, ?18, ?19
+         )",
+        params![
+            &sample.cluster_key,
+            sample.converted_package_id,
+            &sample.original_checksum,
+            &sample.distro,
+            &sample.package_name,
+            &sample.package_version,
+            &sample.package_architecture,
+            &sample.publication_status,
+            &sample.scriptlet_fidelity,
+            &sample.target_compatibility,
+            &sample.reason_codes_json,
+            &sample.blocked_classes_json,
+            &sample.boot_security_intents_json,
+            &sample.security_policy_intents_json,
+            &sample.review_artifact_path,
+            i64::from(sample.review_artifact_stale),
+            &sample.evidence_digest,
+            &sample.curation_evidence_digest,
+            observed_at
+        ],
+    )?;
+    let id = observation_id(conn, sample)?.context("materialized AppArmor observation missing")?;
+    update_sample_row(conn, id, sample)?;
+    conn.execute(
+        "UPDATE scriptlet_evidence_cluster_samples
+         SET observed_at = MIN(observed_at, ?2)
+         WHERE id = ?1",
+        params![id, observed_at],
+    )?;
+    Ok(())
+}
+
+fn remaining_cluster_count(conn: &Connection) -> Result<i64> {
+    conn.query_row(
+        "SELECT COUNT(*)
+         FROM scriptlet_evidence_clusters
+         WHERE blocked_class = ?1
+           AND normalization_version < ?2
+           AND superseded_at IS NULL",
+        params![
+            APPARMOR_BLOCKED_CLASS,
+            SCRIPTLET_EVIDENCE_NORMALIZATION_VERSION
+        ],
+        |row| row.get(0),
+    )
+    .map_err(Into::into)
+}
+
+#[cfg(test)]
+mod tests;

--- a/apps/remi/src/server/scriptlet_evidence_queue/reconciliation/apparmor/tests.rs
+++ b/apps/remi/src/server/scriptlet_evidence_queue/reconciliation/apparmor/tests.rs
@@ -1,0 +1,542 @@
+// apps/remi/src/server/scriptlet_evidence_queue/reconciliation/apparmor/tests.rs
+
+use super::*;
+use conary_core::ccs::convert::ScriptletBundleSummary;
+use conary_core::ccs::legacy_scriptlets::BootSecurityIntentEvidence;
+use conary_core::db::models::{
+    NewScriptletEvidenceCluster, ScriptletEvidenceClusterListFilter, ScriptletEvidenceNote,
+    ScriptletEvidenceState,
+};
+
+use crate::server::scriptlet_evidence_queue::normalization::stable_cluster_key;
+use crate::server::scriptlet_evidence_queue::types::ClusterKeyInput;
+
+fn test_db() -> (tempfile::TempDir, std::path::PathBuf) {
+    let temp = tempfile::tempdir().unwrap();
+    let db_path = temp.path().join("test.db");
+    let conn = Connection::open(&db_path).unwrap();
+    conary_core::db::schema::migrate(&conn).unwrap();
+    (temp, db_path)
+}
+
+fn apparmor_summary(paths: &[&str]) -> ScriptletBundleSummary {
+    ScriptletBundleSummary {
+        scriptlet_fidelity: "blocked".to_string(),
+        target_compatibility: "blocked".to_string(),
+        publication_status: "blocked".to_string(),
+        evidence_digest: Some("sha256:apparmor-evidence".to_string()),
+        blocked_reason_codes: vec!["blocked-class-apparmor".to_string()],
+        blocked_classes: vec!["apparmor".to_string()],
+        boot_security_intents: paths
+            .iter()
+            .map(|path| BootSecurityIntentEvidence {
+                class_id: "apparmor".to_string(),
+                reason_code: "blocked-class-apparmor".to_string(),
+                command: "apparmor_parser".to_string(),
+                argv: vec!["-r".to_string(), (*path).to_string()],
+                phase: Some("postinstall".to_string()),
+                lifecycle_paths: vec![(*path).to_string()],
+            })
+            .collect(),
+        ..ScriptletBundleSummary::default()
+    }
+}
+
+fn seed_converted(
+    conn: &Connection,
+    name: &str,
+    checksum: &str,
+    paths: &[&str],
+) -> ConvertedPackage {
+    let mut converted = ConvertedPackage::new_server(
+        "ubuntu".to_string(),
+        name.to_string(),
+        "1.0.0".to_string(),
+        "deb".to_string(),
+        checksum.to_string(),
+        "partial".to_string(),
+        &["sha256:chunk".to_string()],
+        42,
+        format!("sha256:content-{name}"),
+        format!("/cache/{name}.ccs"),
+    );
+    converted.package_architecture = Some("amd64".to_string());
+    converted
+        .set_scriptlet_metadata(&apparmor_summary(paths))
+        .unwrap();
+    converted.insert(conn).unwrap();
+    converted
+}
+
+fn seed_legacy_cluster(
+    conn: &Connection,
+    cache_dir: &Path,
+    converted: &ConvertedPackage,
+    legacy_shape: &str,
+) -> (String, Vec<String>, i64) {
+    let current = evidence_samples_from_converted(converted, cache_dir).unwrap();
+    let target_keys = current
+        .iter()
+        .map(|pending| pending.cluster.cluster_key.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let stable = stable_cluster_key(&ClusterKeyInput {
+        schema_version: 1,
+        distro: "ubuntu".to_string(),
+        target_profile: "ubuntu-26.04".to_string(),
+        blocked_class: APPARMOR_BLOCKED_CLASS.to_string(),
+        command: "apparmor_parser".to_string(),
+        normalized_command_shape: legacy_shape.to_string(),
+        lifecycle_phase: "postinstall".to_string(),
+    });
+    ScriptletEvidenceCluster::upsert(
+        conn,
+        &NewScriptletEvidenceCluster {
+            cluster_key: stable.cluster_key.clone(),
+            schema_version: 1,
+            normalization_version: 1,
+            distro: "ubuntu".to_string(),
+            target_profile: "ubuntu-26.04".to_string(),
+            blocked_class: APPARMOR_BLOCKED_CLASS.to_string(),
+            command: "apparmor_parser".to_string(),
+            normalized_command_shape: legacy_shape.to_string(),
+            normalized_command_shape_hash: stable.normalized_command_shape_hash,
+            lifecycle_phase: "postinstall".to_string(),
+        },
+    )
+    .unwrap();
+
+    let mut sample = current[0].sample.clone();
+    sample.cluster_key = stable.cluster_key.clone();
+    sample.boot_security_intents_json = sample
+        .boot_security_intents_json
+        .replace("/etc/apparmor.d/usr.bin.demo", "<path>")
+        .replace("/etc/apparmor.d/usr.bin.second", "<path>");
+    let sample_id = ScriptletEvidenceSample::upsert(conn, &sample).unwrap();
+    (stable.cluster_key, target_keys, sample_id)
+}
+
+#[test]
+fn dry_run_reports_key_transformation_without_mutation() {
+    let (temp, db_path) = test_db();
+    let conn = Connection::open(&db_path).unwrap();
+    let converted = seed_converted(
+        &conn,
+        "apparmor-demo",
+        "sha256:apparmor-demo",
+        &["/etc/apparmor.d/usr.bin.demo"],
+    );
+    let (source_key, target_keys, _) =
+        seed_legacy_cluster(&conn, temp.path(), &converted, "apparmor_parser -r <path>");
+
+    let result = reconcile_apparmor_batch(&db_path, temp.path(), true, 100, None).unwrap();
+
+    assert_eq!(result.scanned_cluster_count, 1);
+    assert_eq!(result.rekeyed_cluster_count, 1);
+    assert_eq!(result.remaining_cluster_count, 1);
+    assert_eq!(result.mappings[0].source_cluster_key, source_key);
+    assert_eq!(result.mappings[0].target_cluster_keys, target_keys);
+    let source = ScriptletEvidenceCluster::detail(&conn, &source_key)
+        .unwrap()
+        .unwrap();
+    assert!(source.cluster.superseded_at.is_none());
+    assert_eq!(source.samples.len(), 1);
+    assert_eq!(
+        ConvertedPackage::find_by_checksum(&conn, "sha256:apparmor-demo")
+            .unwrap()
+            .unwrap()
+            .publication_status,
+        "blocked"
+    );
+}
+
+#[test]
+fn identity_apply_advances_version_without_supersession_or_links() {
+    let (temp, db_path) = test_db();
+    let conn = Connection::open(&db_path).unwrap();
+    let converted = seed_converted(
+        &conn,
+        "apparmor-identity",
+        "sha256:apparmor-identity",
+        &["/tmp/private-profile"],
+    );
+    let (source_key, target_keys, source_sample_id) =
+        seed_legacy_cluster(&conn, temp.path(), &converted, "apparmor_parser -r <path>");
+    assert_eq!(target_keys, vec![source_key.clone()]);
+
+    let result = reconcile_apparmor_batch(&db_path, temp.path(), false, 100, None).unwrap();
+
+    assert_eq!(result.identity_cluster_count, 1);
+    assert_eq!(result.rekeyed_cluster_count, 0);
+    assert_eq!(result.remaining_cluster_count, 0);
+    let source = ScriptletEvidenceCluster::detail(&conn, &source_key)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        source.cluster.normalization_version,
+        SCRIPTLET_EVIDENCE_NORMALIZATION_VERSION
+    );
+    assert!(source.cluster.superseded_at.is_none());
+    assert_eq!(source.samples[0].id, source_sample_id);
+    assert!(source.outgoing_reconciliation_links.is_empty());
+    assert!(source.incoming_reconciliation_links.is_empty());
+}
+
+#[test]
+fn apply_rekeys_observation_preserves_workflow_history_and_is_idempotent() {
+    let (temp, db_path) = test_db();
+    let conn = Connection::open(&db_path).unwrap();
+    let converted = seed_converted(
+        &conn,
+        "apparmor-demo",
+        "sha256:apparmor-demo",
+        &["/etc/apparmor.d/usr.bin.demo"],
+    );
+    let (source_key, target_keys, source_sample_id) =
+        seed_legacy_cluster(&conn, temp.path(), &converted, "apparmor_parser -r <path>");
+    ScriptletEvidenceCluster::update_state(
+        &conn,
+        &source_key,
+        ScriptletEvidenceState::AdapterCandidate,
+        "maintainer",
+        Some("reviewed before normalization"),
+    )
+    .unwrap();
+    ScriptletEvidenceNote::insert(&conn, &source_key, "maintainer", "private rationale").unwrap();
+    let source_observed_at = ScriptletEvidenceSample::list_for_cluster(&conn, &source_key).unwrap()
+        [0]
+    .observed_at
+    .clone();
+
+    let result = reconcile_apparmor_batch(&db_path, temp.path(), false, 100, None).unwrap();
+
+    assert_eq!(result.rekeyed_cluster_count, 1);
+    assert_eq!(result.remaining_cluster_count, 0);
+    let source = ScriptletEvidenceCluster::detail(&conn, &source_key)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        source.cluster.state,
+        ScriptletEvidenceState::AdapterCandidate
+    );
+    assert_eq!(
+        source.cluster.superseded_reason.as_deref(),
+        Some(APPARMOR_SUPERSEDED_REASON)
+    );
+    assert!(source.samples.is_empty());
+    assert_eq!(source.state_events.len(), 1);
+    assert_eq!(source.notes.len(), 1);
+    assert_eq!(source.outgoing_reconciliation_links.len(), 1);
+
+    let target = ScriptletEvidenceCluster::detail(&conn, &target_keys[0])
+        .unwrap()
+        .unwrap();
+    assert_eq!(target.cluster.state, ScriptletEvidenceState::NeedsTriage);
+    assert_eq!(target.samples.len(), 1);
+    assert_eq!(target.samples[0].id, source_sample_id);
+    assert_eq!(target.samples[0].observed_at, source_observed_at);
+    assert_eq!(target.incoming_reconciliation_links.len(), 1);
+    assert!(
+        target.samples[0]
+            .boot_security_intents_json
+            .contains("/etc/apparmor.d/usr.bin.demo")
+    );
+
+    let repeat = reconcile_apparmor_batch(&db_path, temp.path(), false, 100, None).unwrap();
+    assert_eq!(repeat.scanned_cluster_count, 0);
+    assert_eq!(repeat.remaining_cluster_count, 0);
+    assert_eq!(
+        ConvertedPackage::find_by_checksum(&conn, "sha256:apparmor-demo")
+            .unwrap()
+            .unwrap()
+            .publication_status,
+        "blocked"
+    );
+}
+
+#[test]
+fn bounded_batches_resume_from_the_returned_cursor() {
+    let (temp, db_path) = test_db();
+    let conn = Connection::open(&db_path).unwrap();
+    let converted = seed_converted(
+        &conn,
+        "apparmor-bounded",
+        "sha256:apparmor-bounded",
+        &["/etc/apparmor.d/usr.bin.demo"],
+    );
+    seed_legacy_cluster(
+        &conn,
+        temp.path(),
+        &converted,
+        "apparmor_parser --replace <path>",
+    );
+    seed_legacy_cluster(&conn, temp.path(), &converted, "apparmor_parser -r <path>");
+
+    let first = reconcile_apparmor_batch(&db_path, temp.path(), false, 1, None).unwrap();
+
+    assert_eq!(first.scanned_cluster_count, 1);
+    assert!(!first.complete);
+    assert_eq!(first.remaining_cluster_count, 1);
+    let cursor = first.next_after_cluster_key.as_deref().unwrap();
+
+    let second = reconcile_apparmor_batch(&db_path, temp.path(), false, 1, Some(cursor)).unwrap();
+
+    assert_eq!(second.scanned_cluster_count, 1);
+    assert!(!second.complete);
+    assert_eq!(second.remaining_cluster_count, 0);
+    let final_cursor = second.next_after_cluster_key.as_deref().unwrap();
+    let final_batch =
+        reconcile_apparmor_batch(&db_path, temp.path(), false, 1, Some(final_cursor)).unwrap();
+    assert!(final_batch.complete);
+    assert_eq!(final_batch.scanned_cluster_count, 0);
+    assert_eq!(final_batch.remaining_cluster_count, 0);
+}
+
+#[test]
+fn apply_records_split_links_without_duplicate_source_observation() {
+    let (temp, db_path) = test_db();
+    let conn = Connection::open(&db_path).unwrap();
+    let converted = seed_converted(
+        &conn,
+        "apparmor-split",
+        "sha256:apparmor-split",
+        &[
+            "/etc/apparmor.d/usr.bin.demo",
+            "/etc/apparmor.d/usr.bin.second",
+        ],
+    );
+    let (source_key, target_keys, source_sample_id) =
+        seed_legacy_cluster(&conn, temp.path(), &converted, "apparmor_parser -r <path>");
+
+    let result = reconcile_apparmor_batch(&db_path, temp.path(), false, 100, None).unwrap();
+
+    assert_eq!(result.split_source_cluster_count, 1);
+    assert_eq!(result.materialized_target_sample_count, 2);
+    let source = ScriptletEvidenceCluster::detail(&conn, &source_key)
+        .unwrap()
+        .unwrap();
+    assert!(source.cluster.superseded_by_cluster_key.is_none());
+    assert!(source.samples.is_empty());
+    assert_eq!(source.outgoing_reconciliation_links.len(), 2);
+
+    let target_samples = target_keys
+        .iter()
+        .flat_map(|target_key| {
+            ScriptletEvidenceSample::list_for_cluster(&conn, target_key).unwrap()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(target_samples.len(), 2);
+    assert!(
+        target_samples
+            .iter()
+            .any(|sample| sample.id == source_sample_id)
+    );
+    let all = ScriptletEvidenceCluster::list(
+        &conn,
+        &ScriptletEvidenceClusterListFilter {
+            include_superseded: true,
+            ..ScriptletEvidenceClusterListFilter::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        all.iter().map(|cluster| cluster.attempt_count).sum::<i64>(),
+        2
+    );
+}
+
+#[test]
+fn split_can_retain_the_source_as_one_current_target() {
+    let (temp, db_path) = test_db();
+    let conn = Connection::open(&db_path).unwrap();
+    let converted = seed_converted(
+        &conn,
+        "apparmor-mixed-split",
+        "sha256:apparmor-mixed-split",
+        &["/etc/apparmor.d/usr.bin.demo", "/tmp/private-profile"],
+    );
+    let (source_key, target_keys, source_sample_id) =
+        seed_legacy_cluster(&conn, temp.path(), &converted, "apparmor_parser -r <path>");
+    assert!(target_keys.contains(&source_key));
+    assert_eq!(target_keys.len(), 2);
+
+    let result = reconcile_apparmor_batch(&db_path, temp.path(), false, 100, None).unwrap();
+
+    assert_eq!(result.split_source_cluster_count, 1);
+    assert_eq!(result.remaining_cluster_count, 0);
+    let source = ScriptletEvidenceCluster::detail(&conn, &source_key)
+        .unwrap()
+        .unwrap();
+    assert!(source.cluster.superseded_at.is_none());
+    assert_eq!(
+        source.cluster.normalization_version,
+        SCRIPTLET_EVIDENCE_NORMALIZATION_VERSION
+    );
+    assert_eq!(source.samples.len(), 1);
+    assert_eq!(source.samples[0].id, source_sample_id);
+    assert_eq!(source.outgoing_reconciliation_links.len(), 1);
+
+    let new_target_key = target_keys
+        .iter()
+        .find(|target_key| *target_key != &source_key)
+        .unwrap();
+    let new_target = ScriptletEvidenceCluster::detail(&conn, new_target_key)
+        .unwrap()
+        .unwrap();
+    assert_eq!(new_target.samples.len(), 1);
+    assert_eq!(new_target.incoming_reconciliation_links.len(), 1);
+}
+
+#[test]
+fn split_moves_only_samples_whose_current_identity_changed() {
+    let (temp, db_path) = test_db();
+    let conn = Connection::open(&db_path).unwrap();
+    let approved = seed_converted(
+        &conn,
+        "apparmor-approved",
+        "sha256:apparmor-approved",
+        &["/etc/apparmor.d/usr.bin.demo"],
+    );
+    let unsafe_path = seed_converted(
+        &conn,
+        "apparmor-unsafe",
+        "sha256:apparmor-unsafe",
+        &["/tmp/private-profile"],
+    );
+    let (source_key, approved_targets, approved_sample_id) =
+        seed_legacy_cluster(&conn, temp.path(), &approved, "apparmor_parser -r <path>");
+    let (same_source_key, unsafe_targets, unsafe_sample_id) = seed_legacy_cluster(
+        &conn,
+        temp.path(),
+        &unsafe_path,
+        "apparmor_parser -r <path>",
+    );
+    assert_eq!(source_key, same_source_key);
+    assert_eq!(unsafe_targets, vec![source_key.clone()]);
+    assert!(!approved_targets.contains(&source_key));
+
+    let result = reconcile_apparmor_batch(&db_path, temp.path(), false, 100, None).unwrap();
+
+    assert_eq!(result.split_source_cluster_count, 1);
+    let source = ScriptletEvidenceCluster::detail(&conn, &source_key)
+        .unwrap()
+        .unwrap();
+    assert_eq!(source.samples.len(), 1);
+    assert_eq!(source.samples[0].id, unsafe_sample_id);
+    assert_ne!(source.samples[0].id, approved_sample_id);
+    assert_eq!(source.outgoing_reconciliation_links.len(), 1);
+    assert_eq!(
+        source.outgoing_reconciliation_links[0].migrated_sample_count,
+        1
+    );
+
+    let approved_target = ScriptletEvidenceCluster::detail(&conn, &approved_targets[0])
+        .unwrap()
+        .unwrap();
+    assert_eq!(approved_target.samples.len(), 1);
+    assert_eq!(approved_target.samples[0].id, approved_sample_id);
+}
+
+#[test]
+fn merge_keeps_conflicting_workflow_history_on_linked_sources() {
+    let (temp, db_path) = test_db();
+    let conn = Connection::open(&db_path).unwrap();
+    let first = seed_converted(
+        &conn,
+        "apparmor-first",
+        "sha256:apparmor-first",
+        &["/etc/apparmor.d/usr.bin.demo"],
+    );
+    let second = seed_converted(
+        &conn,
+        "apparmor-second",
+        "sha256:apparmor-second",
+        &["/etc/apparmor.d/usr.bin.demo"],
+    );
+    let (first_source, first_targets, _) = seed_legacy_cluster(
+        &conn,
+        temp.path(),
+        &first,
+        "apparmor_parser --replace <path>",
+    );
+    let (second_source, second_targets, _) =
+        seed_legacy_cluster(&conn, temp.path(), &second, "apparmor_parser -r <path>");
+    assert_eq!(first_targets, second_targets);
+    ScriptletEvidenceCluster::update_state(
+        &conn,
+        &first_source,
+        ScriptletEvidenceState::InDesign,
+        "maintainer",
+        None,
+    )
+    .unwrap();
+    ScriptletEvidenceCluster::update_state(
+        &conn,
+        &second_source,
+        ScriptletEvidenceState::WontSupport,
+        "maintainer",
+        Some("different disposition"),
+    )
+    .unwrap();
+    ScriptletEvidenceNote::insert(&conn, &first_source, "maintainer", "first note").unwrap();
+    ScriptletEvidenceNote::insert(&conn, &second_source, "maintainer", "second note").unwrap();
+
+    let result = reconcile_apparmor_batch(&db_path, temp.path(), false, 100, None).unwrap();
+
+    assert_eq!(result.merged_target_cluster_count, 1);
+    let target = ScriptletEvidenceCluster::detail(&conn, &first_targets[0])
+        .unwrap()
+        .unwrap();
+    assert_eq!(target.cluster.state, ScriptletEvidenceState::NeedsTriage);
+    assert_eq!(target.incoming_reconciliation_links.len(), 2);
+    let first_source = ScriptletEvidenceCluster::detail(&conn, &first_source)
+        .unwrap()
+        .unwrap();
+    let second_source = ScriptletEvidenceCluster::detail(&conn, &second_source)
+        .unwrap()
+        .unwrap();
+    assert_eq!(first_source.cluster.state, ScriptletEvidenceState::InDesign);
+    assert_eq!(
+        second_source.cluster.state,
+        ScriptletEvidenceState::WontSupport
+    );
+    assert_eq!(first_source.notes[0].body, "first note");
+    assert_eq!(second_source.notes[0].body, "second note");
+}
+
+#[test]
+fn missing_converted_source_stays_active_and_reports_unresolved() {
+    let (temp, db_path) = test_db();
+    let conn = Connection::open(&db_path).unwrap();
+    let converted = seed_converted(
+        &conn,
+        "apparmor-missing",
+        "sha256:apparmor-missing",
+        &["/etc/apparmor.d/usr.bin.demo"],
+    );
+    let (source_key, _, _) =
+        seed_legacy_cluster(&conn, temp.path(), &converted, "apparmor_parser -r <path>");
+    conn.execute(
+        "UPDATE scriptlet_evidence_cluster_samples
+             SET converted_package_id = NULL,
+                 original_checksum = 'sha256:not-present'
+             WHERE cluster_key = ?1",
+        [&source_key],
+    )
+    .unwrap();
+
+    let result = reconcile_apparmor_batch(&db_path, temp.path(), false, 100, None).unwrap();
+
+    assert_eq!(result.unresolved_cluster_count, 1);
+    assert_eq!(
+        result.unresolved_by_reason.get("converted-package-missing"),
+        Some(&1)
+    );
+    assert_eq!(result.remaining_cluster_count, 1);
+    let source = ScriptletEvidenceCluster::find(&conn, &source_key)
+        .unwrap()
+        .unwrap();
+    assert!(source.superseded_at.is_none());
+    assert_eq!(source.normalization_version, 1);
+}

--- a/crates/conary-core/src/db/migrations/mod.rs
+++ b/crates/conary-core/src/db/migrations/mod.rs
@@ -8,12 +8,15 @@
 //! Range files:
 //! - v1_v20: Migrations 1-20 (core tables, repos, components, labels)
 //! - v21_v40: Migrations 21-40 (config, security, federation, derived packages)
-//! - v41_current: Migrations 41-current (collections, TUF, canonical, derivations)
+//! - v41_current: Migrations 41-78 (collections, TUF, canonical, derivations)
+//! - v79_current: Migrations 79-current (scriptlet evidence reconciliation)
 
 mod v1_v20;
 mod v21_v40;
 mod v41_current;
+mod v79_current;
 
 pub use v1_v20::*;
 pub use v21_v40::*;
 pub use v41_current::*;
+pub use v79_current::*;

--- a/crates/conary-core/src/db/migrations/v79_current.rs
+++ b/crates/conary-core/src/db/migrations/v79_current.rs
@@ -1,0 +1,127 @@
+// conary-core/src/db/migrations/v79_current.rs
+
+use crate::error::Result;
+use rusqlite::Connection;
+use tracing::info;
+
+/// Version 79: Scriptlet evidence reconciliation links
+pub fn migrate_v79(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "
+        CREATE TABLE scriptlet_evidence_cluster_reconciliation_links (
+            source_cluster_key TEXT NOT NULL
+                REFERENCES scriptlet_evidence_clusters(cluster_key) ON DELETE CASCADE,
+            target_cluster_key TEXT NOT NULL
+                REFERENCES scriptlet_evidence_clusters(cluster_key) ON DELETE CASCADE,
+            normalization_version INTEGER NOT NULL,
+            migrated_sample_count INTEGER NOT NULL
+                CHECK (migrated_sample_count >= 0),
+            created_at TEXT NOT NULL
+                DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+            PRIMARY KEY (
+                source_cluster_key,
+                target_cluster_key,
+                normalization_version
+            ),
+            CHECK (source_cluster_key != target_cluster_key)
+        );
+
+        CREATE INDEX idx_scriptlet_evidence_reconciliation_links_target
+            ON scriptlet_evidence_cluster_reconciliation_links(
+                target_cluster_key,
+                normalization_version,
+                source_cluster_key
+            );
+        ",
+    )?;
+
+    info!("Schema version 79 applied successfully (scriptlet evidence reconciliation links)");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::schema::migrate;
+
+    #[test]
+    fn migrate_v79_adds_many_to_many_reconciliation_links() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate(&conn).unwrap();
+
+        let columns = conn
+            .prepare("PRAGMA table_info('scriptlet_evidence_cluster_reconciliation_links')")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        for column in [
+            "source_cluster_key",
+            "target_cluster_key",
+            "normalization_version",
+            "migrated_sample_count",
+            "created_at",
+        ] {
+            assert!(columns.contains(&column.to_string()), "missing {column}");
+        }
+
+        let create_sql: String = conn
+            .query_row(
+                "SELECT sql FROM sqlite_master
+                 WHERE type = 'table'
+                   AND name = 'scriptlet_evidence_cluster_reconciliation_links'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(create_sql.contains("source_cluster_key != target_cluster_key"));
+        assert!(create_sql.contains("migrated_sample_count >= 0"));
+    }
+
+    #[test]
+    fn reconciliation_links_preserve_source_and_target_clusters() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate(&conn).unwrap();
+        for cluster_key in ["s1-source", "s1-target"] {
+            conn.execute(
+                "INSERT INTO scriptlet_evidence_clusters (
+                    cluster_key, schema_version, normalization_version, distro,
+                    target_profile, blocked_class, command,
+                    normalized_command_shape, normalized_command_shape_hash,
+                    lifecycle_phase
+                 ) VALUES (
+                    ?1, 1, 1, 'ubuntu', 'ubuntu-26.04', 'apparmor',
+                    'apparmor_parser', 'apparmor_parser -r <path>', ?2,
+                    'postinstall'
+                 )",
+                (cluster_key, format!("hash-{cluster_key}")),
+            )
+            .unwrap();
+        }
+
+        conn.execute(
+            "INSERT INTO scriptlet_evidence_cluster_reconciliation_links (
+                source_cluster_key, target_cluster_key, normalization_version,
+                migrated_sample_count
+             ) VALUES ('s1-source', 's1-target', 2, 3)",
+            [],
+        )
+        .unwrap();
+
+        let (link_count, cluster_count): (i64, i64) = conn
+            .query_row(
+                "SELECT
+                    (SELECT COUNT(*)
+                     FROM scriptlet_evidence_cluster_reconciliation_links),
+                    (SELECT COUNT(*)
+                     FROM scriptlet_evidence_clusters
+                     WHERE cluster_key IN ('s1-source', 's1-target'))",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(link_count, 1);
+        assert_eq!(cluster_count, 2);
+    }
+}

--- a/crates/conary-core/src/db/models/mod.rs
+++ b/crates/conary-core/src/db/models/mod.rs
@@ -109,8 +109,9 @@ pub use scriptlet_entry::ScriptletEntry;
 pub use scriptlet_evidence::{
     BackfillStatus, CLUSTER_KEY_PREFIX, NewScriptletEvidenceCluster, NewScriptletEvidenceSample,
     ScriptletEvidenceBackfillRun, ScriptletEvidenceCluster, ScriptletEvidenceClusterDetail,
-    ScriptletEvidenceClusterListFilter, ScriptletEvidenceClusterSummary, ScriptletEvidenceNote,
-    ScriptletEvidenceSample, ScriptletEvidenceState, ScriptletEvidenceStateEvent,
+    ScriptletEvidenceClusterListFilter, ScriptletEvidenceClusterReconciliationLink,
+    ScriptletEvidenceClusterSummary, ScriptletEvidenceNote, ScriptletEvidenceSample,
+    ScriptletEvidenceState, ScriptletEvidenceStateEvent,
 };
 pub use state::{RestorePlan, StateDiff, StateEngine, StateMember, SystemState};
 pub use subpackage::{RelatedPackages, SubpackageRelationship, show_subpackage_guidance};

--- a/crates/conary-core/src/db/models/scriptlet_evidence.rs
+++ b/crates/conary-core/src/db/models/scriptlet_evidence.rs
@@ -6,6 +6,10 @@ use crate::error::{Error, Result};
 use rusqlite::{Connection, OptionalExtension, Row, ToSql, params};
 use serde::{Deserialize, Serialize};
 
+mod reconciliation;
+
+pub use reconciliation::ScriptletEvidenceClusterReconciliationLink;
+
 pub const CLUSTER_KEY_PREFIX: &str = "s1-";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -113,6 +117,8 @@ pub struct ScriptletEvidenceClusterDetail {
     pub samples: Vec<ScriptletEvidenceSample>,
     pub state_events: Vec<ScriptletEvidenceStateEvent>,
     pub notes: Vec<ScriptletEvidenceNote>,
+    pub outgoing_reconciliation_links: Vec<ScriptletEvidenceClusterReconciliationLink>,
+    pub incoming_reconciliation_links: Vec<ScriptletEvidenceClusterReconciliationLink>,
 }
 
 impl ScriptletEvidenceCluster {
@@ -237,6 +243,10 @@ impl ScriptletEvidenceCluster {
             samples: ScriptletEvidenceSample::list_for_cluster(conn, cluster_key)?,
             state_events: ScriptletEvidenceStateEvent::list_for_cluster(conn, cluster_key)?,
             notes: ScriptletEvidenceNote::list_for_cluster(conn, cluster_key)?,
+            outgoing_reconciliation_links:
+                ScriptletEvidenceClusterReconciliationLink::list_outgoing(conn, cluster_key)?,
+            incoming_reconciliation_links:
+                ScriptletEvidenceClusterReconciliationLink::list_incoming(conn, cluster_key)?,
         }))
     }
 
@@ -914,6 +924,46 @@ mod tests {
         assert_eq!(detail.samples.len(), 1);
         assert_eq!(detail.state_events.len(), 1);
         assert_eq!(detail.notes.len(), 1);
+        assert!(detail.outgoing_reconciliation_links.is_empty());
+        assert!(detail.incoming_reconciliation_links.is_empty());
+    }
+
+    #[test]
+    fn detail_exposes_reconciliation_links_in_both_directions() {
+        let conn = test_conn();
+        let mut source = new_cluster();
+        source.cluster_key = "s1-source".to_string();
+        source.normalization_version = 1;
+        ScriptletEvidenceCluster::upsert(&conn, &source).unwrap();
+
+        let mut target = new_cluster();
+        target.cluster_key = "s1-target".to_string();
+        ScriptletEvidenceCluster::upsert(&conn, &target).unwrap();
+
+        let link = ScriptletEvidenceClusterReconciliationLink::record(
+            &conn,
+            "s1-source",
+            "s1-target",
+            2,
+            3,
+        )
+        .unwrap();
+        assert_eq!(link.migrated_sample_count, 3);
+
+        let source_detail = ScriptletEvidenceCluster::detail(&conn, "s1-source")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            source_detail.outgoing_reconciliation_links,
+            vec![link.clone()]
+        );
+        assert!(source_detail.incoming_reconciliation_links.is_empty());
+
+        let target_detail = ScriptletEvidenceCluster::detail(&conn, "s1-target")
+            .unwrap()
+            .unwrap();
+        assert!(target_detail.outgoing_reconciliation_links.is_empty());
+        assert_eq!(target_detail.incoming_reconciliation_links, vec![link]);
     }
 
     #[test]

--- a/crates/conary-core/src/db/models/scriptlet_evidence/reconciliation.rs
+++ b/crates/conary-core/src/db/models/scriptlet_evidence/reconciliation.rs
@@ -1,0 +1,117 @@
+// conary-core/src/db/models/scriptlet_evidence/reconciliation.rs
+
+use crate::error::{Error, Result};
+use rusqlite::{Connection, OptionalExtension, Row, params};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScriptletEvidenceClusterReconciliationLink {
+    pub source_cluster_key: String,
+    pub target_cluster_key: String,
+    pub normalization_version: i64,
+    pub migrated_sample_count: i64,
+    pub created_at: String,
+}
+
+impl ScriptletEvidenceClusterReconciliationLink {
+    const COLUMNS: &'static str = "source_cluster_key, target_cluster_key, \
+         normalization_version, migrated_sample_count, created_at";
+
+    pub fn record(
+        conn: &Connection,
+        source_cluster_key: &str,
+        target_cluster_key: &str,
+        normalization_version: i64,
+        migrated_sample_count: i64,
+    ) -> Result<Self> {
+        conn.execute(
+            "INSERT INTO scriptlet_evidence_cluster_reconciliation_links (
+                source_cluster_key, target_cluster_key, normalization_version,
+                migrated_sample_count
+             ) VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT (
+                source_cluster_key, target_cluster_key, normalization_version
+             ) DO UPDATE SET
+                migrated_sample_count = excluded.migrated_sample_count",
+            params![
+                source_cluster_key,
+                target_cluster_key,
+                normalization_version,
+                migrated_sample_count
+            ],
+        )?;
+        Self::find(
+            conn,
+            source_cluster_key,
+            target_cluster_key,
+            normalization_version,
+        )?
+        .ok_or_else(|| {
+            Error::NotFound(format!(
+                "scriptlet evidence reconciliation link {source_cluster_key} -> \
+                 {target_cluster_key} at normalization v{normalization_version}"
+            ))
+        })
+    }
+
+    pub fn list_outgoing(conn: &Connection, cluster_key: &str) -> Result<Vec<Self>> {
+        Self::list_by_column(conn, "source_cluster_key", cluster_key)
+    }
+
+    pub fn list_incoming(conn: &Connection, cluster_key: &str) -> Result<Vec<Self>> {
+        Self::list_by_column(conn, "target_cluster_key", cluster_key)
+    }
+
+    fn find(
+        conn: &Connection,
+        source_cluster_key: &str,
+        target_cluster_key: &str,
+        normalization_version: i64,
+    ) -> Result<Option<Self>> {
+        let sql = format!(
+            "SELECT {} FROM scriptlet_evidence_cluster_reconciliation_links
+             WHERE source_cluster_key = ?1
+               AND target_cluster_key = ?2
+               AND normalization_version = ?3",
+            Self::COLUMNS
+        );
+        conn.query_row(
+            &sql,
+            params![
+                source_cluster_key,
+                target_cluster_key,
+                normalization_version
+            ],
+            Self::from_row,
+        )
+        .optional()
+        .map_err(Into::into)
+    }
+
+    fn list_by_column(conn: &Connection, column: &str, cluster_key: &str) -> Result<Vec<Self>> {
+        debug_assert!(matches!(
+            column,
+            "source_cluster_key" | "target_cluster_key"
+        ));
+        let sql = format!(
+            "SELECT {} FROM scriptlet_evidence_cluster_reconciliation_links
+             WHERE {column} = ?1
+             ORDER BY normalization_version, source_cluster_key, target_cluster_key",
+            Self::COLUMNS
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map([cluster_key], Self::from_row)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+
+    fn from_row(row: &Row<'_>) -> rusqlite::Result<Self> {
+        Ok(Self {
+            source_cluster_key: row.get(0)?,
+            target_cluster_key: row.get(1)?,
+            normalization_version: row.get(2)?,
+            migrated_sample_count: row.get(3)?,
+            created_at: row.get(4)?,
+        })
+    }
+}

--- a/crates/conary-core/src/db/schema.rs
+++ b/crates/conary-core/src/db/schema.rs
@@ -11,7 +11,7 @@ use rusqlite::Connection;
 use tracing::info;
 
 /// Current schema version
-pub const SCHEMA_VERSION: i32 = 78;
+pub const SCHEMA_VERSION: i32 = 79;
 
 /// Initialize the schema version tracking table
 fn init_schema_version(conn: &Connection) -> Result<()> {
@@ -202,6 +202,7 @@ fn apply_migration(conn: &Connection, version: i32) -> Result<()> {
         76 => migrations::migrate_v76(conn),
         77 => migrations::migrate_v77(conn),
         78 => migrations::migrate_v78(conn),
+        79 => migrations::migrate_v79(conn),
         _ => Err(crate::error::Error::InitError(format!(
             "Unknown migration version: {}",
             version
@@ -566,7 +567,7 @@ mod tests {
         migrate(&conn).unwrap();
 
         assert_eq!(get_schema_version(&conn).unwrap(), SCHEMA_VERSION);
-        assert_eq!(SCHEMA_VERSION, 78);
+        assert_eq!(SCHEMA_VERSION, 79);
 
         let columns: Vec<(String, String, bool, Option<String>, i32)> = conn
             .prepare("PRAGMA table_info(try_sessions)")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -93,8 +93,8 @@ crates/conary-core/      Core library crate
     +-- lib.rs           Internal workspace crate surface, not a stable external API
     +-- operations.rs    Shared operation vocabulary across CLI and daemon boundaries
     +-- db/              Database layer
-    |   +-- schema.rs    Schema v78, migration dispatcher
-    |   +-- migrations/  Migration functions grouped into v1_v20.rs, v21_v40.rs, v41_current.rs
+    |   +-- schema.rs    Schema v79, migration dispatcher
+    |   +-- migrations/  Migration functions grouped into v1_v20.rs, v21_v40.rs, v41_current.rs, v79_current.rs
     |   +-- models/      ORM-style model structs
     |   |   +-- try_session.rs M1b package try session state
     +-- transaction/     Composefs-native transaction engine
@@ -476,7 +476,7 @@ itself.
 Supports x86_64, aarch64, and riscv64 targets. Dry-run mode
 (`--dry-run`) validates the full pipeline without building.
 
-## Database Schema (v78)
+## Database Schema (v79)
 
 All runtime state lives in SQLite, and migrations are dispatched from
 `crates/conary-core/src/db/schema.rs`.

--- a/docs/conaryopedia-v2.md
+++ b/docs/conaryopedia-v2.md
@@ -445,7 +445,7 @@ sudo conary system init --profile fedora-44
 Use `--profile ubuntu-26.04` or `--profile arch` on those supported hosts. This
 creates the SQLite database at `/var/lib/conary/conary.db`, configures Remi and
 only the selected profile's native repositories, and sets up all tables
-(currently schema v78). The database is the single source of truth for all
+(currently schema v79). The database is the single source of truth for all
 package state -- there are no configuration files for runtime state. Recovery
 metadata is SQLite-native: first-wave adoption and unadoption paths write
 checkpoint backups under the runtime root, and generation publication writes a

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -65,10 +65,9 @@ triage. Approved system policy paths are preserved only when absolute and free
 of `..` traversal components. Preserving `/etc/apparmor.d/<profile>` changes the
 shape of newly observed scriptlet-evidence samples. The bounded admin backfill
 resumes after its stored converted-package high-water mark and does not rebuild
-existing samples; because observation identity includes the normalization-derived
-cluster key, historical AppArmor clusters may retain the older `<path>` shape.
-Consistent historical rematerialization requires a future explicit, versioned
-rebuild or reconciliation path.
+existing samples. Historical AppArmor observations that retain the older
+`<path>` shape are handled by the explicit versioned reconciliation path
+described below rather than by rewinding the forward-only backfill checkpoint.
 
 ### Scriptlet Evidence Queue
 
@@ -117,6 +116,28 @@ by default. Applied batches retain real command signals and supersede structural
 noise without deleting samples, triage state, state events, private notes, or
 evidence digests. Normal cluster listings omit superseded rows; operators can
 request `include_superseded=true` to inspect their history and disposition.
+
+AppArmor path identity also uses normalization contract v2. Operators inspect
+and reconcile older AppArmor clusters with
+`POST /v1/admin/scriptlet-evidence/reconcile-apparmor`. The admin-only route is
+bounded to at most 5,000 source clusters per call, accepts an ordered
+`after_cluster_key` cursor, and defaults to dry-run. It rematerializes queue
+observations from the unchanged `converted_packages` scriptlet summary, so
+approved traversal-free `/etc/apparmor.d/<profile>` paths become part of the
+current cluster key while unsafe or unavailable source evidence stays active
+and reports an unresolved reason.
+
+Applied AppArmor batches run transactionally. One source observation moves to
+the current target cluster when the key changes; a collapsed historical
+observation can split into multiple current clusters, and multiple historical
+clusters can merge into one target. Schema v79 records every non-identity
+source-to-target relationship and migrated-sample count. Samples are moved or
+rematerialized without retaining a second active historical copy. The
+superseded source keeps its triage state, state events, and private notes, while
+a new target starts at `needs-triage` and an existing target keeps its own
+state. Admin cluster detail exposes incoming and outgoing reconciliation links,
+making conflicting source dispositions inspectable without silently choosing
+one. A repeat apply is a no-op once no unresolved v1 AppArmor clusters remain.
 
 The queue is not publication authority. Moving a cluster to
 `covered-public-ready` records maintainer workflow state only; it does not

--- a/docs/modules/test-fixtures.md
+++ b/docs/modules/test-fixtures.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-07-16
-revision: 11
-summary: Map fixture ownership, including the public versioned v4 QEMU image and SSH identity contract
+last_updated: 2026-07-24
+revision: 12
+summary: Map fixture ownership, including versioned queue reconciliation and the public v4 QEMU image contract
 ---
 
 # Test Fixtures And Proof Maps
@@ -263,17 +263,23 @@ Each fixture family should record:
   `apps/remi/src/server/scriptlet_evidence_queue/classification.rs`;
   `apps/remi/src/server/scriptlet_evidence_queue/aggregation.rs`;
   `apps/remi/src/server/scriptlet_evidence_queue/reconciliation.rs`;
+  `apps/remi/src/server/scriptlet_evidence_queue/reconciliation/apparmor.rs`;
+  `apps/remi/src/server/scriptlet_evidence_queue/reconciliation/apparmor/tests.rs`;
   `apps/remi/src/server/handlers/admin/scriptlet_evidence.rs`.
 - **Consumes:** RPM, DEB, and Arch unknown-command classification; bounded
-  dry-run/apply reconciliation; active versus superseded cluster listings; and
+  unknown-command and AppArmor dry-run/apply reconciliation; AppArmor
+  identity, split, merge, missing-source, and idempotence fixtures; active
+  versus superseded cluster listings; source-to-target link readback; and
   private-history preservation.
 - **Fast proof:** `cargo test -p remi scriptlet_evidence`.
 - **Medium proof:** `cargo test -p remi publication`;
   `cargo test -p conary --test conversion_integration golden_conversion`.
 - **Regeneration:** Hand-maintained summaries and temporary SQLite databases.
 - **Safety notes:** Ambiguous identifiers stay visible. Reconciliation must not
-  delete samples, notes, or state events, and must not mutate
-  `converted_packages.publication_status`.
+  delete unknown-command history, duplicate rematerialized AppArmor
+  observations, discard source notes or state events, or mutate
+  `converted_packages.publication_status`. New target clusters do not inherit
+  conflicting source dispositions implicitly.
 
 ### remi-scriptlet-publication-gate
 

--- a/site/src/routes/about/+page.svelte
+++ b/site/src/routes/about/+page.svelte
@@ -151,7 +151,7 @@
 		<dl class="stack-list">
 			<div><dt>Language</dt><dd>Rust, Edition 2024 · 8-member Cargo workspace</dd></div>
 			<div><dt>Filesystem</dt><dd>EROFS · optional composefs and fs-verity integration for generations</dd></div>
-			<div><dt>Database</dt><dd>SQLite · schema version 78 · DB-first runtime state</dd></div>
+			<div><dt>Database</dt><dd>SQLite · schema version 79 · DB-first runtime state</dd></div>
 			<div><dt>Hashing</dt><dd>SHA-256 · XXH128</dd></div>
 			<div><dt>Compression</dt><dd>Zstd · Gzip · XZ</dd></div>
 			<div><dt>Server</dt><dd>Axum · Tantivy full-text search</dd></div>


### PR DESCRIPTION
## Primary Issue

Refs #49

Design / Plan / Roadmap: `docs/modules/remi.md` queue contract; no separate plan document.

## Problem And Outcome

Historical AppArmor queue observations can retain the older generic `<path>` identity after current sanitization began preserving approved traversal-free `/etc/apparmor.d/<profile>` paths. This PR adds an explicit, versioned, admin-only reconciliation path that reports impact before writes, rematerializes bounded batches from converted-package evidence, and preserves historical maintainer workflow state.

The PR intentionally does not close #49: release, production dry-run/apply, aggregate readback, and durable evidence in #44 remain acceptance criteria.

## Changes

- add normalization contract v2 and schema v79 source-to-target reconciliation links
- add bounded, cursor-resumable, dry-run-by-default AppArmor reconciliation with transactional apply
- preserve source states, state events, notes, sample identity where possible, observed timestamps, and merge/split lineage
- keep unresolved or mismatched source evidence active with explicit reason counts
- expose reconciliation through the admin API, cluster detail, and OpenAPI without leaking raw paths or private notes
- reorganize the oversized scriptlet-evidence admin handler into a focused reconciliation child module
- codify the same-slice ownership-refactor gate for planned behavior additions to source files already over 1,000 lines
- update canonical schema, Remi, fixture-map, and public-site truth

## Scope

- In scope: historical AppArmor queue identity, queue persistence, admin observability, handler ownership, maintainability guidance, and schema/public-doc truth.
- Out of scope: AppArmor publication authority, converted-package publication state, unrelated queue classes, and production apply before this change is released.

## Ownership / Boundary

- Owning subsystem: Remi scriptlet-evidence normalization, admin queue, and reconciliation; conary-core owns generic persistence.
- Boundary changed or preserved: queue identity changes are explicit and versioned; CCS conversion and public-serving authority remain fail-closed and unchanged.
- Persisted state or public surface impact: schema v79 adds reconciliation links; a new admin-only POST route and cluster-detail link fields are documented.
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code
- [x] Updated subsystem docs or maps when the "look here first" path changed
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs

```text
cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test -p remi --no-fail-fast
cargo test -p remi scriptlet_evidence --no-fail-fast
cargo test -p remi publication --no-fail-fast
cargo test -p conary-core --no-fail-fast
cargo test -p conary-core v79_current --no-fail-fast
cargo test -p conary-core support_matrix --no-fail-fast
cargo test -p conary --test conversion_integration golden_conversion --no-fail-fast
bash scripts/check-doc-truth.sh
bash scripts/test-doc-truth.sh
bash scripts/test-agent-context.sh
bash scripts/agent-context.sh --validate
bash scripts/maintainability-drift-report.sh
(cd site && npm run check && npm run build)
git diff --check
```

## Review And Merge Notes

- Review focus: merge/split lineage, identity-row reuse, unresolved fail-closed behavior, transaction boundaries, and absence of publication-state mutation.
- User or developer impact: operators gain a safe dry-run/apply route; contributors gain a hard planning gate against adding new behavior directly to >1,000-line source files.
- Required-check bypass: not used
