### PR TITLE
test: prove published native release packages

### DIFF
--- a/.github/workflows/deploy-and-verify.yml
+++ b/.github/workflows/deploy-and-verify.yml
@@ -450,6 +450,16 @@ jobs:
             }
           fi
 
+  prove-conary-release-artifacts:
+    name: prove-conary-release-artifacts
+    needs: [resolve, deploy-conary]
+    if: ${{ needs.resolve.outputs.product == 'conary' && needs.resolve.outputs.deploy_mode == 'release_bundle' && needs.resolve.outputs.dry_run != 'true' && needs.deploy-conary.result == 'success' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/release-artifact-proof.yml
+    with:
+      tag_name: ${{ needs.resolve.outputs.tag_name }}
+
   verify-remi:
     name: verify-remi
     needs: [resolve, validate-routing]

--- a/.github/workflows/release-artifact-proof.yml
+++ b/.github/workflows/release-artifact-proof.yml
@@ -1,0 +1,186 @@
+name: release-artifact-proof
+
+on:
+  workflow_call:
+    inputs:
+      tag_name:
+        description: Published canonical Conary tag to prove.
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Published canonical Conary tag to prove.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-artifact-proof-${{ inputs.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  native-package-lifecycle:
+    name: native-package-lifecycle (${{ matrix.distro }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - distro: fedora44
+            native_format: rpm
+          - distro: ubuntu-26.04
+            native_format: deb
+          - distro: arch
+            native_format: arch
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      RELEASE_TAG: ${{ inputs.tag_name }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-rust-workspace
+      - name: Require the hosted container runtime
+        run: docker info
+      - name: Resolve the published native package
+        id: release
+        shell: bash
+        env:
+          NATIVE_FORMAT: ${{ matrix.native_format }}
+        run: |
+          set -euo pipefail
+
+          metadata_dir="${RUNNER_TEMP}/conary-release-metadata"
+          mkdir -p "$metadata_dir"
+
+          resolved="$(bash scripts/release-matrix.sh resolve-tag "$RELEASE_TAG" --format shell)"
+          product="$(sed -n 's/^product=//p' <<< "$resolved")"
+          resolved_tag="$(sed -n 's/^tag_name=//p' <<< "$resolved")"
+          [[ "$product" == "conary" && "$resolved_tag" == "$RELEASE_TAG" ]] || {
+            echo "tag does not resolve to the canonical Conary release track" >&2
+            exit 1
+          }
+
+          git fetch --force origin \
+            "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          [[ "$(git cat-file -t "$RELEASE_TAG")" == "tag" ]] || {
+            echo "${RELEASE_TAG} is not an annotated tag" >&2
+            exit 1
+          }
+          tag_tree="${RUNNER_TEMP}/conary-release-tag"
+          git worktree add --detach "$tag_tree" "${RELEASE_TAG}^{}"
+
+          gh release download "$RELEASE_TAG" \
+            --repo "$GH_REPO" \
+            --pattern metadata.json \
+            --dir "$metadata_dir"
+
+          metadata="${metadata_dir}/metadata.json"
+          [[ -s "$metadata" && ! -L "$metadata" ]] || {
+            echo "release metadata is missing, empty, or symlinked" >&2
+            exit 1
+          }
+
+          product="$(jq -r '.product' "$metadata")"
+          tag_name="$(jq -r '.tag_name' "$metadata")"
+          version="$(jq -r '.version' "$metadata")"
+          dry_run="$(jq -r '.dry_run' "$metadata")"
+          [[ "$product" == "conary" ]] || {
+            echo "release metadata product is ${product}, expected conary" >&2
+            exit 1
+          }
+          [[ "$tag_name" == "$RELEASE_TAG" ]] || {
+            echo "release metadata tag is ${tag_name}, expected ${RELEASE_TAG}" >&2
+            exit 1
+          }
+          [[ "$dry_run" == "false" ]] || {
+            echo "release metadata is not a live publication" >&2
+            exit 1
+          }
+          bash "$tag_tree/scripts/release-matrix.sh" assert-owned-version conary "$version"
+
+          case "$NATIVE_FORMAT" in
+            rpm) asset="conary-${version}-1.fc44.x86_64.rpm" ;;
+            deb) asset="conary_${version}-1_amd64.deb" ;;
+            arch) asset="conary-${version}-1-x86_64.pkg.tar.zst" ;;
+            *)
+              echo "unsupported native package format: ${NATIVE_FORMAT}" >&2
+              exit 1
+              ;;
+          esac
+
+          release_dir="${RUNNER_TEMP}/conary-release-${NATIVE_FORMAT}"
+          mkdir -p "$release_dir"
+          gh release download "$RELEASE_TAG" \
+            --repo "$GH_REPO" \
+            --pattern SHA256SUMS \
+            --pattern "$asset" \
+            --dir "$release_dir"
+          cp "$metadata" "$release_dir/metadata.json"
+
+          package="${release_dir}/${asset}"
+          checksums="${release_dir}/SHA256SUMS"
+          [[ -s "$package" && ! -L "$package" ]] || {
+            echo "published native package is missing, empty, or symlinked" >&2
+            exit 1
+          }
+          [[ -s "$checksums" && ! -L "$checksums" ]] || {
+            echo "published SHA256SUMS is missing, empty, or symlinked" >&2
+            exit 1
+          }
+
+          (
+            cd "$release_dir"
+            sha256sum -c SHA256SUMS --ignore-missing
+          )
+
+          actual_digest="sha256:$(sha256sum "$package" | awk '{print $1}')"
+          release_json="$(gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets)"
+          published_digest="$(
+            jq -r --arg asset "$asset" \
+              '.assets[] | select(.name == $asset) | .digest' \
+              <<< "$release_json"
+          )"
+          [[ "$published_digest" == "$actual_digest" ]] || {
+            echo "GitHub digest ${published_digest} does not match ${actual_digest}" >&2
+            exit 1
+          }
+
+          echo "native_package=${package}" >> "$GITHUB_OUTPUT"
+          echo "asset=${asset}" >> "$GITHUB_OUTPUT"
+      - name: Build the lifecycle harness
+        run: cargo build -p conary -p conary-test
+      - name: Install the published native package in the test image
+        run: >-
+          cargo run -p conary-test --
+          images build
+          --distro "${{ matrix.distro }}"
+          --native-package "${{ steps.release.outputs.native_package }}"
+      - name: Run Cartesian lifecycle parity with the published binary
+        env:
+          CONARY_TEST_REUSE_IMAGE: "1"
+        run: >-
+          cargo run -p conary-test --
+          run
+          --distro "${{ matrix.distro }}"
+          --phase 4
+          --suite native-cross-source-lifecycle
+
+  release-artifact-proof:
+    name: release-artifact-proof
+    if: ${{ always() }}
+    needs: native-package-lifecycle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every published-package lifecycle job
+        env:
+          MATRIX_RESULT: ${{ needs.native-package-lifecycle.result }}
+        run: |
+          if [[ "$MATRIX_RESULT" != "success" ]]; then
+            echo "published native package lifecycle matrix result: $MATRIX_RESULT" >&2
+            exit 1
+          fi
+          echo "published native package lifecycle matrix result: $MATRIX_RESULT"

--- a/apps/conary-test/src/cli.rs
+++ b/apps/conary-test/src/cli.rs
@@ -174,6 +174,10 @@ enum ImageCommands {
         /// Distro to build
         #[arg(long)]
         distro: String,
+
+        /// Published native Conary package to install in the distro image
+        #[arg(long, value_name = "PATH")]
+        native_package: Option<PathBuf>,
     },
 
     /// List built images
@@ -808,24 +812,51 @@ fn main() -> Result<()> {
         Commands::Images { command } => {
             let rt = tokio::runtime::Runtime::new()?;
             match command {
-                ImageCommands::Build { distro } => {
+                ImageCommands::Build {
+                    distro,
+                    native_package,
+                } => {
                     let config = load_config()?;
                     rt.block_on(async {
                         let backend = conary_test::container::BollardBackend::new()?;
                         let cf_path = containerfile_path(&config, &distro)?;
-                        let build_context = config
+                        let distro_config = config
                             .distros
                             .get(&distro)
-                            .with_context(|| format!("unknown distro: {distro}"))?
-                            .build_context;
+                            .with_context(|| format!("unknown distro: {distro}"))?;
+                        let build_context = distro_config.build_context;
                         tracing::info!(%distro, containerfile = %cf_path.display(), "Building image");
-                        let tag = conary_test::container::build_distro_image(
-                            &backend,
-                            &cf_path,
-                            &distro,
-                            build_context,
-                        )
-                        .await?;
+                        let tag = match native_package {
+                            Some(package) => {
+                                let profile = conary_core::repository::supported_profiles::profile_by_public_id(
+                                    &distro_config.remi_distro,
+                                )
+                                .with_context(|| {
+                                    format!(
+                                        "distro {distro} names unsupported profile {}",
+                                        distro_config.remi_distro
+                                    )
+                                })?;
+                                conary_test::container::build_distro_image_from_native_package(
+                                    &backend,
+                                    &cf_path,
+                                    &distro,
+                                    build_context,
+                                    &package,
+                                    profile.package_format(),
+                                )
+                                .await?
+                            }
+                            None => {
+                                conary_test::container::build_distro_image(
+                                    &backend,
+                                    &cf_path,
+                                    &distro,
+                                    build_context,
+                                )
+                                .await?
+                            }
+                        };
                         if json {
                             println!(
                                 "{}",

--- a/apps/conary-test/src/cli/tests.rs
+++ b/apps/conary-test/src/cli/tests.rs
@@ -61,6 +61,37 @@ fn load_config_succeeds_from_workspace_root() {
 }
 
 #[test]
+fn images_build_accepts_an_explicit_native_package() {
+    let cli = Cli::try_parse_from([
+        "conary-test",
+        "images",
+        "build",
+        "--distro",
+        "fedora44",
+        "--native-package",
+        "/tmp/conary-release.rpm",
+    ])
+    .unwrap();
+
+    match cli.command {
+        Commands::Images {
+            command:
+                ImageCommands::Build {
+                    distro,
+                    native_package,
+                },
+        } => {
+            assert_eq!(distro, "fedora44");
+            assert_eq!(
+                native_package,
+                Some(PathBuf::from("/tmp/conary-release.rpm"))
+            );
+        }
+        _ => panic!("unexpected command"),
+    }
+}
+
+#[test]
 fn deploy_status_port_defaults_to_9090() {
     let _guard = env_lock().lock().expect("env lock");
     set_test_port_env(None);

--- a/apps/conary-test/src/config/tests/workflow.rs
+++ b/apps/conary-test/src/config/tests/workflow.rs
@@ -10,6 +10,8 @@ use std::{
 const MATRIX_JOB_ID: &str = "native-cross-source-lifecycle";
 const MATRIX_GATE_ID: &str = "native-cross-source-lifecycle-gate";
 const STABLE_CHECK_CONTEXT: &str = "native-cross-source-lifecycle";
+const RELEASE_ARTIFACT_MATRIX_JOB_ID: &str = "native-package-lifecycle";
+const RELEASE_ARTIFACT_GATE_ID: &str = "release-artifact-proof";
 
 #[derive(Debug, Deserialize)]
 struct Workflow {
@@ -59,6 +61,33 @@ struct WorkspaceTestJob {
 }
 
 #[derive(Debug, Deserialize)]
+struct ReleaseArtifactMatrixJob {
+    name: String,
+    #[serde(rename = "timeout-minutes")]
+    timeout_minutes: u64,
+    strategy: ReleaseArtifactStrategy,
+    steps: Vec<WorkflowStep>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReleaseArtifactStrategy {
+    #[serde(rename = "fail-fast")]
+    fail_fast: bool,
+    matrix: ReleaseArtifactMatrix,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReleaseArtifactMatrix {
+    include: Vec<ReleaseArtifactLane>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+struct ReleaseArtifactLane {
+    distro: String,
+    native_format: String,
+}
+
+#[derive(Debug, Deserialize)]
 struct WorkflowStep {
     name: Option<String>,
     uses: Option<String>,
@@ -76,11 +105,19 @@ fn workflow_path() -> PathBuf {
 }
 
 fn load_workflow() -> Workflow {
-    let path = workflow_path();
+    load_workflow_from(workflow_path())
+}
+
+fn load_workflow_from(path: PathBuf) -> Workflow {
     let source = std::fs::read_to_string(&path)
         .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
     serde_yaml::from_str(&source)
         .unwrap_or_else(|error| panic!("parse {} as typed YAML: {error}", path.display()))
+}
+
+fn release_artifact_workflow_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../.github/workflows/release-artifact-proof.yml")
 }
 
 fn parse_job<T>(workflow: &Workflow, id: &str) -> T
@@ -243,4 +280,81 @@ fn workspace_gate_provisions_the_exact_namespace_test_boundary() {
     );
     assert!(!tests.continue_on_error);
     assert_eq!(tests.condition, None);
+}
+
+#[test]
+fn release_artifact_workflow_installs_every_published_native_package() {
+    let workflow = load_workflow_from(release_artifact_workflow_path());
+    let job: ReleaseArtifactMatrixJob = parse_job(&workflow, RELEASE_ARTIFACT_MATRIX_JOB_ID);
+
+    assert_eq!(job.name, "native-package-lifecycle (${{ matrix.distro }})");
+    assert_eq!(job.timeout_minutes, 90);
+    assert!(!job.strategy.fail_fast);
+    assert_eq!(
+        job.strategy.matrix.include,
+        [
+            ReleaseArtifactLane {
+                distro: "fedora44".to_string(),
+                native_format: "rpm".to_string(),
+            },
+            ReleaseArtifactLane {
+                distro: "ubuntu-26.04".to_string(),
+                native_format: "deb".to_string(),
+            },
+            ReleaseArtifactLane {
+                distro: "arch".to_string(),
+                native_format: "arch".to_string(),
+            },
+        ]
+    );
+
+    let resolve = named_step(&job.steps, "Resolve the published native package");
+    let resolve_script = resolve.run.as_deref().expect("release resolver script");
+    for required in [
+        "release-matrix.sh resolve-tag",
+        "git cat-file -t",
+        "sha256sum -c SHA256SUMS --ignore-missing",
+        "published_digest",
+        "actual_digest",
+    ] {
+        assert!(
+            resolve_script.contains(required),
+            "release resolver must contain {required}"
+        );
+    }
+
+    let image = named_step(
+        &job.steps,
+        "Install the published native package in the test image",
+    );
+    assert!(
+        image
+            .run
+            .as_deref()
+            .is_some_and(|run| run.contains("--native-package"))
+    );
+
+    let lifecycle = named_step(
+        &job.steps,
+        "Run Cartesian lifecycle parity with the published binary",
+    );
+    assert!(
+        lifecycle
+            .run
+            .as_deref()
+            .is_some_and(|run| run.contains("--suite native-cross-source-lifecycle"))
+    );
+    assert_eq!(
+        lifecycle
+            .env
+            .get("CONARY_TEST_REUSE_IMAGE")
+            .map(String::as_str),
+        Some("1")
+    );
+
+    let gate: GateJob = parse_job(&workflow, RELEASE_ARTIFACT_GATE_ID);
+    assert_eq!(gate.name, RELEASE_ARTIFACT_GATE_ID);
+    assert_eq!(gate.condition, "${{ always() }}");
+    assert_eq!(gate.needs, RELEASE_ARTIFACT_MATRIX_JOB_ID);
+    assert!(!gate.continue_on_error);
 }

--- a/apps/conary-test/src/container/image.rs
+++ b/apps/conary-test/src/container/image.rs
@@ -1,6 +1,7 @@
 // conary-test/src/container/image.rs
 
 use anyhow::{Context, Result, bail};
+use conary_core::repository::supported_profiles::ProfilePackageFormat;
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -12,6 +13,12 @@ use crate::config::DistroBuildContext;
 struct StagedBuildContext {
     root: PathBuf,
     dockerfile: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct NativePackageArtifact<'a> {
+    path: &'a Path,
+    format: ProfilePackageFormat,
 }
 
 impl Drop for StagedBuildContext {
@@ -198,10 +205,50 @@ fn ensure_phase2_fixture_outputs(fixtures_root: &Path, conary_bin: &Path) -> Res
     Ok(())
 }
 
+fn canonical_native_package_name(format: ProfilePackageFormat) -> &'static str {
+    match format {
+        ProfilePackageFormat::Rpm => "conary-release.rpm",
+        ProfilePackageFormat::Deb => "conary-release.deb",
+        ProfilePackageFormat::Arch => "conary-release.pkg.tar.zst",
+    }
+}
+
+fn stage_native_package(root: &Path, artifact: NativePackageArtifact<'_>) -> Result<()> {
+    let metadata = fs::symlink_metadata(artifact.path).with_context(|| {
+        format!(
+            "failed to inspect native package artifact {}",
+            artifact.path.display()
+        )
+    })?;
+    if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+        bail!(
+            "native package artifact must be a real regular file: {}",
+            artifact.path.display()
+        );
+    }
+    if metadata.len() == 0 {
+        bail!(
+            "native package artifact must not be empty: {}",
+            artifact.path.display()
+        );
+    }
+
+    let destination = root.join(canonical_native_package_name(artifact.format));
+    fs::copy(artifact.path, &destination).with_context(|| {
+        format!(
+            "failed to stage native package artifact {} as {}",
+            artifact.path.display(),
+            destination.display()
+        )
+    })?;
+    Ok(())
+}
+
 fn stage_build_context(
     containerfile: &Path,
     distro: &str,
     build_context: DistroBuildContext,
+    native_package: Option<NativePackageArtifact<'_>>,
 ) -> Result<StagedBuildContext> {
     let integration_root = containerfile
         .parent()
@@ -254,6 +301,10 @@ fn stage_build_context(
         .arg(&staged_binary)
         .status();
 
+    if let Some(artifact) = native_package {
+        stage_native_package(&root, artifact)?;
+    }
+
     ensure_phase2_fixture_outputs(&root.join("fixtures"), &binary)?;
 
     if build_context == DistroBuildContext::WorkspaceSource {
@@ -279,13 +330,50 @@ pub async fn build_distro_image(
     distro: &str,
     build_context: DistroBuildContext,
 ) -> Result<String> {
+    build_distro_image_inner(backend, containerfile, distro, build_context, None).await
+}
+
+/// Build a distro-specific test image by installing one exact native package.
+///
+/// The package format comes from Conary's typed supported-profile catalog.
+/// Containerfiles install the staged canonical filename through the distro's
+/// native package manager before any lifecycle proof runs.
+pub async fn build_distro_image_from_native_package(
+    backend: &dyn ContainerBackend,
+    containerfile: &Path,
+    distro: &str,
+    build_context: DistroBuildContext,
+    package: &Path,
+    package_format: ProfilePackageFormat,
+) -> Result<String> {
+    build_distro_image_inner(
+        backend,
+        containerfile,
+        distro,
+        build_context,
+        Some(NativePackageArtifact {
+            path: package,
+            format: package_format,
+        }),
+    )
+    .await
+}
+
+async fn build_distro_image_inner(
+    backend: &dyn ContainerBackend,
+    containerfile: &Path,
+    distro: &str,
+    build_context: DistroBuildContext,
+    native_package: Option<NativePackageArtifact<'_>>,
+) -> Result<String> {
     let tag = format!("conary-test-{distro}:latest");
     let force_rebuild = std::env::var("CONARY_TEST_REBUILD_IMAGE")
         .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
         .unwrap_or(false);
-    let reuse_existing = std::env::var("CONARY_TEST_REUSE_IMAGE")
-        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
-        .unwrap_or(false);
+    let reuse_existing = native_package.is_none()
+        && std::env::var("CONARY_TEST_REUSE_IMAGE")
+            .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+            .unwrap_or(false);
 
     if reuse_existing && !force_rebuild {
         let images = backend
@@ -301,16 +389,23 @@ pub async fn build_distro_image(
         }
     }
 
-    let staged = stage_build_context(containerfile, distro, build_context)?;
+    let staged = stage_build_context(containerfile, distro, build_context, native_package)?;
+    let mut build_args = HashMap::new();
+    if native_package.is_some() {
+        build_args.insert("INSTALL_MODE".to_string(), "package".to_string());
+    }
     backend
-        .build_image(&staged.dockerfile, &tag, HashMap::new())
+        .build_image(&staged.dockerfile, &tag, build_args)
         .await
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{find_project_root, stage_build_context};
+    use super::{
+        NativePackageArtifact, find_project_root, stage_build_context, stage_native_package,
+    };
     use crate::config::DistroBuildContext;
+    use conary_core::repository::supported_profiles::ProfilePackageFormat;
     use std::fs;
     use std::path::Path;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -371,8 +466,9 @@ mod tests {
         )
         .expect("write pkgbuild");
 
-        let staged = stage_build_context(&containerfile, "fedora44", DistroBuildContext::Binary)
-            .expect("stage build context");
+        let staged =
+            stage_build_context(&containerfile, "fedora44", DistroBuildContext::Binary, None)
+                .expect("stage build context");
 
         assert!(
             staged
@@ -397,6 +493,25 @@ mod tests {
         assert!(staged.root.join("conary").is_file());
         assert!(!staged.root.join("target").exists());
         assert!(!staged.root.join("source").exists());
+
+        drop(staged);
+
+        let package = project_root.join("release.rpm");
+        fs::write(&package, "published package bytes").expect("write release package");
+        let staged = stage_build_context(
+            &containerfile,
+            "fedora44",
+            DistroBuildContext::Binary,
+            Some(NativePackageArtifact {
+                path: &package,
+                format: ProfilePackageFormat::Rpm,
+            }),
+        )
+        .expect("stage native package build context");
+        assert_eq!(
+            fs::read(staged.root.join("conary-release.rpm")).expect("read staged package"),
+            b"published package bytes"
+        );
 
         drop(staged);
         fs::remove_dir_all(project_root).expect("cleanup project root");
@@ -487,7 +602,7 @@ printf 'fixture\n' > "$output/$file"
         permissions.set_mode(0o755);
         fs::set_permissions(&conary, permissions).expect("make fake conary executable");
 
-        let staged = stage_build_context(&containerfile, "arch", DistroBuildContext::Binary)
+        let staged = stage_build_context(&containerfile, "arch", DistroBuildContext::Binary, None)
             .expect("stage build context");
 
         assert!(
@@ -567,6 +682,7 @@ printf 'fixture\n' > "$output/$file"
             &containerfile,
             "not-an-ubuntu-name",
             DistroBuildContext::WorkspaceSource,
+            None,
         )
         .expect("stage workspace source context");
         assert!(
@@ -581,6 +697,7 @@ printf 'fixture\n' > "$output/$file"
             &containerfile,
             "ubuntu-name-does-not-matter",
             DistroBuildContext::Binary,
+            None,
         )
         .expect("stage binary context");
         assert!(!binary_staged.root.join("source").exists());
@@ -600,5 +717,51 @@ printf 'fixture\n' > "$output/$file"
             contents.contains("cmake"),
             "Ubuntu source-build image must install cmake for aws-lc-sys"
         );
+    }
+
+    #[test]
+    fn package_mode_containerfiles_install_exact_canonical_artifacts() {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let containers = manifest_dir.join("../conary/tests/integration/remi/containers");
+        for (file, package, install) in [
+            (
+                "Containerfile.fedora44",
+                "conary-release.rpm",
+                "dnf install -y /tmp/install/conary-release.rpm",
+            ),
+            (
+                "Containerfile.ubuntu-26.04",
+                "conary-release.deb",
+                "apt-get install -y /tmp/install/conary-release.deb",
+            ),
+            (
+                "Containerfile.arch",
+                "conary-release.pkg.tar.zst",
+                "pacman -U --noconfirm /tmp/install/conary-release.pkg.tar.zst",
+            ),
+        ] {
+            let contents =
+                fs::read_to_string(containers.join(file)).expect("read package-mode containerfile");
+            assert!(contents.contains(package), "{file} must name {package}");
+            assert!(contents.contains(install), "{file} must run {install}");
+        }
+    }
+
+    #[test]
+    fn native_package_staging_rejects_empty_files() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let package = directory.path().join("empty.rpm");
+        fs::write(&package, []).expect("write empty package");
+
+        let error = stage_native_package(
+            directory.path(),
+            NativePackageArtifact {
+                path: &package,
+                format: ProfilePackageFormat::Rpm,
+            },
+        )
+        .expect_err("empty package must fail");
+
+        assert!(error.to_string().contains("must not be empty"));
     }
 }

--- a/apps/conary-test/src/container/mod.rs
+++ b/apps/conary-test/src/container/mod.rs
@@ -10,7 +10,7 @@ pub use backend::{
     ContainerBackend, ContainerConfig, ContainerId, ContainerInspection, ExecResult, ImageInfo,
     NullBackend, VolumeMount,
 };
-pub use image::build_distro_image;
+pub use image::{build_distro_image, build_distro_image_from_native_package};
 pub use lifecycle::BollardBackend;
 
 #[cfg(test)]

--- a/apps/conary/tests/integration/remi/containers/Containerfile.arch
+++ b/apps/conary/tests/integration/remi/containers/Containerfile.arch
@@ -22,9 +22,9 @@ RUN pacman -Syu --noconfirm \
 # Copy all conary* files from build context (binary or package)
 COPY conary* /tmp/install/
 
-# Install: pkg.tar.zst if present, otherwise raw binary
-RUN if [ "$INSTALL_MODE" = "package" ] && ls /tmp/install/*.pkg.tar.zst 1>/dev/null 2>&1; then \
-        pacman -U --noconfirm /tmp/install/*.pkg.tar.zst; \
+# Install: exact staged Arch package or raw binary
+RUN if [ "$INSTALL_MODE" = "package" ] && [ -f /tmp/install/conary-release.pkg.tar.zst ]; then \
+        pacman -U --noconfirm /tmp/install/conary-release.pkg.tar.zst; \
     elif [ -f /tmp/install/conary ]; then \
         install -m 755 /tmp/install/conary /usr/bin/conary; \
     else \

--- a/apps/conary/tests/integration/remi/containers/Containerfile.fedora44
+++ b/apps/conary/tests/integration/remi/containers/Containerfile.fedora44
@@ -22,9 +22,9 @@ RUN dnf install -y \
 # Copy all conary* files from build context (binary or package)
 COPY conary* /tmp/install/
 
-# Install: RPM package if present, otherwise raw binary
-RUN if [ "$INSTALL_MODE" = "package" ] && ls /tmp/install/*.rpm 1>/dev/null 2>&1; then \
-        dnf install -y /tmp/install/*.rpm; \
+# Install: exact staged RPM package or raw binary
+RUN if [ "$INSTALL_MODE" = "package" ] && [ -f /tmp/install/conary-release.rpm ]; then \
+        dnf install -y /tmp/install/conary-release.rpm; \
     elif [ -f /tmp/install/conary ]; then \
         install -m 755 /tmp/install/conary /usr/bin/conary; \
     else \

--- a/apps/conary/tests/integration/remi/containers/Containerfile.ubuntu-26.04
+++ b/apps/conary/tests/integration/remi/containers/Containerfile.ubuntu-26.04
@@ -44,9 +44,9 @@ COPY conary* /tmp/install/
 # Copy built binary from builder stage (only meaningful in binary mode)
 COPY --from=builder /build/target/release/conary /tmp/install/conary-built
 
-# Install: DEB package or built binary from source
-RUN if [ "$INSTALL_MODE" = "package" ] && ls /tmp/install/*.deb 1>/dev/null 2>&1; then \
-        apt-get update && apt-get install -y /tmp/install/*.deb && rm -rf /var/lib/apt/lists/*; \
+# Install: exact staged DEB package or built binary from source
+RUN if [ "$INSTALL_MODE" = "package" ] && [ -f /tmp/install/conary-release.deb ]; then \
+        apt-get update && apt-get install -y /tmp/install/conary-release.deb && rm -rf /var/lib/apt/lists/*; \
     elif [ "$INSTALL_MODE" = "binary" ] && [ -f /tmp/install/conary-built ] && [ -s /tmp/install/conary-built ]; then \
         install -m 755 /tmp/install/conary-built /usr/bin/conary; \
     elif [ -f /tmp/install/conary ]; then \

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-07-26
-revision: 39
-summary: Document selected-generation cross-source package lifecycle proof and its hosted PR matrix
+revision: 40
+summary: Document selected-generation cross-source package lifecycle proof from source and published native packages
 ---
 
 # Integration Testing
@@ -429,6 +429,15 @@ job; there is no manifest skip fallback. A stable
 `native-cross-source-lifecycle` aggregator fails unless every distro matrix job
 succeeds.
 
+Published-release proof uses the same contract through
+`.github/workflows/release-artifact-proof.yml`. Its explicit
+`conary-test images build --native-package <path>` input resolves the target
+format from the typed supported-profile catalog, stages one canonical package
+filename, and makes the image install that package through `dnf`, `apt`, or
+`pacman`. The workflow independently matches `SHA256SUMS` and the GitHub asset
+digest before the installed `/usr/bin/conary` runs all three source formats.
+Source-built PR evidence is not a substitute for this published-byte lane.
+
 Each full parity run must pass `scripts/check-conary-test-result-gate.sh`,
 which requires zero failed, skipped, and cancelled results before the matrix
 can count as limited-preview release evidence. The `conary-test run` command also exits
@@ -803,6 +812,7 @@ the specific workflow run.
 |----------|---------|---------|
 | `pr-gate` | Pull request + manual dispatch | Unit/static gates plus the focused three-distro native lifecycle matrix |
 | `merge-validation` | Every push to `main` + manual dispatch | Trusted on-merge smoke validation for `conary`, `remi`, `conaryd`, and `conary-test` |
+| `release-artifact-proof` | Conary deployment + manual dispatch | Install each published native package and run the three-distro Cartesian lifecycle with those exact bytes |
 | `scheduled-ops` | Nightly/scheduled + manual dispatch | Deep validation, health checks, and scheduled operational audits |
 
 `conary-test deploy status` is internal infrastructure state, not a product

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-07-27
-revision: 53
+revision: 54
 summary: Route serialized selected-root mutation, typed rollback lineage, canonical-map authority, typed generation GC, exact release authority, and subsystem proof through current feature owners.
 ---
 
@@ -137,7 +137,8 @@ commands.
   `conaryd`, plus `docs/modules/conaryd.md`.
 - Exact-tag release construction, signing, immutable publication, deployment,
   and independent live proof: `docs/modules/feature-ownership.md` slug
-  `release`, plus `docs/operations/release-artifact-matrix.md` and
+  `release`, plus `.github/workflows/release-artifact-proof.yml`,
+  `docs/operations/release-artifact-matrix.md`, and
   `docs/operations/infrastructure.md`.
 - `conary-test`, fixtures, and declarative suites:
   `docs/modules/feature-ownership.md` slug `conary-test`, plus

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-07-27
-revision: 57
+revision: 58
 summary: Route feature ownership through streaming package payloads, serialized selected-root mutation, typed rollback lineage, exact lifecycle, canonical-map authority, typed generation GC, exact release authority, and current canonical docs
 ---
 
@@ -1161,6 +1161,7 @@ serialized deployment, and prove installed or live behavior independently.
 
 **Start here:** `.github/workflows/release-build.yml`;
 `.github/workflows/deploy-and-verify.yml`;
+`.github/workflows/release-artifact-proof.yml`;
 `scripts/release.sh`; `scripts/release-matrix.sh`;
 `scripts/check-release-matrix.sh`; `scripts/test-release-matrix.sh`;
 `scripts/sign-release.sh`; `crates/conary-core/examples/sign_hash.rs`;
@@ -1174,6 +1175,7 @@ static-site deployment, and production health proof.
 
 **Paths:** `.github/workflows/release-build.yml`;
 `.github/workflows/deploy-and-verify.yml`;
+`.github/workflows/release-artifact-proof.yml`;
 `scripts/release.sh`; `scripts/release-matrix.sh`;
 `scripts/check-release-matrix.sh`; `scripts/test-release-matrix.sh`;
 `scripts/sign-release.sh`; `crates/conary-core/examples/sign_hash.rs`;
@@ -1183,11 +1185,15 @@ static-site deployment, and production health proof.
 **Focused proof:** `bash scripts/check-release-matrix.sh`;
 `bash scripts/test-release-matrix.sh`;
 `cargo test -p conary-core --example sign_hash`;
-`cargo test -p conary --test release_ccs_manifest`.
+`cargo test -p conary --test release_ccs_manifest`;
+`cargo test -p conary-test container::image`.
 
 **Interaction gate:** `bash scripts/test-remi-deploy-helper.sh`;
 `bash scripts/test-deploy-sites.sh` when release routing, remote deployment, or
-static-site publication changes.
+static-site publication changes. After a Conary release is published, the
+terminal release-artifact-proof workflow must install all three native
+packages and pass the Cartesian lifecycle before released-binary evidence is
+claimed.
 
 **Docs to update:** `docs/operations/release-artifact-matrix.md`;
 `docs/operations/infrastructure.md`;

--- a/docs/modules/test-fixtures.md
+++ b/docs/modules/test-fixtures.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-07-26
-revision: 22
-summary: Map fixture ownership, including the selected-generation cross-source lifecycle matrix and public v4 QEMU image contract
+revision: 23
+summary: Map fixture ownership, including source-built and published-package cross-source lifecycle proof and the public v4 QEMU image contract
 ---
 
 # Test Fixtures And Proof Maps
@@ -335,6 +335,11 @@ Each fixture family should record:
   image coverage. `fedora44` is the
   existing `conary-test` runner distro key; public CCS target IDs remain
   `fedora-44`, `ubuntu-26.04`, and `arch`.
+  Published artifacts use
+  `cargo run -p conary-test -- images build --distro <distro> --native-package <path>`
+  before the same focused suite. Only
+  `.github/workflows/release-artifact-proof.yml` binds that package to
+  published metadata, `SHA256SUMS`, and the GitHub digest.
 - **Regeneration:** Manifests are hand-maintained TOML. Rotate the test-only
   authority with `apps/conary/tests/fixtures/ccs-test-authority/generate.sh`,
   then rebuild both `conary-test-fixture/build-all.sh` and

--- a/scripts/check-release-matrix.sh
+++ b/scripts/check-release-matrix.sh
@@ -6,6 +6,7 @@ cd "$repo_root"
 
 release_build=".github/workflows/release-build.yml"
 deploy_workflow=".github/workflows/deploy-and-verify.yml"
+artifact_proof_workflow=".github/workflows/release-artifact-proof.yml"
 merge_workflow=".github/workflows/merge-validation.yml"
 pr_workflow=".github/workflows/pr-gate.yml"
 exact_ownership_action=".github/actions/setup-exact-ownership-tests/action.yml"
@@ -155,6 +156,7 @@ validate_deploy_routing_pairs() {
 for required_file in \
     "$release_build" \
     "$deploy_workflow" \
+    "$artifact_proof_workflow" \
     "$merge_workflow" \
     "$pr_workflow" \
     "$exact_ownership_action" \
@@ -306,10 +308,19 @@ require_job_match "$deploy_workflow" deploy-conary 'name: Set up pinned Node\.js
 require_job_match "$deploy_workflow" deploy-conary 'name: Install locked static-site dependencies[\s\S]*npm ci --prefix site[\s\S]*npm ci --prefix web' 'live Conary locked static-site dependency installation'
 require_job_match "$deploy_workflow" deploy-conary 'name: Configure static-site deployment access[\s\S]*REMI_SSH_KEY: \$\{\{ secrets\.REMI_SSH_KEY \}\}[\s\S]*REMI_SSH_TARGET: \$\{\{ secrets\.REMI_SSH_TARGET \}\}' 'live Conary static-site SSH configuration'
 require_job_match "$deploy_workflow" deploy-conary 'name: Deploy both static sites from the release tag[\s\S]*bash deploy/deploy-sites\.sh both' 'live Conary both-site deployment from the release tag'
+require_job_match "$deploy_workflow" prove-conary-release-artifacts 'needs: \[resolve, deploy-conary\][\s\S]*needs\.deploy-conary\.result == '\''success'\''[\s\S]*uses: \./\.github/workflows/release-artifact-proof\.yml[\s\S]*tag_name: \$\{\{ needs\.resolve\.outputs\.tag_name \}\}' 'live Conary deployment must hand the serialized tag to published-artifact proof'
 forbid_match "$deploy_workflow" 'CONARYD_VERIFY_URL' 'legacy public verify URL'
 forbid_match "$deploy_workflow" '24273700060' 'retired one-time conaryd bootstrap exception'
 forbid_match "$deploy_workflow" 'deploy_asset_ref' 'retired bootstrap-only deploy asset ref'
 forbid_match "$deploy_workflow" 'bootstrap_exception' 'retired bootstrap exception output'
+
+require_match "$artifact_proof_workflow" 'workflow_call:[\s\S]*tag_name:[\s\S]*required: true[\s\S]*type: string' 'reusable published-artifact proof input'
+require_match "$artifact_proof_workflow" 'workflow_dispatch:[\s\S]*tag_name:[\s\S]*required: true[\s\S]*type: string' 'manual published-artifact proof input'
+require_job_match "$artifact_proof_workflow" native-package-lifecycle 'distro: fedora44[\s\S]*native_format: rpm[\s\S]*distro: ubuntu-26\.04[\s\S]*native_format: deb[\s\S]*distro: arch[\s\S]*native_format: arch' 'published-artifact three-distro typed matrix'
+require_job_match "$artifact_proof_workflow" native-package-lifecycle 'release-matrix\.sh resolve-tag "\$RELEASE_TAG"[\s\S]*git cat-file -t "\$RELEASE_TAG"[\s\S]*== "tag"[\s\S]*git worktree add --detach "\$tag_tree"[\s\S]*"\$tag_tree/scripts/release-matrix\.sh" assert-owned-version conary "\$version"' 'published artifact proof must bind metadata to an annotated tag and its owned manifest'
+require_job_match "$artifact_proof_workflow" native-package-lifecycle 'gh release download "\$RELEASE_TAG"[\s\S]*--pattern metadata\.json[\s\S]*sha256sum -c SHA256SUMS --ignore-missing[\s\S]*published_digest[\s\S]*actual_digest' 'published artifact metadata, checksum, and GitHub digest proof'
+require_job_match "$artifact_proof_workflow" native-package-lifecycle 'images build[\s\S]*--native-package "\$\{\{ steps\.release\.outputs\.native_package \}\}"[\s\S]*CONARY_TEST_REUSE_IMAGE: "1"[\s\S]*--suite native-cross-source-lifecycle' 'published native package installation and Cartesian lifecycle proof'
+require_job_match "$artifact_proof_workflow" release-artifact-proof 'needs: native-package-lifecycle[\s\S]*MATRIX_RESULT[\s\S]*"\$MATRIX_RESULT" != "success"' 'stable all-distro published-artifact proof gate'
 
 for product in conary remi; do
     require_artifact_matrix_row "$product"

--- a/scripts/test-release-matrix.sh
+++ b/scripts/test-release-matrix.sh
@@ -248,6 +248,7 @@ create_release_policy_fixture() {
     cp "$REPO_ROOT/scripts/release-matrix.sh" "$repo/scripts/release-matrix.sh"
     cp "$REPO_ROOT/.github/workflows/release-build.yml" "$repo/.github/workflows/release-build.yml"
     cp "$REPO_ROOT/.github/workflows/deploy-and-verify.yml" "$repo/.github/workflows/deploy-and-verify.yml"
+    cp "$REPO_ROOT/.github/workflows/release-artifact-proof.yml" "$repo/.github/workflows/release-artifact-proof.yml"
     cp "$REPO_ROOT/.github/workflows/merge-validation.yml" "$repo/.github/workflows/merge-validation.yml"
     cp "$REPO_ROOT/.github/workflows/pr-gate.yml" "$repo/.github/workflows/pr-gate.yml"
     cp "$REPO_ROOT/.github/actions/setup-exact-ownership-tests/action.yml" \


### PR DESCRIPTION
## Primary Issue

Refs #86

Design / Plan / Roadmap: `docs/operations/release-artifact-matrix.md`, `docs/roadmaps/external-tester-milestone.md`

## Problem And Outcome

The release pipeline builds native packages and the PR gate proves the exact tag source, but neither proves that the immutable published RPM, DEB, and Arch package bytes install and execute the Cartesian lifecycle. After merge, one reusable workflow downloads each published native package, verifies release metadata, `SHA256SUMS`, the GitHub digest, and annotated-tag manifest identity, installs it through the target distro package manager, then runs all three source-format lifecycle contracts with that installed binary.

## Changes

- add an explicit `conary-test images build --native-package` path whose format comes from the typed supported-profile catalog
- stage exact canonical package filenames and install them through dnf, apt, or pacman
- add a callable/manual three-distro published-artifact proof workflow and wire future live Conary deployments to it
- add typed workflow/staging tests, release-policy assertions, routing, and integration documentation

## Scope

- In scope: immutable Conary native-package proof and future deployment integration
- Out of scope: changing package lifecycle semantics, release versions, Remi deployment, or supported distro scope

## Ownership / Boundary

- Owning subsystem: `release` with `conary-test` as the execution neighbor
- Boundary changed or preserved: published bytes become the installed test authority; typed source lifecycle and strict release trust are preserved
- Persisted state or public surface impact: no product schema; adds a GitHub workflow and one explicit conary-test CLI option
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code
- [x] Updated subsystem docs or maps when the "look here first" path changed
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs

```text
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p conary-test
- cargo test -p conary-test release_artifact_workflow_installs_every_published_native_package
- bash scripts/check-release-matrix.sh
- bash scripts/test-release-matrix.sh
- bash scripts/test-remi-deploy-helper.sh
- bash scripts/test-deploy-sites.sh
- bash scripts/check-doc-truth.sh
- bash scripts/test-doc-truth.sh
- bash scripts/test-agent-context.sh
- bash scripts/agent-context.sh --validate
- git diff --check
```

The live `release-artifact-proof` workflow is the post-merge interaction proof because this host has no container runtime.

## Review And Merge Notes

- Review focus: annotated-tag binding, no stale-image reuse, exact asset checksum/digest checks, and reusable-workflow gating
- User or developer impact: release evidence can distinguish source-built CI from the bytes users actually install
- Required-check bypass: not used
