### PR TITLE
fix(release): repair Fedora and dry-run build prerequisites

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -122,6 +122,24 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: 1.96.0
+      - name: Cache cargo
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-release-
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev liblzma-dev libseccomp-dev pkg-config cmake
       - name: Prepare dry-run release tree
         if: ${{ github.event_name == 'workflow_dispatch' }}
         shell: bash
@@ -143,24 +161,6 @@ jobs:
           ./scripts/release.sh "$product"
           git tag --points-at HEAD | grep -Fx "$tag_name"
           bash scripts/release-matrix.sh assert-owned-version "$product" "$version"
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: 1.96.0
-      - name: Cache cargo
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-release-
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libssl-dev liblzma-dev libseccomp-dev pkg-config cmake
       - name: Build CCS package
         env:
           RELEASE_SIGNING_KEY: ${{ secrets.RELEASE_SIGNING_KEY }}
@@ -218,7 +218,7 @@ jobs:
     steps:
       - name: Install build dependencies
         run: |
-          dnf install -y rpm-build openssl-devel xz-devel libseccomp-devel pkg-config gcc cmake perl curl git \
+          dnf install -y rpm-build openssl-devel xz-devel libseccomp-devel pkg-config gcc cmake perl systemd-rpm-macros curl git \
           && dnf clean all
       - name: Install Rust
         run: |

--- a/apps/conary/tests/packaged_onboarding.rs
+++ b/apps/conary/tests/packaged_onboarding.rs
@@ -84,3 +84,39 @@ fn every_conary_package_format_activates_exact_booted_generation_work() {
     assert!(unit.contains("Restart=on-failure"));
     assert!(unit.contains("WantedBy=multi-user.target"));
 }
+
+#[test]
+fn fedora_package_declares_and_preflights_systemd_macro_authority() {
+    let spec = read_packaging_file("packaging/rpm/conary.spec");
+    assert!(
+        spec.lines().any(|line| {
+            line.split_once(':').is_some_and(|(field, packages)| {
+                field.trim() == "BuildRequires"
+                    && packages
+                        .split_whitespace()
+                        .any(|package| package == "systemd-rpm-macros")
+            })
+        }),
+        "RPM spec must declare the package that provides %{{_unitdir}}"
+    );
+
+    let containerfile = read_packaging_file("packaging/rpm/Containerfile.build");
+    assert!(containerfile.contains("systemd-rpm-macros"));
+    assert!(containerfile.contains("rpm --eval '%{_unitdir}'"));
+    assert!(containerfile.contains("/usr/lib/systemd/system"));
+
+    let build_script = read_packaging_file("packaging/rpm/build.sh");
+    assert!(build_script.contains("rpm --eval '%{_unitdir}'"));
+    assert!(build_script.contains("Install the systemd-rpm-macros build dependency"));
+
+    let release_workflow = read_packaging_file(".github/workflows/release-build.yml");
+    assert!(
+        release_workflow.lines().any(|line| {
+            line.contains("dnf install -y")
+                && line
+                    .split_whitespace()
+                    .any(|package| package == "systemd-rpm-macros")
+        }),
+        "release RPM build must install systemd-rpm-macros"
+    );
+}

--- a/packaging/rpm/Containerfile.build
+++ b/packaging/rpm/Containerfile.build
@@ -16,8 +16,11 @@ RUN dnf install -y \
         gcc \
         cmake \
         perl \
+        systemd-rpm-macros \
         curl \
     && dnf clean all
+
+RUN test "$(rpm --eval '%{_unitdir}')" = "/usr/lib/systemd/system"
 
 # Install a checksum-pinned rustup bootstrap and the declared MSRV toolchain.
 RUN curl --proto '=https' --tlsv1.2 -sSf \

--- a/packaging/rpm/build.sh
+++ b/packaging/rpm/build.sh
@@ -26,6 +26,20 @@ for arg in "$@"; do
     esac
 done
 
+require_unitdir_macro() {
+    local unitdir
+    unitdir="$(rpm --eval '%{_unitdir}')"
+    if [[ "$unitdir" != "/usr/lib/systemd/system" ]]; then
+        echo "Fedora systemd RPM macro authority is unavailable: %{_unitdir} resolved to $unitdir" >&2
+        echo "Install the systemd-rpm-macros build dependency before building Conary." >&2
+        exit 1
+    fi
+}
+
+if ! $USE_PODMAN; then
+    require_unitdir_macro
+fi
+
 echo "Building $NAME $VERSION RPM"
 
 mkdir -p "$OUTPUT"

