### PR TITLE
chore(release): prepare post-hard-cut suite

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,7 +20,7 @@ body:
     attributes:
       label: Conary version
       description: Paste the output of `conary --version`.
-      placeholder: conary 0.12.0
+      placeholder: conary 0.13.0
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/pre_alpha_feedback.md
+++ b/.github/ISSUE_TEMPLATE/pre_alpha_feedback.md
@@ -32,7 +32,7 @@ Fill this in if you ran the tester loop from the preview post.
 - **Kernel version**: (output of `uname -r`)
 - **Architecture**: (output of `uname -m`)
 - **Conary version or commit**: (output of `conary --version` or commit SHA)
-- **Release tag and package**: (for example, `v0.12.0` and the exact RPM/DEB/Arch package name)
+- **Release tag and package**: (for example, `v0.13.0` and the exact RPM/DEB/Arch package name)
 - **Package checksum verified**: yes/no
 - **VM/snapshot/non-critical host**: yes/no
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,91 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [v0.13.0] - 2026-07-26
+
+### Added
+- Preserve exact RPM, Debian/dpkg, and Arch/ALPM dependency, payload,
+  configuration, helper, trigger, activation, boot, and security authority
+  through conversion and selected-root transactions.
+- Prove every RPM, DEB, and Arch source-format lifecycle across Fedora 44,
+  Ubuntu 26.04, and Arch targets without source package-manager runtime
+  fallback.
+- Add read-only single-package adoption preview and typed canonical mapping
+  exchange.
+
+### Changed
+- Hard-cut the database to the current schema epoch and replace migration,
+  legacy replay, compatibility aliases, bypasses, and review-queue authority
+  with current typed contracts.
+- Replace syscall and string guessing with the stable
+  `scriptlet-boundary-v2` selected-root isolation contract.
+- Decompose large source hubs into focused ownership modules and reconcile
+  assistant-facing documentation and routing.
+
+### Fixed
+- Preserve exact Debian configure identity, target shell ABI,
+  rollback/generation root domains, and stable host-tool test fixtures.
+- Patch both frontend dependency roots and enforce complete Dependabot
+  ownership.
+
+### Security
+- Stream and bound package, payload, and CAS verification; deny semantic
+  host-control and escape classes; and retain fail-closed source trust and
+  target capability validation.
+
+## [remi-v0.8.0] - 2026-07-26
+
+### Added
+- Add exact repository manifests, canonical map exchange, current native
+  publication/conversion storage, and recoverable deployment inspection and
+  repopulation proof.
+
+### Changed
+- Retire the old schema epoch, scriptlet-evidence queue,
+  reconciliation/review routes, heuristic publication gates, and
+  compatibility paths.
+- Make deployment snapshot or retire the prior database, reconcile all
+  configured sources, prewarm conversions for every public profile, and roll
+  back configuration, source, and database state together on failure.
+
+### Security
+- Require typed source parser and trust configuration, bounded streaming
+  storage, exact signed CCS bytes, and fail-closed public serving.
+
+## [conaryd-v0.7.0] - 2026-07-26
+
+### Added
+- Execute package jobs through current Conary CLI contracts and expose
+  risk-tiered mutation intent.
+
+### Changed
+- Adopt the current schema epoch, exact lifecycle authority, focused daemon
+  route ownership, and current package transaction contracts.
+
+### Security
+- Preserve fail-closed daemon write authorization and live-mutation
+  acknowledgement boundaries.
+
+## [conary-test-v0.9.0] - 2026-07-26
+
+### Added
+- Add the Fedora 44, Ubuntu 26.04, and Arch Cartesian cross-source lifecycle
+  matrix with source package-manager executables masked during converted
+  runtime.
+- Add stateless MCP discovery and resources, bootstrap inspection and smoke
+  paths, typed workflow and dependency policy tests, and exact fixture
+  ownership.
+
+### Changed
+- Decompose large harness, configuration, runner, and service test hubs and
+  move `conary-test`, `conary-mcp`, and `conary-agent-contract` onto one owned
+  release version.
+- Stabilize executable host-tool fixtures for parallel CI.
+
+### Security
+- Keep agent operations typed and evidence-bearing, preserve redaction
+  metadata, and reject malformed stateless MCP requests.
+
 ## [remi-v0.7.1] - 2026-07-24
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,7 +994,7 @@ checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "conary"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "conary-agent-contract"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "schemars 1.2.1",
  "serde",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "conary-bootstrap"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "tokio",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "conary-core"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "alpm-types",
  "anyhow",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "conary-mcp"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "conary-agent-contract",
  "rmcp",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "conary-test"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "conaryd"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4857,7 +4857,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remi"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Merge validation](https://github.com/ConaryLabs/Conary/actions/workflows/merge-validation.yml/badge.svg?branch=main)](https://github.com/ConaryLabs/Conary/actions/workflows/merge-validation.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![v0.12.0](https://img.shields.io/badge/version-0.12.0-orange.svg)](CHANGELOG.md)
