### PR TITLE
fix(release): validate CCS and recover ALPM ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [remi-v0.8.1] - 2026-07-27
+
+### Fixed
+- parse ALPM sonames through source grammar
+
 ## [v0.13.0] - 2026-07-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4857,7 +4857,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remi"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/apps/conary/tests/release_ccs_manifest.rs
+++ b/apps/conary/tests/release_ccs_manifest.rs
@@ -1,0 +1,17 @@
+// apps/conary/tests/release_ccs_manifest.rs
+
+use conary_core::ccs::CcsManifest;
+use std::path::PathBuf;
+
+#[test]
+fn shipping_ccs_manifest_parses_with_current_canonical_contract() {
+    let manifest_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../packaging/ccs/ccs.toml");
+
+    CcsManifest::from_file(&manifest_path).unwrap_or_else(|error| {
+        panic!(
+            "shipping CCS manifest {} must parse: {error:#}",
+            manifest_path.display()
+        )
+    });
+}

--- a/apps/remi/Cargo.toml
+++ b/apps/remi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remi"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]

--- a/crates/conary-core/src/packages/arch.rs
+++ b/crates/conary-core/src/packages/arch.rs
@@ -30,7 +30,7 @@ use crate::packages::traits::{
 use crate::repository::dependency_model::{
     RepositoryCapabilityKind, RepositoryRequirementGroup, RepositoryRequirementKind,
 };
-use crate::repository::package_relation::parse_native_relation;
+use crate::repository::package_relation::{parse_arch_provide, parse_native_relation};
 use crate::repository::versioning::VersionScheme;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
@@ -283,8 +283,6 @@ impl ArchPackage {
         package_version: &str,
         entries: &[String],
     ) -> Result<Vec<ProvidedCapability>> {
-        use crate::repository::versioning::{RepoVersionConstraint, parse_repo_constraint};
-
         let mut provides = vec![ProvidedCapability {
             kind: RepositoryCapabilityKind::PackageName,
             name: package_name.to_string(),
@@ -296,38 +294,15 @@ impl ArchPackage {
             architecture_qualifier: Default::default(),
         }];
         for entry in entries {
-            let clause = crate::repository::package_relation::parse_arch_atom(entry)
-                .map_err(Error::ParseError)?;
-            let version =
-                clause
-                    .version_constraint
-                    .as_deref()
-                    .map(|constraint| {
-                        match parse_repo_constraint(VersionScheme::Arch, constraint)? {
-                    RepoVersionConstraint::Exact(version) => Ok(version),
-                    _ => Err(
-                        crate::repository::versioning::VersionComparisonError::InvalidConstraint {
-                            scheme: VersionScheme::Arch.as_str(),
-                            constraint: constraint.to_string(),
-                            reason: "ALPM versioned provides require the exact '=' operator"
-                                .to_string(),
-                        },
-                    ),
-                }
-                    })
-                    .transpose()
-                    .map_err(|error| Error::ParseError(error.to_string()))?;
+            let parsed = parse_arch_provide(entry, package_name).map_err(Error::ParseError)?;
             let provide = ProvidedCapability {
-                kind: if clause.name == package_name {
-                    RepositoryCapabilityKind::PackageName
-                } else {
-                    RepositoryCapabilityKind::Virtual
-                },
-                name: clause.name,
-                version_relation: version
+                kind: parsed.kind,
+                name: parsed.name,
+                version_relation: parsed
+                    .version
                     .as_ref()
                     .map(|_| crate::repository::dependency_model::ProvideVersionRelation::Equal),
-                version,
+                version: parsed.version,
                 version_scheme: VersionScheme::Arch,
                 architecture_qualifier: Default::default(),
             };

--- a/crates/conary-core/src/packages/arch/tests.rs
+++ b/crates/conary-core/src/packages/arch/tests.rs
@@ -133,16 +133,27 @@ fn arch_provides_are_exact_typed_provider_contracts() {
     let parsed = ArchPackage::parse_provides(
         "example",
         "1.0-1",
-        &["virtual-abi=2".to_string(), "unversioned".to_string()],
+        &[
+            "virtual-abi=2".to_string(),
+            "unversioned".to_string(),
+            "libwlroots-0.18.so=libwlroots-0.18.so-64".to_string(),
+            "lib:libwayland-client.so.0".to_string(),
+        ],
     )
     .unwrap();
 
-    assert_eq!(parsed.len(), 3);
+    assert_eq!(parsed.len(), 5);
     assert_eq!(parsed[0].kind, RepositoryCapabilityKind::PackageName);
     assert_eq!(parsed[0].version.as_deref(), Some("1.0-1"));
     assert_eq!(parsed[1].kind, RepositoryCapabilityKind::Virtual);
     assert_eq!(parsed[1].version.as_deref(), Some("2"));
     assert_eq!(parsed[2].version, None);
+    assert_eq!(parsed[3].name, "libwlroots-0.18.so=libwlroots-0.18.so-64");
+    assert_eq!(parsed[3].kind, RepositoryCapabilityKind::Soname);
+    assert_eq!(parsed[3].version, None);
+    assert_eq!(parsed[4].name, "lib:libwayland-client.so.0");
+    assert_eq!(parsed[4].kind, RepositoryCapabilityKind::Soname);
+    assert_eq!(parsed[4].version, None);
 
     let error = ArchPackage::parse_provides("example", "1.0-1", &["virtual-abi>=2".to_string()])
         .unwrap_err();
@@ -152,7 +163,10 @@ fn arch_provides_are_exact_typed_provider_contracts() {
 #[test]
 fn arch_runtime_optional_and_build_requirements_keep_typed_kinds() {
     let runtime = ArchPackage::parse_requirements(
-        &["glibc>=2.34".to_string()],
+        &[
+            "glibc>=2.34".to_string(),
+            "libwlroots-0.18.so=libwlroots-0.18.so-64".to_string(),
+        ],
         RepositoryRequirementKind::Depends,
     )
     .unwrap();
@@ -170,6 +184,15 @@ fn arch_runtime_optional_and_build_requirements_keep_typed_kinds() {
         runtime[0].alternatives[0].version_constraint.as_deref(),
         Some(">= 2.34")
     );
+    assert_eq!(
+        runtime[1].alternatives[0].name,
+        "libwlroots-0.18.so=libwlroots-0.18.so-64"
+    );
+    assert_eq!(
+        runtime[1].alternatives[0].capability_kind,
+        Some(RepositoryCapabilityKind::Soname)
+    );
+    assert!(runtime[1].alternatives[0].version_constraint.is_none());
     assert_eq!(optional[0].kind, RepositoryRequirementKind::Optional);
     assert_eq!(optional[0].description.as_deref(), Some("for scripts"));
     assert_eq!(build[0].kind, RepositoryRequirementKind::Build);

--- a/crates/conary-core/src/repository/package_relation.rs
+++ b/crates/conary-core/src/repository/package_relation.rs
@@ -14,6 +14,13 @@ use super::dependency_model::{
 use super::versioning::{RepoVersionConstraint, repo_version_satisfies};
 use super::versioning::{VersionScheme, parse_repo_constraint};
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParsedArchProvide {
+    pub name: String,
+    pub kind: RepositoryCapabilityKind,
+    pub version: Option<String>,
+}
+
 pub struct PackageRelationProvide<'a> {
     pub name: &'a str,
     pub version: Option<&'a str>,
@@ -562,6 +569,90 @@ pub(crate) fn parse_arch_atom(input: &str) -> Result<RepositoryRequirementClause
     let clause = parse_inline_atom(input, VersionScheme::Arch)?;
     validate_arch_name(&clause.name, input)?;
     Ok(clause)
+}
+
+pub(crate) fn parse_arch_runtime_atom(input: &str) -> Result<RepositoryRequirementClause, String> {
+    match input
+        .parse::<alpm_types::RelationOrSoname>()
+        .map_err(|error| error.to_string())?
+    {
+        alpm_types::RelationOrSoname::Relation(relation) => {
+            Ok(arch_package_relation_clause(relation))
+        }
+        alpm_types::RelationOrSoname::SonameV1(soname) => {
+            Ok(arch_soname_clause(soname.to_string(), input))
+        }
+        alpm_types::RelationOrSoname::SonameV2(soname) => {
+            Ok(arch_soname_clause(soname.to_string(), input))
+        }
+    }
+}
+
+pub(crate) fn parse_arch_provide(
+    input: &str,
+    package_name: &str,
+) -> Result<ParsedArchProvide, String> {
+    match input
+        .parse::<alpm_types::RelationOrSoname>()
+        .map_err(|error| error.to_string())?
+    {
+        alpm_types::RelationOrSoname::Relation(relation) => {
+            let version = match relation.version_requirement {
+                None => None,
+                Some(requirement)
+                    if requirement.comparison == alpm_types::VersionComparison::Equal =>
+                {
+                    Some(requirement.version.to_string())
+                }
+                Some(_) => {
+                    return Err(format!(
+                        "Arch %PROVIDES% entry '{input}' must be unversioned or use the exact '=' relation"
+                    ));
+                }
+            };
+            let name = relation.name.to_string();
+            let kind = if name == package_name {
+                RepositoryCapabilityKind::PackageName
+            } else {
+                RepositoryCapabilityKind::Virtual
+            };
+            Ok(ParsedArchProvide {
+                name,
+                kind,
+                version,
+            })
+        }
+        alpm_types::RelationOrSoname::SonameV1(soname) => Ok(ParsedArchProvide {
+            name: soname.to_string(),
+            kind: RepositoryCapabilityKind::Soname,
+            version: None,
+        }),
+        alpm_types::RelationOrSoname::SonameV2(soname) => Ok(ParsedArchProvide {
+            name: soname.to_string(),
+            kind: RepositoryCapabilityKind::Soname,
+            version: None,
+        }),
+    }
+}
+
+fn arch_package_relation_clause(
+    relation: alpm_types::PackageRelation,
+) -> RepositoryRequirementClause {
+    let name = relation.name.to_string();
+    match relation.version_requirement {
+        Some(requirement) => RepositoryRequirementClause::versioned(
+            name,
+            format!("{} {}", requirement.comparison, requirement.version),
+        ),
+        None => RepositoryRequirementClause::name_only(name),
+    }
+}
+
+fn arch_soname_clause(identity: String, native_text: &str) -> RepositoryRequirementClause {
+    let mut clause = RepositoryRequirementClause::name_only(identity);
+    clause.capability_kind = Some(RepositoryCapabilityKind::Soname);
+    clause.native_text = Some(native_text.to_string());
+    clause
 }
 
 pub(super) fn parse_inline_atom(

--- a/crates/conary-core/src/repository/parsers/arch.rs
+++ b/crates/conary-core/src/repository/parsers/arch.rs
@@ -10,10 +10,10 @@ use crate::compression::decompress_auto;
 use crate::error::{Error, Result};
 use crate::repository::client::RepositoryClient;
 use crate::repository::dependency_model::{
-    RepositoryCapabilityKind, RepositoryDependencyFlavor, RepositoryProvide,
-    RepositoryRequirementGroup, RepositoryRequirementKind,
+    RepositoryDependencyFlavor, RepositoryProvide, RepositoryRequirementGroup,
+    RepositoryRequirementKind,
 };
-use crate::repository::package_relation::parse_native_relation;
+use crate::repository::package_relation::{parse_arch_provide, parse_native_relation};
 use crate::repository::trust::openpgp::PreparedOpenPgpTrust;
 use crate::repository::trust::{ArchSignatureRequirement, RepositoryTrustPolicy, TrustRole};
 use crate::repository::versioning::VersionScheme;
@@ -221,52 +221,17 @@ impl ArchParser {
 
         if let Some(prov_list) = desc_fields.get("PROVIDES") {
             for prov in prov_list {
-                let clause = crate::repository::package_relation::parse_arch_atom(prov).map_err(
-                    |error| {
-                        Error::ParseError(format!(
-                            "invalid Arch %PROVIDES% entry '{prov}': {error}"
-                        ))
-                    },
-                )?;
-                let kind = if clause.name == name {
-                    RepositoryCapabilityKind::PackageName
-                } else {
-                    // ALPM's PROVIDES field declares a capability but does not
-                    // carry a distinct soname/path type. Do not derive one
-                    // from the capability spelling.
-                    RepositoryCapabilityKind::Virtual
-                };
-
-                let prov_version = clause
-                    .version_constraint
-                    .as_deref()
-                    .map(|constraint| {
-                        match crate::repository::versioning::parse_repo_constraint(
-                            VersionScheme::Arch,
-                            constraint,
-                        )
-                        .map_err(|error| {
-                            Error::ParseError(format!(
-                                "invalid Arch %PROVIDES% entry '{prov}': {error}"
-                            ))
-                        })? {
-                            crate::repository::versioning::RepoVersionConstraint::Exact(
-                                version,
-                            ) => Ok(version),
-                            _ => Err(Error::ParseError(format!(
-                                "Arch %PROVIDES% entry '{prov}' must be unversioned or use the exact '=' relation"
-                            ))),
-                        }
-                    })
-                    .transpose()?;
+                let parsed = parse_arch_provide(prov, name).map_err(|error| {
+                    Error::ParseError(format!("invalid Arch %PROVIDES% entry '{prov}': {error}"))
+                })?;
 
                 provides.push(RepositoryProvide {
-                    name: clause.name,
-                    kind,
-                    version_relation: prov_version.as_ref().map(|_| {
+                    name: parsed.name,
+                    kind: parsed.kind,
+                    version_relation: parsed.version.as_ref().map(|_| {
                         crate::repository::dependency_model::ProvideVersionRelation::Equal
                     }),
-                    version: prov_version,
+                    version: parsed.version,
                     architecture_qualifier:
                         crate::repository::dependency_model::ProvideArchitectureQualifier::Implicit,
                     native_text: Some(prov.clone()),
@@ -484,6 +449,7 @@ impl RepositoryParser for ArchParser {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::repository::dependency_model::RepositoryCapabilityKind;
 
     fn parser() -> ArchParser {
         let trust = PreparedOpenPgpTrust::for_test(RepositoryTrustPolicy::Arch {
@@ -791,6 +757,8 @@ x86_64
 %PROVIDES%
 libm.so=6-64
 libpthread.so
+libwlroots-0.18.so=libwlroots-0.18.so-64
+lib:libwayland-client.so.0
 ";
 
         let fields = parser.parse_desc_file(desc).unwrap();
@@ -798,8 +766,8 @@ libpthread.so
             .package_from_fields("https://example.test", &fields, None)
             .unwrap();
 
-        // Self-provide + 2 explicit provides
-        assert!(pkg.provides.len() >= 3);
+        // Self-provide + 4 explicit provides
+        assert_eq!(pkg.provides.len(), 5);
 
         let self_prov = pkg
             .provides
@@ -811,18 +779,60 @@ libpthread.so
         let libm = pkg
             .provides
             .iter()
-            .find(|p| p.name == "libm.so")
+            .find(|p| p.name == "libm.so=6-64")
             .expect("libm.so provide missing");
-        assert_eq!(libm.kind, RepositoryCapabilityKind::Virtual);
-        assert_eq!(libm.version.as_deref(), Some("6-64"));
+        assert_eq!(libm.kind, RepositoryCapabilityKind::Soname);
+        assert!(libm.version.is_none());
 
         let libpthread = pkg
             .provides
             .iter()
             .find(|p| p.name == "libpthread.so")
             .expect("libpthread.so provide missing");
-        assert_eq!(libpthread.kind, RepositoryCapabilityKind::Virtual);
+        assert_eq!(libpthread.kind, RepositoryCapabilityKind::Soname);
         assert!(libpthread.version.is_none());
+
+        let wlroots = pkg
+            .provides
+            .iter()
+            .find(|p| p.name == "libwlroots-0.18.so=libwlroots-0.18.so-64")
+            .expect("versioned soname v1 provide missing");
+        assert_eq!(wlroots.kind, RepositoryCapabilityKind::Soname);
+        assert!(wlroots.version.is_none());
+
+        let wayland = pkg
+            .provides
+            .iter()
+            .find(|p| p.name == "lib:libwayland-client.so.0")
+            .expect("soname v2 provide missing");
+        assert_eq!(wayland.kind, RepositoryCapabilityKind::Soname);
+        assert!(wayland.version.is_none());
+    }
+
+    #[test]
+    fn repository_runtime_sonames_are_atomic_typed_requirements() {
+        let parser = parser();
+        let requirements = parser
+            .parse_structured_depends(
+                "%DEPENDS%\n\
+                 libwlroots-0.18.so=libwlroots-0.18.so-64\n\
+                 lib:libwayland-client.so.0\n",
+            )
+            .unwrap();
+
+        assert_eq!(requirements.len(), 2);
+        for (requirement, identity) in requirements.iter().zip([
+            "libwlroots-0.18.so=libwlroots-0.18.so-64",
+            "lib:libwayland-client.so.0",
+        ]) {
+            let clause = &requirement.alternatives[0];
+            assert_eq!(clause.name, identity);
+            assert_eq!(
+                clause.capability_kind,
+                Some(RepositoryCapabilityKind::Soname)
+            );
+            assert!(clause.version_constraint.is_none());
+        }
     }
 
     #[test]
@@ -877,6 +887,11 @@ x86_64
         let error = parser
             .parse_structured_depends("%DEPENDS%\nopenssl>=\n")
             .unwrap_err();
-        assert!(error.to_string().contains("empty version"), "{error}");
+        assert!(
+            error
+                .to_string()
+                .contains("invalid Arch %DEPENDS% entry 'openssl>='"),
+            "{error}"
+        );
     }
 }

--- a/crates/conary-core/src/repository/requirement.rs
+++ b/crates/conary-core/src/repository/requirement.rs
@@ -42,9 +42,13 @@ pub fn parse_native_requirement(
                 )
             }
         }
-        VersionScheme::Arch => RepositoryRequirementExpression::Atom(
-            super::package_relation::parse_arch_atom(native_text)?,
-        ),
+        VersionScheme::Arch => {
+            RepositoryRequirementExpression::Atom(if kind == RepositoryRequirementKind::Depends {
+                super::package_relation::parse_arch_runtime_atom(native_text)?
+            } else {
+                super::package_relation::parse_arch_atom(native_text)?
+            })
+        }
         VersionScheme::Conary => RepositoryRequirementExpression::Atom(
             super::package_relation::parse_inline_atom(native_text, scheme)?,
         ),

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-26
-revision: 15
+last_updated: 2026-07-27
+revision: 16
 summary: Document exact profile-owned source policy, canonical map authority, native repository authority, package identity, and lifecycle handoff
 ---
 
@@ -201,6 +201,13 @@ three metadata chains. Fedora metalink identity parsing is isolated in
 package checks. Missing keys, a missing required signature, an unsupported
 hash, duplicate authority records, invalid certification thresholds, or any
 identity mismatch fail closed and remove a partially downloaded package.
+
+The Arch repository parser and direct package parser share
+`repository/package_relation.rs` as the ALPM relation authority. Runtime
+dependencies and provisions are parsed through the official typed
+`RelationOrSoname` grammar. Soname v1 and v2 values remain complete atomic
+`Soname` identities; Conary never guesses a package-version boundary inside
+them. Ordinary package relations retain their exact ALPM comparison semantics.
 
 The contract was derived against the package managers' and repository
 generators' own documentation:

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-26
-revision: 32
+last_updated: 2026-07-27
+revision: 33
 summary: Define source-independent lifecycle, generation activation, and configuration transactions for RPM, Debian, and Arch packages
 ---
 
@@ -1043,8 +1043,31 @@ Authoritative references:
 
 - [`alpm-install-scriptlet(5)`](https://man.archlinux.org/man/alpm-install-scriptlet.5.en)
 - [`alpm-hooks(5)`](https://man.archlinux.org/man/alpm-hooks.5.en)
+- [`alpm-package-relation(7)`](https://alpm.archlinux.page/specifications/alpm-package-relation.7.html)
+- [`alpm-sonamev1(7)`](https://alpm.archlinux.page/specifications/alpm-sonamev1.7.html)
+- [`alpm-soname(7)`](https://alpm.archlinux.page/specifications/alpm-soname.7.html)
+- [pinned pacman/libalpm dependency parser](https://gitlab.archlinux.org/pacman/pacman/-/blob/a6f7467d8c7c4d7e9cc846884e74c0ab7215c48d/lib/libalpm/deps.c)
 - [pinned pacman/libalpm source](https://gitlab.archlinux.org/pacman/pacman/-/blob/a6f7467d8c7c4d7e9cc846884e74c0ab7215c48d/lib/libalpm/trans.c)
 - [pinned Arch pacman build contract](https://gitlab.archlinux.org/archlinux/packaging/packages/pacman/-/blob/abdc0dfedf3ca553a02dde8551e972fe745535b7/PKGBUILD)
+
+### ALPM Relations And Sonames
+
+Runtime dependencies and provisions use the official ALPM grammar through
+`alpm_types::RelationOrSoname`, whose parse precedence is soname v2, soname
+v1, then package relation. This is source grammar, not punctuation matching or
+a package exception.
+
+ALPM soname v1 and v2 values are atomic `Soname` capability identities. Conary
+stores the complete canonical string, including a v1 identity such as
+`libwlroots-0.18.so=libwlroots-0.18.so-64`, without treating any portion as an
+Arch package-version constraint. A runtime soname requirement matches only an
+identical typed soname provision; a same-named package or virtual provision is
+not equivalent.
+
+Ordinary package and virtual provisions remain package relations. They may be
+unversioned or use ALPM's exact `=` relation; other comparison operators are
+rejected for provisions. Conflicts, replacements, optional dependencies, and
+build dependencies continue to use their documented package-relation grammar.
 
 ### `.INSTALL` Functions
 

--- a/packaging/ccs/ccs.toml
+++ b/packaging/ccs/ccs.toml
@@ -5,7 +5,7 @@
 
 requirements = [
     { kind = "Depends", behavior = "Hard", expression = { operator = "atom", operands = { name = "glibc", capability_kind = "Virtual", native_text = "glibc" } }, alternatives = [{ name = "glibc", capability_kind = "Virtual", native_text = "glibc" }], native_text = "glibc" },
-    { kind = "Depends", behavior = "Hard", expression = { operator = "atom", operands = { name = "openssl-libs", capability_kind = "PackageName", version_constraint = ">=3.0", native_text = "openssl-libs >=3.0" } }, alternatives = [{ name = "openssl-libs", capability_kind = "PackageName", version_constraint = ">=3.0", native_text = "openssl-libs >=3.0" }], native_text = "openssl-libs >=3.0" },
+    { kind = "Depends", behavior = "Hard", expression = { operator = "atom", operands = { name = "openssl-libs", capability_kind = "PackageName", version_constraint = ">=3.0.0", native_text = "openssl-libs >=3.0.0" } }, alternatives = [{ name = "openssl-libs", capability_kind = "PackageName", version_constraint = ">=3.0.0", native_text = "openssl-libs >=3.0.0" }], native_text = "openssl-libs >=3.0.0" },
     { kind = "Depends", behavior = "Hard", expression = { operator = "atom", operands = { name = "xz-libs", capability_kind = "PackageName", native_text = "xz-libs" } }, alternatives = [{ name = "xz-libs", capability_kind = "PackageName", native_text = "xz-libs" }], native_text = "xz-libs" },
 ]
 


### PR DESCRIPTION
## Primary Issue

Refs #86

Design / Plan / Roadmap: `docs/operations/release-artifact-matrix.md`; `docs/specs/foreign-package-lifecycle-contracts.md`

## Problem And Outcome

The first `v0.13.0` release build reached the shipping CCS manifest after compilation, then rejected its incomplete canonical `>=3.0` constraint. After that repair, the published immutable `remi-v0.8.0` deployment exposed a second exact blocker in live Arch metadata: `%PROVIDES%` contains ALPM soname identities such as `libwlroots-0.18.so=libwlroots-0.18.so-64`, but Conary sent the right-hand side through the Arch package-version parser and aborted the whole multi-repository refresh.

The shipping CCS manifest now proves it conforms to the current parser. Arch repository and direct-package ingestion now share the official typed `alpm_types::RelationOrSoname` grammar, preserving soname v1/v2 as atomic typed capabilities rather than guessing a version boundary. Remi is prepared as `remi-v0.8.1`; the published `remi-v0.8.0` release remains immutable.

## Changes

- Normalize the Conary CCS package's OpenSSL requirement to `>=3.0.0` in every typed and native-text projection.
- Parse ALPM runtime dependencies and provisions through `RelationOrSoname` in the shared relation authority.
- Preserve complete soname v1/v2 strings as typed `Soname` identities; keep ordinary package/virtual relations and exact `=` provide versions unchanged.
- Add regression fixtures for the exact wlroots metadata that stopped production, soname v2, direct package parsing, repository parsing, and the shipping CCS manifest.
- Document the official ALPM relation/soname authority and prepare the immutable Remi 0.8.1 recovery release.

## Scope

- In scope: repair and preflight the Conary v0.13.0 CCS asset; repair the production-discovered Arch ingestion failure; prepare Remi 0.8.1.
- Out of scope: schema changes, distro/package allowlists, heuristic exceptions, compatibility aliases, or replacing the published Remi 0.8.0 release.

## Ownership / Boundary

- Owning subsystems: Conary release packaging; repository metadata, requirements, and SAT resolution.
- Boundary changed or preserved: `repository/package_relation.rs` is the shared ALPM relation authority for repository and direct-package ingestion; no look-here-first path moved.
- Persisted state or public surface impact: no schema change. Existing current-schema Remi state will be deterministically repopulated by the 0.8.1 deployment; soname capabilities retain their complete source identity.
- [x] Ran `bash scripts/agent-context.sh --feature resolution` and all seven focused plus all six interaction-gate commands.
- [x] Updated `docs/modules/source-selection.md` and `docs/specs/foreign-package-lifecycle-contracts.md`.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p conary-core repository::parsers::arch`
- [x] `cargo test -p conary-core packages::arch`
- [x] `bash scripts/agent-context.sh --feature resolution --run focused`
- [x] `bash scripts/agent-context.sh --feature resolution --run gate`
- [x] `cargo test -p remi` (562 library + 5 binary tests; CLI integration also passed)
- [x] `cargo test -p conary --test release_ccs_manifest`
- [x] `cargo run -q -p conary -- capability validate packaging/ccs/ccs.toml`
- [x] `bash scripts/check-release-matrix.sh`
- [x] `bash scripts/test-release-matrix.sh`
- [x] `bash scripts/check-doc-truth.sh`
- [x] `bash scripts/test-doc-truth.sh`
- [x] `bash scripts/test-agent-context.sh`
- [x] `bash scripts/agent-context.sh --validate`
- [x] `git diff --check`

## Review And Merge Notes

- Review focus: official ALPM grammar use; atomic typed soname identity; unchanged ordinary relation semantics; exact release metadata.
- User or developer impact: unblocks the missing v0.13.0 CCS asset and prevents one valid Arch package from aborting every Remi source refresh.
- Required-check bypass: not used.