--- a/packaging/rpm/conary.spec
+++ b/packaging/rpm/conary.spec
@@ -16,6 +16,7 @@ BuildRequires:  libseccomp-devel
 BuildRequires:  pkg-config
 BuildRequires:  cmake
 BuildRequires:  perl
+BuildRequires:  systemd-rpm-macros
 
 Requires:       openssl-libs
 Requires:       xz-libs

--- a/scripts/check-release-matrix.sh
+++ b/scripts/check-release-matrix.sh
@@ -15,6 +15,7 @@ feedback_template=".github/ISSUE_TEMPLATE/pre_alpha_feedback.md"
 site_preview_release="site/src/lib/preview-release.ts"
 site_install_page="site/src/routes/install/+page.svelte"
 rpm_containerfile="packaging/rpm/Containerfile.build"
+rpm_spec="packaging/rpm/conary.spec"
 deb_containerfile="packaging/deb/Containerfile.build"
 arch_containerfile="packaging/arch/Containerfile.build"
 rpm_build_script="packaging/rpm/build.sh"
@@ -165,6 +166,7 @@ for required_file in \
     "$site_preview_release" \
     "$site_install_page" \
     "$rpm_containerfile" \
+    "$rpm_spec" \
     "$deb_containerfile" \
     "$arch_containerfile" \
     "$rpm_build_script" \
@@ -198,9 +200,13 @@ require_literal_count "$release_build" 'bash scripts/release-matrix.sh assert-ow
 require_job_match "$release_build" build-rpm "image: ${fedora_release_image}" 'release-build RPM builder must use the pinned Fedora 44 image'
 require_job_match "$release_build" build-deb "image: ${ubuntu_release_image}" 'release-build DEB builder must use the pinned Ubuntu 26.04 image'
 require_job_match "$release_build" build-arch "image: ${arch_release_image}" 'release-build Arch builder must use the pinned Arch image'
+require_job_match "$release_build" build-ccs 'name: Install build dependencies[\s\S]*name: Prepare dry-run release tree' 'release-build CCS dry-run prerequisites must be installed before release preparation'
 require_match "$rpm_containerfile" "^FROM ${fedora_release_image}$" 'RPM Containerfile must use the release-build Fedora image digest'
 require_match "$deb_containerfile" "^FROM ${ubuntu_release_image}$" 'DEB Containerfile must use the release-build Ubuntu image digest'
 require_match "$arch_containerfile" "^FROM ${arch_release_image}$" 'Arch Containerfile must use the release-build Arch image digest'
+require_match "$rpm_spec" '^BuildRequires:[[:space:]]+systemd-rpm-macros$' 'RPM spec systemd macro build dependency'
+require_job_match "$release_build" build-rpm 'dnf install -y[\s\S]*systemd-rpm-macros' 'release-build RPM systemd macro dependency'
+require_match "$rpm_containerfile" 'systemd-rpm-macros[\s\S]*rpm --eval '\''%\{_unitdir\}'\''[\s\S]*/usr/lib/systemd/system' 'RPM Containerfile systemd macro dependency and expansion proof'
 
 rustup_flow_pattern="${rustup_init_url}[\\s\\S]*${rustup_init_sha256}  /tmp/rustup-init[\\s\\S]*sha256sum -c -[\\s\\S]*/tmp/rustup-init -y --default-toolchain 1\\.96\\.0 --profile minimal[\\s\\S]*rm -f /tmp/rustup-init"
 require_job_match "$release_build" build-rpm "$rustup_flow_pattern" 'release-build RPM builder checksum-pinned rustup-init flow'
@@ -268,6 +274,7 @@ forbid_match "$release_build" 'gh release create "\$TAG_NAME" release-packages/\
 
 require_match "$rpm_build_script" 'find "\$OUTPUT".*\*\.rpm.*-delete' 'RPM build must clean stale package output'
 require_match "$rpm_build_script" 'Expected exactly one \$NAME \$VERSION x86_64 RPM' 'RPM build must fail without its expected package'
+require_match "$rpm_build_script" 'rpm --eval '\''%\{_unitdir\}'\''[\s\S]*systemd-rpm-macros build dependency' 'RPM build must fail fast without systemd macro authority'
 require_match "$deb_build_script" 'find "\$OUTPUT".*\*\.deb.*-delete' 'DEB build must clean stale package output'
 require_match "$deb_build_script" 'EXPECTED_DEB="\$OUTPUT/\$\{NAME\}_\$\{VERSION\}-1_amd64\.deb"[\s\S]*\[\[ ! -s "\$EXPECTED_DEB"' 'DEB build must require its expected package'
 require_match "$arch_build_script" 'find "\$OUTPUT".*\*\.pkg\.tar\.zst.*-delete' 'Arch build must clean stale package output'

