### PR TITLE
fix(test): stabilize host-tool fixtures

### DIFF
--- a/crates/conary-core/src/bootstrap/guest_profile.rs
+++ b/crates/conary-core/src/bootstrap/guest_profile.rs
@@ -207,41 +207,12 @@ d /var/lib/sshd 0700 root root -
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::os::unix::fs::PermissionsExt;
+    use crate::test_support::{HostToolFixture, link_host_tool};
 
     fn write_fake_ssh_keygen(sysroot: &Path) {
         let bin_dir = sysroot.join("usr/bin");
         fs::create_dir_all(&bin_dir).unwrap();
-
-        let script_path = bin_dir.join("ssh-keygen");
-        fs::write(
-            &script_path,
-            r#"#!/usr/bin/env bash
-set -euo pipefail
-
-key_path=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    -f)
-      key_path="$2"
-      shift 2
-      ;;
-    *)
-      shift
-      ;;
-  esac
-done
-
-mkdir -p "$(dirname "$key_path")"
-printf 'fake-private-key\n' > "$key_path"
-printf 'ssh-ed25519 AAAATESTKEY generated-by-test\n' > "$key_path.pub"
-"#,
-        )
-        .unwrap();
-
-        let mut perms = fs::metadata(&script_path).unwrap().permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&script_path, perms).unwrap();
+        link_host_tool(&bin_dir.join("ssh-keygen"), HostToolFixture::SshKeygen);
     }
 
     fn write_fake_sshd_service(sysroot: &Path) {

--- a/crates/conary-core/src/ccs/hooks/capabilities.rs
+++ b/crates/conary-core/src/ccs/hooks/capabilities.rs
@@ -579,29 +579,19 @@ mod tests {
     use super::*;
     use crate::ccs::manifest::Service;
     use crate::ccs::native_lifecycle::SourceFormat;
+    use crate::test_support::{HostToolFixture, link_host_tool};
     use std::fs;
 
     #[cfg(unix)]
     fn fake_interface(directory: &Path, name: &str) -> PathBuf {
-        use std::os::unix::fs::PermissionsExt;
-
         let path = directory.join(name);
-        let version = match name {
-            "systemctl" | "systemd-sysusers" | "systemd-tmpfiles" => "systemd 257",
-            "sysctl" => "sysctl from procps-ng 4.0.6",
-            "ldconfig" => "ldconfig (GNU libc) 2.40",
+        let fixture = match name {
+            "systemctl" | "systemd-sysusers" | "systemd-tmpfiles" => HostToolFixture::Systemd,
+            "sysctl" => HostToolFixture::Sysctl406,
+            "ldconfig" => HostToolFixture::Ldconfig,
             other => panic!("unknown fake interface {other}"),
         };
-        fs::write(
-            &path,
-            format!(
-                "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then printf '%s\\n' '{version}'; fi\nexit 0\n"
-            ),
-        )
-        .unwrap();
-        let mut permissions = fs::metadata(&path).unwrap().permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(&path, permissions).unwrap();
+        link_host_tool(&path, fixture);
         path
     }
 
@@ -736,22 +726,13 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn arch_ldconfig_requires_target_config_and_executable_adapter() {
-        use std::os::unix::fs::PermissionsExt;
-
         let root = tempfile::tempdir().unwrap();
         fs::create_dir_all(root.path().join("etc")).unwrap();
         fs::create_dir_all(root.path().join("sbin")).unwrap();
-        fs::write(
-            root.path().join("sbin/ldconfig"),
-            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'ldconfig (GNU libc) 2.40'; fi\nexit 0\n",
-        )
-        .unwrap();
-
-        let mut permissions = fs::metadata(root.path().join("sbin/ldconfig"))
-            .unwrap()
-            .permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(root.path().join("sbin/ldconfig"), permissions).unwrap();
+        link_host_tool(
+            &root.path().join("sbin/ldconfig"),
+            HostToolFixture::Ldconfig,
+        );
         let inventory = HostCapabilityInventory {
             ldconfig: Some(
                 ExecutableInterface::probe_ldconfig_in_root(

--- a/crates/conary-core/src/ccs/hooks/capabilities/interface_contract.rs
+++ b/crates/conary-core/src/ccs/hooks/capabilities/interface_contract.rs
@@ -404,40 +404,31 @@ fn executable_is_runnable(path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::{HostToolFixture, link_host_tool};
     use std::fs;
 
     #[cfg(unix)]
-    fn executable_script(body: &str) -> (tempfile::TempDir, PathBuf) {
-        use std::os::unix::fs::PermissionsExt;
-
+    fn executable_fixture(fixture: HostToolFixture) -> (tempfile::TempDir, PathBuf) {
         let directory = tempfile::tempdir().unwrap();
         let executable = directory.path().join("tool");
-        fs::write(&executable, body).unwrap();
-        let mut permissions = fs::metadata(&executable).unwrap().permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(&executable, permissions).unwrap();
+        link_host_tool(&executable, fixture);
         (directory, executable)
     }
 
     #[cfg(unix)]
     #[test]
     fn same_name_success_exit_is_not_an_interface_descriptor() {
-        let (_directory, executable) = executable_script("#!/bin/sh\nexit 0\n");
+        let (_directory, executable) = executable_fixture(HostToolFixture::ExitSuccess);
         assert!(ExecutableInterface::probe_systemctl(executable).is_none());
     }
 
     #[cfg(unix)]
     #[test]
     fn descriptor_revalidation_detects_executable_replacement() {
-        let (_directory, executable) = executable_script(
-            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'sysctl from procps-ng 4.0.6'; fi\nexit 0\n",
-        );
+        let (_directory, executable) = executable_fixture(HostToolFixture::Sysctl406);
         let descriptor = ExecutableInterface::probe_sysctl(executable.clone()).unwrap();
-        fs::write(
-            &executable,
-            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'sysctl from procps-ng 4.0.7'; fi\nexit 0\n",
-        )
-        .unwrap();
+        fs::remove_file(&executable).unwrap();
+        link_host_tool(&executable, HostToolFixture::Sysctl407);
 
         assert!(!descriptor.is_available());
     }
@@ -445,23 +436,14 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn descriptor_preserves_and_revalidates_the_selected_symlink_path() {
-        use std::os::unix::fs::{PermissionsExt, symlink};
+        use std::os::unix::fs::symlink;
 
         let directory = tempfile::tempdir().unwrap();
         let first = directory.path().join("first");
         let second = directory.path().join("second");
         let selected = directory.path().join("sysctl");
-        let body = |version: &str| {
-            format!(
-                "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'sysctl from procps-ng {version}'; fi\nexit 0\n"
-            )
-        };
-        for (path, version) in [(&first, "4.0.6"), (&second, "4.0.7")] {
-            fs::write(path, body(version)).unwrap();
-            let mut permissions = fs::metadata(path).unwrap().permissions();
-            permissions.set_mode(0o755);
-            fs::set_permissions(path, permissions).unwrap();
-        }
+        link_host_tool(&first, HostToolFixture::Sysctl406);
+        link_host_tool(&second, HostToolFixture::Sysctl407);
         symlink(&first, &selected).unwrap();
 
         let descriptor = ExecutableInterface::probe_sysctl(selected.clone()).unwrap();
@@ -475,7 +457,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn interface_probe_has_a_hard_timeout() {
-        let (_directory, executable) = executable_script("#!/bin/sh\nsleep 30 &\nwait\n");
+        let (_directory, executable) = executable_fixture(HostToolFixture::Timeout);
         assert!(
             run_probe_with_timeout(
                 &executable,

--- a/crates/conary-core/src/ccs/hooks/systemd.rs
+++ b/crates/conary-core/src/ccs/hooks/systemd.rs
@@ -143,26 +143,15 @@ mod tests {
     use super::*;
     use crate::ccs::hooks::{HostCapabilityInventory, InitSystemCapability, SystemdInterface};
     use crate::ccs::manifest::{Hooks, Service, SystemdHook};
+    use crate::test_support::{HostToolFixture, SYSTEMCTL_CAPTURE_PATH, link_host_tool};
     use std::fs;
     use std::path::Path;
     use tempfile::TempDir;
 
     #[cfg(unix)]
-    fn executor_with_recording_systemctl(root: &Path, log: &Path) -> HookExecutor {
-        use std::os::unix::fs::PermissionsExt;
-
-        let executable = log.parent().unwrap().join("systemctl");
-        fs::write(
-            &executable,
-            format!(
-                "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'systemd 257'; exit 0; fi\nprintf '%s\\n' \"$*\" >> '{}'\n",
-                log.display()
-            ),
-        )
-        .unwrap();
-        let mut permissions = fs::metadata(&executable).unwrap().permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(&executable, permissions).unwrap();
+    fn executor_with_recording_systemctl(root: &Path, tools: &Path) -> HookExecutor {
+        let executable = tools.join("systemctl");
+        link_host_tool(&executable, HostToolFixture::Systemd);
         let capabilities = HostCapabilityInventory {
             init_system: InitSystemCapability::Systemd,
             systemd: Some(SystemdInterface::probe(executable, true).unwrap()),
@@ -176,8 +165,8 @@ mod tests {
     fn target_enable_and_disable_use_systemctl_root_contract() {
         let target = TempDir::new().unwrap();
         let tools = TempDir::new().unwrap();
-        let log = tools.path().join("calls");
-        let executor = executor_with_recording_systemctl(target.path(), &log);
+        let log = target.path().join(SYSTEMCTL_CAPTURE_PATH);
+        let executor = executor_with_recording_systemctl(target.path(), tools.path());
 
         executor
             .systemd_set_enabled("portable.service", true)
@@ -202,9 +191,8 @@ mod tests {
     fn post_hooks_execute_generic_services_and_false_means_disable() {
         let target = TempDir::new().unwrap();
         let tools = TempDir::new().unwrap();
-        let log = tools.path().join("calls");
-        let executor = executor_with_recording_systemctl(target.path(), &log);
-        fs::remove_file(&log).unwrap();
+        let log = target.path().join(SYSTEMCTL_CAPTURE_PATH);
+        let executor = executor_with_recording_systemctl(target.path(), tools.path());
         let mut hooks = Hooks::default();
         hooks.systemd.push(SystemdHook {
             unit: "disabled.service".to_string(),
@@ -237,9 +225,8 @@ mod tests {
     fn runtime_service_action_becomes_activation_intent_without_target_systemctl_call() {
         let target = TempDir::new().unwrap();
         let tools = TempDir::new().unwrap();
-        let log = tools.path().join("calls");
-        let executor = executor_with_recording_systemctl(target.path(), &log);
-        fs::remove_file(&log).unwrap();
+        let log = target.path().join(SYSTEMCTL_CAPTURE_PATH);
+        let executor = executor_with_recording_systemctl(target.path(), tools.path());
         let mut hooks = Hooks::default();
         hooks.services.push(Service {
             name: "api.service".to_string(),
@@ -250,9 +237,8 @@ mod tests {
         let results = executor.execute_post_hooks_with_results(&hooks);
 
         assert!(results.all_succeeded());
-        let calls = fs::read_to_string(&log).unwrap();
         assert!(
-            !calls.contains("reload-or-try-restart api.service"),
+            !log.exists(),
             "runtime action signaled selected-root systemctl"
         );
         let intents = executor.take_activation_invocations();

--- a/crates/conary-core/src/ccs/hooks/tmpfiles.rs
+++ b/crates/conary-core/src/ccs/hooks/tmpfiles.rs
@@ -292,22 +292,11 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn selected_root_persists_and_executes_the_typed_tmpfiles_interface() {
-        use std::os::unix::fs::PermissionsExt;
+        use crate::test_support::{HostToolFixture, TMPFILES_CAPTURE_PATH, link_host_tool};
 
         let directory = tempfile::tempdir().unwrap();
         let executable = directory.path().join("systemd-tmpfiles");
-        let captured = directory.path().join("captured.conf");
-        fs::write(
-            &executable,
-            format!(
-                "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'systemd 257'; exit 0; fi\nif [ \"$1\" = \"--dry-run\" ]; then cat >/dev/null; exit 0; fi\ncase \"$1\" in --root=*) root=${{1#--root=}} ;; *) exit 2 ;; esac\n[ \"$2\" = \"--create\" ] || exit 2\ncp \"$root$3\" '{}'\n",
-                captured.display()
-            ),
-        )
-        .unwrap();
-        let mut permissions = fs::metadata(&executable).unwrap().permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(&executable, permissions).unwrap();
+        link_host_tool(&executable, HostToolFixture::Systemd);
 
         let capabilities = HostCapabilityInventory {
             tmpfiles: Some(TmpfilesInterface::probe(executable).unwrap()),
@@ -323,7 +312,7 @@ mod tests {
         executor.apply_tmpfile(&entry).unwrap();
 
         assert_eq!(
-            fs::read_to_string(captured).unwrap(),
+            fs::read_to_string(target.path().join(TMPFILES_CAPTURE_PATH)).unwrap(),
             render_tmpfiles_entry(&entry).unwrap()
         );
         let config_path = target.path().join(format!(

--- a/crates/conary-core/src/lib.rs
+++ b/crates/conary-core/src/lib.rs
@@ -54,6 +54,9 @@ pub mod trust;
 pub mod util;
 pub mod version;
 
+#[cfg(test)]
+mod test_support;
+
 pub use automation::{AiSuggestion, AutomationManager, AutomationSummary, PendingAction};
 pub use bootstrap::{
     Bootstrap, BootstrapConfig, BootstrapStage, Prerequisites, StageManager, TargetArch, Toolchain,

--- a/crates/conary-core/src/test_support.rs
+++ b/crates/conary-core/src/test_support.rs
@@ -1,0 +1,70 @@
+// crates/conary-core/src/test_support.rs
+
+#[cfg(unix)]
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum HostToolFixture {
+    ExitSuccess,
+    Ldconfig,
+    SshKeygen,
+    Sysctl406,
+    Sysctl407,
+    Systemd,
+    Timeout,
+}
+
+#[cfg(unix)]
+impl HostToolFixture {
+    fn filename(self) -> &'static str {
+        match self {
+            Self::ExitSuccess => "exit-success",
+            Self::Ldconfig => "ldconfig",
+            Self::SshKeygen => "ssh-keygen",
+            Self::Sysctl406 => "sysctl-4.0.6",
+            Self::Sysctl407 => "sysctl-4.0.7",
+            Self::Systemd => "systemd",
+            Self::Timeout => "timeout",
+        }
+    }
+}
+
+#[cfg(unix)]
+fn host_tool_source(fixture: HostToolFixture) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/host-tools")
+        .join(fixture.filename())
+}
+
+/// Link a test-owned command path to a stable checked-in executable.
+///
+/// Tests may create per-case symlinks and data files, but they must not write
+/// the executable inode immediately before production code launches it.
+#[cfg(unix)]
+pub(crate) fn link_host_tool(path: &Path, fixture: HostToolFixture) {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    let source = host_tool_source(fixture);
+    let metadata = source
+        .metadata()
+        .unwrap_or_else(|error| panic!("stat host-tool fixture {}: {error}", source.display()));
+    assert!(
+        metadata.is_file() && metadata.permissions().mode() & 0o111 != 0,
+        "host-tool fixture must be a checked-in executable file: {}",
+        source.display()
+    );
+    symlink(&source, path).unwrap_or_else(|error| {
+        panic!(
+            "link host-tool fixture {} at {}: {error}",
+            source.display(),
+            path.display()
+        )
+    });
+}
+
+#[cfg(unix)]
+pub(crate) const SYSTEMCTL_CAPTURE_PATH: &str = "var/lib/conary-test/systemctl-calls";
+
+#[cfg(unix)]
+pub(crate) const TMPFILES_CAPTURE_PATH: &str = "var/lib/conary-test/systemd-tmpfiles-captured.conf";

--- a/crates/conary-core/tests/fixtures/host-tools/exit-success
+++ b/crates/conary-core/tests/fixtures/host-tools/exit-success
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/crates/conary-core/tests/fixtures/host-tools/ldconfig
+++ b/crates/conary-core/tests/fixtures/host-tools/ldconfig
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+if [ "${1-}" = "--version" ]; then
+    printf 'ldconfig (GNU libc) 2.40\n'
+fi

--- a/crates/conary-core/tests/fixtures/host-tools/ssh-keygen
+++ b/crates/conary-core/tests/fixtures/host-tools/ssh-keygen
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -eu
+
+key_path=
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -f)
+            key_path=$2
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+mkdir -p "$(dirname "$key_path")"
+printf 'fake-private-key\n' > "$key_path"
+printf 'ssh-ed25519 AAAATESTKEY generated-by-test\n' > "$key_path.pub"

--- a/crates/conary-core/tests/fixtures/host-tools/sysctl-4.0.6
+++ b/crates/conary-core/tests/fixtures/host-tools/sysctl-4.0.6
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+if [ "${1-}" = "--version" ]; then
+    printf 'sysctl from procps-ng 4.0.6\n'
+fi

--- a/crates/conary-core/tests/fixtures/host-tools/sysctl-4.0.7
+++ b/crates/conary-core/tests/fixtures/host-tools/sysctl-4.0.7
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+if [ "${1-}" = "--version" ]; then
+    printf 'sysctl from procps-ng 4.0.7\n'
+fi

--- a/crates/conary-core/tests/fixtures/host-tools/systemd
+++ b/crates/conary-core/tests/fixtures/host-tools/systemd
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -eu
+
+case "${1-}" in
+    --version)
+        printf 'systemd 257\n'
+        exit 0
+        ;;
+    show)
+        printf '257\n'
+        exit 0
+        ;;
+    --dry-run)
+        cat >/dev/null
+        exit 0
+        ;;
+    --root=*)
+        root=${1#--root=}
+        if [ "$root" = "/" ]; then
+            exit 0
+        fi
+
+        capture_dir="$root/var/lib/conary-test"
+        mkdir -p "$capture_dir"
+        if [ "${2-}" = "--create" ]; then
+            cp "$root$3" "$capture_dir/systemd-tmpfiles-captured.conf"
+        else
+            printf '%s\n' "$*" >> "$capture_dir/systemctl-calls"
+        fi
+        exit 0
+        ;;
+esac
+
+exit 0

--- a/crates/conary-core/tests/fixtures/host-tools/timeout
+++ b/crates/conary-core/tests/fixtures/host-tools/timeout
@@ -1,0 +1,3 @@
+#!/bin/sh
+sleep 30 &
+wait

--- a/docs/modules/test-fixtures.md
+++ b/docs/modules/test-fixtures.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-07-26
-revision: 21
+revision: 22
 summary: Map fixture ownership, including the selected-generation cross-source lifecycle matrix and public v4 QEMU image contract
 ---
 
@@ -34,6 +34,7 @@ Each fixture family should record:
 | Family ID | Owner | Fast proof |
 |-----------|-------|------------|
 | `foreign-package-lifecycle-contracts` | Source parsers, CCS lifecycle bundle, and transaction planner | `cargo test -p conary-core native_abi`; `cargo test -p conary-core native_lifecycle`; `cargo test -p conary-core native_transaction` |
+| `host-executable-interface-fixtures` | Core test support and checked-in host tools | `cargo test -p conary-core bootstrap::guest_profile::tests`; `cargo test -p conary-core ccs::hooks` |
 | `ccs-v2-native-authority-fixtures` | CCS v2 native authority | `cargo test -p conary-core ccs::v2`; `cargo test -p conary --test packaging_m4a` |
 | `ccs-v2-local-authoring-smoke` | CCS v2 local authoring | `cargo test -p conary --test packaging_m4b` |
 | `ccs-v2-lifecycle-authoring-proof` | CCS v2 lifecycle authoring | `cargo test -p conary --test packaging_m4e`; `cargo test -p conary-core ccs::v2` |
@@ -75,6 +76,38 @@ Each fixture family should record:
   fixture, but neither is expected-output authority. A fixture for an
   missing executable semantic must assert a typed preflight failure before
   payload or database mutation and remain required implementation work.
+
+### host-executable-interface-fixtures
+
+- **Owner:** typed linker and fixture catalog:
+  `crates/conary-core/src/test_support.rs`; stable executable sources:
+  `crates/conary-core/tests/fixtures/host-tools/`.
+- **Purpose:** Exercise guest-profile key generation and the exact systemd,
+  sysusers, tmpfiles, sysctl, and ldconfig executable-interface contracts
+  without writing an executable inode immediately before production code
+  launches it.
+- **Fixture sources:** checked-in executable shell fixtures selected through
+  `HostToolFixture`; each test creates only a per-case symlink and ordinary
+  target-root output. The systemd fixture records systemctl argv under
+  `var/lib/conary-test/systemctl-calls` and copies the selected tmpfiles
+  declaration to
+  `var/lib/conary-test/systemd-tmpfiles-captured.conf`.
+- **Consumes:** `bootstrap::guest_profile::tests`;
+  `ccs::hooks::capabilities::tests`;
+  `ccs::hooks::capabilities::interface_contract::tests`;
+  `ccs::hooks::systemd::tests`; and `ccs::hooks::tmpfiles::tests`.
+- **Fast proof:** `cargo test -p conary-core
+  bootstrap::guest_profile::tests`; `cargo test -p conary-core ccs::hooks`.
+- **Medium proof:** `cargo test -p conary-core --lib`.
+- **Slow proof:** the pull-request `workspace-tests` job under parallel hosted
+  CI.
+- **Regeneration:** hand-maintained, typed fixture selection. Add a distinct
+  checked-in executable when behavior or executable identity must differ; do
+  not generate executable shell files during the consuming test.
+- **Safety notes:** These files are test-only host command doubles. They do not
+  define production capability support, weaken executable digest/version/path
+  revalidation, or authorize host mutation. Do not replace this boundary with
+  retries, sleeps, test serialization, or error-string exceptions.
 
 ### ccs-v2-native-authority-fixtures
 


### PR DESCRIPTION
## Primary Issue

Closes #79

Design / Plan / Roadmap: not required for this bounded test-infrastructure fix

## Problem And Outcome

PR #78's unchanged head failed `workspace-tests` twice in different `conary-core` tests. The first attempt hit Linux `ETXTBSY` while launching a freshly written fake `ssh-keygen`; the second returned `None` while probing a freshly written fake `systemd-tmpfiles`. In both cases, 2,996 sibling tests passed. Re-running CI merely selected a different temporary executable fixture to fail.

After this change, the bootstrap and CCS host-interface tests link per-case command paths to typed, checked-in executable fixtures. Tests still exercise the real executable probe, digest/version/path revalidation, command grammar, and target-root behavior, but no longer write the executable inode immediately before launching it.

## Changes

- Add a typed `HostToolFixture` catalog and one symlink-only test helper.
- Add checked-in executable fixtures for systemd, sysctl 4.0.6/4.0.7, ldconfig, ssh-keygen, success-only, and timeout behavior.
- Convert guest-profile and all neighboring CCS host-interface fixture sites from generated executable scripts to the stable boundary.
- Preserve systemctl argv and tmpfiles content assertions through target-root capture files.
- Register the new `host-executable-interface-fixtures` family in the canonical fixture ownership map.

## Scope

- In scope: bootstrap guest-profile and CCS host-interface test fixtures that wrote and immediately launched temporary executables.
- Out of scope: production probing behavior, retries/sleeps/serialization, unrelated scriptlet or generation fixtures, persisted schemas, and application behavior.

## Ownership / Boundary

- Owning subsystem: `conary-core` test support plus bootstrap guest-profile and CCS typed host-capability proof.
- Boundary changed or preserved: fixture creation now owns only a symlink to stable executable bytes; production executable identity and invocation contracts are preserved.
- Persisted state or public surface impact: none. The only new filesystem outputs are test-root captures under `var/lib/conary-test/`.
- [x] Checked `docs/modules/feature-ownership.md`; `bash scripts/agent-context.sh --path crates/conary-core/src/ccs/hooks/tmpfiles.rs` routed to the CCS card.

## Verification

- [x] Listed the exact verification commands run below
- [x] Updated the fixture construction and retained focused behavior assertions
- [x] Ran affected-package verification directly
- [x] Updated `docs/modules/test-fixtures.md` for the new owner path
- [x] No lifecycle/publication interaction gate was required because production and lifecycle behavior did not change
- [x] Issue #79 contains the complete acceptance boundary

```text
cargo test -p conary-core bootstrap::guest_profile::tests
cargo test -p conary-core ccs::hooks

# Each observed failure site: 64 repetitions at eight-way concurrency
seq 1 64 | xargs -P8 -I{} cargo test -p conary-core bootstrap::guest_profile::tests::guest_profile_owns_test_posture_sshd_config --quiet -- --exact
seq 1 64 | xargs -P8 -I{} cargo test -p conary-core ccs::hooks::tmpfiles::tests::selected_root_persists_and_executes_the_typed_tmpfiles_interface --quiet -- --exact

# Two consecutive complete library runs
cargo test -p conary-core --lib --quiet
cargo test -p conary-core --lib --quiet

cargo fmt --all -- --check
cargo clippy -p conary-core --all-targets -- -D warnings
bash -n crates/conary-core/tests/fixtures/host-tools/*
bash scripts/check-doc-truth.sh
bash scripts/test-doc-truth.sh
bash scripts/test-agent-context.sh
bash scripts/agent-context.sh --validate
git diff --check
```

Results: 5 guest-profile tests and 48 CCS hook tests pass; both observed failure sites pass all 64 concurrent repetitions; both full library runs pass 2,997 active tests with two existing ignored tests; Clippy, formatting, shell syntax, doc truth, agent-context tests, all 15 ownership cards, and diff checks pass.

## Review And Merge Notes

- Review focus: stable executable ownership, symlink-following digest/version/path proof, and exact systemctl/tmpfiles target-root capture behavior.
- User or developer impact: removes nondeterministic parallel-CI failures without retries, sleeps, or weakened assertions.
- Required-check bypass: not used

Triggering evidence: https://github.com/ConaryLabs/Conary/actions/runs/30202936679
Dependency-only PR blocked by this foundation issue: #78