+[![v0.13.0](https://img.shields.io/badge/version-0.13.0-orange.svg)](CHANGELOG.md)
 
 **Website:** [conary.io](https://conary.io) | **Packages:** [remi.conary.io](https://remi.conary.io) | **Discussions:** [GitHub Discussions](https://github.com/ConaryLabs/Conary/discussions)
 
@@ -53,7 +53,7 @@ attach only a reviewed support bundle.
 ## Try It
 
 Download the pinned preview release from
-[v0.12.0](https://github.com/ConaryLabs/Conary/releases/tag/v0.12.0) after its
+[v0.13.0](https://github.com/ConaryLabs/Conary/releases/tag/v0.13.0) after its
 release page publishes `SHA256SUMS`, verify the package checksum, and install it
 only on a VM or non-critical host. Release artifact expectations are tracked in
 [docs/operations/release-artifact-matrix.md](docs/operations/release-artifact-matrix.md).

--- a/apps/conary-test/Cargo.toml
+++ b/apps/conary-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conary-test"
-version = "0.8.0"
+version = "0.9.0"
 # Canonical release track: conary-test-v*
 edition = "2024"
 rust-version = "1.96"

--- a/apps/conary/Cargo.toml
+++ b/apps/conary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conary"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]

--- a/apps/conary/man/conary.1
+++ b/apps/conary/man/conary.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH conary 1  "conary 0.12.0"
+.TH conary 1  "conary 0.13.0"
 .SH NAME
 conary \- Early\-preview Linux package manager with native\-package adoption
 .SH SYNOPSIS
@@ -81,6 +81,6 @@ Daily workflow examples:
 
 Advanced packaging and platform commands: run \*(Aqconary \-\-help\-advanced\*(Aq
 .SH VERSION
-v0.12.0
+v0.13.0
 .SH AUTHORS
 Conary Project

--- a/apps/conaryd/Cargo.toml
+++ b/apps/conaryd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conaryd"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]

--- a/apps/remi/Cargo.toml
+++ b/apps/remi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remi"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]

--- a/crates/conary-agent-contract/Cargo.toml
+++ b/crates/conary-agent-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conary-agent-contract"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]

--- a/crates/conary-bootstrap/Cargo.toml
+++ b/crates/conary-bootstrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conary-bootstrap"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]

--- a/crates/conary-core/Cargo.toml
+++ b/crates/conary-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conary-core"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]

--- a/crates/conary-mcp/Cargo.toml
+++ b/crates/conary-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conary-mcp"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]

--- a/docs/guides/agent-assisted-tester-loop.md
+++ b/docs/guides/agent-assisted-tester-loop.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-07-25
-revision: 11
-summary: Pin the agent-supervised cross-distro package tester loop to v0.12.0
+last_updated: 2026-07-26
+revision: 12
+summary: Pin the agent-supervised cross-distro package tester loop to v0.13.0
 ---
 
 # Agent-Assisted Tester Loop
@@ -14,7 +14,7 @@ stays responsible for approving every command that mutates system state.
 Use a disposable VM, a snapshot, or a non-critical host. Do not run this loop
 first on an irreplaceable daily driver.
 
-This guide is pinned to `v0.12.0`. Do not begin the loop unless that release
+This guide is pinned to `v0.13.0`. Do not begin the loop unless that release
 page publishes the package for this host plus `SHA256SUMS`, and do not continue
 when the downloaded package fails checksum verification.
 
@@ -26,19 +26,19 @@ Paste this into the agent running inside the VM or snapshot:
 I want you to help me run the Conary first external tester loop on this host.
 
 Read this guide first:
-https://github.com/ConaryLabs/Conary/blob/v0.12.0/docs/guides/agent-assisted-tester-loop.md
+https://github.com/ConaryLabs/Conary/blob/v0.13.0/docs/guides/agent-assisted-tester-loop.md
 
 Goal: install, inspect, update-preview, and remove a package whose source
 format differs from this host's native package format with pinned Conary
-v0.12.0, then draft a pre-alpha tester feedback issue. You are testing the user-facing
+v0.13.0, then draft a pre-alpha tester feedback issue. You are testing the user-facing
 cross-distro package-manager flow, not developing Conary itself.
 
 Safety rules:
 - Stop immediately if this is not a VM, snapshot, or explicitly non-critical
   host.
 - Confirm distro, architecture, kernel, and sudo before installing anything.
-- Use only the pinned v0.12.0 release from
-  https://github.com/ConaryLabs/Conary/releases/tag/v0.12.0 and confirm its
+- Use only the pinned v0.13.0 release from
+  https://github.com/ConaryLabs/Conary/releases/tag/v0.13.0 and confirm its
   release page provides the package for this host plus SHA256SUMS.
 - Verify SHA256SUMS for every downloaded artifact before installation.
 - Run dry-run commands before live commands when the loop provides both.
@@ -64,7 +64,7 @@ Stop and do not install Conary if any of these are true:
 - the host is not Fedora 44, Ubuntu 26.04 LTS, or Arch Linux;
 - the host is not `x86_64`;
 - `sudo -v` fails;
-- the pinned `v0.12.0` release page does not provide the package for this host
+- the pinned `v0.13.0` release page does not provide the package for this host
   plus `SHA256SUMS`;
 - downloaded artifact checksums do not match `SHA256SUMS`;
 - the agent or human cannot explain what a live mutation command is about to
@@ -100,45 +100,45 @@ support. Those only matter for generation-model features outside this test.
 Create a clean work directory:
 
 ```bash
-mkdir -p "$HOME/conary-preview-v0.12.0"
-cd "$HOME/conary-preview-v0.12.0"
+mkdir -p "$HOME/conary-preview-v0.13.0"
+cd "$HOME/conary-preview-v0.13.0"
 ```
 
 Download `SHA256SUMS` and the package for the current distro from:
 
 ```text
-https://github.com/ConaryLabs/Conary/releases/tag/v0.12.0
+https://github.com/ConaryLabs/Conary/releases/tag/v0.13.0
 ```
 
 Use exactly one package. Fedora 44:
 
 ```bash
-base="https://github.com/ConaryLabs/Conary/releases/download/v0.12.0"
+base="https://github.com/ConaryLabs/Conary/releases/download/v0.13.0"
 curl -fLO "$base/SHA256SUMS"
-curl -fLO "$base/conary-0.12.0-1.fc44.x86_64.rpm"
+curl -fLO "$base/conary-0.13.0-1.fc44.x86_64.rpm"
 ```
 
 Ubuntu 26.04 LTS:
 
 ```bash
-base="https://github.com/ConaryLabs/Conary/releases/download/v0.12.0"
+base="https://github.com/ConaryLabs/Conary/releases/download/v0.13.0"
 curl -fLO "$base/SHA256SUMS"
-curl -fLO "$base/conary_0.12.0-1_amd64.deb"
+curl -fLO "$base/conary_0.13.0-1_amd64.deb"
 ```
 
 Arch Linux:
 
 ```bash
-base="https://github.com/ConaryLabs/Conary/releases/download/v0.12.0"
+base="https://github.com/ConaryLabs/Conary/releases/download/v0.13.0"
 curl -fLO "$base/SHA256SUMS"
-curl -fLO "$base/conary-0.12.0-1-x86_64.pkg.tar.zst"
+curl -fLO "$base/conary-0.13.0-1-x86_64.pkg.tar.zst"
 ```
 
 Downloaded package names:
 
-- Fedora 44: `conary-0.12.0-1.fc44.x86_64.rpm`
-- Ubuntu 26.04 LTS: `conary_0.12.0-1_amd64.deb`
-- Arch Linux: `conary-0.12.0-1-x86_64.pkg.tar.zst`
+- Fedora 44: `conary-0.13.0-1.fc44.x86_64.rpm`
+- Ubuntu 26.04 LTS: `conary_0.13.0-1_amd64.deb`
+- Arch Linux: `conary-0.13.0-1-x86_64.pkg.tar.zst`
 
 Verify the downloaded package against `SHA256SUMS`:
 
@@ -155,19 +155,19 @@ Ask the human before running the matching install command.
 Fedora 44:
 
 ```bash
-sudo dnf install ./conary-0.12.0-1.fc44.x86_64.rpm
+sudo dnf install ./conary-0.13.0-1.fc44.x86_64.rpm
 ```
 
 Ubuntu 26.04 LTS:
 
 ```bash
-sudo apt install ./conary_0.12.0-1_amd64.deb
+sudo apt install ./conary_0.13.0-1_amd64.deb
 ```
 
 Arch Linux:
 
 ```bash
-sudo pacman -U ./conary-0.12.0-1-x86_64.pkg.tar.zst
+sudo pacman -U ./conary-0.13.0-1-x86_64.pkg.tar.zst
 ```
 
 Then record:

--- a/docs/operations/external-tester-outreach.md
+++ b/docs/operations/external-tester-outreach.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-25
-revision: 3
+last_updated: 2026-07-26
+revision: 4
 status: postponed
 target_release: v0.13.0
 summary: Postponed multi-venue launch packet for the first cross-distro tester loop
@@ -11,11 +11,10 @@ summary: Postponed multi-venue launch packet for the first cross-distro tester l
 > **POSTPONED; NO NEW DATE IS ASSIGNED:** the current qualifying milestone is
 > 0/10. The two earlier supported-host reports remain useful adoption and
 > onboarding evidence, but neither installed a source package whose format
-> differed from the host's native format. Immutable `v0.12.0` is therefore a
-> historical safety baseline, not the release for this launch packet. Do not
-> publish the copy below until the cross-distro implementation has an immutable
-> release, exact artifact and deployment proof, and the existing external
-> cached-history and venue-eligibility gates are closed.
+> differed from the host's native format. Intended release `v0.13.0` remains a
+> candidate, not a published tester baseline. Do not publish the copy below
+> until the cross-distro implementation has exact artifact and deployment
+> proof and the external cached-history and venue-eligibility gates are closed.
 
 `v0.13.0` is the intended release for this packet. Treat that tag and every
 link below as a candidate until the release artifact matrix records the

--- a/docs/operations/infrastructure.md
+++ b/docs/operations/infrastructure.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-25
-revision: 16
+last_updated: 2026-07-26
+revision: 17
 summary: Non-secret infrastructure, agent-operations transport, release, Remi deploy, TLS renewal, remote development, and Forge staging guidance for Conary contributors and coding assistants
 ---
 
@@ -265,6 +265,12 @@ old process. That can fail with `Text file busy`.
 - Run `./scripts/release.sh [conary|remi|conaryd|conary-test|all]` to inspect
   the current release baseline, bump owned versions, update release state, and
   create canonical tags
+- When the product decision is intentionally different from conventional-commit
+  inference, pass an exact typed target such as
+  `--target remi=0.8.0`. The script validates that the product is selected,
+  the version is an increasing `MAJOR.MINOR.PATCH`, and scoped changes exist.
+- Use `--prepare-only` for an issue-backed release PR that must update and
+  stage multiple product tracks without creating commits or tags before merge.
 - The supported release tracks are:
   - `conary`
   - `remi`

--- a/docs/operations/release-artifact-matrix.md
+++ b/docs/operations/release-artifact-matrix.md
@@ -1,60 +1,51 @@
 ---
-last_updated: 2026-07-25
-revision: 17
-summary: Record the published v0.12.0 and remi-v0.7.1 artifact proof contracts
+last_updated: 2026-07-26
+revision: 18
+summary: Track the post-hard-cut release suite and the proof required before its artifacts become preview-supported
 ---
 
 # Release Artifact Matrix
 
-This matrix is the limited-preview artifact contract. It keeps public tester
-instructions honest by naming whether each product has published artifacts or
-is still source-build-only, and by listing the evidence required before a row
-can be treated as preview-supported.
+This matrix is the limited-preview artifact contract. It distinguishes a
+versioned release target from a published and independently verified release.
+Artifact URLs, checksums, signatures, deployments, and runtime behavior become
+authority only after their exact evidence is recorded here.
 
 Remote Forge validation is paused until a KVM-capable runner replaces the old
 VPS host. Local QEMU/KVM evidence may support a preview row only when it names
 the absolute run date, distro, suite, and pass counts.
 
-## Current Preview State
+## Current Release Target
 
-Immutable `v0.12.0` carries the safe in-root system-symlink handling exposed by
-issue #41 and the repaired installed-host support bundle. Remediation merge
-validation `30041401268` and exact release-commit validation `30042990554`
-each passed all 11 jobs. Release-build `30043930486`, exact-tag
-deploy-and-verify `30047027525`, independent artifact/signature checks,
-installed-binary self-update, supported Arch-path proof, and live-service
-checks all passed. Manual outreach remains postponed; a replacement schedule
-still requires GitHub Support cached-history dereferencing and fresh venue
-checks.
+The issue #86 release suite targets `v0.13.0`, `remi-v0.8.0`,
+`conaryd-v0.7.0`, and `conary-test-v0.9.0` from one reviewed release commit.
+All four rows are **pending publication**. Their candidate URLs must not be
+treated as downloads until the corresponding GitHub release exists and its
+assets pass the evidence gate below.
 
-Canonical `remi-v0.7.1` is the current maintainer-operated service release.
-Release-commit validation `30073358549`, exact-tag release-build
-`30074239104`, production deploy-and-verify `30076168995`, independent asset
-downloads, installed-binary identity, and pre/post-reconciliation live-service
-checks all passed. The AppArmor normalization-v2 inventory contained zero
-active or historical production clusters, so dry run, apply, and repeat apply
-completed as verified no-ops while preserving both queue fingerprints and a
-representative public-sanitized packet.
+The preceding release proof is available through Git history. It is not
+current artifact authority after the owned manifests move to this suite.
+External outreach remains postponed until the Conary and Remi rows are
+published, deployed where applicable, and independently verified.
 
-| Product | Artifact classes | Release workflow | Source commit | Binary download or package URL | Required evidence | Preview support | Known caveats | Source-build fallback |
+| Product | Artifact classes | Release workflow | Source authority | Candidate release URL | Required evidence | Preview support | Known caveats | Source-build fallback |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `conary` | binary, `.ccs`, `.rpm`, `.deb`, `.pkg.tar.zst`, or source build | `.github/workflows/release-build.yml`, `scripts/release.sh conary`, `scripts/release-matrix.sh` | annotated tag object `8411169b40d8523ee716518cb3dc3e51acddb019` peels to commit `eb256b19b4f04ca1d03b6af39a2819d746d3a22a` | https://github.com/ConaryLabs/Conary/releases/tag/v0.12.0 | published immutable at `2026-07-23T21:39:20Z`; remediation merge CI `30041401268` and release-commit CI `30042990554` passed 11/11 jobs, release-build `30043930486` passed, and exact-tag deploy-and-verify `30047027525` passed; seven assets published; checksums: all five `SHA256SUMS` payloads and all seven REST digests matched independent downloads; signature status: the official preceding binary verified the detached CCS signature; an isolated schema-77 self-update reached `v0.12.0` and then reported current; the exact Arch package binary initialized profile `arch`, synchronized 15,462 Arch-only rows, installed/executed/removed `htop 3.5.2-1`, accepted `/usr/lib64 -> lib` while normalizing the stored path, and rejected an out-of-root symlink without writing through it; support-bundle self-tests and an isolated integrity/profile bundle passed without including the database; Remi health passed 10/10, six public routes returned HTTP 200, and the deployed CCS matched release hash `c973fb654b67da0619d6837b34e2f5f78bbea90dfd9fb8de19b6edf9cbe9582a`, size `16183371`, and signature; SBOM/provenance status: not published or planned | published limited-preview baseline; broad outreach remains postponed through the separate cached-history and venue gates | early preview; package installs can fail while Remi scriptlet review/adapters mature; native PM remains authoritative for adopted packages; the Arch proof used the exact released package binary in an isolated writable root with live-host pacman evidence read-only, not native `pacman -U` or a pristine VM; this host had no installed root-owned Conary database, so the successful cached-sudo bundle path remains regression-tested rather than live-proven here; Fedora-form proof from the preceding release remains a conaryOS `minimal-boot-v4` baseline, not literal stock Fedora native-PM onboarding; Remi first-use conversion can be slow; no SBOM/provenance sidecars | `cargo build -p conary` remains available for source rebuilds |
-| `remi` | binary, deploy bundle, or source build | `.github/workflows/release-build.yml`, `scripts/release.sh remi`, `scripts/release-matrix.sh` | annotated tag object `d21eef4349b5b694c7ee66039524e5925bba0f41` peels to commit `301985230834112c8e08ad016921374b43dd8d2e` | https://github.com/ConaryLabs/Conary/releases/tag/remi-v0.7.1 | published immutable at `2026-07-24T07:39:02Z`; release-commit CI `30073358549` passed 11/11 jobs, exact-tag release-build `30074239104` passed, and production deploy-and-verify `30076168995` passed its real `deploy-remi` lane; checksums: all three REST digests matched independent downloads: `metadata.json` SHA-256 `9bc6f722c368acceacdb1b3fd4a024a9317e00ea3597c5f4155260f6bb83f310`, standalone binary `28be831a930aa0a43c1612e080fc4ee6e65d519dd55ba5b68128d1bc01bd358c`, and tarball `eabd6f404c15b6c2a86af9278e0ba7c06ff415dfdfffe657b6a520cbff3c254c`; the standalone, unpacked, and installed binaries matched and reported `remi 0.7.1`; full public health passed 10/10 before deploy, after deploy, and after reconciliation; production contained zero active or historical AppArmor clusters, the bounded dry run preserved the 932-cluster / 3,988-attempt active fingerprint and 1,020-cluster / 5,996-attempt historical fingerprint, explicit apply and repeat apply each scanned zero with zero remaining, and a representative public-sanitized packet retained its canonical JSON fingerprint while exposing empty incoming/outgoing reconciliation links; deterministic fixtures cover identity, rekey, split, merge, conflicting-state preservation, lineage, and private-output behavior for non-empty populations; signature status: no detached binary signature is published; SBOM/provenance status: not published | published maintainer-operated service binary; service operator preview remains maintainer-led | admin origin must stay explicit; no detached signature or SBOM/provenance sidecars; expected clean-VM build time and wider operator guidance remain required before an operator tester post | `cargo build -p remi` remains available for source rebuilds |
-| `conaryd` | binary, package artifacts, or source build | `.github/workflows/release-build.yml`, `scripts/release.sh conaryd`, `scripts/release-matrix.sh` | tester post must pin an exact commit or release tag | source-build-only until daemon preview artifacts are linked | checksums: pending for binaries; signature status: pending for binaries; SBOM/provenance status: pending for binaries; Unix-socket auth check; package-job queue smoke | local daemon preview | Forge staging deploy is paused; package jobs keep the CLI live-mutation acknowledgement boundary | `cargo build -p conaryd`; expected clean-VM build time must be measured before daemon tester post |
-| `conary-test` | binary, package artifacts, or source build | `.github/workflows/release-build.yml`, `scripts/release.sh conary-test`, `scripts/release-matrix.sh` | tester post must pin an exact commit or release tag | source-build-only until validation-tooling artifacts are linked | checksums: pending for binaries; signature status: pending for binaries; SBOM/provenance status: pending for binaries; suite inventory parse; fixture manifest check | validation tooling | QEMU/KVM suites require a capable local host while remote validation is paused | `cargo build -p conary-test`; expected clean-VM build time must be measured before validation tester post |
+| `conary` | binary, `.ccs`, `.rpm`, `.deb`, `.pkg.tar.zst` | `.github/workflows/release-build.yml`, `scripts/release.sh conary`, `scripts/release-matrix.sh` | pending reviewed commit and annotated `v0.13.0` tag | https://github.com/ConaryLabs/Conary/releases/tag/v0.13.0 | pending: terminal merge and release CI; exact tag/commit proof; complete asset inventory; independent checksums and GitHub digests; CCS signature verification; installed-binary identity and self-update; RPM/DEB/Arch package smoke; one exact cross-distro lifecycle loop; exact-tag site and Remi deployment proof; SBOM/provenance status | closed pending evidence | pre-alpha; use only on a disposable VM or non-critical host; no artifact is supported before this row records proof | `cargo build -p conary` |
+| `remi` | binary and deploy bundle | `.github/workflows/release-build.yml`, `scripts/release.sh remi`, `scripts/release-matrix.sh` | pending reviewed commit and annotated `remi-v0.8.0` tag | https://github.com/ConaryLabs/Conary/releases/tag/remi-v0.8.0 | pending: terminal release CI; exact tag/commit proof; independent checksums and GitHub digests; installed-binary identity; deployment snapshot/retirement/repopulation result; pre/post full health; public-route and exact CCS proof; signature status; SBOM/provenance status | closed pending evidence | deployment intentionally retires the previous schema epoch and must prove rollback safety; no detached binary signature is expected unless publication says otherwise | `cargo build -p remi` |
+| `conaryd` | binary and tarball | `.github/workflows/release-build.yml`, `scripts/release.sh conaryd`, `scripts/release-matrix.sh` | pending reviewed commit and annotated `conaryd-v0.7.0` tag | https://github.com/ConaryLabs/Conary/releases/tag/conaryd-v0.7.0 | pending: terminal release CI; exact tag/commit proof; asset inventory; independent checksums and GitHub digests; binary identity; signature status; SBOM/provenance status | release artifact only; no deployment | Forge staging remains paused; package jobs retain the CLI live-mutation acknowledgement boundary | `cargo build -p conaryd` |
+| `conary-test` | binary and tarball | `.github/workflows/release-build.yml`, `scripts/release.sh conary-test`, `scripts/release-matrix.sh` | pending reviewed commit and annotated `conary-test-v0.9.0` tag | https://github.com/ConaryLabs/Conary/releases/tag/conary-test-v0.9.0 | pending: terminal release CI; exact tag/commit proof; asset inventory; independent checksums and GitHub digests; binary identity and suite inventory; signature status; SBOM/provenance status | release artifact only; no deployment | QEMU/KVM suites require a capable local host while remote validation is paused | `cargo build -p conary-test` |
 
 Deploy-helper artifact publication uses CI-produced trust inputs as evidence:
-`conary-remi-deploy deploy-conary` verifies the staged `SHA256SUMS` file before
+`conary-remi-deploy deploy-conary` verifies staged `SHA256SUMS` before
 installing release files, copies the verified checksum file into the installed
 release directory, refuses symlinked trust inputs, and requires a sibling
-`.ccs.sig` whenever a staged `.ccs` artifact is present. This does not by itself
-make public binary downloads preview-supported; rows remain source-build-only
-until concrete artifact URLs or paths are listed above.
+`.ccs.sig` whenever a staged `.ccs` artifact is present. This does not make a
+candidate release preview-supported without the recorded proof above.
 
 ## Evidence Command Block
 
-Run these commands from the repository root before publishing a limited-preview
-tester post or refreshing artifact status:
+Run these commands before publication and again where the proof depends on the
+published tag:
 
 ```bash
 cargo fmt --check
@@ -65,24 +56,26 @@ bash scripts/check-release-matrix.sh
 bash scripts/release-cargo-audit.sh
 ```
 
-For source-build-only rows, add a dated clean-VM build measurement before
-linking public tester instructions. The matrix must not imply binaries,
-checksums, signatures, SBOMs, or SLSA/provenance sidecars exist until their
-URLs or paths are listed here.
+For each published release, also record:
+
+- annotated tag object and peeled commit;
+- publication time and complete asset names;
+- workflow run IDs and terminal conclusions;
+- independently downloaded asset SHA-256 values and matching GitHub digests;
+- binary `--version` output from the downloaded artifact;
+- signature, SBOM, and provenance status;
+- deployment and live-behavior proof required by that product row.
 
 ## Support Loop
 
-First-wave tester instructions should link all of these:
+First-wave tester instructions link the support-bundle command,
+`.github/ISSUE_TEMPLATE/pre_alpha_feedback.md`, this matrix, and the evidence
+command block.
 
-- Support bundle command: `bash scripts/conary-support-bundle.sh`
-- Pre-alpha tester feedback template: `.github/ISSUE_TEMPLATE/pre_alpha_feedback.md`
-- This release/source expectation matrix
-- The evidence command block above
-
-The support bundle is local-only. On an installed host, run `sudo -v` first; the
-script uses cached authorization only for allowlisted database-backed
-diagnostics and stops before writing a bundle if that authorization is
-unavailable. Review the result before attaching it to an issue. Do not include
-`/etc/conary/trust`, private keys, SSH keys, host-local credential files, raw
-logs, environment dumps, or live `conary.db` files unless a maintainer
-explicitly asks for a separately reviewed follow-up.
+The support bundle is local-only. On an installed host, run `sudo -v` first;
+the script uses cached authorization only for allowlisted database-backed
+diagnostics and stops before writing a bundle if authorization is unavailable.
+Review the result before attaching it. Do not include `/etc/conary/trust`,
+private keys, SSH keys, host-local credential files, raw logs, environment
+dumps, or live `conary.db` files unless a maintainer explicitly asks for a
+separately reviewed follow-up.

--- a/docs/roadmaps/external-tester-milestone.md
+++ b/docs/roadmaps/external-tester-milestone.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-25
-revision: 3
+last_updated: 2026-07-26
+revision: 4
 status: active
 current_result: 0/10
 summary: Outcome tracker for Conary's first cross-distro external tester milestone
@@ -15,9 +15,10 @@ records an evidence-backed pivot for a reproducible systemic blocker. Interest,
 downloads, partial attempts, and repeated runs by the same person do not count
 as separate completions.
 
-**Current result: 0/10 qualifying cross-distro completions.** The previous two
-supported-host reports from one person remain valid adoption/onboarding
-evidence, but neither crossed a source-package/host-package format boundary.
+**Current result: 0/10 qualifying cross-distro completions.** Two earlier
+supported-host reports from one person remain valid adoption and onboarding
+evidence, but neither crossed a source-package and host-package format
+boundary.
 
 ## Qualifying Flow
 
@@ -27,141 +28,67 @@ Each qualifying report covers this sequence on one supported host:
 foreign artifact install -> list/query -> update --dry-run -> remove
 ```
 
-The report must confirm that the tester used the pinned release, stayed within
-the supported host scope, named both the source package format and host native
-format, and completed every stage. A failed attempt remains useful evidence but
-does not count as a completion.
+The report confirms that the tester used the pinned release, stayed within the
+supported host scope, named both the source package format and host native
+format, and completed every stage. A failed attempt remains useful evidence
+but does not count as a completion.
 
-## Launch Record
+## Release Gate
 
-- Pinned Conary release: immutable `v0.12.0`, published at
-  `2026-07-23T21:39:20Z`. Annotated tag object
-  `8411169b40d8523ee716518cb3dc3e51acddb019` peels to commit
-  `eb256b19b4f04ca1d03b6af39a2819d746d3a22a`. Remediation merge CI
-  `30041401268` and exact release-commit CI `30042990554` passed 11/11 jobs;
-  release-build `30043930486` and exact-tag deploy-and-verify `30047027525`
-  passed.
-- Release payload evidence: all seven assets are published. Independent
-  downloads matched every manifest payload and every GitHub REST digest:
+The pinned target is `v0.13.0`. It is not a tester release until
+`docs/operations/release-artifact-matrix.md` records all of the following:
 
-  | Manifest payload | SHA-256 |
-  | --- | --- |
-  | `conary-0.12.0-1-x86_64.pkg.tar.zst` | `60cb2a4bfc804e7d2f80950b2b60902643c0d33bc1df63fc66d7e5c389bf2256` |
-  | `conary-0.12.0-1.fc44.x86_64.rpm` | `23c2946e68b124092f0d5f32e573b8f6b2ad9695611052a04b4cdf4d7937cc3c` |
-  | `conary-0.12.0.ccs` | `c973fb654b67da0619d6837b34e2f5f78bbea90dfd9fb8de19b6edf9cbe9582a` |
-  | `conary_0.12.0-1_amd64.deb` | `0c2b2ea1a42753cf398b9119fc85b28c757cc7ec4ecc1dc1b328e737729e65a1` |
-  | `metadata.json` | `11337f7d9e0ee5abdc270c21259be90a8dffeaa676c5b6d5fa3ec376f7572231` |
+- the published annotated tag, peeled commit, release time, and terminal CI;
+- all expected `conary-0.13.0` and `conary_0.13.0` assets with independently
+  verified checksums and matching GitHub digests;
+- CCS signature and installed-binary identity/self-update proof;
+- native RPM, DEB, and Arch package smoke proof;
+- at least one exact foreign-format install, query, update preview, and remove
+  loop using the released binary;
+- exact-tag Conary site deployment and compatible `remi-v0.8.0` production
+  deployment with full health and public artifact checks;
+- explicit signature, SBOM, and provenance status.
 
-  The official preceding binary verified the detached CCS signature. No SBOM
-  or provenance sidecars are published or planned for this limited preview;
-  their absence remains an explicit caveat.
-- Installed-binary evidence: the official preceding-preview binary initialized
-  an isolated schema-77/profile-`arch` database, verified the signed update,
-  replaced itself with `v0.12.0`, preserved schema 77, and then reported
-  `Already up to date (v0.12.0)`. The updated binary SHA-256 is
-  `5f790b11d8137f293cbf53fce210af17e7ed8d1d6648f1075ecb621a7283be9e`.
-- Supported Arch evidence: the exact manifest-matched Arch package binary
-  initialized schema 77/profile `arch` and synchronized 15,462 Remi rows with
-  zero foreign-distro rows. It planned, installed, and executed
-  `htop 3.5.2-1-arch` with five dependencies and five files, then removed all
-  five files and the trove. A shipped-binary package probe installed
-  `/usr/lib64/safe-proof.txt` through the real target symlink
-  `/usr/lib64 -> lib`, recorded `/usr/lib/safe-proof.txt`, removed it cleanly,
-  and preserved the symlink. A paired out-of-root symlink probe failed with a
-  path-safety error, wrote nothing outside the root, and recorded no trove.
-  Host pacman inventory, linker cache, installed Conary binary, and host
-  `/usr/lib64` stayed unchanged.
-- Arch caveat: this proof used the exact released package binary in an
-  isolated writable root with the current Arch host's pacman evidence
-  read-only. It was not a native `pacman -U` into the host or a pristine VM;
-  the two path probes used locally built unsigned one-file CCS packages so the
-  shipped installer could exercise the exact safe and escaping ancestors.
-- Fedora-form evidence was not rerun for `v0.12.0`; the preceding conaryOS
-  `minimal-boot-v4` proof remains a regression baseline, not literal stock
-  Fedora native-PM onboarding.
-- Compatible rewritten Remi commit:
-  `27ec2eccb6befdf06d9a826b84cc5a6948eff5fb`. It and deployed pre-rewrite
-  source commit `c001f8d69b9e8ef34fba39139576a9809800a9a6` have the same tree. The
-  deployed binary SHA-256 is
-  `c955a24ff6b90f98ba5f20b37e6a67b79bdde199ec0dcbfac0ce78b001d0f485`.
-- Pinned `v0.12.0` prewarm set: `curl`, `htop`, `nano`, and `zstd` for Fedora,
-  Ubuntu, and Arch. Eleven conversion-version-6 rows were public; Ubuntu
-  `nano` was held in the now-retired `private-review` workflow. That is
-  historical release evidence, not the current source contract. The
-  current-only typed lifecycle path needs fresh deployment proof before broad
-  outreach resumes.
-- Deployment evidence: exact-tag run `30047027525` deployed the Conary bundle.
-  Full Remi health passed 10/10, all six checked public routes returned HTTP
-  200, and the checked Conary pages carried `v0.12.0`. The self-update API CCS
-  matched release hash
-  `c973fb654b67da0619d6837b34e2f5f78bbea90dfd9fb8de19b6edf9cbe9582a`,
-  size `16183371`, and detached signature.
-- Repository-community closeout: the
-  [Welcome Discussion](https://github.com/ConaryLabs/Conary/discussions/36) is
-  live, and [issue #35's released-path proof](https://github.com/ConaryLabs/Conary/issues/35#issuecomment-5009942880)
-  was recorded before the issue was closed. These repository actions do not
-  count as a qualifying external completion or launch the broad outreach loop.
-- Organic prelaunch tester evidence: [issue #37](https://github.com/ConaryLabs/Conary/issues/37)
-  completed the full then-current loop on x86_64 Ubuntu 26.04 LTS and
-  [confirmed the DEB checksum](https://github.com/ConaryLabs/Conary/issues/37#issuecomment-5010174050).
-  [Issue #38](https://github.com/ConaryLabs/Conary/issues/38) completed the same
-  loop on x86_64 Fedora 44 from a never-synced Remi state and
-  [confirmed the RPM checksum](https://github.com/ConaryLabs/Conary/issues/38#issuecomment-5010310461).
-  Both reports came from the same external tester, so they establish two
-  supported-host successes but count once toward the ten-person milestone.
-  They do not start the broad-outreach stall clock.
-- Prelaunch remediation evidence:
-  [issue #41](https://github.com/ConaryLabs/Conary/issues/41) reports that
-  the preceding preview rejects the legitimate Arch-style `/usr/lib64 -> lib`
-  ancestor while validating a Fedora-form CCS payload on Artix. Artix remains
-  outside the supported-host claim, but cross-distro package installation is
-  now the product contract and the in-root symlink false-positive is a valid
-  path-safety defect. Immutable
-  `v0.12.0` carries the repair, and the shipped-binary safe/escape probes above
-  close its supported Arch-path gate. Support-bundle self-tests passed, and an
-  isolated schema-77 bundle recorded integrity, table, repository, and
-  source-selection summaries without including the database. This proof host had
-  no installed `/var/lib/conary/conary.db`, so the successful root-owned
-  cached-sudo path remains regression-tested; affected reporters must run
-  `sudo -v` before collecting a fresh reviewed bundle.
-- Supported hosts: Fedora 44, Ubuntu 26.04 LTS, and Arch Linux on the release's
-  supported architecture and compatibility baseline.
-- Rescheduling sequence, using the venue-specific copy in
-  `docs/operations/external-tester-outreach.md`:
+Until that evidence is durable, the release link and all launch copy are
+candidates, the result remains 0/10, and outreach remains postponed. Do not
+substitute evidence from an earlier release.
 
-  | Venue | New timestamp | State |
-  | --- | --- | --- |
-  | Show HN | TBD | postponed; the 2026-07-20 slot passed without a post |
-  | r/codex | TBD | postponed; the 2026-07-21 slot passed without a post; re-check rules and posting eligibility |
-  | r/ClaudeAI | TBD | postponed; the 2026-07-22 slot passed without a post; requires current showcase eligibility and posting-account karma over 50 |
+Supported tester hosts are x86_64 Fedora 44, Ubuntu 26.04 LTS, and Arch Linux.
+Use a disposable VM, snapshot, spare system, or other non-critical host.
 
-- Actual post URLs and launch timestamps: not launched. The release,
-  supported-Arch remediation, deployment, and public-claim refresh are
-  complete, but the former dates remain retired and outreach stays postponed.
-  Assign replacement dates only after GitHub Support dereferences the cached
-  pull-request and commit views that still expose pre-rewrite history and the
-  per-venue eligibility checks pass. Record each post immediately after
-  submission. The three-week stall clock starts from the first actual launch
-  timestamp.
-- Privacy-safe feedback path: the pre-alpha tester-feedback issue template and a reviewed
-  support bundle; never request secrets, credential files, private keys, broad
-  environment dumps, or a live database by default.
+## Launch State
+
+No broad-outreach post has been published and no new date is assigned. The
+venue copy remains in `docs/operations/external-tester-outreach.md`. Fresh
+dates require:
+
+- complete `v0.13.0` and `remi-v0.8.0` release and deployment proof;
+- GitHub Support dereferencing of cached pre-rewrite history;
+- current venue-rule and posting-eligibility checks.
+
+Record each actual post URL and timestamp immediately after submission. The
+three-week stall clock starts from the first actual launch timestamp, not from
+release publication.
 
 ## Outcomes
 
 Use an opaque report or issue reference rather than a person's name or host
-identity. The triage owner is responsible for keeping secrets and broad machine
-dumps out of linked evidence.
+identity. The triage owner keeps secrets and broad machine dumps out of linked
+evidence.
 
-| Attempt | Date | Privacy-safe report | Distro and host scope | Pinned release | Full flow completed | Friction or failure | Triage status | Triage owner |
+| Attempt | Date | Privacy-safe report | Distro and host scope | Pinned release | Full qualifying flow completed | Friction or failure | Triage status | Triage owner |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1a | 2026-07-18 | [issue #37](https://github.com/ConaryLabs/Conary/issues/37) | Ubuntu 26.04 LTS, x86_64, VM/snapshot/non-critical host confirmed | then-current DEB; checksum confirmed | yes, 11/11 steps | No functional failure; public-report verbosity and terminal-control-sequence guidance routed through [issue #39](https://github.com/ConaryLabs/Conary/issues/39) | `validated-no-action` | maintainer |
-| 1b | 2026-07-18 | [issue #38](https://github.com/ConaryLabs/Conary/issues/38) | Fedora 44, x86_64, VM/snapshot/non-critical host confirmed | then-current RPM; checksum confirmed | yes, 11/11 steps | No functional failure; clean never-synced Remi start; same reporting-guidance follow-up as 1a | `validated-no-action` | maintainer |
+| 1a | 2026-07-18 | [issue #37](https://github.com/ConaryLabs/Conary/issues/37) | Ubuntu 26.04 LTS, x86_64, VM/snapshot/non-critical host confirmed | then-current DEB; checksum confirmed | no; same-format onboarding flow | No functional failure; reporting guidance advanced through issue #39 | `validated-no-action` | maintainer |
+| 1b | 2026-07-18 | [issue #38](https://github.com/ConaryLabs/Conary/issues/38) | Fedora 44, x86_64, VM/snapshot/non-critical host confirmed | then-current RPM; checksum confirmed | no; same-format onboarding flow | No functional failure; clean never-synced Remi start; same reporting follow-up as 1a | `validated-no-action` | maintainer |
 
-Attempts 1a and 1b came from the same person and therefore contribute one, not
-two, to the unique-tester result. Triage statuses are `fix-now`, `next-slice`,
+Attempts 1a and 1b came from the same person and contribute zero qualifying
+cross-distro completions. Triage statuses are `fix-now`, `next-slice`,
 `validated-no-action`, and `declined-with-reason`. Qualifying and failed
 attempts both require an owner and a triage disposition.
+
+The public feedback path is the pre-alpha tester-feedback issue template plus a
+reviewed support bundle. Never request secrets, credential files, private keys,
+broad environment dumps, or a live database by default.
 
 ## Stall and Pivot Rules
 

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -4,7 +4,7 @@
 # Builds from a vendored source tarball (no network access needed during build).
 
 pkgname=conary
-pkgver=0.12.0
+pkgver=0.13.0
 pkgrel=1
 pkgdesc='Early-preview Linux package manager with native-package adoption'
 arch=('x86_64')

--- a/packaging/ccs/ccs.toml
+++ b/packaging/ccs/ccs.toml
@@ -11,7 +11,7 @@ requirements = [
 
 [package]
 name = "conary"
-version = "0.12.0"
+version = "0.13.0"
 version_scheme = "conary"
 release = "1"
 kind = "package"

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,9 @@
+conary (0.13.0-1) unstable; urgency=medium
+
+  * Release 0.13.0
+
+ -- Conary Contributors <contributors@conary.io>  Sun, 26 Jul 2026 17:11:05 +0200
+
 conary (0.12.0-1) unstable; urgency=medium
 
   * Release 0.12.0

--- a/packaging/rpm/conary.spec
+++ b/packaging/rpm/conary.spec
@@ -1,7 +1,7 @@
 %global crate conary
 
 Name:           conary
-Version:        0.12.0
+Version:        0.13.0
 Release:        1%{?dist}
 Summary:        Early-preview Linux package manager with native-package adoption
 

--- a/scripts/release-matrix.sh
+++ b/scripts/release-matrix.sh
@@ -92,7 +92,8 @@ version_owned_manifests_for() {
         conary-test)
             printf '%s\n' \
                 'apps/conary-test/Cargo.toml' \
-                'crates/conary-mcp/Cargo.toml'
+                'crates/conary-mcp/Cargo.toml' \
+                'crates/conary-agent-contract/Cargo.toml'
             ;;
         *) return 1 ;;
     esac
@@ -136,6 +137,7 @@ bump_scope_paths_for() {
                 'apps/conary-test/' \
                 'crates/conary-core/' \
                 'crates/conary-mcp/' \
+                'crates/conary-agent-contract/' \
                 'scripts/test-release-matrix.sh' \
                 '.github/workflows/release-build.yml' \
                 '.github/workflows/deploy-and-verify.yml'

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -15,7 +15,7 @@ mapfile -t PRODUCTS < <(bash "$MATRIX" products)
 
 usage() {
     cat <<'EOF'
-Usage: scripts/release.sh [conary|remi|conaryd|conary-test|all] [--dry-run]
+Usage: scripts/release.sh [conary|remi|conaryd|conary-test|all] [OPTIONS]
 
 Analyze conventional commits since the latest product release tag and bump versions.
   conary       - conary CLI + owned crates + packaging
@@ -23,7 +23,11 @@ Analyze conventional commits since the latest product release tag and bump versi
   conaryd      - daemon service app
   conary-test  - integration harness + conary-mcp
   all          - all release tracks
-  --dry-run    Show what would happen without making changes
+
+Options:
+  --dry-run                  Show what would happen without making changes.
+  --prepare-only             Update and stage release files without committing or tagging.
+  --target PRODUCT=VERSION   Use an explicit exact target for one selected product.
 EOF
     exit 1
 }
@@ -39,6 +43,10 @@ is_product() {
     done
 
     return 1
+}
+
+is_release_version() {
+    [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
 }
 
 matrix_field() {
@@ -219,7 +227,9 @@ generate_changelog() {
     local date
     local line
     local subject
+    local description
     local -a features=()
+    local -a changed=()
     local -a fixes=()
     local -a security=()
     local -a perf=()
@@ -235,16 +245,19 @@ generate_changelog() {
         while IFS= read -r line; do
             [[ -n "$line" ]] || continue
             subject="${line#* }"
+            description="${subject#*: }"
 
-            if [[ "$subject" =~ ^feat!?: ]]; then
-                features+=("- ${subject#*: }")
-            elif [[ "$subject" =~ ^fix: ]]; then
-                fixes+=("- ${subject#*: }")
-            elif [[ "$subject" =~ ^security: ]]; then
-                security+=("- ${subject#*: }")
-            elif [[ "$subject" =~ ^perf: ]]; then
-                perf+=("- ${subject#*: }")
-            elif [[ "$subject" =~ ^(refactor|test|chore|docs): ]]; then
+            if [[ "$subject" =~ ^feat(\(.+\))?!?: ]]; then
+                features+=("- ${description}")
+            elif [[ "$subject" =~ ^refactor(\(.+\))?!?: ]]; then
+                changed+=("- ${description}")
+            elif [[ "$subject" =~ ^fix(\(.+\))?!?: ]]; then
+                fixes+=("- ${description}")
+            elif [[ "$subject" =~ ^security(\(.+\))?!?: ]]; then
+                security+=("- ${description}")
+            elif [[ "$subject" =~ ^perf(\(.+\))?!?: ]]; then
+                perf+=("- ${description}")
+            elif [[ "$subject" =~ ^(test|chore|docs)(\(.+\))?!?: ]]; then
                 :
             else
                 other+=("- ${subject}")
@@ -254,6 +267,11 @@ generate_changelog() {
         if [[ ${#features[@]} -gt 0 ]]; then
             printf '### Added\n'
             printf '%s\n' "${features[@]}"
+            printf '\n'
+        fi
+        if [[ ${#changed[@]} -gt 0 ]]; then
+            printf '### Changed\n'
+            printf '%s\n' "${changed[@]}"
             printf '\n'
         fi
         if [[ ${#fixes[@]} -gt 0 ]]; then
@@ -385,28 +403,91 @@ regenerate_conary_man_page() {
 
 main() {
     local DRY_RUN=false
+    local PREPARE_ONLY=false
     local -a RELEASE_GROUPS=()
+    local -A TARGET_VERSIONS=()
     local arg
+    local target_product
 
-    for arg in "$@"; do
+    append_release_group() {
+        local candidate="$1"
+        local existing
+
+        for existing in "${RELEASE_GROUPS[@]}"; do
+            if [[ "$existing" == "$candidate" ]]; then
+                return
+            fi
+        done
+        RELEASE_GROUPS+=("$candidate")
+    }
+
+    register_target() {
+        local spec="$1"
+        local product="${spec%%=*}"
+        local version="${spec#*=}"
+
+        if [[ "$product" == "$spec" || -z "$product" || -z "$version" ]]; then
+            die "release target must use PRODUCT=VERSION"
+        fi
+        is_product "$product" || die "unknown release target product: $product"
+        is_release_version "$version" ||
+            die "release target for ${product} must be an exact MAJOR.MINOR.PATCH version"
+        if [[ -n "${TARGET_VERSIONS[$product]:-}" && "${TARGET_VERSIONS[$product]}" != "$version" ]]; then
+            die "conflicting release targets for ${product}"
+        fi
+        TARGET_VERSIONS["$product"]="$version"
+    }
+
+    while [[ $# -gt 0 ]]; do
+        arg="$1"
         case "$arg" in
             --dry-run)
                 DRY_RUN=true
                 ;;
+            --prepare-only)
+                PREPARE_ONLY=true
+                ;;
+            --target)
+                shift
+                [[ $# -gt 0 ]] || die "--target requires PRODUCT=VERSION"
+                register_target "$1"
+                ;;
+            --target=*)
+                register_target "${arg#--target=}"
+                ;;
             all)
-                RELEASE_GROUPS=("${PRODUCTS[@]}")
+                for target_product in "${PRODUCTS[@]}"; do
+                    append_release_group "$target_product"
+                done
                 ;;
             *)
                 if is_product "$arg"; then
-                    RELEASE_GROUPS+=("$arg")
+                    append_release_group "$arg"
                 else
                     usage
                 fi
                 ;;
         esac
+        shift
     done
 
     [[ ${#RELEASE_GROUPS[@]} -gt 0 ]] || usage
+    if [[ "$DRY_RUN" == "true" && "$PREPARE_ONLY" == "true" ]]; then
+        die "--dry-run and --prepare-only cannot be combined"
+    fi
+
+    for target_product in "${!TARGET_VERSIONS[@]}"; do
+        local selected=false
+        local release_group
+        for release_group in "${RELEASE_GROUPS[@]}"; do
+            if [[ "$release_group" == "$target_product" ]]; then
+                selected=true
+                break
+            fi
+        done
+        [[ "$selected" == "true" ]] ||
+            die "release target provided for unselected product: ${target_product}"
+    done
 
     local product
     for product in "${RELEASE_GROUPS[@]}"; do
@@ -457,21 +538,33 @@ main() {
         printf '  Owned manifest baseline: %s\n' "$manifest_version"
         printf '  Current: %s\n' "$current_tag"
 
-        level="$(determine_bump "$product" "$local_history_tag")"
-        if [[ "$level" == "none" ]]; then
-            if [[ -n "$local_history_tag" ]]; then
-                printf '  No version-bumping commits since %s. Skipping.\n' "$local_history_tag"
-            else
-                printf '  No version-bumping commits found in product scope. Skipping.\n'
+        if [[ -n "${TARGET_VERSIONS[$product]:-}" ]]; then
+            new_version="${TARGET_VERSIONS[$product]}"
+            version_lt "$history_version" "$new_version" ||
+                die "explicit release target ${new_version} must be greater than published history baseline ${history_version} for ${product}"
+            if [[ -n "$local_history_tag" && -z "$(commits_for_product "$product" "$local_history_tag")" ]]; then
+                die "explicit release target for ${product} has no scoped changes since ${local_history_tag}"
             fi
-            print_owned_paths "${owned_paths[@]}"
-            printf '  Bundle: %s\n' "$bundle_name"
-            printf '  Deploy mode: %s\n' "$deploy_mode"
-            printf '\n'
-            continue
+            level="explicit"
+            printf '  Target authority: explicit\n'
+        else
+            level="$(determine_bump "$product" "$local_history_tag")"
+            if [[ "$level" == "none" ]]; then
+                if [[ -n "$local_history_tag" ]]; then
+                    printf '  No version-bumping commits since %s. Skipping.\n' "$local_history_tag"
+                else
+                    printf '  No version-bumping commits found in product scope. Skipping.\n'
+                fi
+                print_owned_paths "${owned_paths[@]}"
+                printf '  Bundle: %s\n' "$bundle_name"
+                printf '  Deploy mode: %s\n' "$deploy_mode"
+                printf '\n'
+                continue
+            fi
+            new_version="$(bump_version "$current_version" "$level")"
+            printf '  Target authority: conventional commits (%s)\n' "$level"
         fi
 
-        new_version="$(bump_version "$current_version" "$level")"
         if version_lt "$new_version" "$manifest_version"; then
             die "computed release target ${new_version} would be lower than owned manifest version ${manifest_version} for ${product}"
         fi
@@ -535,6 +628,10 @@ main() {
             # Force-add this one exact artifact so the release tag carries the
             # CLI surface generated for the version being published.
             git add -f -- apps/conary/man/conary.1
+        fi
+        if [[ "$PREPARE_ONLY" == "true" ]]; then
+            printf '  [PREPARED] Updated %s without commit or tag\n\n' "$new_tag"
+            continue
         fi
         git commit -m "chore: release ${new_tag}"
         git tag -a "$new_tag" -m "Release ${new_tag}"

--- a/scripts/test-release-matrix.sh
+++ b/scripts/test-release-matrix.sh
@@ -69,6 +69,7 @@ create_release_fixture() {
         "$repo/crates/conary-core" \
         "$repo/crates/conary-bootstrap" \
         "$repo/crates/conary-mcp" \
+        "$repo/crates/conary-agent-contract" \
         "$repo/packaging/rpm" \
         "$repo/packaging/arch" \
         "$repo/packaging/deb/debian" \
@@ -86,6 +87,10 @@ create_release_fixture() {
     write_cargo_manifest "$repo/apps/conaryd/Cargo.toml" "conaryd" "0.5.0"
     write_cargo_manifest "$repo/apps/conary-test/Cargo.toml" "conary-test" "0.7.0"
     write_cargo_manifest "$repo/crates/conary-mcp/Cargo.toml" "conary-mcp" "0.7.0"
+    write_cargo_manifest \
+        "$repo/crates/conary-agent-contract/Cargo.toml" \
+        "conary-agent-contract" \
+        "0.7.0"
 
     printf 'fn main() {}\n' > "$repo/apps/conary/build.rs"
     printf '.TH conary 1 "" "conary 0.7.0"\n' > "$repo/apps/conary/man/conary.1"
@@ -191,10 +196,11 @@ commit_empty() {
 run_release_dry_run() {
     local repo="$1"
     local product="$2"
+    shift 2
 
     (
         cd "$repo"
-        ./scripts/release.sh "$product" --dry-run
+        ./scripts/release.sh "$product" --dry-run "$@"
     )
 }
 
@@ -202,12 +208,13 @@ run_release() {
     local repo="$1"
     local product="$2"
     local stale_man="${RELEASE_FIXTURE_STALE_MAN:-0}"
+    shift 2
 
     (
         cd "$repo"
         export PATH="$repo/test-bin:$PATH"
         export RELEASE_FIXTURE_STALE_MAN="$stale_man"
-        ./scripts/release.sh "$product"
+        ./scripts/release.sh "$product" "$@"
     )
 }
 
@@ -450,6 +457,81 @@ test_release_dry_run_conary_test_uses_owned_manifest_baseline() {
     output="$(run_release_dry_run "$repo" conary-test)"
     assert_contains "$output" "Current: conary-test-v0.7.0" "conary-test should respect owned manifest versions"
     assert_contains "$output" "Tag: conary-test-v0.7.1" "conary-test should bump from the owned-manifest baseline"
+}
+
+test_release_dry_run_accepts_explicit_target() {
+    local repo
+    local output
+
+    repo="$(create_release_fixture)"
+    tag_head "$repo" "remi-v0.5.0"
+    commit_change "$repo" "apps/remi/changes.txt" "fix(remi): tighten deploy flow"
+    commit_change "$repo" "apps/remi/changes.txt" "refactor(remi): hard-cut service schema"
+
+    output="$(run_release_dry_run "$repo" remi --target remi=0.6.0)"
+    assert_contains "$output" "Target authority: explicit" "explicit target should own the release decision"
+    assert_contains "$output" "Tag: remi-v0.6.0" "explicit target should select the exact canonical tag"
+    assert_contains "$output" "### Fixed" "scoped fixes should be categorized in release notes"
+    assert_contains "$output" "- tighten deploy flow" "scoped fix prefixes should be removed"
+    assert_contains "$output" "### Changed" "refactors should be categorized in release notes"
+    assert_contains "$output" "- hard-cut service schema" "scoped refactor prefixes should be removed"
+}
+
+test_release_prepare_only_updates_all_conary_test_manifests() {
+    local repo
+    local committed_head
+    local output
+    local staged_files
+
+    repo="$(create_release_fixture)"
+    tag_head "$repo" "conary-test-v0.7.0"
+    commit_change "$repo" "apps/conary-test/changes.txt" "feat(test): add exact lifecycle proof"
+    committed_head="$(git -C "$repo" rev-parse HEAD)"
+
+    run_release "$repo" conary-test --prepare-only --target conary-test=0.9.0
+
+    assert_eq "0.9.0" \
+        "$(run_repo_matrix "$repo" max-owned-version conary-test)" \
+        "prepare-only should update the complete conary-test version set"
+    run_repo_matrix "$repo" assert-owned-version conary-test 0.9.0
+    assert_eq "$committed_head" "$(git -C "$repo" rev-parse HEAD)" \
+        "prepare-only should not create a commit"
+    assert_eq "" "$(git -C "$repo" tag --list conary-test-v0.9.0)" \
+        "prepare-only should not create a tag"
+    staged_files="$(git -C "$repo" diff --cached --name-only)"
+    assert_contains "$staged_files" \
+        "crates/conary-agent-contract/Cargo.toml" \
+        "prepare-only should stage the agent contract version"
+
+    output="$(run_release_dry_run "$repo" conary-test --target conary-test=0.9.0)"
+    assert_contains "$output" \
+        "Tag: conary-test-v0.9.0" \
+        "prepared explicit target should remain reproducible before publication"
+}
+
+test_release_rejects_target_for_unselected_product() {
+    local repo
+    local output
+    local status
+
+    repo="$(create_release_fixture)"
+    tag_head "$repo" "remi-v0.5.0"
+    commit_change "$repo" "apps/remi/changes.txt" "fix(remi): tighten deploy flow"
+
+    set +e
+    output="$(
+        cd "$repo"
+        ./scripts/release.sh remi --dry-run --target conary=0.8.0 2>&1
+    )"
+    status=$?
+    set -e
+
+    if [[ "$status" -eq 0 ]]; then
+        fail "release target for an unselected product should fail"
+    fi
+    assert_contains "$output" \
+        "release target provided for unselected product: conary" \
+        "unselected explicit target should fail clearly"
 }
 
 test_release_conary_regenerates_and_stages_man_page() {
@@ -777,6 +859,9 @@ main() {
         test_release_dry_run_remi_prefers_highest_numeric_history
         test_release_dry_run_conaryd_canonical_history
         test_release_dry_run_conary_test_uses_owned_manifest_baseline
+        test_release_dry_run_accepts_explicit_target
+        test_release_prepare_only_updates_all_conary_test_manifests
+        test_release_rejects_target_for_unselected_product
         test_release_conary_regenerates_and_stages_man_page
         test_release_conary_rejects_stale_generated_man_page
         test_check_release_matrix_rejects_beta_maturity_drift

--- a/site/src/lib/preview-release.ts
+++ b/site/src/lib/preview-release.ts
@@ -6,8 +6,8 @@ export type PreviewTarget = {
 	installCommand: string;
 };
 
-const version = '0.12.0';
-const tag = 'v0.12.0';
+const version = '0.13.0';
+const tag = 'v0.13.0';
 const releaseUrl = `https://github.com/ConaryLabs/Conary/releases/tag/${tag}`;
 const downloadBaseUrl = `https://github.com/ConaryLabs/Conary/releases/download/${tag}`;
 
@@ -24,22 +24,22 @@ export const previewRelease = {
 			id: 'fedora',
 			name: 'Fedora 44',
 			profile: 'fedora-44',
-			asset: 'conary-0.12.0-1.fc44.x86_64.rpm',
-			installCommand: 'sudo dnf install ./conary-0.12.0-1.fc44.x86_64.rpm'
+			asset: 'conary-0.13.0-1.fc44.x86_64.rpm',
+			installCommand: 'sudo dnf install ./conary-0.13.0-1.fc44.x86_64.rpm'
 		},
 		{
 			id: 'ubuntu',
 			name: 'Ubuntu 26.04 LTS',
 			profile: 'ubuntu-26.04',
-			asset: 'conary_0.12.0-1_amd64.deb',
-			installCommand: 'sudo apt install ./conary_0.12.0-1_amd64.deb'
+			asset: 'conary_0.13.0-1_amd64.deb',
+			installCommand: 'sudo apt install ./conary_0.13.0-1_amd64.deb'
 		},
 		{
 			id: 'arch',
 			name: 'Arch Linux',
 			profile: 'arch',
-			asset: 'conary-0.12.0-1-x86_64.pkg.tar.zst',
-			installCommand: 'sudo pacman -U ./conary-0.12.0-1-x86_64.pkg.tar.zst'
+			asset: 'conary-0.13.0-1-x86_64.pkg.tar.zst',
+			installCommand: 'sudo pacman -U ./conary-0.13.0-1-x86_64.pkg.tar.zst'
 		}
 	] satisfies PreviewTarget[]
 } as const;


### PR DESCRIPTION
## Primary Issue

Refs #86

Design / Plan / Roadmap:

- `docs/specs/foreign-package-lifecycle-contracts.md`
- `docs/roadmaps/development-roadmap.md`
- `docs/roadmaps/external-tester-milestone.md`

## Problem And Outcome

The published artifacts predate PR #61's intentional schema, lifecycle-authority, route, and compatibility hard cut. This prepares one exact reviewed commit for Conary 0.13.0, Remi 0.8.0, conaryd 0.7.0, and conary-test 0.9.0 without creating premature tags or claiming unpublished evidence.

## Changes

- Add validated exact per-product release targets and a prepare-only mode.
- Categorize scoped conventional commits correctly and retain refactors under `Changed`.
- Make `conary-agent-contract` part of the conary-test release track.
- Bump all owned manifests, packaging metadata, lockfile entries, and generated Conary man-page version.
- Add concise product-owned hard-cut changelog entries.
- Pin README, tester guide, feedback surfaces, and tagged sites to v0.13.0.
- Replace obsolete active-release proof with an explicit pending-publication matrix and closed tester gate; measured artifact and deployment evidence will replace it after the tags run.

## Scope

- In scope: exact release preparation, version ownership, candidate public references, and pre-publication truth gates.
- Out of scope: creating tags, publishing releases, deploying services/sites, broad outreach, or implementing new product features. Those remain in issue #86 after merge.

## Ownership / Boundary

- Owning subsystem: release automation and product-owned artifact/version metadata.
- Boundary changed or preserved: explicit target authority augments conventional inference without weakening canonical tags, owned manifests, or publication gates.
- Persisted state or public surface impact: all shipped product versions advance; Remi 0.8 declares the current-only schema/deployment transition; public surfaces identify v0.13.0 as a candidate until proof lands.
- [x] Checked `docs/modules/feature-ownership.md`; `bash scripts/agent-context.sh --path scripts/release.sh` confirms these release/meta paths have no matching feature card, so the owning release/docs gates are used directly.

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected release and public-surface verification directly
- [x] Updated release operations docs when the ownership path changed
- [x] Ran the available docs and release interaction gates
- [x] Issue #86 remains open for publication, deployment, independent proof, and closeout

Release and documentation proof:

```text
bash -n scripts/release.sh scripts/release-matrix.sh scripts/test-release-matrix.sh
bash scripts/agent-context.sh --path scripts/release.sh
bash scripts/test-release-matrix.sh
bash scripts/release.sh all --dry-run --target conary=0.13.0 --target remi=0.8.0 --target conaryd=0.7.0 --target conary-test=0.9.0
bash scripts/release-matrix.sh assert-owned-version conary 0.13.0
bash scripts/release-matrix.sh assert-owned-version remi 0.8.0
bash scripts/release-matrix.sh assert-owned-version conaryd 0.7.0
bash scripts/release-matrix.sh assert-owned-version conary-test 0.9.0
bash scripts/check-release-matrix.sh
bash scripts/check-doc-truth.sh
bash scripts/test-doc-truth.sh
bash scripts/test-agent-context.sh
bash scripts/agent-context.sh --validate
(cd site && npm run check && npm run build)
git diff --check
```

Full Rust and dependency proof:

```text
cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace --exclude conary-test --verbose
cargo test -p conary-test --verbose
cargo test --doc --workspace --verbose
cargo run -p conary-test -- list
bash scripts/release-cargo-audit.sh
```

All commands passed. `release-cargo-audit.sh` retained only the repository's two explicit audit exceptions: `proc-macro-error2` / RUSTSEC-2026-0173 and yanked `spin 0.9.8`.

Exact-head CI:

- [`pr-gate` run 30208129258](https://github.com/ConaryLabs/Conary/actions/runs/30208129258) passed all 15 jobs at `60c2c3a99e896d125152856ddb94e6878ce0f329`.
- The three native lifecycle lanes and their stable aggregate check all passed.
- No required-check bypass was used.

## Review And Merge Notes

- Review focus: explicit-target validation, complete version ownership, honest pending-publication wording, and exact four-tag scope.
- User or developer impact: creates the sole commit from which the four canonical release tags will be cut after merge.
- Required-check bypass: not used