### PR TITLE
fix(ci): share exact ownership namespace setup

### DIFF
--- a/.github/actions/setup-exact-ownership-tests/action.yml
+++ b/.github/actions/setup-exact-ownership-tests/action.yml
@@ -1,0 +1,15 @@
+name: setup-exact-ownership-tests
+description: Enable and prove the namespaces required by exact ownership tests.
+runs:
+  using: composite
+  steps:
+    - name: Enable exact ownership-test namespaces
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if [[ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]]; then
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+        fi
+
+        unshare --user --map-root-user --mount --propagation private /bin/true

--- a/.github/workflows/merge-validation.yml
+++ b/.github/workflows/merge-validation.yml
@@ -131,6 +131,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-rust-workspace
+      - uses: ./.github/actions/setup-exact-ownership-tests
       - name: Run workspace tests
         run: cargo test --workspace --exclude conary-test --verbose
 

--- a/.github/workflows/merge-validation.yml
+++ b/.github/workflows/merge-validation.yml
@@ -131,7 +131,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-rust-workspace
-      - uses: ./.github/actions/setup-exact-ownership-tests
+      - name: Enable exact ownership-test namespaces
+        uses: ./.github/actions/setup-exact-ownership-tests
       - name: Run workspace tests
         run: cargo test --workspace --exclude conary-test --verbose
 

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -125,10 +125,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-rust-workspace
-      - name: Enable exact ownership-test namespaces
-        run: |
-          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-          unshare --user --map-root-user --mount --propagation private /bin/true
+      - uses: ./.github/actions/setup-exact-ownership-tests
       - name: Run workspace tests
         run: cargo test --workspace --exclude conary-test --verbose
 

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -125,7 +125,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-rust-workspace
-      - uses: ./.github/actions/setup-exact-ownership-tests
+      - name: Enable exact ownership-test namespaces
+        uses: ./.github/actions/setup-exact-ownership-tests
       - name: Run workspace tests
         run: cargo test --workspace --exclude conary-test --verbose
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -100,6 +100,7 @@ jobs:
       - uses: ./.github/actions/setup-rust-workspace
         with:
           components: clippy,rustfmt
+      - uses: ./.github/actions/setup-exact-ownership-tests
       - name: Check formatting
         run: cargo fmt --check
       - name: Run clippy

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -100,7 +100,8 @@ jobs:
       - uses: ./.github/actions/setup-rust-workspace
         with:
           components: clippy,rustfmt
-      - uses: ./.github/actions/setup-exact-ownership-tests
+      - name: Enable exact ownership-test namespaces
+        uses: ./.github/actions/setup-exact-ownership-tests
       - name: Check formatting
         run: cargo fmt --check
       - name: Run clippy

