### PR TITLE
chore: release remi-v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [remi-v0.7.1] - 2026-07-24
+
+### Other
+- fix(remi): reconcile historical AppArmor evidence (#57)
 ## [remi-v0.7.0] - 2026-07-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4646,7 +4646,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remi"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/apps/remi/Cargo.toml
+++ b/apps/remi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remi"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]


### PR DESCRIPTION
## Primary Issue

Refs #49

Design / Plan / Roadmap: `docs/modules/remi.md` queue reconciliation contract.

## Problem And Outcome

Production needs the AppArmor evidence reconciliation route and schema v79 merged in #57 before historical queue observations can be dry-run, reconciled, and recorded against #44. Remi 0.7.1 is the formal service release for that operational closeout.

This PR intentionally does not close #49. After merge, the canonical tag will be created on the actual merged commit; the tag-driven release and deploy-and-verify workflows must succeed before production reconciliation begins.

## Changes

- bump the Remi-owned version from 0.7.0 to 0.7.1
- refresh the workspace lockfile
- generate the canonical `remi-v0.7.1` changelog entry from #57

## Scope

- In scope: Remi release metadata for the already-merged reconciliation behavior.
- Out of scope: new service behavior, direct production mutation before deployment verification, or closing #49 before reconciliation evidence exists.

## Ownership / Boundary

- Owning subsystem: Remi release track.
- Boundary changed or preserved: release metadata only; the behavior and publication boundary were reviewed in #57.
- Persisted state or public surface impact: publishing and deploying this tag will make schema v79 and the new admin route available in production.
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code
- [x] Updated subsystem docs or maps when the "look here first" path changed
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs

```text
bash scripts/release.sh remi --dry-run
bash scripts/check-release-matrix.sh
bash scripts/test-release-matrix.sh
bash scripts/release-matrix.sh assert-owned-version remi 0.7.1
cargo build -p remi --release
<configured-target-dir>/release/remi --version  # remi 0.7.1
cargo test -p remi --no-fail-fast
cargo clippy --workspace --all-targets -- -D warnings
cargo fmt --check
git diff --check origin/main...HEAD
```

## Review And Merge Notes

- Review focus: the version, lockfile, changelog entry, and absence of unrelated files.
- User or developer impact: enables the tag-driven 0.7.1 artifact publication and production rollout.
- Required-check bypass: not used
