### PR TITLE
fix: parse RPM rich dependencies and isolate Remi refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [remi-v0.8.2] - 2026-07-27
+
+### Fixed
+- isolate repository refresh outcomes
+- match RPM rich dependency grammar
+- sign canonical CCS artifacts (#90)
+
 ## [remi-v0.8.1] - 2026-07-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4857,7 +4857,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remi"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/apps/remi/Cargo.toml
+++ b/apps/remi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remi"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]

--- a/apps/remi/src/server/admin_service.rs
+++ b/apps/remi/src/server/admin_service.rs
@@ -9,7 +9,6 @@
 //! The service layer is also the integration point for MCP tool handlers,
 //! which need the same business logic without HTTP framing.
 
-use futures::StreamExt;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::{net::IpAddr, str::FromStr};
@@ -27,8 +26,14 @@ use crate::federation::{Peer, PeerTier};
 use crate::server::ServerState;
 use crate::server::auth::{generate_token, hash_token, validate_scopes};
 
+mod refresh;
 mod test_data;
 
+pub use refresh::{
+    RepoRefreshBatch, RepoRefreshBatchState, RepoRefreshFailure, RepoRefreshFailureKind,
+    RepoRefreshResult,
+};
+use refresh::{RepoRefreshOutcome, collect_refresh_outcomes};
 pub use test_data::{
     PushStepData, PushTestResultData, TestDetail, TestHealthSummary, TestRunDetail,
     TestStepWithLogs, create_test_run, get_test_detail, get_test_logs, get_test_run_detail,
@@ -563,14 +568,6 @@ pub struct UpdateRepoInput {
     pub trust: Option<RepositoryTrustPolicy>,
 }
 
-/// Result of a repository metadata refresh.
-#[derive(Debug, Clone)]
-pub struct RepoRefreshResult {
-    pub name: String,
-    pub packages_synced: usize,
-    pub skipped: bool,
-}
-
 enum RepoRefreshPlan {
     Missing,
     Skipped(RepoRefreshResult),
@@ -684,12 +681,14 @@ async fn refresh_loaded_repo(
     repo: Repository,
 ) -> Result<RepoRefreshResult, ServiceError> {
     let name = repo.name.clone();
+    let source_profile = repo.source_profile.clone();
     let packages_synced = conary_core::repository::sync_repository_from_db_path(db, repo)
         .await
         .map_err(ServiceError::from)?;
 
     Ok(RepoRefreshResult {
         name,
+        source_profile,
         packages_synced,
         skipped: false,
     })
@@ -750,6 +749,7 @@ pub async fn sync_repo(
         if !force && !conary_core::repository::needs_sync(&repo) {
             return Ok(RepoRefreshPlan::Skipped(RepoRefreshResult {
                 name: repo.name,
+                source_profile: repo.source_profile,
                 packages_synced: 0,
                 skipped: true,
             }));
@@ -770,7 +770,7 @@ pub async fn sync_repo(
 pub async fn refresh_repositories(
     state: &Arc<RwLock<ServerState>>,
     force: bool,
-) -> Result<Vec<RepoRefreshResult>, ServiceError> {
+) -> Result<RepoRefreshBatch, ServiceError> {
     let db = db_path(state).await;
     let repos = blocking_anyhow({
         let db = db.clone();
@@ -781,29 +781,36 @@ pub async fn refresh_repositories(
     })
     .await?;
 
-    let mut refresh_stream = futures::stream::iter(repos.into_iter().map(|repo| {
-        let db = db.clone();
-        async move {
-            if !force && !conary_core::repository::needs_sync(&repo) {
-                return Ok(RepoRefreshResult {
-                    name: repo.name,
-                    packages_synced: 0,
-                    skipped: true,
-                });
+    let jobs =
+        repos.into_iter().map(|repo| {
+            let db = db.clone();
+            let name = repo.name.clone();
+            let source_profile = repo.source_profile.clone();
+            async move {
+                let result = if !force && !conary_core::repository::needs_sync(&repo) {
+                    Ok(RepoRefreshResult {
+                        name: name.clone(),
+                        source_profile: source_profile.clone(),
+                        packages_synced: 0,
+                        skipped: true,
+                    })
+                } else {
+                    refresh_loaded_repo(db, repo).await
+                };
+                match result {
+                    Ok(result) => RepoRefreshOutcome::Success(result),
+                    Err(error) => RepoRefreshOutcome::Failure(
+                        RepoRefreshFailure::from_service_error(name, source_profile, error),
+                    ),
+                }
             }
-            refresh_loaded_repo(db, repo).await
-        }
-    }))
-    .buffer_unordered(4);
+        });
+    let batch = collect_refresh_outcomes(jobs).await;
 
-    let mut results = Vec::new();
-    while let Some(result) = refresh_stream.next().await {
-        results.push(result?);
-    }
-
-    // After successful sync, trigger canonical rebuild if cooldown elapsed.
+    // After at least one successful source, trigger canonical rebuild if the
+    // cooldown elapsed. One failed source must not starve successful sources.
     // Failures here are non-fatal -- the sync result is returned regardless.
-    {
+    if !batch.results.is_empty() {
         let db_path = db_path(state).await;
         let canonical_cfg = state.read().await.canonical_config.clone();
         blocking(move || {
@@ -826,5 +833,5 @@ pub async fn refresh_repositories(
         .unwrap_or_else(|e| tracing::warn!("Post-sync canonical rebuild task failed: {e}"));
     }
 
-    Ok(results)
+    Ok(batch)
 }

--- a/apps/remi/src/server/admin_service/refresh.rs
+++ b/apps/remi/src/server/admin_service/refresh.rs
@@ -1,0 +1,219 @@
+// apps/remi/src/server/admin_service/refresh.rs
+
+//! Typed outcomes and bounded collection for multi-source refresh.
+
+use futures::StreamExt;
+use std::future::Future;
+
+use super::ServiceError;
+
+/// Result of one successful repository metadata refresh.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RepoRefreshResult {
+    pub name: String,
+    pub source_profile: Option<String>,
+    pub packages_synced: usize,
+    pub skipped: bool,
+}
+
+/// Stable failure class for one repository refresh.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RepoRefreshFailureKind {
+    SourceRejected,
+    SourceNotFound,
+    Conflict,
+    Internal,
+}
+
+/// Failure from one source in a multi-repository refresh.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RepoRefreshFailure {
+    pub name: String,
+    pub source_profile: Option<String>,
+    pub kind: RepoRefreshFailureKind,
+    pub message: String,
+}
+
+impl RepoRefreshFailure {
+    pub(super) fn from_service_error(
+        name: String,
+        source_profile: Option<String>,
+        error: ServiceError,
+    ) -> Self {
+        let kind = match &error {
+            ServiceError::BadRequest(_) => RepoRefreshFailureKind::SourceRejected,
+            ServiceError::NotFound(_) => RepoRefreshFailureKind::SourceNotFound,
+            ServiceError::Conflict(_) => RepoRefreshFailureKind::Conflict,
+            ServiceError::Internal(_) => RepoRefreshFailureKind::Internal,
+        };
+        Self {
+            name,
+            source_profile,
+            kind,
+            message: error.to_string(),
+        }
+    }
+}
+
+/// Aggregate state of a multi-repository refresh.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RepoRefreshBatchState {
+    Complete,
+    Partial,
+    Failed,
+}
+
+impl RepoRefreshBatchState {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Complete => "complete",
+            Self::Partial => "partial",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+/// Typed per-source outcomes for one multi-repository refresh.
+#[derive(Debug, Default)]
+pub struct RepoRefreshBatch {
+    pub results: Vec<RepoRefreshResult>,
+    pub failures: Vec<RepoRefreshFailure>,
+}
+
+impl RepoRefreshBatch {
+    pub fn state(&self) -> RepoRefreshBatchState {
+        match (self.results.is_empty(), self.failures.is_empty()) {
+            (_, true) => RepoRefreshBatchState::Complete,
+            (false, false) => RepoRefreshBatchState::Partial,
+            (true, false) => RepoRefreshBatchState::Failed,
+        }
+    }
+
+    pub fn synced_count(&self) -> usize {
+        self.results.iter().filter(|result| !result.skipped).count()
+    }
+
+    pub fn skipped_count(&self) -> usize {
+        self.results.iter().filter(|result| result.skipped).count()
+    }
+}
+
+pub(super) enum RepoRefreshOutcome {
+    Success(RepoRefreshResult),
+    Failure(RepoRefreshFailure),
+}
+
+pub(super) async fn collect_refresh_outcomes<I, F>(jobs: I) -> RepoRefreshBatch
+where
+    I: IntoIterator<Item = F>,
+    F: Future<Output = RepoRefreshOutcome>,
+{
+    let mut stream = futures::stream::iter(jobs).buffer_unordered(4);
+    let mut batch = RepoRefreshBatch::default();
+    while let Some(outcome) = stream.next().await {
+        match outcome {
+            RepoRefreshOutcome::Success(result) => batch.results.push(result),
+            RepoRefreshOutcome::Failure(failure) => batch.failures.push(failure),
+        }
+    }
+    batch
+        .results
+        .sort_by(|left, right| left.name.cmp(&right.name));
+    batch
+        .failures
+        .sort_by(|left, right| left.name.cmp(&right.name));
+    batch
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    #[tokio::test]
+    async fn one_source_failure_does_not_discard_successful_outcomes() {
+        let jobs = vec![
+            futures::future::ready(RepoRefreshOutcome::Failure(RepoRefreshFailure {
+                name: "fedora-44".to_string(),
+                source_profile: Some("fedora-44".to_string()),
+                kind: RepoRefreshFailureKind::SourceRejected,
+                message: "invalid RPM metadata".to_string(),
+            })),
+            futures::future::ready(RepoRefreshOutcome::Success(RepoRefreshResult {
+                name: "ubuntu-26.04".to_string(),
+                source_profile: Some("ubuntu-26.04".to_string()),
+                packages_synced: 42,
+                skipped: false,
+            })),
+        ];
+
+        let batch = collect_refresh_outcomes(jobs).await;
+        assert_eq!(batch.state(), RepoRefreshBatchState::Partial);
+        assert_eq!(batch.results.len(), 1);
+        assert_eq!(batch.failures.len(), 1);
+        assert_eq!(batch.synced_count(), 1);
+        assert_eq!(batch.skipped_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn configured_source_failure_preserves_current_source_result() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let db_path = temp.path().join("conary.db");
+        let chunk_dir = temp.path().join("chunks");
+        let cache_dir = temp.path().join("cache");
+        std::fs::create_dir_all(&chunk_dir).expect("create chunks");
+        std::fs::create_dir_all(&cache_dir).expect("create cache");
+
+        {
+            let conn = rusqlite::Connection::open(&db_path).expect("open database");
+            conary_core::db::schema::ensure_current(&conn).expect("prepare schema");
+
+            let mut current = conary_core::db::models::Repository::new(
+                "current-fedora".to_string(),
+                "https://current.example.test".to_string(),
+            );
+            current.source_profile = Some("fedora-44".to_string());
+            current.metadata_expire = 21_600;
+            current.insert(&conn).expect("insert current source");
+            conn.execute(
+                "UPDATE repositories SET last_sync = ?1 WHERE name = ?2",
+                rusqlite::params![
+                    conary_core::repository::current_timestamp(),
+                    "current-fedora"
+                ],
+            )
+            .expect("mark source current");
+
+            let mut broken = conary_core::db::models::Repository::new(
+                "broken-fedora".to_string(),
+                "https://broken.example.test".to_string(),
+            );
+            broken.source_profile = Some("fedora-44".to_string());
+            broken.insert(&conn).expect("insert broken source");
+        }
+
+        let config = crate::server::ServerConfig {
+            db_path,
+            chunk_dir,
+            cache_dir,
+            ..Default::default()
+        };
+        let state = Arc::new(RwLock::new(
+            crate::server::ServerState::new(config).expect("build server state"),
+        ));
+
+        let batch = super::super::refresh_repositories(&state, false)
+            .await
+            .expect("enumerate configured sources");
+        assert_eq!(batch.state(), RepoRefreshBatchState::Partial);
+        assert_eq!(batch.results.len(), 1);
+        assert_eq!(batch.results[0].name, "current-fedora");
+        assert!(batch.results[0].skipped);
+        assert_eq!(batch.failures.len(), 1);
+        assert_eq!(batch.failures[0].name, "broken-fedora");
+        assert_eq!(batch.failures[0].kind, RepoRefreshFailureKind::Internal);
+    }
+}

--- a/apps/remi/src/server/handlers/admin/repos.rs
+++ b/apps/remi/src/server/handlers/admin/repos.rs
@@ -10,7 +10,9 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::server::ServerState;
-use crate::server::admin_service::{self, CreateRepoInput, UpdateRepoInput};
+use crate::server::admin_service::{
+    self, CreateRepoInput, RepoRefreshBatch, RepoRefreshBatchState, UpdateRepoInput,
+};
 use crate::server::auth::{Scope, TokenScopes, json_error};
 use conary_core::db::models::RepositoryOwnership;
 use conary_core::repository::{RepositoryFormat, RepositoryParserConfig, RepositoryTrustPolicy};
@@ -352,6 +354,7 @@ pub async fn sync_repo(
                 "repo.synced",
                 serde_json::json!({
                     "name": &result.name,
+                    "source_profile": &result.source_profile,
                     "packages_synced": result.packages_synced,
                     "skipped": result.skipped,
                     "force": query.force,
@@ -361,6 +364,7 @@ pub async fn sync_repo(
             Json(serde_json::json!({
                 "status": if result.skipped { "up_to_date" } else { "synced" },
                 "name": result.name,
+                "source_profile": result.source_profile,
                 "packages_synced": result.packages_synced,
                 "skipped": result.skipped,
                 "force": query.force,
@@ -389,41 +393,60 @@ pub async fn refresh_repos(
     }
 
     match admin_service::refresh_repositories(&state, query.force).await {
-        Ok(results) => {
-            let synced = results.iter().filter(|r| !r.skipped).count();
-            let skipped = results.iter().filter(|r| r.skipped).count();
-
-            let guard = state.read().await;
-            guard.publish_event(
-                "repos.refreshed",
-                serde_json::json!({
-                    "force": query.force,
-                    "synced": synced,
-                    "skipped": skipped,
-                }),
-            );
-            drop(guard);
-
-            Json(serde_json::json!({
-                "status": "ok",
-                "force": query.force,
-                "synced": synced,
-                "skipped": skipped,
-                "results": results
-                    .into_iter()
-                    .map(|r| serde_json::json!({
-                        "name": r.name,
-                        "packages_synced": r.packages_synced,
-                        "skipped": r.skipped,
-                    }))
-                    .collect::<Vec<_>>(),
-            }))
-            .into_response()
-        }
+        Ok(batch) => refresh_batch_response(&state, query.force, batch).await,
         Err(e) => {
             tracing::error!("Failed to refresh repositories: {e}");
             json_error(500, "Failed to refresh repositories", "INTERNAL_ERROR")
         }
+    }
+}
+
+/// Publish and render the one canonical multi-source refresh result.
+pub(crate) async fn refresh_batch_response(
+    state: &Arc<RwLock<ServerState>>,
+    force: bool,
+    batch: RepoRefreshBatch,
+) -> Response {
+    let batch_state = batch.state();
+    let synced = batch.synced_count();
+    let skipped = batch.skipped_count();
+    let failed = batch.failures.len();
+    let status_code = refresh_status_code(batch_state);
+
+    {
+        let guard = state.read().await;
+        guard.publish_event(
+            "repos.refreshed",
+            serde_json::json!({
+                "force": force,
+                "state": batch_state,
+                "synced": synced,
+                "skipped": skipped,
+                "failed": failed,
+            }),
+        );
+    }
+
+    (
+        status_code,
+        Json(serde_json::json!({
+            "status": batch_state.as_str(),
+            "force": force,
+            "synced": synced,
+            "skipped": skipped,
+            "failed": failed,
+            "results": batch.results,
+            "failures": batch.failures,
+        })),
+    )
+        .into_response()
+}
+
+fn refresh_status_code(batch_state: RepoRefreshBatchState) -> StatusCode {
+    match batch_state {
+        RepoRefreshBatchState::Complete => StatusCode::OK,
+        RepoRefreshBatchState::Partial => StatusCode::MULTI_STATUS,
+        RepoRefreshBatchState::Failed => StatusCode::BAD_GATEWAY,
     }
 }
 
@@ -433,6 +456,7 @@ mod tests {
     use tower::ServiceExt;
 
     use super::super::test_helpers::{rebuild_app, test_app};
+    use super::{RepoRefreshBatchState, refresh_status_code};
 
     #[tokio::test]
     async fn test_repo_crud_lifecycle() {
@@ -606,9 +630,26 @@ mod tests {
             .await
             .unwrap();
         let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
-        assert_eq!(body["status"], "ok");
+        assert_eq!(body["status"], "complete");
         assert_eq!(body["synced"], 0);
         assert_eq!(body["skipped"], 0);
+        assert_eq!(body["failed"], 0);
+    }
+
+    #[test]
+    fn refresh_batch_state_has_distinct_http_outcomes() {
+        assert_eq!(
+            refresh_status_code(RepoRefreshBatchState::Complete),
+            StatusCode::OK
+        );
+        assert_eq!(
+            refresh_status_code(RepoRefreshBatchState::Partial),
+            StatusCode::MULTI_STATUS
+        );
+        assert_eq!(
+            refresh_status_code(RepoRefreshBatchState::Failed),
+            StatusCode::BAD_GATEWAY
+        );
     }
 
     #[tokio::test]

--- a/apps/remi/src/server/handlers/openapi.rs
+++ b/apps/remi/src/server/handlers/openapi.rs
@@ -285,21 +285,37 @@ pub async fn openapi_spec() -> Response {
                 "post": {
                     "operationId": "syncRepo",
                     "summary": "Trigger repository metadata sync",
-                    "description": "Starts an asynchronous metadata sync for the specified repository. Returns immediately with 202. Monitor progress via the SSE events endpoint with ?filter=repo. Requires repos:write scope.",
+                    "description": "Synchronously refreshes the specified repository and returns its exact source profile and package count. Requires repos:write scope.",
                     "tags": ["repos"],
                     "security": [{ "bearerAuth": [] }],
-                    "parameters": [{ "name": "name", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Repository identifier" }],
-                    "responses": { "202": { "description": "Sync started" }, "401": { "description": "Invalid or missing token" }, "404": { "description": "Repository not found" } }
+                    "parameters": [
+                        { "name": "name", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Repository identifier" },
+                        { "name": "force", "in": "query", "required": false, "schema": { "type": "boolean", "default": false }, "description": "Refresh even when metadata is still current" }
+                    ],
+                    "responses": { "200": { "description": "Repository synchronized or already current" }, "401": { "description": "Invalid or missing token" }, "404": { "description": "Repository not found" }, "500": { "description": "Repository synchronization failed" } }
                 }
             },
             "/v1/admin/refresh": {
                 "post": {
                     "operationId": "refreshRepos",
                     "summary": "Refresh upstream repository state",
-                    "description": "Triggers a repository refresh across configured upstreams. Use repository sync endpoints for per-repo refreshes.",
+                    "description": "Synchronously refreshes every configured upstream and returns typed per-source outcomes. Successful sources commit independently; one failed source does not discard other results. A complete refresh returns 200, a mixed result returns 207, and an all-failed refresh returns 502.",
                     "tags": ["repos"],
                     "security": [{ "bearerAuth": [] }],
-                    "responses": { "202": { "description": "Refresh queued" }, "401": { "description": "Invalid or missing token" }, "403": { "description": "Insufficient scope" } }
+                    "parameters": [{
+                        "name": "force",
+                        "in": "query",
+                        "required": false,
+                        "schema": { "type": "boolean", "default": false },
+                        "description": "Refresh sources even when their metadata is still current"
+                    }],
+                    "responses": {
+                        "200": { "description": "Every configured source completed or was current" },
+                        "207": { "description": "Some sources completed and some failed; the body contains both outcome sets" },
+                        "401": { "description": "Invalid or missing token" },
+                        "403": { "description": "Insufficient scope" },
+                        "502": { "description": "Every configured source failed; the body contains typed per-source failures" }
+                    }
                 }
             },
             "/v1/admin/federation/peers": {

--- a/apps/remi/src/server/mod.rs
+++ b/apps/remi/src/server/mod.rs
@@ -68,6 +68,7 @@ pub use security::BanList;
 
 use anyhow::{Context, Result};
 use dashmap::DashMap;
+use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -93,6 +94,14 @@ async fn ensure_admin_bootstrap_token(
     })
     .await??;
     Ok(())
+}
+
+fn successful_refresh_profiles(batch: &admin_service::RepoRefreshBatch) -> HashSet<&str> {
+    batch
+        .results
+        .iter()
+        .filter_map(|result| result.source_profile.as_deref())
+        .collect()
 }
 
 /// Server configuration
@@ -565,15 +574,34 @@ pub async fn run_server_from_config(remi_config: &RemiConfig) -> Result<()> {
                 match crate::server::admin_service::refresh_repositories(&refresh_state, false)
                     .await
                 {
-                    Ok(results) => {
-                        let synced = results.iter().filter(|r| !r.skipped).count();
-                        let skipped = results.iter().filter(|r| r.skipped).count();
+                    Ok(batch) => {
+                        let synced = batch.synced_count();
+                        let skipped = batch.skipped_count();
                         tracing::info!(
-                            "Background metadata refresh complete: {} synced, {} skipped",
+                            "Background metadata refresh {}: {} synced, {} skipped, {} failed",
+                            batch.state().as_str(),
                             synced,
-                            skipped
+                            skipped,
+                            batch.failures.len()
                         );
+                        for failure in &batch.failures {
+                            tracing::warn!(
+                                repository = %failure.name,
+                                source_profile = failure.source_profile.as_deref().unwrap_or("<none>"),
+                                kind = ?failure.kind,
+                                "Repository metadata refresh failed: {}",
+                                failure.message
+                            );
+                        }
+                        let successful_profiles = successful_refresh_profiles(&batch);
                         for job in &prewarm_jobs {
+                            if !successful_profiles.contains(job.distro.as_str()) {
+                                tracing::warn!(
+                                    "Post-refresh pre-warm for {} skipped: no repository for that exact profile completed refresh",
+                                    job.distro
+                                );
+                                continue;
+                            }
                             match prewarm::run_prewarm(job).await {
                                 Ok(result) => tracing::info!(
                                     "Post-refresh pre-warm for {}: {} converted, {} skipped, {} failed",
@@ -736,6 +764,10 @@ async fn initialize_bloom_filter(state: Arc<RwLock<ServerState>>) -> Result<()> 
 mod tests {
     use super::{
         build_http_client, ensure_admin_bootstrap_token, ensure_database_ready, open_runtime_db,
+        successful_refresh_profiles,
+    };
+    use crate::server::admin_service::{
+        RepoRefreshBatch, RepoRefreshFailure, RepoRefreshFailureKind, RepoRefreshResult,
     };
 
     fn test_db_path() -> std::path::PathBuf {
@@ -814,6 +846,38 @@ mod tests {
         let err = build_http_client(std::time::Duration::from_secs(30), "bad\0agent")
             .expect_err("invalid user agent should be surfaced as an error");
         assert!(err.to_string().contains("HTTP client"));
+    }
+
+    #[test]
+    fn failed_source_does_not_remove_successful_prewarm_profiles() {
+        let batch = RepoRefreshBatch {
+            results: vec![
+                RepoRefreshResult {
+                    name: "fedora".to_string(),
+                    source_profile: Some("fedora-44".to_string()),
+                    packages_synced: 76_354,
+                    skipped: false,
+                },
+                RepoRefreshResult {
+                    name: "ubuntu".to_string(),
+                    source_profile: Some("ubuntu-26.04".to_string()),
+                    packages_synced: 6_487,
+                    skipped: false,
+                },
+            ],
+            failures: vec![RepoRefreshFailure {
+                name: "arch-extra".to_string(),
+                source_profile: Some("arch".to_string()),
+                kind: RepoRefreshFailureKind::Internal,
+                message: "source unavailable".to_string(),
+            }],
+        };
+
+        let profiles = successful_refresh_profiles(&batch);
+        assert_eq!(profiles.len(), 2);
+        assert!(profiles.contains("fedora-44"));
+        assert!(profiles.contains("ubuntu-26.04"));
+        assert!(!profiles.contains("arch"));
     }
 
     #[test]

--- a/apps/remi/src/server/routes/admin.rs
+++ b/apps/remi/src/server/routes/admin.rs
@@ -274,38 +274,7 @@ async fn refresh_upstream(
     Query(query): Query<admin_handlers::RefreshQuery>,
 ) -> Response {
     match crate::server::admin_service::refresh_repositories(&state, query.force).await {
-        Ok(results) => {
-            let synced = results.iter().filter(|r| !r.skipped).count();
-            let skipped = results.iter().filter(|r| r.skipped).count();
-
-            {
-                let guard = state.read().await;
-                guard.publish_event(
-                    "repos.refreshed",
-                    serde_json::json!({
-                        "force": query.force,
-                        "synced": synced,
-                        "skipped": skipped,
-                    }),
-                );
-            }
-
-            Json(serde_json::json!({
-                "status": "ok",
-                "force": query.force,
-                "synced": synced,
-                "skipped": skipped,
-                "results": results
-                    .into_iter()
-                    .map(|r| serde_json::json!({
-                        "name": r.name,
-                        "packages_synced": r.packages_synced,
-                        "skipped": r.skipped,
-                    }))
-                    .collect::<Vec<_>>(),
-            }))
-            .into_response()
-        }
+        Ok(batch) => admin_handlers::refresh_batch_response(&state, query.force, batch).await,
         Err(e) => {
             tracing::error!("Upstream refresh failed: {e}");
             (

--- a/crates/conary-core/src/repository/package_relation.rs
+++ b/crates/conary-core/src/repository/package_relation.rs
@@ -94,7 +94,7 @@ pub fn parse_native_relation(
     }
 
     let expression = match scheme {
-        VersionScheme::Rpm => super::rpm_dependency::parse_rpm_dependency(native_text)?,
+        VersionScheme::Rpm => super::rpm_dependency::parse_rpm_dependency(kind, native_text)?,
         VersionScheme::Debian => parse_debian_relation(native_text)?,
         VersionScheme::Arch => RepositoryRequirementExpression::Atom(parse_arch_atom(native_text)?),
         VersionScheme::Conary => {

--- a/crates/conary-core/src/repository/parsers/fedora/relation.rs
+++ b/crates/conary-core/src/repository/parsers/fedora/relation.rs
@@ -142,8 +142,11 @@ pub(super) fn rpm_require_to_group(
     } else {
         format!("{name} {constraint}")
     };
-    let expression = crate::repository::rpm_dependency::parse_rpm_dependency(&native_text)
-        .map_err(Error::ParseError)?;
+    let expression = crate::repository::rpm_dependency::parse_rpm_dependency(
+        RepositoryRequirementKind::Depends,
+        &native_text,
+    )
+    .map_err(Error::ParseError)?;
     let clauses = expression.atoms().into_iter().cloned().collect::<Vec<_>>();
     let behavior = if expression.is_conditional() {
         ConditionalRequirementBehavior::Conditional

--- a/crates/conary-core/src/repository/parsers/fedora/tests.rs
+++ b/crates/conary-core/src/repository/parsers/fedora/tests.rs
@@ -682,8 +682,9 @@ fn malformed_rich_dependency_rejects_repository_metadata() {
 </metadata>
 "#;
 
-    let error = parser
-        .parse_primary_xml(xml, "https://example.com")
-        .unwrap_err();
-    assert!(error.to_string().contains("repeats binary operator 'if'"));
+    assert!(
+        parser
+            .parse_primary_xml(xml, "https://example.com")
+            .is_err()
+    );
 }

--- a/crates/conary-core/src/repository/requirement.rs
+++ b/crates/conary-core/src/repository/requirement.rs
@@ -24,7 +24,7 @@ pub fn parse_native_requirement(
     }
 
     let expression = match scheme {
-        VersionScheme::Rpm => super::rpm_dependency::parse_rpm_dependency(native_text)?,
+        VersionScheme::Rpm => super::rpm_dependency::parse_rpm_dependency(kind, native_text)?,
         VersionScheme::Debian => {
             let operands = native_text
                 .split('|')
@@ -191,6 +191,7 @@ mod tests {
     #[test]
     fn accepts_full_rpm_boolean_requirement() {
         let expression = parse_rpm_dependency(
+            RepositoryRequirementKind::Depends,
             "((feature-a with feature-b) if engine else (fallback without incompatible))",
         )
         .unwrap();

--- a/crates/conary-core/src/repository/rpm_dependency.rs
+++ b/crates/conary-core/src/repository/rpm_dependency.rs
@@ -1,323 +1,466 @@
 // conary-core/src/repository/rpm_dependency.rs
 
-//! Formal parser for RPM boolean dependency expressions.
+//! Source-derived parser for RPM boolean dependency expressions.
+//!
+//! The grammar and parser-state checks mirror RPM's `rpmrichParseInternal()`
+//! and `rpmrichParseForTag()` at upstream commit
+//! `a8f0192aee1c08bd1454ed2ac6ebaf506004b55c`. Keep conformance tests tied to
+//! that source boundary; package names and diagnostic text are never grammar.
 
 use super::dependency_model::{
     RepositoryRequirementClause, RepositoryRequirementExpression as Expression,
+    RepositoryRequirementKind,
 };
 
-/// Parse one RPM dependency name or parenthesized boolean expression.
-pub fn parse_rpm_dependency(input: &str) -> Result<Expression, String> {
+const CHECK_ACTIVE: u8 = 1 << 0;
+const CHECK_NO_WITH: u8 = 1 << 1;
+const CHECK_NO_AND: u8 = 1 << 2;
+const CHECK_NO_OR: u8 = 1 << 3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RichOperator {
+    And,
+    Or,
+    If,
+    Unless,
+    Else,
+    With,
+    Without,
+}
+
+impl RichOperator {
+    fn parse(token: &str) -> Option<Self> {
+        match token {
+            "and" => Some(Self::And),
+            "or" => Some(Self::Or),
+            "if" => Some(Self::If),
+            "unless" => Some(Self::Unless),
+            "else" => Some(Self::Else),
+            "with" => Some(Self::With),
+            "without" => Some(Self::Without),
+            _ => None,
+        }
+    }
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::And => "and",
+            Self::Or => "or",
+            Self::If => "if",
+            Self::Unless => "unless",
+            Self::Else => "else",
+            Self::With => "with",
+            Self::Without => "without",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct ParseChecks(u8);
+
+impl ParseChecks {
+    const fn active() -> Self {
+        Self(CHECK_ACTIVE)
+    }
+
+    const fn only_activation(self) -> Self {
+        Self(self.0 & CHECK_ACTIVE)
+    }
+
+    fn contains(self, flag: u8) -> bool {
+        self.0 & flag != 0
+    }
+
+    fn insert(&mut self, flag: u8) {
+        self.0 |= flag;
+    }
+
+    fn remove(&mut self, flag: u8) {
+        self.0 &= !flag;
+    }
+
+    fn merge(&mut self, other: Self) {
+        self.0 |= other.0;
+    }
+}
+
+/// Parse one RPM dependency according to the source tag represented by `kind`.
+///
+/// RPM validates `if`/`unless` context differently for conflict-like tags.
+/// Carrying the typed relation kind into this boundary keeps that decision out
+/// of package names, repository names, and caller-specific heuristics.
+pub fn parse_rpm_dependency(
+    kind: RepositoryRequirementKind,
+    input: &str,
+) -> Result<Expression, String> {
     let input = input.trim();
     if input.is_empty() {
         return Err("RPM dependency expression is empty".to_string());
     }
-    let unwrapped = strip_outer_parentheses(input)?;
-    if unwrapped == input && !top_level_operators(input)?.is_empty() {
+
+    let mut parser = Parser::new(input);
+    let expression = if parser.peek() == Some('(') {
+        let mut checks = ParseChecks::active();
+        let expression = parser.parse_rich(&mut checks)?;
+        validate_tag_context(kind, checks)?;
+        expression
+    } else {
+        parser.parse_simple()?
+    };
+
+    parser.skip_separators();
+    if !parser.is_finished() {
         return Err(format!(
-            "RPM boolean dependency must be enclosed in parentheses: {input}"
+            "junk after RPM dependency expression: {}",
+            parser.remaining()
         ));
     }
-    let expression = parse_expression(input)?;
-    validate_operator_nesting(&expression)?;
     Ok(expression)
 }
 
-fn parse_expression(input: &str) -> Result<Expression, String> {
-    let input = strip_outer_parentheses(input)?;
-    let operators = top_level_operators(input)?;
-
-    if let Some(index) = unique_operator(&operators, "if")? {
-        reject_operators(&operators, &["or", "unless"], "if")?;
-        let else_index = unique_operator(&operators, "else")?;
-        let condition_end = else_index.unwrap_or(input.len());
-        return Ok(Expression::If {
-            requirement: Box::new(parse_expression(input[..index].trim())?),
-            condition: Box::new(parse_expression(
-                input[index + "if".len()..condition_end].trim(),
-            )?),
-            otherwise: else_index
-                .map(|index| parse_expression(input[index + "else".len()..].trim()).map(Box::new))
-                .transpose()?,
-        });
-    }
-
-    if let Some(index) = unique_operator(&operators, "unless")? {
-        reject_operators(&operators, &["and", "if"], "unless")?;
-        let else_index = unique_operator(&operators, "else")?;
-        let condition_end = else_index.unwrap_or(input.len());
-        return Ok(Expression::Unless {
-            requirement: Box::new(parse_expression(input[..index].trim())?),
-            condition: Box::new(parse_expression(
-                input[index + "unless".len()..condition_end].trim(),
-            )?),
-            otherwise: else_index
-                .map(|index| parse_expression(input[index + "else".len()..].trim()).map(Box::new))
-                .transpose()?,
-        });
-    }
-
-    if operators.iter().any(|(_, operator)| *operator == "else") {
-        return Err(format!(
-            "RPM dependency has 'else' without 'if' or 'unless': {input}"
-        ));
-    }
-
-    if operators.iter().any(|(_, operator)| *operator == "or") {
-        reject_operators(&operators, &["and", "with", "without"], "or")?;
-        return parse_chain(input, &operators, "or", Expression::Or);
-    }
-    if operators.iter().any(|(_, operator)| *operator == "and") {
-        reject_operators(&operators, &["with", "without"], "and")?;
-        return parse_chain(input, &operators, "and", Expression::And);
-    }
-    if let Some(index) = unique_operator(&operators, "with")? {
-        reject_operators(&operators, &["without"], "with")?;
-        return Ok(Expression::With {
-            left: Box::new(parse_expression(input[..index].trim())?),
-            right: Box::new(parse_expression(input[index + "with".len()..].trim())?),
-        });
-    }
-    if let Some(index) = unique_operator(&operators, "without")? {
-        return Ok(Expression::Without {
-            left: Box::new(parse_expression(input[..index].trim())?),
-            right: Box::new(parse_expression(input[index + "without".len()..].trim())?),
-        });
-    }
-
-    parse_atom(input)
+struct Parser<'a> {
+    input: &'a str,
+    cursor: usize,
 }
 
-fn strip_outer_parentheses(input: &str) -> Result<&str, String> {
-    if !input.starts_with('(') {
-        return Ok(input);
+impl<'a> Parser<'a> {
+    const fn new(input: &'a str) -> Self {
+        Self { input, cursor: 0 }
     }
-    let mut depth = 0_u32;
-    for (index, character) in input.char_indices() {
-        match character {
-            '(' => depth += 1,
-            ')' => {
-                depth = depth
-                    .checked_sub(1)
-                    .ok_or_else(|| format!("unbalanced RPM dependency parentheses: {input}"))?;
-                if depth == 0 && index + character.len_utf8() != input.len() {
-                    return Ok(input);
-                }
-            }
-            _ => {}
+
+    fn is_finished(&self) -> bool {
+        self.cursor == self.input.len()
+    }
+
+    fn remaining(&self) -> &'a str {
+        &self.input[self.cursor..]
+    }
+
+    fn peek(&self) -> Option<char> {
+        self.remaining().chars().next()
+    }
+
+    fn bump(&mut self) -> Option<char> {
+        let character = self.peek()?;
+        self.cursor += character.len_utf8();
+        Some(character)
+    }
+
+    fn skip_separators(&mut self) {
+        while self
+            .peek()
+            .is_some_and(|ch| ch.is_whitespace() || ch == ',')
+        {
+            self.bump();
         }
     }
-    if depth != 0 || !input.ends_with(')') {
-        return Err(format!("unbalanced RPM dependency parentheses: {input}"));
+
+    fn parse_rich(&mut self, parent_checks: &mut ParseChecks) -> Result<Expression, String> {
+        let expression_start = self.cursor;
+        if self.bump() != Some('(') {
+            return Err("RPM rich dependency does not start with '('".to_string());
+        }
+
+        let mut checks = *parent_checks;
+        let mut operands = Vec::new();
+        let mut operators = Vec::new();
+        let mut chain_operator = None;
+        let mut previous_operator = None;
+
+        loop {
+            self.skip_separators();
+            if self.peek() == Some(')') {
+                return Err(if chain_operator.is_some() {
+                    "missing argument to RPM rich dependency operator".to_string()
+                } else {
+                    "RPM rich dependency has empty parentheses".to_string()
+                });
+            }
+
+            let operand = if self.peek() == Some('(') {
+                let mut nested_checks = checks.only_activation();
+                let operand = self.parse_rich(&mut nested_checks)?;
+                if matches!(
+                    previous_operator,
+                    Some(RichOperator::If | RichOperator::Unless)
+                ) {
+                    nested_checks.remove(CHECK_NO_AND | CHECK_NO_OR);
+                }
+                checks.merge(nested_checks);
+                operand
+            } else {
+                self.parse_simple()?
+            };
+            operands.push(operand);
+
+            self.skip_separators();
+            match self.peek() {
+                None => {
+                    return Err(format!(
+                        "unterminated RPM rich dependency: {}",
+                        &self.input[expression_start..]
+                    ));
+                }
+                Some(')') => break,
+                Some(_) => {}
+            }
+
+            let operator = self.parse_rich_operator()?;
+            if operator == RichOperator::Else
+                && matches!(
+                    chain_operator,
+                    Some(RichOperator::If | RichOperator::Unless)
+                )
+            {
+                chain_operator = None;
+            }
+            if let Some(chained) = chain_operator {
+                if operator != chained {
+                    return Err(format!(
+                        "cannot chain different RPM rich dependency operators '{}' and '{}'",
+                        chained.as_str(),
+                        operator.as_str()
+                    ));
+                }
+                if !matches!(
+                    operator,
+                    RichOperator::And | RichOperator::Or | RichOperator::With
+                ) {
+                    return Err(format!(
+                        "RPM rich dependency operator '{}' cannot be chained",
+                        operator.as_str()
+                    ));
+                }
+            }
+            chain_operator = Some(operator);
+            previous_operator = Some(operator);
+            operators.push(operator);
+        }
+
+        let first_operator = operators.first().copied();
+        let last_operator = operators.last().copied();
+        if let Some(operator) = first_operator {
+            validate_parse_checks(operator, checks)?;
+        }
+
+        if first_operator == Some(RichOperator::If) {
+            checks.insert(CHECK_NO_OR);
+        }
+        if first_operator == Some(RichOperator::Unless) {
+            checks.insert(CHECK_NO_AND);
+        }
+        if matches!(last_operator, Some(RichOperator::And | RichOperator::Or)) {
+            checks.remove(CHECK_NO_AND | CHECK_NO_OR);
+        }
+        if !matches!(
+            last_operator,
+            None | Some(RichOperator::With | RichOperator::Without | RichOperator::Or)
+        ) {
+            checks.insert(CHECK_NO_WITH);
+        }
+
+        debug_assert_eq!(self.peek(), Some(')'));
+        self.bump();
+        parent_checks.merge(checks);
+        build_expression(operands, operators)
     }
-    parse_balanced_inner(&input[1..input.len() - 1])
+
+    fn parse_simple(&mut self) -> Result<Expression, String> {
+        let name = self.take_dependency_token();
+        if name.is_empty() {
+            return Err("RPM dependency name is required".to_string());
+        }
+
+        self.skip_separators();
+        let comparison_start = self.cursor;
+        let comparison = self.take_dependency_token();
+        let Some(comparison) = canonical_comparison(comparison) else {
+            self.cursor = comparison_start;
+            return Ok(Expression::Atom(RepositoryRequirementClause::name_only(
+                name.to_string(),
+            )));
+        };
+
+        self.skip_separators();
+        let version = self.take_dependency_token();
+        if version.is_empty() {
+            return Err(format!(
+                "RPM dependency version is required after '{comparison}'"
+            ));
+        }
+        Ok(Expression::Atom(RepositoryRequirementClause::versioned(
+            name.to_string(),
+            format!("{comparison} {version}"),
+        )))
+    }
+
+    /// Match RPM's `SKIPNONWHITEX`: capability names may contain balanced
+    /// parentheses, while a top-level right parenthesis ends the operand.
+    fn take_dependency_token(&mut self) -> &'a str {
+        let start = self.cursor;
+        let mut nested_parentheses = 0_u32;
+        while let Some(character) = self.peek() {
+            if character.is_whitespace() || character == ',' {
+                break;
+            }
+            match character {
+                '(' => {
+                    nested_parentheses += 1;
+                    self.bump();
+                }
+                ')' if nested_parentheses == 0 => break,
+                ')' => {
+                    nested_parentheses -= 1;
+                    self.bump();
+                }
+                _ => {
+                    self.bump();
+                }
+            }
+        }
+        &self.input[start..self.cursor]
+    }
+
+    fn parse_rich_operator(&mut self) -> Result<RichOperator, String> {
+        let start = self.cursor;
+        while self
+            .peek()
+            .is_some_and(|character| !character.is_whitespace() && character != ')')
+        {
+            self.bump();
+        }
+        let token = &self.input[start..self.cursor];
+        RichOperator::parse(token)
+            .ok_or_else(|| format!("unknown RPM rich dependency operator '{token}'"))
+    }
 }
 
-fn parse_balanced_inner(input: &str) -> Result<&str, String> {
-    if input.trim().is_empty() {
-        Err("RPM dependency expression has empty parentheses".to_string())
-    } else {
-        Ok(input.trim())
+fn canonical_comparison(token: &str) -> Option<&'static str> {
+    match token {
+        "<=" | "=<" => Some("<="),
+        "<" => Some("<"),
+        "==" | "=" => Some("="),
+        ">=" | "=>" => Some(">="),
+        ">" => Some(">"),
+        _ => None,
     }
 }
 
-fn top_level_operators(input: &str) -> Result<Vec<(usize, &str)>, String> {
-    const OPERATORS: [&str; 7] = ["and", "or", "if", "unless", "else", "with", "without"];
-    let mut depth = 0_u32;
-    let mut operators = Vec::new();
-    let mut word_start = None;
-    for (index, character) in input
-        .char_indices()
-        .chain(std::iter::once((input.len(), ' ')))
+fn validate_parse_checks(operator: RichOperator, checks: ParseChecks) -> Result<(), String> {
+    if matches!(operator, RichOperator::With | RichOperator::Without)
+        && checks.contains(CHECK_NO_WITH)
     {
-        match character {
-            '(' => {
-                depth += 1;
-                word_start = None;
-            }
-            ')' => {
-                depth = depth
-                    .checked_sub(1)
-                    .ok_or_else(|| format!("unbalanced RPM dependency parentheses: {input}"))?;
-                word_start = None;
-            }
-            character if depth == 0 && character.is_whitespace() => {
-                if let Some(start) = word_start.take() {
-                    let word = &input[start..index];
-                    if let Some(operator) = OPERATORS.iter().find(|operator| **operator == word) {
-                        operators.push((start, *operator));
-                    }
-                }
-            }
-            _ if depth == 0 => {
-                word_start.get_or_insert(index);
-            }
-            _ => {}
-        }
+        return Err("illegal RPM rich dependency operator inside 'with/without'".to_string());
     }
-    if depth != 0 {
-        return Err(format!("unbalanced RPM dependency parentheses: {input}"));
+    if !checks.contains(CHECK_ACTIVE) {
+        return Ok(());
     }
-    Ok(operators)
+    if matches!(operator, RichOperator::And | RichOperator::If) && checks.contains(CHECK_NO_AND) {
+        return Err("illegal RPM 'unless' context; use 'or' instead".to_string());
+    }
+    if matches!(operator, RichOperator::Or | RichOperator::Unless) && checks.contains(CHECK_NO_OR) {
+        return Err("illegal RPM 'if' context; use 'and' instead".to_string());
+    }
+    Ok(())
 }
 
-fn unique_operator(operators: &[(usize, &str)], expected: &str) -> Result<Option<usize>, String> {
-    let matches = operators
-        .iter()
-        .filter(|(_, operator)| *operator == expected)
-        .map(|(index, _)| *index)
-        .collect::<Vec<_>>();
-    match matches.as_slice() {
-        [] => Ok(None),
-        [index] => Ok(Some(*index)),
-        _ => Err(format!(
-            "RPM dependency repeats binary operator '{expected}'"
-        )),
-    }
-}
-
-fn reject_operators(
-    operators: &[(usize, &str)],
-    rejected: &[&str],
-    context: &str,
+fn validate_tag_context(
+    kind: RepositoryRequirementKind,
+    checks: ParseChecks,
 ) -> Result<(), String> {
-    if let Some((_, operator)) = operators
-        .iter()
-        .find(|(_, operator)| rejected.contains(operator))
-    {
-        return Err(format!(
-            "RPM dependency mixes '{context}' and '{operator}' without nested parentheses"
-        ));
-    }
-    Ok(())
-}
-
-fn parse_chain(
-    input: &str,
-    operators: &[(usize, &str)],
-    expected: &str,
-    constructor: fn(Vec<Expression>) -> Expression,
-) -> Result<Expression, String> {
-    let positions = operators
-        .iter()
-        .filter(|(_, operator)| *operator == expected)
-        .map(|(index, _)| *index)
-        .collect::<Vec<_>>();
-    let mut operands = Vec::with_capacity(positions.len() + 1);
-    let mut start = 0;
-    for index in positions {
-        operands.push(parse_expression(input[start..index].trim())?);
-        start = index + expected.len();
-    }
-    operands.push(parse_expression(input[start..].trim())?);
-    Ok(constructor(operands))
-}
-
-fn parse_atom(input: &str) -> Result<Expression, String> {
-    let parts = input.split_whitespace().collect::<Vec<_>>();
-    let clause = match parts.as_slice() {
-        [name] if !name.is_empty() => RepositoryRequirementClause::name_only((*name).to_string()),
-        [name, operator, version] if matches!(*operator, "<" | "<=" | "=" | ">=" | ">" | "!=") => {
-            RepositoryRequirementClause::versioned(
-                (*name).to_string(),
-                format!("{operator} {version}"),
-            )
-        }
-        _ => return Err(format!("invalid RPM dependency atom: {input}")),
+    let tag_operator = if kind == RepositoryRequirementKind::Conflict {
+        RichOperator::Or
+    } else {
+        RichOperator::And
     };
-    Ok(Expression::Atom(clause))
+    validate_parse_checks(tag_operator, checks)
 }
 
-fn validate_operator_nesting(expression: &Expression) -> Result<(), String> {
-    match expression {
-        Expression::And(operands) => {
-            if operands.iter().any(contains_unless) {
-                return Err(
-                    "RPM dependency cannot nest 'unless' inside an 'and' expression".to_string(),
-                );
-            }
-            for operand in operands {
-                validate_operator_nesting(operand)?;
-            }
-        }
-        Expression::Or(operands) => {
-            if operands.iter().any(contains_if) {
-                return Err("RPM dependency cannot nest 'if' inside an 'or' expression".to_string());
-            }
-            for operand in operands {
-                validate_operator_nesting(operand)?;
-            }
-        }
-        Expression::If {
-            requirement,
-            condition,
-            otherwise,
-        }
-        | Expression::Unless {
-            requirement,
-            condition,
-            otherwise,
-        } => {
-            validate_operator_nesting(requirement)?;
-            validate_operator_nesting(condition)?;
-            if let Some(otherwise) = otherwise {
-                validate_operator_nesting(otherwise)?;
-            }
-        }
-        Expression::With { left, right } | Expression::Without { left, right } => {
-            validate_operator_nesting(left)?;
-            validate_operator_nesting(right)?;
-        }
-        Expression::Atom(_) => {}
+fn build_expression(
+    mut operands: Vec<Expression>,
+    operators: Vec<RichOperator>,
+) -> Result<Expression, String> {
+    if operators.is_empty() {
+        return operands
+            .pop()
+            .ok_or_else(|| "RPM dependency expression has no operand".to_string());
     }
-    Ok(())
-}
-
-fn contains_if(expression: &Expression) -> bool {
-    match expression {
-        Expression::If { .. } => true,
-        Expression::And(operands) | Expression::Or(operands) => operands.iter().any(contains_if),
-        Expression::Unless {
-            requirement,
-            condition,
-            otherwise,
-        } => {
-            contains_if(requirement)
-                || contains_if(condition)
-                || otherwise.as_deref().is_some_and(contains_if)
-        }
-        Expression::With { left, right } | Expression::Without { left, right } => {
-            contains_if(left) || contains_if(right)
-        }
-        Expression::Atom(_) => false,
+    if operands.len() != operators.len() + 1 {
+        return Err("RPM dependency expression has mismatched operands and operators".to_string());
     }
-}
 
-fn contains_unless(expression: &Expression) -> bool {
-    match expression {
-        Expression::Unless { .. } => true,
-        Expression::And(operands) | Expression::Or(operands) => {
-            operands.iter().any(contains_unless)
+    match operators.as_slice() {
+        [RichOperator::And, ..]
+            if operators
+                .iter()
+                .all(|operator| *operator == RichOperator::And) =>
+        {
+            Ok(Expression::And(operands))
         }
-        Expression::If {
-            requirement,
-            condition,
-            otherwise,
-        } => {
-            contains_unless(requirement)
-                || contains_unless(condition)
-                || otherwise.as_deref().is_some_and(contains_unless)
+        [RichOperator::Or, ..]
+            if operators
+                .iter()
+                .all(|operator| *operator == RichOperator::Or) =>
+        {
+            Ok(Expression::Or(operands))
         }
-        Expression::With { left, right } | Expression::Without { left, right } => {
-            contains_unless(left) || contains_unless(right)
+        [RichOperator::With, ..]
+            if operators
+                .iter()
+                .all(|operator| *operator == RichOperator::With) =>
+        {
+            let mut operands = operands.into_iter().rev();
+            let mut expression = operands
+                .next()
+                .expect("operator count guarantees a final operand");
+            for left in operands {
+                expression = Expression::With {
+                    left: Box::new(left),
+                    right: Box::new(expression),
+                };
+            }
+            Ok(expression)
         }
-        Expression::Atom(_) => false,
+        [RichOperator::Without] => Ok(Expression::Without {
+            left: Box::new(operands.remove(0)),
+            right: Box::new(operands.remove(0)),
+        }),
+        [RichOperator::If] | [RichOperator::If, RichOperator::Else] => {
+            let requirement = Box::new(operands.remove(0));
+            let condition = Box::new(operands.remove(0));
+            let otherwise = operands.pop().map(Box::new);
+            Ok(Expression::If {
+                requirement,
+                condition,
+                otherwise,
+            })
+        }
+        [RichOperator::Unless] | [RichOperator::Unless, RichOperator::Else] => {
+            let requirement = Box::new(operands.remove(0));
+            let condition = Box::new(operands.remove(0));
+            let otherwise = operands.pop().map(Box::new);
+            Ok(Expression::Unless {
+                requirement,
+                condition,
+                otherwise,
+            })
+        }
+        [RichOperator::Else] => {
+            Err("RPM dependency has 'else' without 'if' or 'unless'".to_string())
+        }
+        _ => Err("invalid RPM rich dependency operator sequence".to_string()),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const REQUIRES: RepositoryRequirementKind = RepositoryRequirementKind::Depends;
+
+    fn parse(input: &str) -> Result<Expression, String> {
+        parse_rpm_dependency(REQUIRES, input)
+    }
 
     #[test]
     fn parses_every_rpm_boolean_operator_and_nesting() {
@@ -326,16 +469,105 @@ mod tests {
             "(a or (b and c))",
             "(a if b)",
             "(a if b else c)",
-            "(a unless b)",
-            "(a unless b else c)",
             "(a with b)",
             "(a without b)",
             "((a with b) or (c without d))",
             "((a >= 2 and (b or c)) if d)",
         ] {
-            parse_rpm_dependency(expression)
+            parse(expression).unwrap_or_else(|error| panic!("{expression}: {error}"));
+        }
+        for expression in ["(a unless b)", "(a unless b else c)"] {
+            parse_rpm_dependency(RepositoryRequirementKind::Conflict, expression)
                 .unwrap_or_else(|error| panic!("{expression}: {error}"));
         }
+    }
+
+    #[test]
+    fn chained_with_is_right_associative_like_rpm() {
+        let expression = parse("(a with b with c)").unwrap();
+        assert_eq!(
+            expression,
+            Expression::With {
+                left: Box::new(atom("a")),
+                right: Box::new(Expression::With {
+                    left: Box::new(atom("b")),
+                    right: Box::new(atom("c")),
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_fedora_44_chained_with_requirements() {
+        let corpus = include_str!("../../tests/fixtures/rpm/fedora-44-rich-dependencies.txt");
+        let expressions = corpus
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty() && !line.starts_with('#'))
+            .collect::<Vec<_>>();
+        assert_eq!(expressions.len(), 8, "fixture count drifted");
+        for expression in expressions {
+            parse(expression).unwrap_or_else(|error| panic!("{expression}: {error}"));
+        }
+    }
+
+    #[test]
+    fn canonicalizes_every_upstream_rpm_comparison_spelling() {
+        for (operator, expected) in [
+            ("<=", "<="),
+            ("=<", "<="),
+            ("<", "<"),
+            ("==", "="),
+            ("=", "="),
+            (">=", ">="),
+            ("=>", ">="),
+            (">", ">"),
+        ] {
+            let Expression::Atom(clause) = parse(&format!("pkg {operator} 1")).unwrap() else {
+                panic!("comparison must produce an atom");
+            };
+            assert_eq!(
+                clause.version_constraint.as_deref(),
+                Some(format!("{expected} 1").as_str())
+            );
+        }
+        assert!(parse("pkg != 1").is_err());
+    }
+
+    #[test]
+    fn enforces_upstream_chain_rules() {
+        for expression in [
+            "(a and b or c)",
+            "(a without b without c)",
+            "(a if b if c)",
+            "(a if b unless c)",
+        ] {
+            assert!(parse(expression).is_err(), "{expression} should fail");
+        }
+        for expression in [
+            "(a and b and c)",
+            "(a or b or c)",
+            "(a with b with c)",
+            "(a if b else c)",
+        ] {
+            parse(expression).unwrap_or_else(|error| panic!("{expression}: {error}"));
+        }
+        parse_rpm_dependency(RepositoryRequirementKind::Conflict, "(a unless b else c)").unwrap();
+    }
+
+    #[test]
+    fn enforces_upstream_tag_context_rules() {
+        assert!(parse("(a unless b)").is_err());
+        assert!(parse_rpm_dependency(RepositoryRequirementKind::Conflict, "(a if b)").is_err());
+        assert!(parse("((a unless b) and c)").is_err());
+        assert!(
+            parse_rpm_dependency(RepositoryRequirementKind::Conflict, "((a if b) or c)").is_err()
+        );
+
+        parse("(a if b)").unwrap();
+        parse_rpm_dependency(RepositoryRequirementKind::Conflict, "(a unless b)").unwrap();
+        parse("((a if b) and c)").unwrap();
+        parse_rpm_dependency(RepositoryRequirementKind::Conflict, "((a unless b) or c)").unwrap();
     }
 
     #[test]
@@ -343,30 +575,28 @@ mod tests {
         for expression in [
             "",
             "()",
-            "(a if b if c)",
-            "(a if b or c)",
-            "(a unless b and c)",
             "(a else b)",
             "(a or)",
             "(a >=)",
             "(a",
             "a or b",
-            "((a if b) or c)",
-            "((a unless b) and c)",
+            "(a and b) trailing",
+            "((a and b) with c)",
         ] {
-            assert!(
-                parse_rpm_dependency(expression).is_err(),
-                "{expression} should fail"
-            );
+            assert!(parse(expression).is_err(), "{expression} should fail");
         }
     }
 
     #[test]
     fn accepts_parenthesized_capability_names_as_single_atoms() {
-        let expression = parse_rpm_dependency("libc.so.6(GLIBC_2.34)(64bit)").unwrap();
+        let expression = parse("libc.so.6(GLIBC_2.34)(64bit)").unwrap();
         let Expression::Atom(clause) = expression else {
             panic!("parenthesized capability name must remain one atom");
         };
         assert_eq!(clause.name, "libc.so.6(GLIBC_2.34)(64bit)");
+    }
+
+    fn atom(name: &str) -> Expression {
+        Expression::Atom(RepositoryRequirementClause::name_only(name.to_string()))
     }
 }

--- a/crates/conary-core/src/resolver/requirements.rs
+++ b/crates/conary-core/src/resolver/requirements.rs
@@ -486,7 +486,8 @@ fn atom_satisfied(
 mod tests {
     use super::*;
     use crate::repository::dependency_model::{
-        DebianMultiArch, ProvideArchitectureQualifier, RequirementArchitectureQualifier,
+        DebianMultiArch, ProvideArchitectureQualifier, RepositoryRequirementKind,
+        RequirementArchitectureQualifier,
     };
     use crate::repository::rpm_dependency::parse_rpm_dependency;
     use crate::resolver::identity::ProvidedCapability;
@@ -543,7 +544,11 @@ mod tests {
 
     #[test]
     fn with_requires_one_provider_to_supply_both_atoms() {
-        let expression = parse_rpm_dependency("(feature-a with feature-b)").unwrap();
+        let expression = parse_rpm_dependency(
+            RepositoryRequirementKind::Depends,
+            "(feature-a with feature-b)",
+        )
+        .unwrap();
         assert!(
             !requirement_expression_satisfied(
                 &expression,

--- a/crates/conary-core/src/resolver/sat/tests/root_requirements.rs
+++ b/crates/conary-core/src/resolver/sat/tests/root_requirements.rs
@@ -88,7 +88,7 @@ fn root_and_or_and_version_constraints_reach_sat_exactly() {
 }
 
 #[test]
-fn root_if_and_unless_else_preserve_boolean_semantics() {
+fn root_if_else_preserves_boolean_semantics() {
     let (_temp, conn) = setup_test_db();
     let repository_id = repository(&conn);
     for name in ["condition", "required", "alternate"] {
@@ -104,20 +104,6 @@ fn root_if_and_unless_else_preserve_boolean_semantics() {
     let if_names = selected_names(&if_result);
     assert!(if_names.contains(&"condition"));
     assert!(if_names.contains(&"required"));
-
-    let unless_result = solve_rpm_roots(
-        &conn,
-        &["(required unless condition else alternate)", "condition"],
-    );
-    assert!(
-        unless_result.conflict_message.is_none(),
-        "{:?}",
-        unless_result.conflict_message
-    );
-    let unless_names = selected_names(&unless_result);
-    assert!(unless_names.contains(&"condition"));
-    assert!(unless_names.contains(&"alternate"));
-    assert!(!unless_names.contains(&"required"));
 }
 
 #[test]

--- a/crates/conary-core/tests/fixtures/rpm/fedora-44-rich-dependencies.txt
+++ b/crates/conary-core/tests/fixtures/rpm/fedora-44-rich-dependencies.txt
@@ -1,0 +1,16 @@
+# Source: Fedora 44 Everything x86_64 primary metadata
+# Repository: https://dl.fedoraproject.org/pub/fedora/linux/releases/44/Everything/x86_64/os/
+# repomd primary checksum: c48e47563bbf65b996c95caf4a608223f982c314cab637e6ab87dd1df67b9d26
+# Captured: 2026-07-27
+#
+# This bounded corpus is exact source metadata, not a package allowlist. Every
+# entry exercises an RPM grammar shape that Conary must parse generically.
+
+((python3.14dist(azure-cosmos) >= 3 with python3.14dist(azure-cosmos) < 4) with python3.14dist(azure-cosmos) >= 3.0.2)
+((python3.14dist(configobj) >= 5 with python3.14dist(configobj) < 6) with python3.14dist(configobj) >= 5.0.6)
+((python3.14dist(click) < 8.1.8 or python3.14dist(click) > 8.1.8) with (python3.14dist(click) < 8.2~~ or python3.14dist(click) >= 8.3) with (python3.14dist(click) < 8.3 or python3.14dist(click) > 8.3) with python3.14dist(click) < 9~~ with python3.14dist(click) >= 4.1)
+((python3.14dist(dynaconf) < 3.1.3 or python3.14dist(dynaconf) > 3.1.3) with python3.14dist(dynaconf) < 4~~ with python3.14dist(dynaconf) >= 3)
+((python3.14dist(coverage) < 6.1 or python3.14dist(coverage) > 6.1) with (python3.14dist(coverage) < 6.1.1 or python3.14dist(coverage) > 6.1.1) with (python3.14dist(coverage) < 6~~ or python3.14dist(coverage) >= 6.1) with python3.14dist(coverage) < 8~~ with python3.14dist(coverage) >= 5)
+((python3.14dist(google-api-core) < 2.1~~ or python3.14dist(google-api-core) >= 2.2) with (python3.14dist(google-api-core) < 2.2~~ or python3.14dist(google-api-core) >= 2.3) with (python3.14dist(google-api-core) < 2.3 or python3.14dist(google-api-core) > 2.3) with (python3.14dist(google-api-core) < 2~~ or python3.14dist(google-api-core) >= 2.1) with python3.14dist(google-api-core) < 3~~ with python3.14dist(google-api-core) >= 1.31.5)
+((python3.14dist(protobuf) < 3.20 or python3.14dist(protobuf) > 3.20) with (python3.14dist(protobuf) < 3.20.1 or python3.14dist(protobuf) > 3.20.1) with (python3.14dist(protobuf) < 4.21.1 or python3.14dist(protobuf) > 4.21.1) with (python3.14dist(protobuf) < 4.21.2 or python3.14dist(protobuf) > 4.21.2) with (python3.14dist(protobuf) < 4.21.3 or python3.14dist(protobuf) > 4.21.3) with (python3.14dist(protobuf) < 4.21.4 or python3.14dist(protobuf) > 4.21.4) with (python3.14dist(protobuf) < 4.21.5 or python3.14dist(protobuf) > 4.21.5) with python3.14dist(protobuf) < 6~~dev0 with python3.14dist(protobuf) >= 3.19.5)
+((python3.14dist(pyparsing) < 3 or python3.14dist(pyparsing) > 3) with (python3.14dist(pyparsing) < 3.0.1 or python3.14dist(pyparsing) > 3.0.1) with (python3.14dist(pyparsing) < 3.0.2 or python3.14dist(pyparsing) > 3.0.2) with (python3.14dist(pyparsing) < 3.0.3 or python3.14dist(pyparsing) > 3.0.3) with python3.14dist(pyparsing) < 4~~ with python3.14dist(pyparsing) >= 2.4.2)

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-07-27
-revision: 56
+revision: 57
 summary: Route feature ownership through streaming package payloads, serialized selected-root mutation, typed rollback lineage, exact lifecycle, canonical-map authority, typed generation GC, exact release authority, and current canonical docs
 ---
 
@@ -381,6 +381,7 @@ package transactions.
 `crates/conary-core/src/repository/parsers/fedora/metalink.rs`;
 `crates/conary-core/src/repository/sync.rs`;
 `crates/conary-core/src/repository/download.rs`;
+`crates/conary-core/src/repository/rpm_dependency.rs`;
 `crates/conary-core/src/repository/requirement.rs`;
 `crates/conary-core/src/repository/package_relation.rs`;
 `crates/conary-core/src/repository/resolution_policy.rs`;
@@ -402,6 +403,7 @@ selection; installed package state; model replatform planning; Remi repository
 manifests, admin routes, and hosted feed configuration.
 
 **Paths:** `crates/conary-core/src/repository/*`;
+`crates/conary-core/tests/fixtures/rpm/*`;
 `crates/conary-core/src/resolver/*`;
 `crates/conary-core/src/transaction/package_relations.rs`;
 `crates/conary-core/src/transaction/package_relations/*`;
@@ -987,6 +989,9 @@ release uploads, and static test fixtures through Remi.
 
 **Start here:** `apps/remi/src/server/release_publish.rs`;
 `apps/remi/src/deployment.rs`;
+`apps/remi/src/server/mod.rs`;
+`apps/remi/src/server/admin_service.rs`;
+`apps/remi/src/server/admin_service/refresh.rs`;
 `apps/remi/src/server/repository_manifest.rs`;
 `deploy/remi-repositories.toml`;
 `crates/conary-core/src/db/current_schema/sql/remi.sql`;
@@ -1017,6 +1022,7 @@ feed profiles.
 
 **Focused proof:** `cargo test -p remi release_upload_`;
 `cargo test -p remi native_publish`;
+`cargo test -p remi refresh`;
 `cargo test -p conary --test packaging_m4c`;
 `cargo test -p remi remi_release_parity`;
 `cargo test -p remi conversion`;

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-26
-revision: 7
+last_updated: 2026-07-27
+revision: 8
 summary: Document Remi source, canonical-map, repository trust, conversion, publication, and serving authority
 ---
 
@@ -51,9 +51,25 @@ read-only deployment inspection. It snapshots a current database or retires an
 old schema epoch before replacement, so health failure can restore config,
 source authority, and SQLite state together. Startup reconciles the installed
 manifest before opening listeners, then immediately refreshes metadata and
-runs prewarm jobs. The release deployment gate requires exact source
-reconciliation, all sources populated, and at least one conversion and
-validated converted artifact for every configured public profile.
+runs prewarm jobs. Multi-source refresh returns one typed result or failure per
+source. A source failure remains visible but cannot discard successful source
+commits or suppress prewarm for another exact profile. Prewarm eligibility
+comes only from the successful result's persisted `source_profile`; repository
+names, URLs, formats, and error text are not selectors.
+
+Both internal and external `POST /v1/admin/refresh` routes use the same response
+projection: HTTP 200 means every source completed or was current, 207 carries a
+mixed success/failure batch, and 502 means every configured source failed.
+Global database/setup failures remain HTTP 500. The release deployment gate
+still requires exact source reconciliation, all sources populated, and at
+least one conversion and validated converted artifact for every configured
+public profile. Result and failure arrays are sorted by exact repository name,
+so concurrent completion order is not API order.
+
+`apps/remi/src/server/admin_service/refresh.rs` owns the batch state, typed
+per-source results, and bounded concurrent collection. `server/mod.rs` owns the
+exact-profile handoff from successful refresh results into configured prewarm
+jobs; HTTP handlers only publish events and project the shared batch.
 
 ## Canonical Map Exchange
 

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-07-27
-revision: 16
+revision: 17
 summary: Document exact profile-owned source policy, canonical map authority, native repository authority, package identity, and lifecycle handoff
 ---
 
@@ -208,6 +208,17 @@ dependencies and provisions are parsed through the official typed
 `RelationOrSoname` grammar. Soname v1 and v2 values remain complete atomic
 `Soname` identities; Conary never guesses a package-version boundary inside
 them. Ordinary package relations retain their exact ALPM comparison semantics.
+
+RPM requirement grammar is owned by
+`repository/rpm_dependency.rs`. Its parser state is derived from RPM
+`a8f0192aee1c08bd1454ed2ac6ebaf506004b55c`
+[`rpmrichParseInternal()` and `rpmrichParseForTag()`](https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/lib/rpmds.cc#L1309-L1421),
+not from dependency text or a package list. It accepts RPM's exact comparison
+spellings and canonicalizes aliases before typed version evaluation; enforces
+the same-operator chain and tag-context rules; and constructs repeated `with`
+from the right side as RPM does. The source-pinned Fedora 44 corpus under
+`crates/conary-core/tests/fixtures/rpm/` proves real repository expressions
+without granting those packages exceptional behavior.
 
 The contract was derived against the package managers' and repository
 generators' own documentation:

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-07-27
-revision: 33
+revision: 34
 summary: Define source-independent lifecycle, generation activation, and configuration transactions for RPM, Debian, and Arch packages
 ---
 
@@ -618,6 +618,18 @@ scheme, relation, and EVR boundary from the header. `<`, `<=`, `=`, `>=`, and
 overlap, including inclusive/exclusive endpoints, unversioned existence
 provides, and RPM's partial-EVR equality behavior. It never substitutes the
 owning package EVR or reinterprets the range through another ecosystem.
+
+RPM rich requirements are typed source ABI, not text to split later. The
+parser is pinned to RPM
+[`rpmrichParseInternal()`](https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/lib/rpmds.cc#L1309-L1396)
+and carries `and`, `or`, `if`, `unless`, `else`, `with`, and `without` into
+`RepositoryRequirementExpression`. Only `and`, `or`, and `with` may repeat at
+one level; repeated `with` is represented by RPM's right-side chain. RPM's
+`=<`, `==`, and `=>` comparison aliases canonicalize to `<=`, `=`, and `>=`
+before native RPM version evaluation, while `!=` is not an RPM dependency
+operator. Requires-like and conflict-like tag contexts retain RPM's distinct
+`if`/`unless` nesting checks. The implementation never recognizes a dependency
+by package name or adds a skip/allowlist for repository metadata.
 
 ### RPM Lifecycle Surface
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -617,7 +617,7 @@ main() {
         if [[ -f CHANGELOG.md ]]; then
             tmp="$(mktemp)"
             head -5 CHANGELOG.md > "$tmp"
-            printf '%s' "$changelog_entry" >> "$tmp"
+            printf '%s\n' "$changelog_entry" >> "$tmp"
             tail -n +6 CHANGELOG.md >> "$tmp"
             mv "$tmp" CHANGELOG.md
         fi

--- a/scripts/test-release-matrix.sh
+++ b/scripts/test-release-matrix.sh
@@ -96,6 +96,7 @@ create_release_fixture() {
     printf '.TH conary 1 "" "conary 0.7.0"\n' > "$repo/apps/conary/man/conary.1"
     printf '# release fixture lockfile\n' > "$repo/Cargo.lock"
     printf '/apps/conary/man/\n' > "$repo/.gitignore"
+    printf '%s' $'# Changelog\n\nFixture release history.\n\nEntries are newest first.\n\n## [fixture] - 2026-01-01\n' > "$repo/CHANGELOG.md"
 
     cat > "$repo/test-bin/cargo" <<'EOF'
 #!/usr/bin/env bash
@@ -506,6 +507,9 @@ test_release_prepare_only_updates_all_conary_test_manifests() {
     assert_contains "$staged_files" \
         "crates/conary-agent-contract/Cargo.toml" \
         "prepare-only should stage the agent contract version"
+    assert_contains "$(<"$repo/CHANGELOG.md")" \
+        $'- add exact lifecycle proof\n\n## [fixture]' \
+        "release notes should leave a blank line before prior history"
 
     output="$(run_release_dry_run "$repo" conary-test --target conary-test=0.9.0)"
     assert_contains "$output" \


### PR DESCRIPTION
## Primary Issue

Refs #91

Design / Plan / Roadmap:

- Parent release issue #86
- `docs/modules/source-selection.md`
- `docs/modules/remi.md`
- `docs/specs/foreign-package-lifecycle-contracts.md`

## Problem And Outcome

The `remi-v0.8.1` deployment installed the intended binary but could not repopulate because Conary rejected valid Fedora 44 repeated-`with` rich dependencies. Remi then aborted the multi-source aggregate on that one Fedora failure, starving healthy source profiles of prewarm work.

After merge, RPM rich dependencies follow the pinned upstream RPM grammar/state contract without package exceptions or string heuristics. Remi retains typed outcomes per source, commits successful refreshes independently, and starts prewarm only from exact successful `source_profile` values. This tree also prepares the immutable recovery release as `remi-v0.8.2`; #91 remains open until deployment proves every configured source and conversion profile.

## Changes

- Replace the partial RPM rich-dependency parser with a state parser derived from RPM commit `a8f0192aee1c08bd1454ed2ac6ebaf506004b55c`.
- Cover all documented operators, comparison spellings, chain rules, tag contexts, trailing input, and right-associated repeated `with` behavior.
- Add a source-pinned Fedora 44 regression corpus containing the real chained-`with` metadata that stopped production refresh.
- Remove an invalid legacy resolver expectation that allowed `unless` in RPM `Requires`; upstream restricts it to conflict-like contexts.
- Extract typed multi-source refresh collection into `admin_service/refresh.rs`, preserving successes when another source fails.
- Return deterministic 200/207/502 complete/partial/failed refresh responses from both admin routes.
- Bind post-refresh prewarm eligibility to exact successful persisted profiles, never names, URLs, formats, or error text.
- Prepare Remi `0.8.2` and repair release-note section spacing with a regression test.
- Update feature routing and durable source-selection, lifecycle, and Remi ownership docs.

## Scope

- In scope: RPM dependency grammar, Fedora metadata regression proof, Remi refresh/prewarm isolation, refresh API outcomes, Remi `0.8.2` preparation, touched release-note generation.
- Out of scope: package allowlists, parse bypasses, trust weakening, schema changes, unrelated distro/package-format additions.

## Ownership / Boundary

- Owning subsystem: `resolution` and `remi` feature cards, with the release track for the prepared recovery version.
- Boundary changed or preserved: RPM source grammar becomes the parsing oracle; per-source refresh outcome collection moves to `apps/remi/src/server/admin_service/refresh.rs`; strict deployment acceptance is preserved.
- Persisted state or public surface impact: repository rows and conversions repopulate operationally without a schema change; admin refresh now exposes typed per-source outcomes and 207/502 aggregate states.
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code
- [x] Updated subsystem docs or maps when the "look here first" path changed
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs

```text
cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test -p conary-core repository::rpm_dependency
cargo test -p conary-core repository
cargo test -p conary-core resolver
cargo test -p conary-core transaction::package_relations
cargo test -p remi
cargo test -p conary --lib commands::repo
cargo test -p conary --lib cli::tests
cargo test -p conary --lib commands::install
cargo test -p conary --test conversion_integration
bash scripts/test-release-matrix.sh
bash scripts/check-release-matrix.sh
bash scripts/release-cargo-audit.sh
bash scripts/check-doc-truth.sh
bash scripts/test-doc-truth.sh
bash scripts/test-agent-context.sh
bash scripts/agent-context.sh --validate
git diff --check
```

A clean authenticated Fedora 44 `primary.xml.zst` refresh also parsed and committed all 76,354 package records (`1 synced, 0 skipped, 0 failed`) against the exact source metadata that failed under `remi-v0.8.1`.

## Review And Merge Notes

- Review focus: fidelity of parser state/context checks; typed partial refresh behavior; exact-profile prewarm selection; preservation of strict deployment gating.
- User or developer impact: Fedora metadata refresh no longer fails on valid rich dependencies, and one bad upstream no longer hides or starves successful sources.
- Required-check bypass: not used
- #91 must remain open after merge until `remi-v0.8.2` deploys and independent production proof passes.