--- a/apps/conary-test/src/config/tests/workflow.rs
+++ b/apps/conary-test/src/config/tests/workflow.rs
@@ -61,6 +61,7 @@ struct WorkspaceTestJob {
 #[derive(Debug, Deserialize)]
 struct WorkflowStep {
     name: Option<String>,
+    uses: Option<String>,
     run: Option<String>,
     #[serde(rename = "continue-on-error", default)]
     continue_on_error: bool,
@@ -214,15 +215,28 @@ fn workspace_gate_provisions_the_exact_namespace_test_boundary() {
 
     let namespace = named_step(&job.steps, "Enable exact ownership-test namespaces");
     assert_eq!(
-        namespace.run.as_deref(),
-        Some(
-            "sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0\nunshare --user --map-root-user --mount --propagation private /bin/true\n"
-        )
+        namespace.uses.as_deref(),
+        Some("./.github/actions/setup-exact-ownership-tests")
     );
+    assert_eq!(namespace.run, None);
     assert!(!namespace.continue_on_error);
     assert_eq!(namespace.condition, None);
 
     let tests = named_step(&job.steps, "Run workspace tests");
+    let namespace_index = job
+        .steps
+        .iter()
+        .position(|step| step.name.as_deref() == Some("Enable exact ownership-test namespaces"))
+        .expect("namespace setup step should exist");
+    let tests_index = job
+        .steps
+        .iter()
+        .position(|step| step.name.as_deref() == Some("Run workspace tests"))
+        .expect("workspace test step should exist");
+    assert!(
+        namespace_index < tests_index,
+        "namespace setup must run before workspace tests"
+    );
     assert_eq!(
         tests.run.as_deref(),
         Some("cargo test --workspace --exclude conary-test --verbose")

--- a/scripts/check-release-matrix.sh
+++ b/scripts/check-release-matrix.sh
@@ -243,9 +243,10 @@ for workflow in "$pr_workflow" "$merge_workflow" "$release_build"; do
     require_literal_count "$workflow" 'uses: ./.github/actions/setup-exact-ownership-tests' 1 'shared exact ownership setup'
     forbid_match "$workflow" 'apparmor_restrict_unprivileged_userns|unshare --user' 'inline exact ownership namespace setup'
 done
-require_job_match "$pr_workflow" workspace-tests 'uses: \./\.github/actions/setup-exact-ownership-tests' 'PR workspace tests exact ownership setup'
-require_job_match "$merge_workflow" workspace-tests 'uses: \./\.github/actions/setup-exact-ownership-tests' 'merge workspace tests exact ownership setup'
-require_job_match "$release_build" workspace-validation 'uses: \./\.github/actions/setup-exact-ownership-tests' 'release workspace validation exact ownership setup'
+namespace_before_tests_pattern='uses: \./\.github/actions/setup-exact-ownership-tests[\s\S]*cargo test --workspace --exclude conary-test --verbose'
+require_job_match "$pr_workflow" workspace-tests "$namespace_before_tests_pattern" 'PR workspace tests exact ownership setup order'
+require_job_match "$merge_workflow" workspace-tests "$namespace_before_tests_pattern" 'merge workspace tests exact ownership setup order'
+require_job_match "$release_build" workspace-validation "$namespace_before_tests_pattern" 'release workspace validation exact ownership setup order'
 require_match "$release_build" 'build-ccs:[\s\S]*needs: \[prepare, workspace-validation\]' 'ccs build should need workspace validation'
 require_match "$release_build" 'build-remi:[\s\S]*needs: \[prepare, workspace-validation\]' 'remi build should need workspace validation'
 require_match "$release_build" 'publish-remi:[\s\S]*needs: \[prepare, workspace-validation, build-remi\]' 'remi publish should need workspace validation'

--- a/scripts/check-release-matrix.sh
+++ b/scripts/check-release-matrix.sh
@@ -7,6 +7,8 @@ cd "$repo_root"
 release_build=".github/workflows/release-build.yml"
 deploy_workflow=".github/workflows/deploy-and-verify.yml"
 merge_workflow=".github/workflows/merge-validation.yml"
+pr_workflow=".github/workflows/pr-gate.yml"
+exact_ownership_action=".github/actions/setup-exact-ownership-tests/action.yml"
 artifact_matrix="docs/operations/release-artifact-matrix.md"
 feedback_template=".github/ISSUE_TEMPLATE/pre_alpha_feedback.md"
 site_preview_release="site/src/lib/preview-release.ts"
@@ -151,6 +153,11 @@ validate_deploy_routing_pairs() {
 }
 
 for required_file in \
+    "$release_build" \
+    "$deploy_workflow" \
+    "$merge_workflow" \
+    "$pr_workflow" \
+    "$exact_ownership_action" \
     "$artifact_matrix" \
     "$feedback_template" \
     "$site_preview_release" \
@@ -227,6 +234,18 @@ require_match "$release_build" 'cargo clippy --workspace --all-targets -- -D war
 require_match "$release_build" 'cargo test --workspace --exclude conary-test --verbose' 'release workspace test validation'
 require_match "$release_build" 'cargo test -p conary-test --verbose' 'release conary-test validation'
 require_match "$release_build" 'cargo test --doc --workspace --verbose' 'release doctest validation'
+require_match "$exact_ownership_action" '^        set -euo pipefail$' 'fail-closed exact ownership namespace setup'
+require_match "$exact_ownership_action" 'sudo sysctl -w kernel\.apparmor_restrict_unprivileged_userns=0' 'AppArmor user-namespace enablement'
+require_match "$exact_ownership_action" 'unshare --user --map-root-user --mount --propagation private /bin/true' 'exact ownership namespace proof'
+require_literal_count "$exact_ownership_action" 'sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0' 1 'centralized AppArmor namespace setup'
+require_literal_count "$exact_ownership_action" 'unshare --user --map-root-user --mount --propagation private /bin/true' 1 'centralized namespace proof'
+for workflow in "$pr_workflow" "$merge_workflow" "$release_build"; do
+    require_literal_count "$workflow" 'uses: ./.github/actions/setup-exact-ownership-tests' 1 'shared exact ownership setup'
+    forbid_match "$workflow" 'apparmor_restrict_unprivileged_userns|unshare --user' 'inline exact ownership namespace setup'
+done
+require_job_match "$pr_workflow" workspace-tests 'uses: \./\.github/actions/setup-exact-ownership-tests' 'PR workspace tests exact ownership setup'
+require_job_match "$merge_workflow" workspace-tests 'uses: \./\.github/actions/setup-exact-ownership-tests' 'merge workspace tests exact ownership setup'
+require_job_match "$release_build" workspace-validation 'uses: \./\.github/actions/setup-exact-ownership-tests' 'release workspace validation exact ownership setup'
 require_match "$release_build" 'build-ccs:[\s\S]*needs: \[prepare, workspace-validation\]' 'ccs build should need workspace validation'
 require_match "$release_build" 'build-remi:[\s\S]*needs: \[prepare, workspace-validation\]' 'remi build should need workspace validation'
 require_match "$release_build" 'publish-remi:[\s\S]*needs: \[prepare, workspace-validation, build-remi\]' 'remi publish should need workspace validation'

--- a/scripts/test-release-matrix.sh
+++ b/scripts/test-release-matrix.sh
@@ -727,8 +727,8 @@ test_check_release_matrix_requires_shared_namespace_setup_in_every_workspace_lan
         repo="$(create_release_policy_fixture)"
         replace_fixture_text_once \
             "$repo/.github/workflows/$workflow" \
-            '      - uses: ./.github/actions/setup-exact-ownership-tests' \
-            '      - run: echo "exact ownership setup removed"'
+            '        uses: ./.github/actions/setup-exact-ownership-tests' \
+            '        run: echo "exact ownership setup removed"'
 
         assert_check_release_matrix_fails "$repo" "shared exact ownership setup"
     done
@@ -743,6 +743,21 @@ test_check_release_matrix_rejects_unproven_namespace_action() {
         '        /bin/true'
 
     assert_check_release_matrix_fails "$repo" "exact ownership namespace proof"
+}
+
+test_check_release_matrix_rejects_namespace_setup_after_workspace_tests() {
+    local repo
+    repo="$(create_release_policy_fixture)"
+    replace_fixture_text_once \
+        "$repo/.github/workflows/release-build.yml" \
+        '        uses: ./.github/actions/setup-exact-ownership-tests' \
+        '        run: echo "namespace setup delayed"'
+    replace_fixture_text_once \
+        "$repo/.github/workflows/release-build.yml" \
+        '        run: cargo test --workspace --exclude conary-test --verbose' \
+        $'        run: cargo test --workspace --exclude conary-test --verbose\n      - name: Delayed exact ownership setup\n        uses: ./.github/actions/setup-exact-ownership-tests'
+
+    assert_check_release_matrix_fails "$repo" "release workspace validation exact ownership setup order"
 }
 
 test_check_release_matrix_rejects_non_failing_artifact_upload() {
@@ -906,6 +921,7 @@ main() {
         test_check_release_matrix_rejects_missing_live_version_assertion
         test_check_release_matrix_requires_shared_namespace_setup_in_every_workspace_lane
         test_check_release_matrix_rejects_unproven_namespace_action
+        test_check_release_matrix_rejects_namespace_setup_after_workspace_tests
         test_check_release_matrix_rejects_non_failing_artifact_upload
         test_check_release_matrix_rejects_missing_exact_ccs_asset_assertion
         test_check_release_matrix_rejects_unpinned_tester_guide_link

--- a/scripts/test-release-matrix.sh
+++ b/scripts/test-release-matrix.sh
@@ -234,6 +234,7 @@ create_release_policy_fixture() {
     repo="$(mktemp -d "${REPO_ROOT}/.tmp-release-matrix-test.XXXXXX")"
     mkdir -p \
         "$repo/scripts" \
+        "$repo/.github/actions/setup-exact-ownership-tests" \
         "$repo/.github/ISSUE_TEMPLATE" \
         "$repo/.github/workflows" \
         "$repo/docs/operations" \
@@ -247,6 +248,9 @@ create_release_policy_fixture() {
     cp "$REPO_ROOT/.github/workflows/release-build.yml" "$repo/.github/workflows/release-build.yml"
     cp "$REPO_ROOT/.github/workflows/deploy-and-verify.yml" "$repo/.github/workflows/deploy-and-verify.yml"
     cp "$REPO_ROOT/.github/workflows/merge-validation.yml" "$repo/.github/workflows/merge-validation.yml"
+    cp "$REPO_ROOT/.github/workflows/pr-gate.yml" "$repo/.github/workflows/pr-gate.yml"
+    cp "$REPO_ROOT/.github/actions/setup-exact-ownership-tests/action.yml" \
+        "$repo/.github/actions/setup-exact-ownership-tests/action.yml"
     cp "$REPO_ROOT/.github/ISSUE_TEMPLATE/pre_alpha_feedback.md" "$repo/.github/ISSUE_TEMPLATE/pre_alpha_feedback.md"
     cp "$REPO_ROOT/docs/operations/release-artifact-matrix.md" "$repo/docs/operations/release-artifact-matrix.md"
     cp "$REPO_ROOT/site/src/lib/preview-release.ts" "$repo/site/src/lib/preview-release.ts"
@@ -715,6 +719,32 @@ test_check_release_matrix_rejects_missing_live_version_assertion() {
     assert_check_release_matrix_fails "$repo" "live tag preparation must match every owned manifest"
 }
 
+test_check_release_matrix_requires_shared_namespace_setup_in_every_workspace_lane() {
+    local repo
+    local workflow
+
+    for workflow in pr-gate.yml merge-validation.yml release-build.yml; do
+        repo="$(create_release_policy_fixture)"
+        replace_fixture_text_once \
+            "$repo/.github/workflows/$workflow" \
+            '      - uses: ./.github/actions/setup-exact-ownership-tests' \
+            '      - run: echo "exact ownership setup removed"'
+
+        assert_check_release_matrix_fails "$repo" "shared exact ownership setup"
+    done
+}
+
+test_check_release_matrix_rejects_unproven_namespace_action() {
+    local repo
+    repo="$(create_release_policy_fixture)"
+    replace_fixture_text_once \
+        "$repo/.github/actions/setup-exact-ownership-tests/action.yml" \
+        '        unshare --user --map-root-user --mount --propagation private /bin/true' \
+        '        /bin/true'
+
+    assert_check_release_matrix_fails "$repo" "exact ownership namespace proof"
+}
+
 test_check_release_matrix_rejects_non_failing_artifact_upload() {
     local repo
     repo="$(create_release_policy_fixture)"
@@ -874,6 +904,8 @@ main() {
         test_check_release_matrix_rejects_unpinned_ccs_toolchain
         test_check_release_matrix_rejects_unpinned_arch_toolchain
         test_check_release_matrix_rejects_missing_live_version_assertion
+        test_check_release_matrix_requires_shared_namespace_setup_in_every_workspace_lane
+        test_check_release_matrix_rejects_unproven_namespace_action
         test_check_release_matrix_rejects_non_failing_artifact_upload
         test_check_release_matrix_rejects_missing_exact_ccs_asset_assertion
         test_check_release_matrix_rejects_unpinned_tester_guide_link


### PR DESCRIPTION
## Primary Issue

Refs #86

Design / Plan / Roadmap: issue #86 release-recovery slice

## Problem And Outcome

All four post-hard-cut release workflows stopped in `workspace-validation` because release validation ran the exact ownership tests without the user/mount namespace setup already present in the PR gate. Merge validation had the same latent drift. After this PR, every full workspace-test lane uses one fail-closed namespace setup and policy tests reject future workflow drift.

## Changes

- move AppArmor/user/mount namespace setup into a focused local composite action
- invoke that action before the exact ownership tests in PR, merge, and release workspace validation
- extend release-matrix policy to require the shared action exactly once in each owning lane, require correct ordering, and forbid inline copies
- update conary-test's typed PR-workflow contract to assert the shared action and its ordering
- add fixtures proving missing workflow use, late setup, and a non-probing action all fail policy

## Scope

- In scope: CI environment parity required to recover the four failed, assetless #86 release tags
- Out of scope: product behavior, package lifecycle logic, version changes, tag replacement, publication, deployment, and release-proof documentation

## Ownership / Boundary

- Owning subsystem: release and merge validation tooling
- Boundary changed or preserved: namespace setup is centralized; the exact ownership tests and their product semantics are unchanged
- Persisted state or public surface impact: none
- [x] Checked `docs/modules/feature-ownership.md`; no current feature card routes workflow-only release policy

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code (not applicable; no service/daemon code changed)
- [x] Updated subsystem docs or maps when the "look here first" path changed (not applicable; no product look-first path changed)
- [x] Ran the broader interaction gate when the feature ownership card required it (no feature-card match)
- [x] Updated the primary issue with any acceptance criteria left for later PRs (issue #86 remains open for release completion)

```text
- bash -n scripts/check-release-matrix.sh scripts/test-release-matrix.sh scripts/check-github-action-runtimes.sh scripts/test-github-action-runtimes.sh
- cargo fmt --check
- bash scripts/check-release-matrix.sh
- bash scripts/test-release-matrix.sh
- cargo test -p conary-test
- bash scripts/check-github-action-runtimes.sh
- bash scripts/test-github-action-runtimes.sh
- git diff --check
```

## Review And Merge Notes

- Review focus: the local action remains fail-closed and every full workspace lane invokes it before the exact ownership tests
- User or developer impact: release builds no longer fail solely because their runner setup drifted from PR validation
- Required-check bypass: not used