--- a/scripts/test-release-matrix.sh
+++ b/scripts/test-release-matrix.sh
@@ -258,6 +258,7 @@ create_release_policy_fixture() {
     cp "$REPO_ROOT/site/src/lib/preview-release.ts" "$repo/site/src/lib/preview-release.ts"
     cp "$REPO_ROOT/site/src/routes/install/+page.svelte" "$repo/site/src/routes/install/+page.svelte"
     cp "$REPO_ROOT/packaging/rpm/Containerfile.build" "$repo/packaging/rpm/Containerfile.build"
+    cp "$REPO_ROOT/packaging/rpm/conary.spec" "$repo/packaging/rpm/conary.spec"
     cp "$REPO_ROOT/packaging/deb/Containerfile.build" "$repo/packaging/deb/Containerfile.build"
     cp "$REPO_ROOT/packaging/arch/Containerfile.build" "$repo/packaging/arch/Containerfile.build"
     cp "$REPO_ROOT/packaging/rpm/build.sh" "$repo/packaging/rpm/build.sh"


### PR DESCRIPTION
## Primary Issue

Refs #86

Design / Plan / Roadmap: `docs/operations/release-artifact-matrix.md`

## Problem And Outcome

The unpublished `v0.13.0` release run `30236052093` compiled the Fedora RPM for 22 minutes, then failed because `%{_unitdir}` remained unexpanded in `%install` and `%files`. The hard-cut package added the generation-activation unit without installing the Fedora package that defines that macro. Fedora identifies `systemd-rpm-macros` as the package providing `rpm_macro(_unitdir)`: https://packages.fedoraproject.org/pkgs/systemd/systemd-rpm-macros/fedora-44-updates.html

The independent dry-run rehearsal then exposed a second prerequisite-order defect: `build-ccs` invoked `release.sh` before installing `libseccomp-dev`, even though release preparation regenerates the Conary CLI documentation and therefore links Conary. Run `30238268124` failed that synthetic `v0.13.1` CCS lane with `rust-lld: error: unable to find library -lseccomp`; live tag builds do not enter the dry-run preparation path.

After this PR:

- the spec declares the exact Fedora macro provider;
- both Fedora builders install it and fail before vendoring or compilation unless RPM resolves `%{_unitdir}` to `/usr/lib/systemd/system`; and
- the CCS builder installs its pinned Rust toolchain and native dependencies before invoking dry-run release preparation, with workflow policy enforcing that order.

## Changes

- declare and install `systemd-rpm-macros` in the spec, release job, and local Fedora builder image
- preflight the authoritative RPM macro expansion before the expensive build
- order CCS dry-run prerequisites before release-tree preparation
- extend packaged-onboarding and release-policy guards across every owned builder surface

## Scope

- In scope: Fedora 44 RPM construction and reproducible Conary dry-run construction for the unpublished 0.13.0 release
- Out of scope: changing package lifecycle behavior, the systemd unit contract, published releases, or deployment routing

## Ownership / Boundary

- Owning subsystem: release
- Boundary changed or preserved: preserves the statically enabled booted-generation activation unit and repairs only package-builder prerequisite authority
- Persisted state or public surface impact: none until the repaired native package is published; no schema change
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code (not applicable)
- [x] Updated subsystem docs or maps when the look-here-first path changed (no path changed)
- [x] Ran the broader interaction gate when the feature ownership card required it (not required; routing and deployment are unchanged)
- [x] Updated the primary issue with any acceptance criteria left for later PRs

```text
cargo test -p conary --test packaged_onboarding
bash scripts/check-release-matrix.sh
bash scripts/test-release-matrix.sh
bash -n packaging/rpm/build.sh
cargo fmt --check
git diff --check
```

The exact Fedora builder is running as dry-run release proof. The failed CCS lane is retained as evidence for the newly enforced prerequisite order; the final exact-tag `v0.13.0` workflow remains the definitive whole-release proof.

## Review And Merge Notes

- Review focus: exact macro provider, fail-fast expansion proof, CCS prerequisite ordering, and parity between CI and the local builder image
- User or developer impact: restores the Fedora RPM release and its dry-run tooling without bypassing or weakening the systemd unit contract
- Required-check bypass: not used
