### PR TITLE
fix(remi): provision exact-profile signing authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [remi-v0.8.3] - 2026-07-27
+
+### Fixed
+- repair Fedora and dry-run build prerequisites (#94)
+- provision durable exact-profile CCS/TUF signing authority and reject
+  incomplete, aliased, or insecure key state (#95)
+- route successful refreshes and public TUF operations through typed profile
+  identity, and accept source-validated RPM symlink payloads (#95)
+
 ## [remi-v0.8.2] - 2026-07-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4857,7 +4857,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remi"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/apps/conary-test/src/container/image.rs
+++ b/apps/conary-test/src/container/image.rs
@@ -707,7 +707,7 @@ printf 'fixture\n' > "$output/$file"
     }
 
     #[test]
-    fn ubuntu_source_builder_installs_native_crypto_build_tools() {
+    fn ubuntu_source_builder_proves_pinned_rust_and_native_crypto_tools() {
         let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
         let containerfile = manifest_dir
             .join("../conary/tests/integration/remi/containers/Containerfile.ubuntu-26.04");
@@ -716,6 +716,16 @@ printf 'fixture\n' > "$output/$file"
         assert!(
             contents.contains("cmake"),
             "Ubuntu source-build image must install cmake for aws-lc-sys"
+        );
+        assert!(
+            contents.contains("--output \"$installer\"")
+                && contents.contains("--default-toolchain 1.96.0")
+                && contents.contains("/root/.cargo/bin/cargo --version"),
+            "Ubuntu source-build image must download, pin, and prove Rust explicitly"
+        );
+        assert!(
+            !contents.contains("https://sh.rustup.rs |"),
+            "Ubuntu source-build image must not hide rustup download failures in a pipeline"
         );
     }
 

--- a/apps/conary/tests/integration/remi/containers/Containerfile.ubuntu-26.04
+++ b/apps/conary/tests/integration/remi/containers/Containerfile.ubuntu-26.04
@@ -13,9 +13,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential cmake pkg-config libssl-dev libseccomp-dev curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-    sh -s -- -y --default-toolchain 1.96.0 --profile minimal
+# Install the pinned Rust toolchain without a pipeline that can hide a failed
+# download behind a successful empty shell invocation.
+RUN set -eu; \
+    installer=/tmp/rustup-init.sh; \
+    curl --proto '=https' --tlsv1.2 \
+        --fail --show-error --silent --location \
+        --retry 5 --retry-all-errors \
+        --output "$installer" \
+        https://sh.rustup.rs; \
+    sh "$installer" -y --default-toolchain 1.96.0 --profile minimal; \
+    rm -f "$installer"; \
+    /root/.cargo/bin/cargo --version; \
+    /root/.cargo/bin/rustc --version
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 ARG INSTALL_MODE=binary

--- a/apps/conary/tests/packaging_m4c.rs
+++ b/apps/conary/tests/packaging_m4c.rs
@@ -32,6 +32,7 @@ use serde_json::Value;
 use std::collections::BTreeMap;
 use std::fs;
 use std::net::SocketAddr;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::sync::Arc;
@@ -462,16 +463,21 @@ fn sample_hermetic_evidence(name: &str, version: &str) -> HermeticBuildEvidence 
     }
 }
 
-fn write_tuf_role_keys(keys_dir: &Path, distro: &str) {
-    let distro_dir = keys_dir.join(distro);
-    fs::create_dir_all(&distro_dir).unwrap();
+fn write_tuf_role_keys(keys_dir: &Path, route_slug: &str) {
+    let profile =
+        conary_core::repository::supported_profiles::profile_for_remi_route(route_slug).unwrap();
+    let profile_dir = keys_dir.join(profile.id());
+    fs::create_dir_all(&profile_dir).unwrap();
+    fs::set_permissions(keys_dir, fs::Permissions::from_mode(0o700)).unwrap();
+    fs::set_permissions(&profile_dir, fs::Permissions::from_mode(0o700)).unwrap();
     for role in ["targets", "snapshot", "timestamp"] {
+        let private_path = profile_dir.join(format!("{role}.private"));
+        let public_path = profile_dir.join(format!("{role}.public"));
         SigningKeyPair::generate()
             .with_key_id(role)
-            .save_to_files(
-                &distro_dir.join(format!("{role}.private")),
-                &distro_dir.join(format!("{role}.public")),
-            )
+            .save_to_files(&private_path, &public_path)
             .unwrap();
+        fs::set_permissions(private_path, fs::Permissions::from_mode(0o600)).unwrap();
+        fs::set_permissions(public_path, fs::Permissions::from_mode(0o644)).unwrap();
     }
 }

--- a/apps/remi/Cargo.toml
+++ b/apps/remi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remi"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]

--- a/apps/remi/src/bin/remi.rs
+++ b/apps/remi/src/bin/remi.rs
@@ -284,6 +284,10 @@ struct DeploymentPrepareArgs {
     #[arg(long, default_value = "/etc/conary/remi-repositories.toml")]
     repository_manifest_target: PathBuf,
 
+    /// Durable exact-profile repository signing authority.
+    #[arg(long, default_value = "/conary/repository-keys")]
+    repository_keys_dir: PathBuf,
+
     /// Stable deployment identity used in the recoverable backup name.
     #[arg(long)]
     deployment_id: String,
@@ -338,6 +342,7 @@ fn run_deployment_command(command: DeploymentCommand) -> Result<()> {
                 config_path: args.config,
                 repository_manifest_source: args.repository_manifest,
                 repository_manifest_target: args.repository_manifest_target,
+                repository_keys_dir: args.repository_keys_dir,
                 deployment_id: args.deployment_id,
                 max_concurrent: args.max_concurrent,
             })?;

--- a/apps/remi/src/deployment.rs
+++ b/apps/remi/src/deployment.rs
@@ -14,6 +14,7 @@ use std::path::{Path, PathBuf};
 
 const TRANSITION_SCHEMA: u32 = 1;
 const DEFAULT_REPOSITORY_MANIFEST_TARGET: &str = "/etc/conary/remi-repositories.toml";
+const DEFAULT_REPOSITORY_KEYS_DIR: &str = "/conary/repository-keys";
 
 #[derive(Debug, Clone, Serialize)]
 pub struct DeploymentState {
@@ -23,6 +24,7 @@ pub struct DeploymentState {
     pub populated_sources: usize,
     pub repository_packages: i64,
     pub converted_packages: i64,
+    pub signing_profiles: Vec<String>,
     pub sources: Vec<DeploymentSourceState>,
 }
 
@@ -53,6 +55,7 @@ pub struct PrepareOptions {
     pub config_path: PathBuf,
     pub repository_manifest_source: PathBuf,
     pub repository_manifest_target: PathBuf,
+    pub repository_keys_dir: PathBuf,
     pub deployment_id: String,
     pub max_concurrent: usize,
 }
@@ -68,6 +71,7 @@ impl PrepareOptions {
             config_path: PathBuf::from("/etc/conary/remi.toml"),
             repository_manifest_source,
             repository_manifest_target: PathBuf::from(DEFAULT_REPOSITORY_MANIFEST_TARGET),
+            repository_keys_dir: PathBuf::from(DEFAULT_REPOSITORY_KEYS_DIR),
             deployment_id,
             max_concurrent,
         }
@@ -131,6 +135,10 @@ pub fn prepare(options: &PrepareOptions) -> Result<PathBuf> {
     if repository_manifest.repositories.is_empty() {
         bail!("deployment repository manifest must declare at least one source");
     }
+    crate::server::signing_authority::ensure_repository_authority(
+        &repository_manifest,
+        &options.repository_keys_dir,
+    )?;
 
     let new_config = build_current_config(options, &repository_manifest)?;
     let parsed_config: RemiConfig =
@@ -210,6 +218,15 @@ pub fn inspect_state(config_path: &Path) -> Result<DeploymentState> {
         .context("Remi config does not declare repository_manifest")?;
     require_plain_file(repository_manifest_path, "repository manifest")?;
     let repository_manifest = RepositoryManifest::load(repository_manifest_path)?;
+    let repository_keys_dir = config
+        .release_publish
+        .repository_keys_dir
+        .as_deref()
+        .context("Remi config does not declare release_publish.repository_keys_dir")?;
+    let signing_profiles = crate::server::signing_authority::inspect_repository_authority(
+        &repository_manifest,
+        repository_keys_dir,
+    )?;
     let db_path = config.storage_root().join("metadata/conary.db");
     match conary_core::db::schema::inspect(&db_path)? {
         SchemaCompatibility::Current => {}
@@ -253,6 +270,7 @@ pub fn inspect_state(config_path: &Path) -> Result<DeploymentState> {
         populated_sources,
         repository_packages: count_rows(&conn, "repository_packages")?,
         converted_packages: count_rows(&conn, "converted_packages")?,
+        signing_profiles,
         sources,
     })
 }
@@ -294,6 +312,21 @@ fn build_current_config(
     conversion.insert(
         "max_concurrent".to_string(),
         toml::Value::Integer(options.max_concurrent as i64),
+    );
+    let release_publish = root
+        .entry("release_publish")
+        .or_insert_with(|| toml::Value::Table(toml::map::Map::new()))
+        .as_table_mut()
+        .context("release_publish must be a TOML table")?;
+    release_publish.insert(
+        "repository_keys_dir".to_string(),
+        toml::Value::String(
+            options
+                .repository_keys_dir
+                .to_str()
+                .context("repository signing authority path must be UTF-8")?
+                .to_string(),
+        ),
     );
     let prewarm = root
         .entry("prewarm")
@@ -682,6 +715,7 @@ fn sync_parent(path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::fs::DirBuilderExt;
     use std::os::unix::fs::symlink;
 
     fn write(path: &Path, content: &str) {
@@ -742,6 +776,7 @@ fingerprint = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
             config_path: root.join("etc/remi.toml"),
             repository_manifest_source: root.join("staged-repositories.toml"),
             repository_manifest_target: root.join("etc/remi-repositories.toml"),
+            repository_keys_dir: root.join("repository-keys"),
             deployment_id: "remi-0.8.0".to_string(),
             max_concurrent: 32,
         }
@@ -752,6 +787,10 @@ fingerprint = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
         let root = temp.path().to_path_buf();
         fs::create_dir(root.join("etc")).unwrap();
         fs::create_dir(root.join("metadata")).unwrap();
+        fs::DirBuilder::new()
+            .mode(0o700)
+            .create(root.join("repository-keys"))
+            .unwrap();
         write(&root.join("etc/remi.toml"), &base_config(&root));
         write(
             &root.join("staged-repositories.toml"),
@@ -770,6 +809,7 @@ fingerprint = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
         assert!(!config.contains("[upstream"));
         assert!(config.contains("max_concurrent = 32"));
         assert!(config.contains("repository_manifest"));
+        assert!(config.contains("repository_keys_dir"));
         assert!(config.contains("convert_top_n = 1000"));
         assert!(config.contains("distros = [\"fedora\"]"));
         assert_eq!(
@@ -811,6 +851,7 @@ fingerprint = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
         assert_eq!(state.schema_epoch, SCHEMA_EPOCH);
         assert_eq!(state.configured_sources, 1);
         assert_eq!(state.populated_sources, 0);
+        assert_eq!(state.signing_profiles, vec!["fedora-44"]);
         assert_eq!(state.sources[0].name, "opaque-source");
         assert_eq!(state.sources[0].profile, "fedora-44");
         assert_eq!(state.sources[0].package_format, "rpm");

--- a/apps/remi/src/server/config.rs
+++ b/apps/remi/src/server/config.rs
@@ -722,6 +722,18 @@ impl RemiConfig {
                 );
             }
         }
+        if self.repository_manifest.is_some() {
+            let keys_dir = self
+                .release_publish
+                .repository_keys_dir
+                .as_deref()
+                .context(
+                    "release_publish.repository_keys_dir is required with repository_manifest",
+                )?;
+            if !keys_dir.is_absolute() {
+                anyhow::bail!("release_publish.repository_keys_dir must be an absolute path");
+            }
+        }
 
         // Validate federation tier
         let valid_tiers = ["region_hub", "cell_hub", "leaf"];

--- a/apps/remi/src/server/config/tests.rs
+++ b/apps/remi/src/server/config/tests.rs
@@ -177,6 +177,9 @@ chunk_min = 16384
 chunk_avg = 65536
 chunk_max = 262144
 
+[release_publish]
+repository_keys_dir = "/conary/repository-keys"
+
 [federation]
 enabled = false
 
@@ -202,6 +205,33 @@ bootstrap_token = "bootstrap-token"
         config.admin.bootstrap_token.as_deref(),
         Some("bootstrap-token")
     );
+}
+
+#[test]
+fn repository_manifest_requires_absolute_signing_authority_root() {
+    let mut missing = RemiConfig {
+        repository_manifest: Some(PathBuf::from("/etc/conary/remi-repositories.toml")),
+        ..RemiConfig::default()
+    };
+    let error = missing.validate().unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("repository_keys_dir is required"),
+        "{error:#}"
+    );
+
+    missing.release_publish.repository_keys_dir = Some(PathBuf::from("relative/keys"));
+    let error = missing.validate().unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("repository_keys_dir must be an absolute path"),
+        "{error:#}"
+    );
+
+    missing.release_publish.repository_keys_dir = Some(PathBuf::from("/conary/repository-keys"));
+    missing.validate().unwrap();
 }
 
 #[test]

--- a/apps/remi/src/server/conversion/recipe.rs
+++ b/apps/remi/src/server/conversion/recipe.rs
@@ -2,6 +2,7 @@
 //! Recipe URL fetching, SSRF validation, and server-side recipe builds.
 
 use super::{ConversionService, ScriptletPackageMetadata, ServerConversionResult};
+use crate::server::signing_authority::{RepositorySigningRole, load_role_key};
 use anyhow::{Context, Result, anyhow};
 use conary_core::ccs::convert::ScriptletBundleSummary;
 use tempfile::TempDir;
@@ -49,9 +50,7 @@ impl ConversionService {
         let keys_dir = self.repository_keys_dir.as_ref().context(
             "Remi recipe builds require release_publish.repository_keys_dir for CCS authority signing",
         )?;
-        let key_path = keys_dir.join(profile.id()).join("targets.private");
-        let signing_key = conary_core::ccs::SigningKeyPair::load_from_file(&key_path)
-            .with_context(|| format!("load Remi recipe signing key {}", key_path.display()))?;
+        let signing_key = load_role_key(keys_dir, profile.id(), RepositorySigningRole::Targets)?;
         let config = KitchenConfig {
             source_cache: self.cache_dir.join("sources"),
             use_isolation: true, // Always use isolation on server

--- a/apps/remi/src/server/conversion/workflow.rs
+++ b/apps/remi/src/server/conversion/workflow.rs
@@ -7,6 +7,7 @@ use super::persistence::PersistConversionInput;
 use crate::server::conversion_timing::{
     ConversionPhase, ConversionPhaseTiming, ConversionSkippedPhase, ConversionTimingReport,
 };
+use crate::server::signing_authority::{RepositorySigningRole, load_role_key};
 use anyhow::{Context, Result, anyhow};
 use conary_core::ccs::convert::{ConversionOptions, ConversionResult, NativePackageConverter};
 use conary_core::db::models::RepositoryPackage;
@@ -258,11 +259,7 @@ impl ConversionService {
         let keys_dir = self.repository_keys_dir.as_ref().context(
             "Remi conversion requires release_publish.repository_keys_dir for CCS authority signing",
         )?;
-        let signing_key = conary_core::ccs::SigningKeyPair::load_from_file(
-            &keys_dir.join(source_profile).join("targets.private"),
-        )
-        .map_err(anyhow::Error::from)
-        .with_context(|| format!("load Remi CCS authority key for {source_profile}"))?;
+        let signing_key = load_role_key(keys_dir, source_profile, RepositorySigningRole::Targets)?;
         let converter = NativePackageConverter::new(options)
             .with_source_profile(source_profile)
             .with_conversion_tool("remi")

--- a/apps/remi/src/server/handlers/admin/mod.rs
+++ b/apps/remi/src/server/handlers/admin/mod.rs
@@ -176,10 +176,15 @@ pub(crate) mod test_helpers {
     fn test_release_publish(
         root: &std::path::Path,
     ) -> crate::server::config::ReleasePublishSection {
+        use std::os::unix::fs::PermissionsExt;
+
         let keys_dir = root.join("keys");
-        for distro in ["fedora", "ubuntu"] {
-            let distro_dir = keys_dir.join(distro);
+        std::fs::create_dir_all(&keys_dir).unwrap();
+        std::fs::set_permissions(&keys_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        for profile in ["fedora-44", "ubuntu-26.04"] {
+            let distro_dir = keys_dir.join(profile);
             std::fs::create_dir_all(&distro_dir).unwrap();
+            std::fs::set_permissions(&distro_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
             let private = distro_dir.join("targets.private");
             let public = distro_dir.join("targets.public");
             if !private.exists() {

--- a/apps/remi/src/server/handlers/tuf.rs
+++ b/apps/remi/src/server/handlers/tuf.rs
@@ -10,6 +10,7 @@
 //! - {version}.root.json (versioned roots for key rotation)
 
 use crate::server::ServerState;
+use crate::server::signing_authority::{RepositorySigningRole, load_role_key};
 use anyhow::{Context, Result, bail};
 use axum::{
     Json,
@@ -17,7 +18,6 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
-use conary_core::ccs::signing::SigningKeyPair;
 use conary_core::trust::{
     MetaFile, Signed, TUF_SPEC_VERSION, TimestampMetadata, sign_tuf_metadata,
 };
@@ -166,6 +166,13 @@ pub async fn refresh_timestamp_for_distro(
     state: &Arc<RwLock<ServerState>>,
     distro: &str,
 ) -> Result<TimestampRefreshResult> {
+    let source_profile =
+        conary_core::repository::supported_profiles::profile_for_remi_route(distro)
+            .with_context(|| {
+                format!("release route {distro} does not map to exactly one repository profile")
+            })?
+            .id()
+            .to_string();
     let (db_path, keys_dir) = {
         let guard = state.read().await;
         let keys_dir = guard
@@ -179,7 +186,7 @@ pub async fn refresh_timestamp_for_distro(
     let distro = distro.to_string();
 
     tokio::task::spawn_blocking(move || {
-        refresh_timestamp_for_distro_blocking(&db_path, &keys_dir, &distro)
+        refresh_timestamp_for_distro_blocking(&db_path, &keys_dir, &distro, &source_profile)
     })
     .await
     .context("refresh timestamp blocking task failed")?
@@ -270,32 +277,23 @@ fn query_tuf_role_metadata(
         .optional()?)
 }
 
-pub(crate) fn load_release_tuf_key(
-    keys_dir: &StdPath,
-    distro: &str,
-    role: &str,
-) -> Result<SigningKeyPair> {
-    let path = keys_dir.join(distro).join(format!("{role}.private"));
-    SigningKeyPair::load_from_file(&path)
-        .map_err(anyhow::Error::from)
-        .with_context(|| format!("load Remi {role} TUF signing key {}", path.display()))
-}
-
 fn refresh_timestamp_for_distro_blocking(
     db_path: &StdPath,
     keys_dir: &StdPath,
     distro: &str,
+    source_profile: &str,
 ) -> Result<TimestampRefreshResult> {
     let conn = open_handler_db(db_path)?;
-    refresh_timestamp_for_distro_in_conn(&conn, keys_dir, distro)
+    refresh_timestamp_for_distro_in_conn(&conn, keys_dir, distro, source_profile)
 }
 
 pub(crate) fn refresh_timestamp_for_distro_in_conn(
     conn: &rusqlite::Connection,
     keys_dir: &StdPath,
     distro: &str,
+    source_profile: &str,
 ) -> Result<TimestampRefreshResult> {
-    let timestamp_key = load_release_tuf_key(keys_dir, distro, "timestamp")?;
+    let timestamp_key = load_role_key(keys_dir, source_profile, RepositorySigningRole::Timestamp)?;
     let repo_id: i64 = conn
         .query_row(
             "SELECT id FROM repositories WHERE name = ?1 AND tuf_enabled = 1",
@@ -817,11 +815,20 @@ mod tests {
 
     impl TimestampRefreshFixture {
         fn new(distro: &str, write_timestamp_key: bool) -> Self {
+            use std::os::unix::fs::PermissionsExt;
+
             let temp = tempfile::tempdir().unwrap();
             let db_path = temp.path().join("remi.db");
             let keys_dir = temp.path().join("keys");
-            let distro_key_dir = keys_dir.join(distro);
+            let source_profile =
+                conary_core::repository::supported_profiles::profile_for_remi_route(distro)
+                    .unwrap()
+                    .id();
+            let distro_key_dir = keys_dir.join(source_profile);
             std::fs::create_dir_all(&distro_key_dir).unwrap();
+            std::fs::set_permissions(&keys_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+            std::fs::set_permissions(&distro_key_dir, std::fs::Permissions::from_mode(0o700))
+                .unwrap();
 
             let conn = Connection::open(&db_path).unwrap();
             conn.execute("PRAGMA foreign_keys = ON", []).unwrap();

--- a/apps/remi/src/server/mod.rs
+++ b/apps/remi/src/server/mod.rs
@@ -48,6 +48,7 @@ pub mod repository_manifest;
 mod routes;
 pub mod search;
 pub mod security;
+pub(crate) mod signing_authority;
 pub mod test_db;
 
 pub use analytics::AnalyticsRecorder;
@@ -96,12 +97,17 @@ async fn ensure_admin_bootstrap_token(
     Ok(())
 }
 
-fn successful_refresh_profiles(batch: &admin_service::RepoRefreshBatch) -> HashSet<&str> {
+fn successful_refresh_profile_ids(batch: &admin_service::RepoRefreshBatch) -> HashSet<&str> {
     batch
         .results
         .iter()
         .filter_map(|result| result.source_profile.as_deref())
         .collect()
+}
+
+fn prewarm_route_refreshed(route: &str, successful_profile_ids: &HashSet<&str>) -> bool {
+    conary_core::repository::supported_profiles::profile_for_remi_route(route)
+        .is_some_and(|profile| successful_profile_ids.contains(profile.id()))
 }
 
 /// Server configuration
@@ -395,6 +401,12 @@ pub async fn run_server_from_config(remi_config: &RemiConfig) -> Result<()> {
     ensure_database_ready(&server_config.db_path)?;
     if let Some(manifest_path) = remi_config.repository_manifest.as_deref() {
         let manifest = repository_manifest::RepositoryManifest::load(manifest_path)?;
+        let keys_root = server_config
+            .release_publish
+            .repository_keys_dir
+            .as_deref()
+            .context("release_publish.repository_keys_dir is required with repository_manifest")?;
+        signing_authority::ensure_repository_authority(&manifest, keys_root)?;
         let mut conn = open_runtime_db(&server_config.db_path)?;
         let reconciled = manifest.reconcile(&mut conn)?;
         tracing::info!(
@@ -593,11 +605,11 @@ pub async fn run_server_from_config(remi_config: &RemiConfig) -> Result<()> {
                                 failure.message
                             );
                         }
-                        let successful_profiles = successful_refresh_profiles(&batch);
+                        let successful_profiles = successful_refresh_profile_ids(&batch);
                         for job in &prewarm_jobs {
-                            if !successful_profiles.contains(job.distro.as_str()) {
+                            if !prewarm_route_refreshed(&job.distro, &successful_profiles) {
                                 tracing::warn!(
-                                    "Post-refresh pre-warm for {} skipped: no repository for that exact profile completed refresh",
+                                    "Post-refresh pre-warm for {} skipped: its exact profile did not complete refresh",
                                     job.distro
                                 );
                                 continue;
@@ -764,7 +776,7 @@ async fn initialize_bloom_filter(state: Arc<RwLock<ServerState>>) -> Result<()> 
 mod tests {
     use super::{
         build_http_client, ensure_admin_bootstrap_token, ensure_database_ready, open_runtime_db,
-        successful_refresh_profiles,
+        prewarm_route_refreshed, successful_refresh_profile_ids,
     };
     use crate::server::admin_service::{
         RepoRefreshBatch, RepoRefreshFailure, RepoRefreshFailureKind, RepoRefreshResult,
@@ -873,11 +885,14 @@ mod tests {
             }],
         };
 
-        let profiles = successful_refresh_profiles(&batch);
+        let profiles = successful_refresh_profile_ids(&batch);
         assert_eq!(profiles.len(), 2);
         assert!(profiles.contains("fedora-44"));
         assert!(profiles.contains("ubuntu-26.04"));
         assert!(!profiles.contains("arch"));
+        assert!(prewarm_route_refreshed("fedora", &profiles));
+        assert!(prewarm_route_refreshed("ubuntu", &profiles));
+        assert!(!prewarm_route_refreshed("arch", &profiles));
     }
 
     #[test]

--- a/apps/remi/src/server/native_publish/persistence.rs
+++ b/apps/remi/src/server/native_publish/persistence.rs
@@ -17,11 +17,12 @@ use rusqlite::{OptionalExtension, params};
 use tokio::sync::RwLock;
 
 use crate::server::ServerState;
-use crate::server::handlers::tuf::{load_release_tuf_key, refresh_timestamp_for_distro_in_conn};
+use crate::server::handlers::tuf::refresh_timestamp_for_distro_in_conn;
 use crate::server::native_publish::storage::PromotedNativeArtifact;
 use crate::server::native_publish::{
     NativePublishError, NativePublishErrorCode, VerifiedNativeArtifact,
 };
+use crate::server::signing_authority::{RepositorySigningRole, load_role_key};
 
 #[derive(Debug)]
 struct SupersededNativePublication {
@@ -97,7 +98,15 @@ pub fn commit_native_publication_blocking(
         &artifact,
         &promoted,
     )?;
-    refresh_release_tuf_metadata(&tx, keys_dir, distro, repo_id, &artifact, &promoted)?;
+    refresh_release_tuf_metadata(
+        &tx,
+        keys_dir,
+        distro,
+        source_profile,
+        repo_id,
+        &artifact,
+        &promoted,
+    )?;
     tx.commit()?;
 
     for old in superseded {
@@ -310,12 +319,13 @@ fn refresh_release_tuf_metadata(
     conn: &rusqlite::Connection,
     keys_dir: &Path,
     distro: &str,
+    source_profile: &str,
     repo_id: i64,
     artifact: &VerifiedNativeArtifact,
     promoted: &PromotedNativeArtifact,
 ) -> Result<()> {
-    let targets_key = load_release_tuf_key(keys_dir, distro, "targets")?;
-    let snapshot_key = load_release_tuf_key(keys_dir, distro, "snapshot")?;
+    let targets_key = load_role_key(keys_dir, source_profile, RepositorySigningRole::Targets)?;
+    let snapshot_key = load_role_key(keys_dir, source_profile, RepositorySigningRole::Snapshot)?;
 
     let targets_version = next_tuf_metadata_version(conn, repo_id, "targets")?;
     conn.execute(
@@ -372,7 +382,7 @@ fn refresh_release_tuf_metadata(
     };
     persist_signed_snapshot(conn, repo_id, &signed_snapshot)?;
 
-    refresh_timestamp_for_distro_in_conn(conn, keys_dir, distro)?;
+    refresh_timestamp_for_distro_in_conn(conn, keys_dir, distro, source_profile)?;
     Ok(())
 }
 

--- a/apps/remi/src/server/release_publish.rs
+++ b/apps/remi/src/server/release_publish.rs
@@ -301,7 +301,7 @@ mod tests {
             let keys_dir = temp.path().join("keys");
             std::fs::create_dir_all(&chunk_dir).unwrap();
             std::fs::create_dir_all(&cache_dir).unwrap();
-            write_tuf_role_keys(&keys_dir, TEST_DISTRO, tuf_roles);
+            write_tuf_role_keys(&keys_dir, TEST_PROFILE, tuf_roles);
 
             let conn = rusqlite::Connection::open(&db_path).unwrap();
             conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
@@ -683,8 +683,12 @@ mod tests {
     }
 
     fn write_tuf_role_keys(keys_dir: &Path, distro: &str, roles: &[&str]) {
+        use std::os::unix::fs::PermissionsExt;
+
         let distro_dir = keys_dir.join(distro);
         std::fs::create_dir_all(&distro_dir).unwrap();
+        std::fs::set_permissions(keys_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        std::fs::set_permissions(&distro_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
         for role in roles {
             SigningKeyPair::generate()
                 .with_key_id(role)

--- a/apps/remi/src/server/release_publish.rs
+++ b/apps/remi/src/server/release_publish.rs
@@ -439,7 +439,7 @@ mod tests {
         }
 
         fn remove_tuf_role_key(&self, role: &str) {
-            let distro_dir = self.keys_dir.join(TEST_DISTRO);
+            let distro_dir = self.keys_dir.join(TEST_PROFILE);
             let _ = std::fs::remove_file(distro_dir.join(format!("{role}.private")));
             let _ = std::fs::remove_file(distro_dir.join(format!("{role}.public")));
         }

--- a/apps/remi/src/server/signing_authority.rs
+++ b/apps/remi/src/server/signing_authority.rs
@@ -1,0 +1,601 @@
+// apps/remi/src/server/signing_authority.rs
+//! Durable, exact-profile signing authority for Remi conversion and TUF roles.
+
+use crate::server::repository_manifest::RepositoryManifest;
+use anyhow::{Context, Result, bail};
+use conary_core::ccs::signing::{SigningKeyPair, load_signing_public_key};
+use conary_core::repository::supported_profiles::{SupportedProfile, profile_by_public_id};
+use nix::errno::Errno;
+use nix::fcntl::{RenameFlags, renameat2};
+use nix::unistd::{Gid, Uid, chown};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, File};
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::path::{Component, Path};
+
+const AUTHORITY_DIRECTORY_MODE: u32 = 0o700;
+const PRIVATE_KEY_MODE: u32 = 0o600;
+const PUBLIC_KEY_MODE: u32 = 0o644;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RepositorySigningRole {
+    Targets,
+    Snapshot,
+    Timestamp,
+}
+
+impl RepositorySigningRole {
+    const ALL: [Self; 3] = [Self::Targets, Self::Snapshot, Self::Timestamp];
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Targets => "targets",
+            Self::Snapshot => "snapshot",
+            Self::Timestamp => "timestamp",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AuthorityOwner {
+    uid: u32,
+    gid: u32,
+}
+
+pub(crate) fn ensure_repository_authority(
+    manifest: &RepositoryManifest,
+    keys_root: &Path,
+) -> Result<Vec<String>> {
+    let profiles = exact_profiles(manifest)?;
+    let owner = require_authority_root(keys_root)?;
+    reject_route_slug_authority(keys_root, &profiles)?;
+    reject_unexpected_root_entries(keys_root, &profiles)?;
+    for profile in &profiles {
+        ensure_profile_authority(keys_root, profile, owner)?;
+    }
+    Ok(profiles
+        .into_iter()
+        .map(|profile| profile.id().to_string())
+        .collect())
+}
+
+pub(crate) fn inspect_repository_authority(
+    manifest: &RepositoryManifest,
+    keys_root: &Path,
+) -> Result<Vec<String>> {
+    let profiles = exact_profiles(manifest)?;
+    let owner = require_authority_root(keys_root)?;
+    reject_route_slug_authority(keys_root, &profiles)?;
+    reject_unexpected_root_entries(keys_root, &profiles)?;
+    for profile in &profiles {
+        validate_profile_authority(&keys_root.join(profile.id()), profile.id(), owner)?;
+    }
+    Ok(profiles
+        .into_iter()
+        .map(|profile| profile.id().to_string())
+        .collect())
+}
+
+pub(crate) fn load_role_key(
+    keys_root: &Path,
+    profile_id: &str,
+    role: RepositorySigningRole,
+) -> Result<SigningKeyPair> {
+    let profile = profile_by_public_id(profile_id)
+        .with_context(|| format!("unknown exact repository profile '{profile_id}'"))?;
+    let owner = require_authority_root(keys_root)?;
+    let profile_dir = keys_root.join(profile.id());
+    validate_profile_directory(&profile_dir, profile.id(), owner)?;
+    validate_role_pair(&profile_dir, profile.id(), role, owner)?;
+    SigningKeyPair::load_from_file(&profile_dir.join(format!("{}.private", role.as_str())))
+        .map_err(anyhow::Error::from)
+        .with_context(|| {
+            format!(
+                "load Remi {} signing key for exact profile {}",
+                role.as_str(),
+                profile.id()
+            )
+        })
+}
+
+fn exact_profiles(manifest: &RepositoryManifest) -> Result<Vec<&'static SupportedProfile>> {
+    manifest.validate()?;
+    let mut profiles = BTreeMap::new();
+    for repository in &manifest.repositories {
+        let profile = profile_by_public_id(&repository.profile).with_context(|| {
+            format!(
+                "repository '{}' names unknown exact profile '{}'",
+                repository.name, repository.profile
+            )
+        })?;
+        require_safe_profile_component(profile.id())?;
+        profiles.insert(profile.id(), profile);
+    }
+    Ok(profiles.into_values().collect())
+}
+
+fn require_safe_profile_component(profile_id: &str) -> Result<()> {
+    let mut components = Path::new(profile_id).components();
+    if !matches!(components.next(), Some(Component::Normal(_))) || components.next().is_some() {
+        bail!("repository profile '{profile_id}' is not one safe path component");
+    }
+    Ok(())
+}
+
+fn require_authority_root(keys_root: &Path) -> Result<AuthorityOwner> {
+    let metadata = fs::symlink_metadata(keys_root).with_context(|| {
+        format!(
+            "repository signing authority root {} does not exist",
+            keys_root.display()
+        )
+    })?;
+    if !metadata.file_type().is_dir() || metadata.file_type().is_symlink() {
+        bail!(
+            "repository signing authority root {} must be a plain directory",
+            keys_root.display()
+        );
+    }
+    require_mode(keys_root, &metadata, AUTHORITY_DIRECTORY_MODE)?;
+    Ok(AuthorityOwner {
+        uid: metadata.uid(),
+        gid: metadata.gid(),
+    })
+}
+
+fn reject_route_slug_authority(keys_root: &Path, profiles: &[&SupportedProfile]) -> Result<()> {
+    for profile in profiles {
+        let route = profile.remi_route_slug();
+        if route == profile.id() {
+            continue;
+        }
+        match fs::symlink_metadata(keys_root.join(route)) {
+            Ok(_) => {
+                bail!(
+                    "repository signing authority uses route slug '{}' for exact profile '{}'; remove the ambiguous route authority after preserving any required public trust data",
+                    route,
+                    profile.id()
+                );
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "inspect ambiguous route authority {}",
+                        keys_root.join(route).display()
+                    )
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn reject_unexpected_root_entries(keys_root: &Path, profiles: &[&SupportedProfile]) -> Result<()> {
+    let expected = profiles
+        .iter()
+        .map(|profile| profile.id())
+        .collect::<BTreeSet<_>>();
+    for entry in fs::read_dir(keys_root)
+        .with_context(|| format!("read repository authority root {}", keys_root.display()))?
+    {
+        let entry = entry.with_context(|| {
+            format!(
+                "read repository authority entry under {}",
+                keys_root.display()
+            )
+        })?;
+        let name = entry.file_name();
+        if !expected
+            .iter()
+            .any(|profile_id| name == std::ffi::OsStr::new(profile_id))
+        {
+            bail!(
+                "repository signing authority root {} contains unexpected entry {:?}",
+                keys_root.display(),
+                name
+            );
+        }
+    }
+    Ok(())
+}
+
+fn ensure_profile_authority(
+    keys_root: &Path,
+    profile: &SupportedProfile,
+    owner: AuthorityOwner,
+) -> Result<()> {
+    let profile_dir = keys_root.join(profile.id());
+    match fs::symlink_metadata(&profile_dir) {
+        Ok(_) => validate_profile_authority(&profile_dir, profile.id(), owner),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            create_profile_authority(keys_root, profile, owner)
+        }
+        Err(error) => Err(error).with_context(|| {
+            format!(
+                "inspect repository signing authority {}",
+                profile_dir.display()
+            )
+        }),
+    }
+}
+
+fn create_profile_authority(
+    keys_root: &Path,
+    profile: &SupportedProfile,
+    owner: AuthorityOwner,
+) -> Result<()> {
+    let staging = tempfile::Builder::new()
+        .prefix(".authority-")
+        .tempdir_in(keys_root)
+        .with_context(|| {
+            format!(
+                "create staged signing authority under {}",
+                keys_root.display()
+            )
+        })?;
+    fs::set_permissions(
+        staging.path(),
+        fs::Permissions::from_mode(AUTHORITY_DIRECTORY_MODE),
+    )?;
+
+    for role in RepositorySigningRole::ALL {
+        let private = staging.path().join(format!("{}.private", role.as_str()));
+        let public = staging.path().join(format!("{}.public", role.as_str()));
+        SigningKeyPair::generate()
+            .with_key_id(role.as_str())
+            .save_to_files(&private, &public)
+            .map_err(anyhow::Error::from)
+            .with_context(|| {
+                format!(
+                    "generate Remi {} authority for exact profile {}",
+                    role.as_str(),
+                    profile.id()
+                )
+            })?;
+        fs::set_permissions(&private, fs::Permissions::from_mode(PRIVATE_KEY_MODE))?;
+        fs::set_permissions(&public, fs::Permissions::from_mode(PUBLIC_KEY_MODE))?;
+        align_owner(&private, owner)?;
+        align_owner(&public, owner)?;
+        File::open(&private)?.sync_all()?;
+        File::open(&public)?.sync_all()?;
+    }
+    align_owner(staging.path(), owner)?;
+    validate_profile_authority(staging.path(), profile.id(), owner)?;
+    File::open(staging.path())?.sync_all()?;
+
+    let root = File::open(keys_root)?;
+    let staged_name = staging
+        .path()
+        .file_name()
+        .context("staged authority directory has no basename")?;
+    match renameat2(
+        &root,
+        Path::new(staged_name),
+        &root,
+        Path::new(profile.id()),
+        RenameFlags::RENAME_NOREPLACE,
+    ) {
+        Ok(()) => {
+            root.sync_all()?;
+            validate_profile_authority(&keys_root.join(profile.id()), profile.id(), owner)
+        }
+        Err(Errno::EEXIST) => {
+            validate_profile_authority(&keys_root.join(profile.id()), profile.id(), owner)
+        }
+        Err(error) => Err(anyhow::Error::from(error)).with_context(|| {
+            format!(
+                "publish staged signing authority for exact profile {}",
+                profile.id()
+            )
+        }),
+    }
+}
+
+fn validate_profile_authority(
+    profile_dir: &Path,
+    profile_id: &str,
+    owner: AuthorityOwner,
+) -> Result<()> {
+    validate_profile_directory(profile_dir, profile_id, owner)?;
+    reject_unexpected_profile_entries(profile_dir, profile_id)?;
+    for role in RepositorySigningRole::ALL {
+        validate_role_pair(profile_dir, profile_id, role, owner)?;
+    }
+    Ok(())
+}
+
+fn reject_unexpected_profile_entries(profile_dir: &Path, profile_id: &str) -> Result<()> {
+    let expected = RepositorySigningRole::ALL
+        .into_iter()
+        .flat_map(|role| {
+            [
+                format!("{}.private", role.as_str()),
+                format!("{}.public", role.as_str()),
+            ]
+        })
+        .collect::<BTreeSet<_>>();
+    for entry in fs::read_dir(profile_dir)
+        .with_context(|| format!("read signing authority for exact profile {profile_id}"))?
+    {
+        let entry = entry.with_context(|| {
+            format!("read signing authority entry for exact profile {profile_id}")
+        })?;
+        let name = entry.file_name();
+        if !expected
+            .iter()
+            .any(|expected_name| name == std::ffi::OsStr::new(expected_name))
+        {
+            bail!(
+                "repository signing authority for exact profile {profile_id} contains unexpected entry {:?}",
+                name
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validate_profile_directory(
+    profile_dir: &Path,
+    profile_id: &str,
+    owner: AuthorityOwner,
+) -> Result<()> {
+    let metadata = fs::symlink_metadata(profile_dir).with_context(|| {
+        format!("repository signing authority for exact profile {profile_id} is missing")
+    })?;
+    if !metadata.file_type().is_dir() || metadata.file_type().is_symlink() {
+        bail!(
+            "repository signing authority {} must be a plain directory",
+            profile_dir.display()
+        );
+    }
+    require_mode(profile_dir, &metadata, AUTHORITY_DIRECTORY_MODE)?;
+    require_owner(profile_dir, &metadata, owner)?;
+    Ok(())
+}
+
+fn validate_role_pair(
+    profile_dir: &Path,
+    profile_id: &str,
+    role: RepositorySigningRole,
+    owner: AuthorityOwner,
+) -> Result<()> {
+    let private = profile_dir.join(format!("{}.private", role.as_str()));
+    let public = profile_dir.join(format!("{}.public", role.as_str()));
+    let private_metadata = require_plain_file(&private, "private signing key")?;
+    let public_metadata = require_plain_file(&public, "public signing key")?;
+    require_mode(&private, &private_metadata, PRIVATE_KEY_MODE)?;
+    require_mode(&public, &public_metadata, PUBLIC_KEY_MODE)?;
+    require_owner(&private, &private_metadata, owner)?;
+    require_owner(&public, &public_metadata, owner)?;
+
+    let private_key = SigningKeyPair::load_from_file(&private)
+        .map_err(anyhow::Error::from)
+        .with_context(|| {
+            format!(
+                "load private {} authority for exact profile {profile_id}",
+                role.as_str()
+            )
+        })?;
+    if private_key.key_id() != Some(role.as_str()) {
+        bail!(
+            "private authority {} has key ID {:?}; expected '{}'",
+            private.display(),
+            private_key.key_id(),
+            role.as_str()
+        );
+    }
+    let public_key = load_signing_public_key(&public)
+        .map_err(anyhow::Error::from)
+        .with_context(|| {
+            format!(
+                "load public {} authority for exact profile {profile_id}",
+                role.as_str()
+            )
+        })?;
+    if public_key.key_id() != Some(role.as_str()) {
+        bail!(
+            "public authority {} has key ID {:?}; expected '{}'",
+            public.display(),
+            public_key.key_id(),
+            role.as_str()
+        );
+    }
+    if public_key.public_key_base64() != private_key.public_key_base64() {
+        bail!(
+            "public and private {} authority disagree for exact profile {profile_id}",
+            role.as_str()
+        );
+    }
+    Ok(())
+}
+
+fn require_plain_file(path: &Path, description: &str) -> Result<fs::Metadata> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("{description} {} is missing", path.display()))?;
+    if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+        bail!("{description} {} must be a plain file", path.display());
+    }
+    Ok(metadata)
+}
+
+fn require_mode(path: &Path, metadata: &fs::Metadata, expected: u32) -> Result<()> {
+    let observed = metadata.permissions().mode() & 0o777;
+    if observed != expected {
+        bail!(
+            "repository signing authority {} has mode {observed:#05o}; expected {expected:#05o}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+fn require_owner(path: &Path, metadata: &fs::Metadata, expected: AuthorityOwner) -> Result<()> {
+    if metadata.uid() != expected.uid || metadata.gid() != expected.gid {
+        bail!(
+            "repository signing authority {} has owner {}:{}; expected {}:{}",
+            path.display(),
+            metadata.uid(),
+            metadata.gid(),
+            expected.uid,
+            expected.gid
+        );
+    }
+    Ok(())
+}
+
+fn align_owner(path: &Path, owner: AuthorityOwner) -> Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.uid() == owner.uid && metadata.gid() == owner.gid {
+        return Ok(());
+    }
+    chown(
+        path,
+        Some(Uid::from_raw(owner.uid)),
+        Some(Gid::from_raw(owner.gid)),
+    )
+    .with_context(|| {
+        format!(
+            "set repository signing authority owner on {}",
+            path.display()
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::{DirBuilderExt, symlink};
+
+    fn manifest() -> RepositoryManifest {
+        toml::from_str(
+            r#"
+schema_version = 2
+
+[[repositories]]
+name = "fedora-source"
+url = "https://packages.example.test/fedora"
+profile = "fedora-44"
+enabled = true
+priority = 100
+metadata_expire_seconds = 21600
+
+[repositories.parser]
+package_format = "rpm"
+architecture = "x86_64"
+
+[repositories.trust]
+ecosystem = "rpm"
+
+[repositories.trust.metadata]
+kind = "metalink"
+url = "https://mirrors.example.test/metalink"
+
+[[repositories.trust.package_keys]]
+url = "https://keys.example.test/fedora.gpg"
+fingerprint = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+"#,
+        )
+        .unwrap()
+    }
+
+    fn authority_root() -> (tempfile::TempDir, std::path::PathBuf) {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("repository-keys");
+        fs::DirBuilder::new()
+            .mode(AUTHORITY_DIRECTORY_MODE)
+            .create(&root)
+            .unwrap();
+        (temp, root)
+    }
+
+    #[test]
+    fn first_bootstrap_is_complete_and_repeat_preserves_exact_key_bytes() {
+        let (_temp, root) = authority_root();
+        let profiles = ensure_repository_authority(&manifest(), &root).unwrap();
+        assert_eq!(profiles, vec!["fedora-44"]);
+
+        let profile_dir = root.join("fedora-44");
+        let before = RepositorySigningRole::ALL
+            .into_iter()
+            .flat_map(|role| {
+                let profile_dir = profile_dir.clone();
+                ["private", "public"].map(move |kind| {
+                    let path = profile_dir.join(format!("{}.{}", role.as_str(), kind));
+                    (path.clone(), fs::read(path).unwrap())
+                })
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        ensure_repository_authority(&manifest(), &root).unwrap();
+        let after = before
+            .keys()
+            .map(|path| (path.clone(), fs::read(path).unwrap()))
+            .collect::<BTreeMap<_, _>>();
+        assert_eq!(after, before);
+        assert_eq!(
+            inspect_repository_authority(&manifest(), &root).unwrap(),
+            vec!["fedora-44"]
+        );
+    }
+
+    #[test]
+    fn partial_or_mismatched_authority_fails_without_replacement() {
+        let (_temp, root) = authority_root();
+        ensure_repository_authority(&manifest(), &root).unwrap();
+        let public = root.join("fedora-44/targets.public");
+        fs::remove_file(&public).unwrap();
+
+        let error = ensure_repository_authority(&manifest(), &root).unwrap_err();
+        assert!(error.to_string().contains("is missing"), "{error:#}");
+        assert!(!public.exists());
+    }
+
+    #[test]
+    fn insecure_private_mode_and_symlinked_profile_fail_closed() {
+        let (_temp, root) = authority_root();
+        ensure_repository_authority(&manifest(), &root).unwrap();
+        let private = root.join("fedora-44/targets.private");
+        fs::set_permissions(&private, fs::Permissions::from_mode(0o644)).unwrap();
+        let error = inspect_repository_authority(&manifest(), &root).unwrap_err();
+        assert!(error.to_string().contains("expected 0o600"), "{error:#}");
+
+        let (_second_temp, second_root) = authority_root();
+        symlink(&root, second_root.join("fedora-44")).unwrap();
+        let error = ensure_repository_authority(&manifest(), &second_root).unwrap_err();
+        assert!(error.to_string().contains("plain directory"), "{error:#}");
+    }
+
+    #[test]
+    fn route_slug_directory_is_rejected_as_duplicate_authority() {
+        let (_temp, root) = authority_root();
+        fs::DirBuilder::new()
+            .mode(AUTHORITY_DIRECTORY_MODE)
+            .create(root.join("fedora"))
+            .unwrap();
+
+        let error = ensure_repository_authority(&manifest(), &root).unwrap_err();
+        assert!(
+            error.to_string().contains("route slug 'fedora'"),
+            "{error:#}"
+        );
+        assert!(!root.join("fedora-44").exists());
+    }
+
+    #[test]
+    fn unexpected_root_or_profile_authority_fails_without_replacement() {
+        let (_temp, root) = authority_root();
+        fs::write(root.join("unowned-key-material"), b"unexpected").unwrap();
+        let error = ensure_repository_authority(&manifest(), &root).unwrap_err();
+        assert!(error.to_string().contains("unexpected entry"), "{error:#}");
+        assert!(!root.join("fedora-44").exists());
+
+        fs::remove_file(root.join("unowned-key-material")).unwrap();
+        ensure_repository_authority(&manifest(), &root).unwrap();
+        let private = root.join("fedora-44/targets.private");
+        let before = fs::read(&private).unwrap();
+        fs::write(root.join("fedora-44/legacy.private"), b"unexpected").unwrap();
+        let error = ensure_repository_authority(&manifest(), &root).unwrap_err();
+        assert!(error.to_string().contains("unexpected entry"), "{error:#}");
+        assert_eq!(fs::read(private).unwrap(), before);
+    }
+}

--- a/crates/conary-core/src/ccs/signing.rs
+++ b/crates/conary-core/src/ccs/signing.rs
@@ -269,8 +269,29 @@ struct KeyFile {
     key_id: Option<String>,
 }
 
-/// Load a public key from a file (for trust policy)
-pub fn load_public_key(path: &Path) -> Result<String> {
+/// Parsed public half of a CCS signing key pair.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SigningPublicKey {
+    key: String,
+    key_id: Option<String>,
+}
+
+impl SigningPublicKey {
+    /// Get the base64-encoded Ed25519 public key.
+    #[must_use]
+    pub fn public_key_base64(&self) -> &str {
+        &self.key
+    }
+
+    /// Get the persisted role/key identifier.
+    #[must_use]
+    pub fn key_id(&self) -> Option<&str> {
+        self.key_id.as_deref()
+    }
+}
+
+/// Load and validate a public signing-key file.
+pub fn load_signing_public_key(path: &Path) -> Result<SigningPublicKey> {
     let content = fs::read_to_string(path).map_err(|e| {
         Error::IoError(format!(
             "Failed to read public key {}: {}",
@@ -287,7 +308,22 @@ pub fn load_public_key(path: &Path) -> Result<String> {
         ))
     })?;
 
-    Ok(key_file.key)
+    if key_file.algorithm != "ed25519" {
+        return Err(Error::ParseError(format!(
+            "Unsupported public key algorithm: {}",
+            key_file.algorithm
+        )));
+    }
+
+    Ok(SigningPublicKey {
+        key: key_file.key,
+        key_id: key_file.key_id,
+    })
+}
+
+/// Load a public key from a file (for trust policy)
+pub fn load_public_key(path: &Path) -> Result<String> {
+    load_signing_public_key(path).map(|key| key.key)
 }
 
 #[cfg(test)]
@@ -389,5 +425,29 @@ mod tests {
 
         let public_key = load_public_key(&public_path).unwrap();
         assert_eq!(public_key, keypair.public_key_base64());
+    }
+
+    #[test]
+    fn public_key_loader_preserves_role_identity_and_rejects_other_algorithms() {
+        let temp_dir = TempDir::new().unwrap();
+        let private_path = temp_dir.path().join("targets.private");
+        let public_path = temp_dir.path().join("targets.public");
+        let keypair = SigningKeyPair::generate().with_key_id("targets");
+        keypair.save_to_files(&private_path, &public_path).unwrap();
+
+        let public_key = load_signing_public_key(&public_path).unwrap();
+        assert_eq!(public_key.public_key_base64(), keypair.public_key_base64());
+        assert_eq!(public_key.key_id(), Some("targets"));
+
+        let unsupported = fs::read_to_string(&public_path)
+            .unwrap()
+            .replace("algorithm = \"ed25519\"", "algorithm = \"rsa\"");
+        fs::write(&public_path, unsupported).unwrap();
+        let error = load_signing_public_key(&public_path).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("Unsupported public key algorithm")
+        );
     }
 }

--- a/crates/conary-core/src/packages/rpm/payload.rs
+++ b/crates/conary-core/src/packages/rpm/payload.rs
@@ -257,35 +257,45 @@ fn project_single(
     member: stream::PayloadMember,
 ) -> Result<PackagePayloadFile> {
     let node = source_node(record)?;
-    let (content_authority, source) = if matches!(node.kind, PayloadNodeKind::Regular { .. }) {
-        let source = member.source.ok_or_else(|| {
-            parse_error(format!(
-                "RPM regular node {} has no payload source",
-                record.path
-            ))
-        })?;
-        require_regular_content(record, member.content_size, &source)?;
-        let sha256 = member.sha256.ok_or_else(|| {
-            parse_error(format!(
-                "RPM regular node {} has no SHA-256 authority",
-                record.path
-            ))
-        })?;
-        (
-            Some(PayloadContentAuthority {
-                sha256,
-                size: member.content_size,
-            }),
-            Some(source),
-        )
-    } else {
-        if member.content_size != 0 || member.source.is_some() || member.sha256.is_some() {
-            return Err(parse_error(format!(
-                "non-regular RPM node {} retained ambiguous payload content",
-                record.path
-            )));
+    let (content_authority, source) = match &node.kind {
+        PayloadNodeKind::Regular { .. } => {
+            let source = member.source.ok_or_else(|| {
+                parse_error(format!(
+                    "RPM regular node {} has no payload source",
+                    record.path
+                ))
+            })?;
+            require_regular_content(record, member.content_size, &source)?;
+            let sha256 = member.sha256.ok_or_else(|| {
+                parse_error(format!(
+                    "RPM regular node {} has no SHA-256 authority",
+                    record.path
+                ))
+            })?;
+            (
+                Some(PayloadContentAuthority {
+                    sha256,
+                    size: member.content_size,
+                }),
+                Some(source),
+            )
         }
-        (None, None)
+        PayloadNodeKind::Symlink { target }
+            if member.content_size == target.len() as u64
+                && member.source.is_none()
+                && member.sha256.is_none() =>
+        {
+            (None, None)
+        }
+        _ => {
+            if member.content_size != 0 || member.source.is_some() || member.sha256.is_some() {
+                return Err(parse_error(format!(
+                    "non-regular RPM node {} retained ambiguous payload content",
+                    record.path
+                )));
+            }
+            (None, None)
+        }
     };
     validate_projected(&record.path, &node, content_authority.as_ref())?;
     PackagePayloadFile::new(record.path.clone(), node, content_authority, source)
@@ -596,6 +606,7 @@ mod tests {
         RpmFileDigestAlgorithm, apply_capability_operation, digest_hex, parse,
         parse_file_capabilities, require_partial_hardlink_count,
     };
+    use crate::payload::PayloadNodeKind;
     use rpm::IndexTag;
     use std::io::Cursor;
 
@@ -646,6 +657,32 @@ mod tests {
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].path, "/usr/share/sha1-fixture/data");
         assert_eq!(files[0].content, content);
+    }
+
+    #[test]
+    fn source_validated_rpm_symlink_projects_without_regular_content_authority() {
+        let path = "/usr/lib/.build-id/a7/232a5f6ed485eb65b89f39caa2da4dfe8288b5";
+        let target = "../../../../usr/bin/curl";
+        let mut builder =
+            rpm::PackageBuilder::new("symlink-fixture", "1", "MIT", "x86_64", "symlink fixture");
+        builder
+            .with_symlink(rpm::FileOptions::symlink(path, target))
+            .unwrap();
+        let package = builder.build().unwrap();
+
+        let payload = parse(&package).unwrap();
+        assert_eq!(payload.files().len(), 1);
+        let file = &payload.files()[0];
+        assert_eq!(file.path, path);
+        assert_eq!(
+            file.node.kind,
+            PayloadNodeKind::Symlink {
+                target: target.to_string()
+            }
+        );
+        assert!(file.content_authority.is_none());
+        assert!(file.source().is_none());
+        assert!(file.to_extracted_in_memory().unwrap().content.is_empty());
     }
 
     fn main_header_value_offset(bytes: &[u8], header_start: usize, wanted: IndexTag) -> usize {

--- a/crates/conary-core/src/packages/rpm/payload/stream.rs
+++ b/crates/conary-core/src/packages/rpm/payload/stream.rs
@@ -444,6 +444,26 @@ mod tests {
     use super::*;
     use std::io;
 
+    fn header_record(mode: u32, size: u64, link_target: Option<&str>) -> HeaderRecord {
+        HeaderRecord {
+            path: "/usr/lib/.build-id/fixture".to_string(),
+            mode,
+            user: "root".to_string(),
+            group: "root".to_string(),
+            mtime: 0,
+            size,
+            ghost: false,
+            digest: None,
+            link_target: link_target.map(str::to_string),
+            caps: None,
+            ima_signature: None,
+            device: 0,
+            inode: 0,
+            rdev: 0,
+            nlink: None,
+        }
+    }
+
     struct ZeroReader {
         max_requested: usize,
     }
@@ -495,5 +515,51 @@ mod tests {
         .read_to_end(&mut decoded)
         .unwrap();
         assert_eq!(decoded, input);
+    }
+
+    #[test]
+    fn symlink_payload_comparison_rejects_bytes_that_differ_from_filelinktos() {
+        let error = compare_exact_payload(
+            &mut io::Cursor::new(b"../../expecteD-target"),
+            b"../../expected-target",
+            "/usr/lib/.build-id/fixture",
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("payload target differs from FILELINKTOS")
+        );
+    }
+
+    #[test]
+    fn symlink_size_and_other_nonregular_payload_content_remain_rejected() {
+        let target = b"../../expected-target";
+        let symlink = [header_record(
+            libc::S_IFLNK | 0o777,
+            target.len() as u64,
+            Some(std::str::from_utf8(target).unwrap()),
+        )];
+        let spool = PayloadSpool::new(0).unwrap();
+        let mut reader = RpmPayloadReader::new(Box::new(io::Cursor::new(target)), &symlink, &spool);
+        let error = reader
+            .read_member_content(0, target.len() as u64 - 1, None)
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("size disagrees with FILELINKTOS"),
+            "{error}"
+        );
+
+        let directory = [header_record(libc::S_IFDIR | 0o755, 0, None)];
+        let mut reader = RpmPayloadReader::new(Box::new(io::Cursor::new(b"x")), &directory, &spool);
+        let error = reader.read_member_content(0, 1, None).unwrap_err();
+        assert!(
+            error.to_string().contains(
+                "non-regular RPM node /usr/lib/.build-id/fixture carries 1 payload bytes"
+            ),
+            "{error}"
+        );
     }
 }

--- a/deploy/remi-deploy-helper.sh
+++ b/deploy/remi-deploy-helper.sh
@@ -90,6 +90,25 @@ install_owned_file() {
     install -m "$mode" "${owners[@]}" "$src" "$dest"
 }
 
+ensure_repository_keys_root() {
+    local path="$1"
+    if [[ -e "$path" || -L "$path" ]]; then
+        [[ -d "$path" && ! -L "$path" ]] ||
+            die "repository signing authority root is not a plain directory: $path"
+        [[ "$(stat -c '%a' "$path")" == "700" ]] ||
+            die "repository signing authority root must have mode 0700: $path"
+        if [[ -z "$ROOT" ]]; then
+            local expected_owner observed_owner
+            expected_owner="$(id -u conary):$(id -g conary)"
+            observed_owner="$(stat -c '%u:%g' "$path")"
+            [[ "$observed_owner" == "$expected_owner" ]] ||
+                die "repository signing authority root must be owned by conary:conary: $path"
+        fi
+        return
+    fi
+    install_owned_dir 0700 "$path"
+}
+
 restart_remi() {
     [[ "$SKIP_RESTART" == "1" ]] && return 0
     systemctl restart remi
@@ -171,7 +190,7 @@ deploy_remi() {
     [[ -f "$repositories" && ! -L "$repositories" ]] ||
         die "repository manifest is not a plain file: $repositories"
 
-    local tmpdir bin candidate backup had_previous transition_manifest
+    local tmpdir bin candidate backup had_previous transition_manifest repository_keys_dir
     tmpdir="$(mktemp -d /tmp/remi-install.XXXXXX)"
     backup="${tmpdir}/remi.previous"
     bin="$(root_path /usr/local/bin/remi)"
@@ -183,6 +202,9 @@ deploy_remi() {
     [[ -f "$candidate" && ! -L "$candidate" ]] || die "bundle did not contain remi-${version}-linux-x64"
     [[ "$("$candidate" --version)" == "remi ${version}" ]] ||
         die "candidate binary version does not match ${version}"
+
+    repository_keys_dir="$(root_path /conary/repository-keys)"
+    ensure_repository_keys_root "$repository_keys_dir"
 
     if [[ -f "$bin" ]]; then
         cp "$bin" "$backup"
@@ -198,6 +220,7 @@ deploy_remi() {
             --config "$(root_path /etc/conary/remi.toml)" \
             --repository-manifest "$repositories" \
             --repository-manifest-target "$(root_path /etc/conary/remi-repositories.toml)" \
+            --repository-keys-dir "$repository_keys_dir" \
             --deployment-id "remi-${version}" \
             --max-concurrent "$max_concurrent"
     )"; then

--- a/deploy/remi.toml.example
+++ b/deploy/remi.toml.example
@@ -90,6 +90,12 @@ enabled = true
 # Search index directory (defaults to {storage.root}/search-index)
 # index_dir = "/conary/search-index"
 
+[release_publish]
+# Durable exact-profile CCS and TUF signing authority. The deployment helper
+# creates this root for the conary service account; Remi atomically provisions
+# one targets/snapshot/timestamp role set per repository-manifest profile.
+repository_keys_dir = "/conary/repository-keys"
+
 [prewarm]
 # Pre-warming pipeline: proactively convert popular packages
 enabled = true

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-07-27
-revision: 54
-summary: Route serialized selected-root mutation, typed rollback lineage, canonical-map authority, typed generation GC, exact release authority, and subsystem proof through current feature owners.
+revision: 55
+summary: Route exact Remi signing, serialized selected-root mutation, typed rollback lineage, canonical-map authority, typed generation GC, exact release authority, and subsystem proof through current feature owners.
 ---
 
 # Assistant Subsystem Map
@@ -132,7 +132,10 @@ commands.
   `apps/conary/src/commands/try_session/session/watch_marker.rs`.
 - Remi, federation, publication, and service-owned conversion:
   `docs/modules/feature-ownership.md` slug `remi`, plus `docs/modules/remi.md`
-  and `docs/modules/federation.md`.
+  and `docs/modules/federation.md`. Durable exact-profile CCS/TUF signing
+  authority starts in `apps/remi/src/server/signing_authority.rs`; deployment
+  wiring and validation start in `apps/remi/src/deployment.rs` and
+  `deploy/remi-deploy-helper.sh`.
 - conaryd routes and package jobs: `docs/modules/feature-ownership.md` slug
   `conaryd`, plus `docs/modules/conaryd.md`.
 - Exact-tag release construction, signing, immutable publication, deployment,

--- a/docs/modules/ccs.md
+++ b/docs/modules/ccs.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-26
-revision: 47
+last_updated: 2026-07-27
+revision: 48
 summary: Convert foreign packages into source-independent CCS lifecycle transactions and export CCS as native packages
 ---
 
@@ -146,6 +146,12 @@ both source identity and resolved numeric identity so later generation,
 rollback, query, and verification paths do not repeat or guess resolution.
 Unknown names, conflicting header/payload facts, unsupported archive records,
 and missing content authority reject the package before filesystem mutation.
+For an RPM symlink, `FILELINKTOS` owns the target and the CPIO member must carry
+exactly those target bytes at exactly that length. After the streaming parser
+proves that equality, projection retains the target as symlink variant data
+without inventing regular-file content authority. Any mismatched target or
+length still fails, and every other non-regular node must carry zero payload
+bytes.
 
 **convert/** -- RPM, Debian, and Arch to CCS conversion. Source package parsers
 produce a typed native ABI before conversion: exact lifecycle slots, body

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-07-27
-revision: 59
+revision: 60
 summary: Route feature ownership through exact Remi signing, streaming package payloads, serialized selected-root mutation, typed rollback lineage, exact lifecycle, canonical-map authority, typed generation GC, exact release authority, and current canonical docs
 ---
 
@@ -1235,6 +1235,7 @@ matrix job in `.github/workflows/pr-gate.yml`.
 
 **Paths:** `apps/conary-test/*`;
 `apps/conary/tests/fixtures/*`;
+`apps/conary/tests/integration/remi/containers/*`;
 `apps/conary/tests/integration/remi/manifests/*`;
 `.github/workflows/pr-gate.yml`.
 

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -592,6 +592,7 @@ packages, install CCS packages, and preserve their exact lifecycle ABIs.
 `crates/conary-core/src/filesystem/cas/stream.rs`;
 `crates/conary-core/src/packages/rpm/payload.rs`;
 `crates/conary-core/src/packages/rpm/payload/header.rs`;
+`crates/conary-core/src/packages/rpm/payload/stream.rs`;
 `crates/conary-core/src/packages/rpm/scriptlets.rs`;
 `crates/conary-core/src/packages/rpm/scriptlets/runtime_context.rs`;
 `crates/conary-core/src/packages/deb/lifecycle_helpers.rs`;
@@ -661,6 +662,7 @@ metadata, scriptlet sandboxing (`crates/conary-core/src/scriptlet/mod.rs`,
 
 **Focused proof:** `cargo test -p conary-core ccs::v2`;
 `cargo test -p conary-core filesystem::cas`;
+`cargo test -p conary-core packages::rpm::payload`;
 `cargo test -p conary-core --lib lifecycle_helpers`;
 `cargo test -p conary --test packaging_m4b`;
 `cargo test -p conary --test packaging_m4e`;

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-07-27
-revision: 58
-summary: Route feature ownership through streaming package payloads, serialized selected-root mutation, typed rollback lineage, exact lifecycle, canonical-map authority, typed generation GC, exact release authority, and current canonical docs
+revision: 59
+summary: Route feature ownership through exact Remi signing, streaming package payloads, serialized selected-root mutation, typed rollback lineage, exact lifecycle, canonical-map authority, typed generation GC, exact release authority, and current canonical docs
 ---
 
 # Feature Ownership And Interaction Gates
@@ -989,6 +989,7 @@ release uploads, and static test fixtures through Remi.
 
 **Start here:** `apps/remi/src/server/release_publish.rs`;
 `apps/remi/src/deployment.rs`;
+`apps/remi/src/server/signing_authority.rs`;
 `apps/remi/src/server/mod.rs`;
 `apps/remi/src/server/admin_service.rs`;
 `apps/remi/src/server/admin_service/refresh.rs`;
@@ -1009,6 +1010,7 @@ release uploads, and static test fixtures through Remi.
 `apps/remi/src/server/conversion/benchmark.rs`;
 `apps/remi/src/server/index_gen.rs`;
 `apps/remi/src/server/prewarm.rs`; `apps/remi/src/server/handlers/`;
+`deploy/remi-deploy-helper.sh`;
 `docs/modules/remi.md`; `docs/modules/test-fixtures.md`.
 
 **Neighbor systems:** CCS conversion metadata, repository client behavior,
@@ -1021,13 +1023,16 @@ feed profiles.
 `deploy/remi-repositories.toml`.
 
 **Focused proof:** `cargo test -p remi release_upload_`;
+`cargo test -p remi signing_authority`;
+`cargo test -p remi deployment`;
 `cargo test -p remi native_publish`;
 `cargo test -p remi refresh`;
 `cargo test -p conary --test packaging_m4c`;
 `cargo test -p remi remi_release_parity`;
 `cargo test -p remi conversion`;
 `cargo test -p remi test_upload_fixture`;
-`cargo test -p remi test_public_fixture_get_and_head`.
+`cargo test -p remi test_public_fixture_get_and_head`;
+`bash scripts/test-remi-deploy-helper.sh`.
 
 **Interaction gate:** `cargo test -p remi`;
 `cargo test -p conary --test conversion_integration golden_conversion` when
@@ -1048,7 +1053,10 @@ policy, validate source-independent lifecycle authority structurally, and
 publish package rows, native publication rows, chunks, and TUF targets only
 after the shared gate and lifecycle validation pass. Native CCS release uploads
 must not create synthetic `converted_packages` rows; failed replacement must
-preserve the last public native generation.
+preserve the last public native generation. Repository signing keys are owned
+only by exact source-profile directories; deployment must preserve complete
+existing role sets unchanged and reject partial, aliased, insecure, or
+unexpected authority before activation.
 
 ## conaryd Package Jobs And Daemon Routes
 

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-07-27
-revision: 8
-summary: Document Remi source, canonical-map, repository trust, conversion, publication, and serving authority
+revision: 9
+summary: Document Remi source, signing, canonical-map, repository trust, conversion, publication, and serving authority
 ---
 
 # Remi
@@ -70,6 +70,30 @@ so concurrent completion order is not API order.
 per-source results, and bounded concurrent collection. `server/mod.rs` owns the
 exact-profile handoff from successful refresh results into configured prewarm
 jobs; HTTP handlers only publish events and project the shared batch.
+
+## Durable Repository Signing Authority
+
+`apps/remi/src/server/signing_authority.rs` owns Remi's durable CCS and TUF
+signing authority. Deployment derives the unique exact profiles from the typed
+repository manifest and provisions one complete Ed25519
+`targets`/`snapshot`/`timestamp` role set per profile under
+`/conary/repository-keys/<exact-profile>/`. The root and profile directories
+are mode `0700`, private files are `0600`, and public files are `0644`. A
+profile role set is staged, synced, and atomically published; a repeat deploy
+validates and preserves the existing bytes.
+
+Existing authority is never repaired by replacement. Missing halves,
+malformed keys, mismatched private/public material, incorrect role IDs,
+symlinked or incorrectly owned entries, unsafe modes, unexpected files, and
+route-slug directories fail deployment. `deployment inspect` independently
+validates that the manifest profiles and complete signing profiles agree.
+Signing authority lives outside binary/config rollback paths.
+
+Conversion and recipe builds load `targets` by the persisted exact source
+profile. Public native-release and timestamp routes first resolve their route
+slug through the supported-profile registry, then load the exact profile's
+role keys. `fedora` and `ubuntu` are therefore never key-directory aliases for
+`fedora-44` and `ubuntu-26.04`.
 
 ## Canonical Map Exchange
 

--- a/docs/operations/infrastructure.md
+++ b/docs/operations/infrastructure.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-26
-revision: 17
+last_updated: 2026-07-27
+revision: 18
 summary: Non-secret infrastructure, agent-operations transport, release, Remi deploy, TLS renewal, remote development, and Forge staging guidance for Conary contributors and coding assistants
 ---
 
@@ -148,11 +148,20 @@ not cover the task or when you are debugging the underlying service path itself.
   `/conary/deployment-backups/`, and emits the transition manifest used for
   automatic rollback. The pre-deploy database remains recoverable; retired
   schemas are not migrated in place.
+- The helper creates `/conary/repository-keys` as a `conary:conary` mode-0700
+  durable authority root before candidate preparation. The candidate
+  atomically creates one complete targets/snapshot/timestamp key set under
+  each exact manifest profile. Repeat deployments preserve those bytes.
+  Existing wrong ownership or modes, partial or mismatched role pairs,
+  symlinks, unexpected entries, and route-slug aliases fail before service
+  activation. This directory is deliberately outside release rollback and
+  deletion paths.
 - After health succeeds, the deployment job polls
   `conary-remi-deploy inspect-remi --require-repopulated`. Success requires all
-  configured sources to contain metadata and at least one validated converted
-  artifact for every configured public profile; dispatch or a green health
-  probe alone is not deployment proof.
+  configured sources to contain metadata, a complete signing role set for
+  every exact source profile, and at least one validated converted artifact for
+  every configured public profile; dispatch or a green health probe alone is
+  not deployment proof.
 - Conary release artifact publication through the same helper verifies the
   CI-produced `SHA256SUMS` file from the staging directory before installing
   files into `/conary/releases/<version>`. The helper copies that verified

--- a/scripts/test-remi-deploy-helper.sh
+++ b/scripts/test-remi-deploy-helper.sh
@@ -77,10 +77,15 @@ fi
 if [[ "\${1:-}" == "deployment" && "\${2:-}" == "prepare" ]]; then
     shift 2
     config=""
+    repository_keys_dir=""
     while [[ \$# -gt 0 ]]; do
         case "\$1" in
             --config)
                 config="\$2"
+                shift 2
+                ;;
+            --repository-keys-dir)
+                repository_keys_dir="\$2"
                 shift 2
                 ;;
             *)
@@ -89,8 +94,10 @@ if [[ "\${1:-}" == "deployment" && "\${2:-}" == "prepare" ]]; then
                 ;;
         esac
     done
+    [[ -d "\$repository_keys_dir" && ! -L "\$repository_keys_dir" ]]
     transition="\${config}.transition.json"
     printf '{}\n' >"\$transition"
+    printf '%s\n' "\$repository_keys_dir" >"\${config}.repository-keys-path"
     echo "\$transition"
     exit 0
 fi
@@ -236,8 +243,43 @@ test_deploy_remi_uses_candidate_owned_transition() {
     run_helper "$fake_root" deploy-remi 0.8.0 "$bundle" "$repositories" 32
 
     test "$("$fake_root/usr/local/bin/remi" --version)" = "remi 0.8.0"
+    test "$(cat "$fake_root/etc/conary/remi.toml.repository-keys-path")" = \
+        "$fake_root/conary/repository-keys"
+    test "$(stat -c '%a' "$fake_root/conary/repository-keys")" = "700"
+    printf 'stable-authority\n' >"$fake_root/conary/repository-keys/preserved"
     test ! -e "$bundle"
     test ! -e "$repositories"
+
+    bundle="${tmpdir}/remi-0.8.1.tar.gz"
+    repositories="${tmpdir}/repositories-repeat.toml"
+    make_fake_remi_bundle "$bundle" 0.8.1
+    printf 'schema_version = 2\nrepositories = []\n' >"$repositories"
+    run_helper "$fake_root" deploy-remi 0.8.1 "$bundle" "$repositories" 32
+
+    test "$("$fake_root/usr/local/bin/remi" --version)" = "remi 0.8.1"
+    test "$(cat "$fake_root/conary/repository-keys/preserved")" = "stable-authority"
+}
+
+test_deploy_remi_rejects_malformed_authority_root() {
+    local fake_root="${tmpdir}/root-remi-malformed"
+    local bundle="${tmpdir}/remi-malformed.tar.gz"
+    local repositories="${tmpdir}/repositories-malformed.toml"
+    write_config "$fake_root"
+    mkdir -p "$fake_root/usr/local/bin" "$fake_root/conary/repository-keys"
+    chmod 0755 "$fake_root/conary/repository-keys"
+    make_fake_remi_bundle "$bundle" 0.8.0
+    printf 'schema_version = 2\nrepositories = []\n' >"$repositories"
+
+    expect_fail "insecure repository authority root" \
+        run_helper "$fake_root" deploy-remi 0.8.0 "$bundle" "$repositories" 32
+    test ! -e "$fake_root/usr/local/bin/remi"
+
+    chmod 0700 "$fake_root/conary/repository-keys"
+    rmdir "$fake_root/conary/repository-keys"
+    ln -s "${tmpdir}" "$fake_root/conary/repository-keys"
+    expect_fail "symlinked repository authority root" \
+        run_helper "$fake_root" deploy-remi 0.8.0 "$bundle" "$repositories" 32
+    test ! -e "$fake_root/usr/local/bin/remi"
 }
 
 test_install_helper_requires_exact_digest() {
@@ -268,6 +310,7 @@ main() {
     test_deploy_site_replaces_web_root_from_staging
     test_deploy_site_rejects_unknown_target
     test_deploy_remi_uses_candidate_owned_transition
+    test_deploy_remi_rejects_malformed_authority_root
     test_install_helper_requires_exact_digest
 
     echo "remi deploy helper smoke passed"


### PR DESCRIPTION
## Primary Issue

Refs #95

Design / Plan / Roadmap: `docs/modules/remi.md`; parent release issue #86

## Problem And Outcome

The Remi 0.8.2 production gate populated every configured repository but could not produce a current conversion. Refresh results used exact profile IDs while prewarm jobs used public route slugs, production had no durable CCS/TUF signing authority, and the RPM projection rejected a Fedora build-id symlink after the stream parser had already validated its exact target bytes.

After this change, deployment provisions and validates one stable role-separated authority per exact manifest profile, all consumers resolve to that identity through the typed profile registry, successful refreshes schedule the matching prewarm job, and source-validated RPM symlinks project without invented regular-file authority. Remi 0.8.3 is prepared for the protected replacement deployment.

The required hosted lifecycle gate also exposed that Ubuntu's source-builder piped the rustup download directly into `sh`, allowing a failed download to surface later as an opaque missing-tool exit. The builder now downloads with explicit failure/retry semantics and proves the pinned Cargo and Rust compiler before source staging.

## Changes

- add an atomic exact-profile `targets`/`snapshot`/`timestamp` signing-authority owner with strict ownership, mode, key-pair, role-ID, and unexpected-entry validation
- wire the durable authority through candidate deployment, current config, inspection, conversion, recipe builds, native publication, and timestamp refresh
- map exact refresh results to route-facing prewarm jobs through the supported-profile registry
- preserve validated RPM symlink targets while retaining strict rejection for mismatched targets/sizes and payload-bearing other non-regular nodes
- make the Ubuntu lifecycle source-builder fail at the rustup download boundary and route its container files to the conary-test owner card
- update Remi, CCS, operator, routing, ownership, deployment-helper proof, and immutable 0.8.3 release state

## Scope

- In scope: deterministic production conversion blockers, durable signing authority, typed identity routing, RPM symlink projection, required lifecycle-gate reliability, Remi 0.8.3 release preparation
- Out of scope: package exceptions, heuristic classification, schema migration, key rotation/HSM support, unrelated distro expansion

## Ownership / Boundary

- Owning subsystem: `remi` with the `ccs` RPM payload boundary and the required `conary-test` lifecycle gate
- Boundary changed or preserved: new signing authority lives in `apps/remi/src/server/signing_authority.rs`; public route slugs resolve to exact profiles before key lookup; the RPM stream parser remains target-byte authority; Ubuntu's source builder proves its pinned toolchain before compiling
- Persisted state or public surface impact: durable private keys under `/conary/repository-keys`, Remi config and deployment inspection output, CCS/TUF signatures, conversion scheduling
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code
- [x] Updated subsystem docs or maps when the "look here first" path changed
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs

```text
- cargo test -p conary-core ccs::signing
- cargo test -p conary-core packages::rpm
- cargo test -p remi signing_authority
- cargo test -p remi deployment
- cargo test -p remi prewarm
- cargo test -p remi native_publish
- cargo test -p remi handlers::tuf
- cargo test -p remi release_upload_
- cargo test -p remi conversion
- cargo test -p remi
- cargo test -p conary --test conversion_integration golden_conversion
- cargo test -p conary --test packaging_m4c
- cargo test -p conary-test container::image
- cargo test -p conary-test ubuntu_source_builder_proves_pinned_rust_and_native_crypto_tools
- bash scripts/test-remi-deploy-helper.sh
- bash scripts/check-doc-truth.sh
- bash scripts/test-doc-truth.sh
- bash scripts/test-agent-context.sh
- bash scripts/agent-context.sh --validate
- bash scripts/agent-context.sh --path apps/remi/src/server/signing_authority.rs
- bash scripts/agent-context.sh --path crates/conary-core/src/packages/rpm/payload/stream.rs
- bash scripts/agent-context.sh --path apps/conary/tests/integration/remi/containers/Containerfile.ubuntu-26.04
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --check
- git diff --check
```

Protected release/deployment and independent production proof remain tracked on #95 after merge; this PR intentionally uses `Refs #95` rather than closing it before that evidence exists.

## Review And Merge Notes

- Review focus: atomic authority publication and non-replacement behavior; exact route/profile identity; RPM target-byte authority; fail-closed Ubuntu toolchain acquisition
- User or developer impact: fresh Remi deployment becomes self-contained and conversion-capable without manual package or key exceptions; hosted lifecycle failures identify the real acquisition boundary
- Required-check bypass: not used