### PR TITLE
security(deps): cover both frontend manifests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directories:
+      - "/site"
+      - "/web"
+    schedule:
+      interval: "weekly"
+    groups:
+      frontend-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+      shared-frontend-versions:
+        group-by: "dependency-name"

--- a/apps/conary-test/src/config/tests.rs
+++ b/apps/conary-test/src/config/tests.rs
@@ -885,5 +885,6 @@ fn active_manifest_live_mutation_commands_acknowledge_mutation_and_protect_lifec
     }
 }
 
+mod dependabot;
 mod manifests;
 mod workflow;

--- a/apps/conary-test/src/config/tests/dependabot.rs
+++ b/apps/conary-test/src/config/tests/dependabot.rs
@@ -1,0 +1,149 @@
+// conary-test/src/config/tests/dependabot.rs
+
+use serde::Deserialize;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug, Deserialize)]
+struct DependabotConfig {
+    version: u8,
+    updates: Vec<DependabotUpdate>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DependabotUpdate {
+    #[serde(rename = "package-ecosystem")]
+    package_ecosystem: String,
+    #[serde(default)]
+    directory: Option<String>,
+    #[serde(default)]
+    directories: Vec<String>,
+    schedule: DependabotSchedule,
+    #[serde(rename = "target-branch", default)]
+    target_branch: Option<String>,
+    #[serde(default)]
+    groups: BTreeMap<String, DependabotGroup>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DependabotSchedule {
+    interval: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DependabotGroup {
+    #[serde(rename = "applies-to", default)]
+    applies_to: Option<String>,
+    #[serde(default)]
+    patterns: Vec<String>,
+    #[serde(rename = "group-by", default)]
+    group_by: Option<String>,
+}
+
+fn repository_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn load_dependabot_config(root: &Path) -> DependabotConfig {
+    let path = root.join(".github/dependabot.yml");
+    let source = std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    serde_yaml::from_str(&source)
+        .unwrap_or_else(|error| panic!("parse {} as typed YAML: {error}", path.display()))
+}
+
+fn top_level_npm_projects(root: &Path) -> BTreeSet<String> {
+    std::fs::read_dir(root)
+        .unwrap_or_else(|error| panic!("read repository root {}: {error}", root.display()))
+        .map(|entry| entry.expect("read repository entry"))
+        .filter(|entry| {
+            entry
+                .file_type()
+                .expect("read repository entry type")
+                .is_dir()
+        })
+        .filter_map(|entry| {
+            let path = entry.path();
+            (path.join("package.json").is_file() && path.join("package-lock.json").is_file()).then(
+                || {
+                    let directory = entry
+                        .file_name()
+                        .into_string()
+                        .expect("npm project directory name must be UTF-8");
+                    format!("/{directory}")
+                },
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn dependabot_npm_policy_covers_every_top_level_project() {
+    let root = repository_root();
+    let config = load_dependabot_config(&root);
+
+    assert_eq!(config.version, 2, "Dependabot config must use version 2");
+
+    let npm_updates = config
+        .updates
+        .iter()
+        .filter(|update| update.package_ecosystem == "npm")
+        .collect::<Vec<_>>();
+    assert_eq!(
+        npm_updates.len(),
+        1,
+        "Dependabot must have exactly one npm update block so cross-directory grouping stays effective"
+    );
+
+    let npm = npm_updates[0];
+    assert_eq!(
+        npm.directory, None,
+        "the npm update block must use `directories`, not a single `directory`"
+    );
+    assert_eq!(
+        npm.directories.iter().cloned().collect::<BTreeSet<_>>(),
+        top_level_npm_projects(&root),
+        "Dependabot npm directories must cover every top-level project with package.json and package-lock.json"
+    );
+    assert_eq!(
+        npm.schedule.interval, "weekly",
+        "routine frontend dependency updates must run weekly"
+    );
+    assert_eq!(
+        npm.target_branch, None,
+        "target-branch disables security updates for the ecosystem and must stay unset"
+    );
+
+    let security_groups = npm
+        .groups
+        .values()
+        .filter(|group| group.applies_to.as_deref() == Some("security-updates"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        security_groups.len(),
+        1,
+        "the npm policy must define exactly one security-update group"
+    );
+    assert!(
+        security_groups[0]
+            .patterns
+            .iter()
+            .any(|pattern| pattern == "*"),
+        "the security-update group must cover every npm dependency"
+    );
+
+    let version_groups = npm
+        .groups
+        .values()
+        .filter(|group| {
+            group.applies_to.as_deref().unwrap_or("version-updates") == "version-updates"
+                && group.group_by.as_deref() == Some("dependency-name")
+        })
+        .count();
+    assert_eq!(
+        version_groups, 1,
+        "routine updates must be grouped by dependency name across npm projects"
+    );
+}

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"devDependencies": {
 				"@sveltejs/adapter-static": "^3.0.8",
-				"@sveltejs/kit": "^2.16.0",
+				"@sveltejs/kit": "^2.70.1",
 				"@sveltejs/vite-plugin-svelte": "^7.1.2",
 				"@types/node": "^20.19.41",
 				"svelte": "^5.0.0",
@@ -448,9 +448,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.65.2",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.65.2.tgz",
-			"integrity": "sha512-ZIkyEmxT1gcq50Opn1ZIIx6vc/yt2zNN0rF5hS6op95gqHtNw8QMKDhjJI+RyjMcbvECRw+FzEeAoBe/MOz9AA==",
+			"version": "2.70.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.70.1.tgz",
+			"integrity": "sha512-nY9SPHGOZro3doud9vZXDBwl9tCZIouuJztjgSHs6PAIrv9M/z5O7eOhPV5xU7CgVHA976Jwu3BA1hIFvXztkA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1046,9 +1046,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.12",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -1099,9 +1099,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.15",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+			"version": "8.5.23",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+			"integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
 			"dev": true,
 			"funding": [
 				{
@@ -1119,7 +1119,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.12",
+				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},

--- a/site/package.json
+++ b/site/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-static": "^3.0.8",
-		"@sveltejs/kit": "^2.16.0",
+		"@sveltejs/kit": "^2.70.1",
 		"@sveltejs/vite-plugin-svelte": "^7.1.2",
 		"@types/node": "^20.19.41",
 		"svelte": "^5.0.0",


### PR DESCRIPTION
## Primary Issue

Closes #77

Design / Plan / Roadmap: not required for this bounded maintenance slice

## Problem And Outcome

Dependabot security PRs #75 and #76 patched `web/`, but the independent `site/` lockfile retained the same vulnerable PostCSS and SvelteKit versions. Because the repository had no tracked Dependabot configuration, both frontend manifest roots and their synchronization policy were not durable repository truth.

After this change, both frontends resolve patched dependencies, Dependabot owns `/site` and `/web` through one npm policy, and a typed regression test prevents a top-level npm project from silently falling outside that policy.

## Changes

- Update `site/` to SvelteKit 2.70.1, PostCSS 8.5.23, and Nanoid 3.3.16.
- Add `.github/dependabot.yml` with weekly npm updates across `/site` and `/web`.
- Group security updates across both directories and group routine version updates by dependency name.
- Add typed YAML coverage in `conary-test` that discovers all top-level npm lockfile roots and enforces the Dependabot ownership and grouping contract.

## Scope

- In scope: frontend npm security remediation, multi-directory Dependabot ownership, and deterministic regression proof.
- Out of scope: automatic merging, non-npm dependency policy, unrelated upgrades, and application behavior changes.

## Ownership / Boundary

- Owning subsystem: repository dependency automation and the `site/` and `web/` static frontend build boundary.
- Boundary changed or preserved: future npm updates are generated across both frontend roots; application runtime behavior remains unchanged.
- Persisted state or public surface impact: no Conary persisted state, schema, package-management API, or runtime service changes; frontend build provenance and future Dependabot PR shape change.
- [x] Checked `docs/modules/feature-ownership.md`; `bash scripts/agent-context.sh --path site/package.json` reports no matching feature card, so the existing frontend and `conary-test` gates own proof.

## Verification

- [x] Listed the exact verification commands run below
- [x] Added a typed regression test for the automation contract
- [x] Ran affected-package verification directly
- [x] No subsystem docs or look-here paths changed
- [x] No feature interaction gate was selected
- [x] Issue #77 contains the complete acceptance boundary

```text
# Red proof before adding .github/dependabot.yml (expected failure: file missing)
cargo test -p conary-test config::tests::dependabot --verbose

# Green proof
cargo test -p conary-test config::tests::dependabot --verbose
npm audit --prefix site --package-lock-only --audit-level=low
npm audit --prefix web --package-lock-only --audit-level=low
bash scripts/check-frontends.sh
cargo fmt --all -- --check
cargo test -p conary-test --quiet
cargo clippy -p conary-test --all-targets -- -D warnings
cargo clippy --workspace --all-targets -- -D warnings
git diff --check
```

Results: both npm audits report zero vulnerabilities; both frontends clean-install, type-check, and build; 344 `conary-test` library tests and 17 CLI tests pass with one existing ignored test; targeted and workspace Clippy are clean.

## Review And Merge Notes

- Review focus: Dependabot multi-directory/group semantics and whether the typed test precisely captures the intended repository invariant.
- User or developer impact: known `site/` dependency alerts are removed, shared frontend dependencies stop drifting between manifests, and newly added top-level npm projects must be added to the canonical Dependabot policy in the same change.
- Required-check bypass: not used