### PR TITLE
fix(remi): type conversion source checksums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - carry typed SHA-256 source identities through native conversion so Remi
   prewarming emits and persists signed CCS packages (#95)
+- accept dpkg's exact zero-sized archive-root directory as container metadata
+  without admitting an empty deployable package path (#95)
 
 ## [remi-v0.8.3] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [remi-v0.8.4] - 2026-07-27
+
+### Fixed
+- carry typed SHA-256 source identities through native conversion so Remi
+  prewarming emits and persists signed CCS packages (#95)
+
 ## [remi-v0.8.3] - 2026-07-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4857,7 +4857,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remi"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/apps/conary/src/commands/cook/foreign_package.rs
+++ b/apps/conary/src/commands/cook/foreign_package.rs
@@ -30,14 +30,10 @@ pub(super) fn cook_foreign_package(
     })?;
     let mut package_file = std::fs::File::open(package_path)
         .with_context(|| format!("Failed to open foreign package: {}", package_path.display()))?;
-    let checksum = format!(
-        "sha256:{}",
-        conary_core::hash::hash_reader(
-            conary_core::hash::HashAlgorithm::Sha256,
-            &mut package_file,
-        )?
-        .value
-    );
+    let checksum = conary_core::hash::hash_reader(
+        conary_core::hash::HashAlgorithm::Sha256,
+        &mut package_file,
+    )?;
     let payload = package.package_payload().with_context(|| {
         format!(
             "Failed to open payload for foreign package: {}",

--- a/apps/conary/src/commands/install/conversion.rs
+++ b/apps/conary/src/commands/install/conversion.rs
@@ -149,8 +149,8 @@ pub async fn try_convert_to_ccs(
                     "Failed to stream package checksum: {}",
                     package_path.display()
                 )
-            })?
-            .to_prefixed_string();
+            })?;
+    let original_checksum_text = original_checksum.to_prefixed_string();
 
     // Determine format string
     let format_str = match format {
@@ -165,13 +165,13 @@ pub async fn try_convert_to_ccs(
     // Check if already converted (skip re-conversion)
     if let Some(existing) = conary_core::db::models::ConvertedPackage::find_installed_by_checksum(
         &conn,
-        &original_checksum,
+        &original_checksum_text,
     )? {
         if existing.needs_reconversion() {
             info!("Re-converting {} (algorithm upgraded)", pkg.name());
             conary_core::db::models::ConvertedPackage::delete_installed_by_checksum(
                 &conn,
-                &original_checksum,
+                &original_checksum_text,
             )?;
         } else {
             // Already converted and up to date

--- a/apps/conary/tests/conversion_integration.rs
+++ b/apps/conary/tests/conversion_integration.rs
@@ -92,7 +92,8 @@ impl InMemoryConversionForTest for NativePackageConverter {
     ) -> anyhow::Result<conary_core::ccs::convert::ConversionResult> {
         let payload =
             conary_core::packages::PackagePayload::from_extracted_in_memory(files.to_vec())?;
-        self.convert_payload(metadata, payload.files(), format, checksum)
+        let checksum = conary_core::hash::Hash::parse_prefixed(checksum)?;
+        self.convert_payload(metadata, payload.files(), format, &checksum)
             .map_err(Into::into)
     }
 }

--- a/apps/remi/Cargo.toml
+++ b/apps/remi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remi"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]

--- a/apps/remi/src/server/conversion/persistence.rs
+++ b/apps/remi/src/server/conversion/persistence.rs
@@ -92,7 +92,7 @@ impl ConversionService {
             .as_ref()
             .ok_or_else(|| anyhow!("No CCS package path"))?;
 
-        let content_hash = Self::calculate_checksum(ccs_path)?;
+        let content_hash = Self::calculate_sha256(ccs_path)?.to_prefixed_string();
         let total_size = std::fs::metadata(ccs_path)?.len();
 
         let package_architecture = repo_pkg

--- a/apps/remi/src/server/conversion/storage.rs
+++ b/apps/remi/src/server/conversion/storage.rs
@@ -179,10 +179,13 @@ impl ConversionService {
         })
     }
 
-    /// Calculate SHA-256 checksum of a file
-    pub(super) fn calculate_checksum(path: &Path) -> Result<String> {
+    /// Calculate the typed SHA-256 checksum of a file.
+    pub(super) fn calculate_sha256(path: &Path) -> Result<conary_core::hash::Hash> {
         let mut file = std::fs::File::open(path)?;
-        Ok(conary_core::hash::sha256_reader_hex(&mut file)?)
+        Ok(conary_core::hash::hash_reader(
+            conary_core::hash::HashAlgorithm::Sha256,
+            &mut file,
+        )?)
     }
 }
 
@@ -216,17 +219,18 @@ mod tests {
     }
 
     #[test]
-    fn test_calculate_checksum_valid_file() {
+    fn calculated_sha256_is_typed_and_serializes_with_algorithm() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let file_path = temp_dir.path().join("test.pkg");
         std::fs::write(&file_path, b"hello world").unwrap();
 
-        let checksum = ConversionService::calculate_checksum(&file_path).unwrap();
+        let checksum = ConversionService::calculate_sha256(&file_path).unwrap();
         // SHA-256 of "hello world"
         assert_eq!(
-            checksum,
-            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+            checksum.to_prefixed_string(),
+            "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
         );
+        assert_eq!(checksum.algorithm, conary_core::hash::HashAlgorithm::Sha256);
     }
 
     #[test]
@@ -235,17 +239,17 @@ mod tests {
         let file_path = temp_dir.path().join("empty.pkg");
         std::fs::write(&file_path, b"").unwrap();
 
-        let checksum = ConversionService::calculate_checksum(&file_path).unwrap();
+        let checksum = ConversionService::calculate_sha256(&file_path).unwrap();
         // SHA-256 of empty string
         assert_eq!(
-            checksum,
-            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            checksum.to_prefixed_string(),
+            "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         );
     }
 
     #[test]
     fn test_calculate_checksum_missing_file() {
-        let result = ConversionService::calculate_checksum(Path::new("/nonexistent/file.pkg"));
+        let result = ConversionService::calculate_sha256(Path::new("/nonexistent/file.pkg"));
         assert!(result.is_err());
     }
 

--- a/apps/remi/src/server/conversion/workflow.rs
+++ b/apps/remi/src/server/conversion/workflow.rs
@@ -120,14 +120,15 @@ impl ConversionService {
         let checksum_path = pkg_path.clone();
         let started = Instant::now();
         let original_checksum =
-            tokio::task::spawn_blocking(move || Self::calculate_checksum(&checksum_path))
+            tokio::task::spawn_blocking(move || Self::calculate_sha256(&checksum_path))
                 .await
                 .map_err(|e| anyhow!("checksum task panicked: {e}"))??;
         timing.record(ConversionPhase::Checksum, started.elapsed());
+        let original_checksum_text = original_checksum.to_prefixed_string();
 
         let started = Instant::now();
         if let Some(existing) = self
-            .cached_conversion_result_async(source_feed.id(), &repo_pkg, &original_checksum)
+            .cached_conversion_result_async(source_feed.id(), &repo_pkg, &original_checksum_text)
             .await?
         {
             timing.record(ConversionPhase::CacheLookup, started.elapsed());
@@ -223,7 +224,7 @@ impl ConversionService {
         repo_pkg: RepositoryPackage,
         pkg_path: PathBuf,
         output_dir: PathBuf,
-        original_checksum: String,
+        original_checksum: conary_core::hash::Hash,
     ) -> Result<ParsedConversion> {
         let mut phase_timings = Vec::new();
         let mut skipped_phases = Vec::new();
@@ -286,7 +287,7 @@ impl ConversionService {
         Ok(ParsedConversion {
             metadata,
             format,
-            original_checksum,
+            original_checksum: original_checksum.to_prefixed_string(),
             conversion_result,
             repo_pkg,
             phase_timings,

--- a/crates/conary-core/src/ccs/convert/converter.rs
+++ b/crates/conary-core/src/ccs/convert/converter.rs
@@ -27,6 +27,7 @@ use crate::ccs::native_lifecycle::NativeLifecycleBundle;
 use crate::ccs::policy::BuildPolicyConfig;
 use crate::ccs::signing::SigningKeyPair;
 use crate::ccs::v2::PackageKindTagV2;
+use crate::hash::{Hash, HashAlgorithm};
 use crate::packages::common::PackageMetadata;
 use crate::packages::payload::PackagePayloadFile;
 use crate::recipe::hermetic::{
@@ -135,8 +136,15 @@ impl NativePackageConverter {
         metadata: &PackageMetadata,
         files: &[PackagePayloadFile],
         format: &str,
-        checksum: &str,
+        checksum: &Hash,
     ) -> Result<ConversionResult, ConversionError> {
+        if checksum.algorithm != HashAlgorithm::Sha256 {
+            return Err(ConversionError::ManifestError(format!(
+                "foreign conversion source checksum must use SHA-256, got '{}'",
+                checksum.algorithm
+            )));
+        }
+        let checksum = checksum.to_prefixed_string();
         let final_metadata = metadata.clone();
         let expected_version_scheme = match format {
             "rpm" => VersionScheme::Rpm,
@@ -160,7 +168,7 @@ impl NativePackageConverter {
         let build_risk_report = classify_foreign_build_body_risk(format, files);
         let scriptlet_risk_report = classify_foreign_scriptlet_risk(metadata);
         let conversion_evidence =
-            foreign_conversion_evidence(format, checksum, metadata, &build_risk_report);
+            foreign_conversion_evidence(format, &checksum, metadata, &build_risk_report);
         let conversion_evidence_hash =
             canonical_json_hash(&conversion_evidence).map_err(|error| {
                 ConversionError::ManifestError(format!(
@@ -185,7 +193,7 @@ impl NativePackageConverter {
             source_profile: self.source_profile.as_deref(),
             source_release: self.source_release.as_deref(),
             source_arch: metadata.architecture.as_deref(),
-            source_checksum: Some(checksum),
+            source_checksum: Some(&checksum),
             conversion_tool: self.conversion_tool.as_str(),
             conversion_tool_version: env!("CARGO_PKG_VERSION"),
         })
@@ -269,7 +277,7 @@ impl NativePackageConverter {
         let boundary = ForeignConversionBoundary {
             schema_version: FOREIGN_CONVERSION_BOUNDARY_SCHEMA_V1,
             source_format: format.to_string(),
-            source_checksum: checksum.to_string(),
+            source_checksum: checksum.clone(),
             output_identity,
             build_risk_report_hash: Some(build_risk_report_hash),
             build_risk_report: Some(build_risk_report),
@@ -328,7 +336,7 @@ impl NativePackageConverter {
             ))
         })?;
         let provenance = if artifact_exists {
-            NativeProvenance::extract_from_path(format, checksum, &metadata.package_path).map_err(
+            NativeProvenance::extract_from_path(format, &checksum, &metadata.package_path).map_err(
                 |error| {
                     ConversionError::IoError(format!(
                         "Failed to extract native package provenance: {error:#}"
@@ -340,7 +348,7 @@ impl NativePackageConverter {
                 "Native package artifact is unavailable for provenance inspection: {:?}",
                 metadata.package_path
             );
-            NativeProvenance::new(format, checksum)
+            NativeProvenance::new(format, &checksum)
         };
         if provenance.has_content() {
             tracing::info!(
@@ -357,7 +365,7 @@ impl NativePackageConverter {
             build_result,
             package_path: Some(package_path),
             original_format: format.to_string(),
-            original_checksum: checksum.to_string(),
+            original_checksum: checksum,
             native_provenance,
             native_lifecycle: Some(scriptlet_bundle.bundle),
             scriptlet_metadata: scriptlet_bundle.summary,

--- a/crates/conary-core/src/ccs/convert/converter/tests.rs
+++ b/crates/conary-core/src/ccs/convert/converter/tests.rs
@@ -30,7 +30,9 @@ impl InMemoryConversionForTest for NativePackageConverter {
     ) -> Result<ConversionResult, ConversionError> {
         let payload = crate::packages::PackagePayload::from_extracted_in_memory(files.to_vec())
             .map_err(|error| ConversionError::IoError(error.to_string()))?;
-        self.convert_payload(metadata, payload.files(), format, checksum)
+        let checksum =
+            crate::hash::Hash::parse_prefixed(checksum).expect("valid conversion test checksum");
+        self.convert_payload(metadata, payload.files(), format, &checksum)
     }
 }
 
@@ -234,6 +236,27 @@ fn passive_test_converter(output_dir: &std::path::Path) -> NativePackageConverte
     .with_signing_key(std::sync::Arc::new(
         crate::ccs::signing::SigningKeyPair::generate().with_key_id("converter-test"),
     ))
+}
+
+#[test]
+fn conversion_requires_typed_sha256_source_identity() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let metadata = make_test_metadata();
+    let files = make_test_files();
+    let payload = crate::packages::PackagePayload::from_extracted_in_memory(files).unwrap();
+    let checksum =
+        crate::hash::Hash::new(crate::hash::HashAlgorithm::Xxh128, "a".repeat(32)).unwrap();
+
+    let error = passive_test_converter(temp_dir.path())
+        .convert_payload(&metadata, payload.files(), "rpm", &checksum)
+        .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("source checksum must use SHA-256"),
+        "{error}"
+    );
 }
 
 fn verified_converted_package(result: &ConversionResult) -> crate::ccs::CcsPackage {

--- a/crates/conary-core/src/packages/deb/payload.rs
+++ b/crates/conary-core/src/packages/deb/payload.rs
@@ -23,6 +23,7 @@ use crate::payload::{
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::io::{Read, Write};
+use std::path::{Component, Path};
 #[cfg(test)]
 use std::sync::Arc;
 
@@ -168,6 +169,7 @@ fn parse_reader(
     let mut pending_long_name: Option<Vec<u8>> = None;
     let mut pending_long_link: Option<Vec<u8>> = None;
     let mut entries_seen = 0usize;
+    let mut archive_root_seen = false;
 
     while let Some(block) = read_header_block(&mut reader)? {
         if block.iter().all(|byte| *byte == 0) {
@@ -200,7 +202,22 @@ fn parse_reader(
 
         let raw_path = utf8_field(&header.path, "entry path")?;
         let directory_from_trailing_slash =
-            header.entry_type == TYPE_REGULAR && raw_path.ends_with('/');
+            matches!(header.entry_type, TYPE_REGULAR_OLD | TYPE_REGULAR) && raw_path.ends_with('/');
+        if is_archive_root_path(raw_path) {
+            if header.entry_type != TYPE_DIRECTORY && !directory_from_trailing_slash {
+                return Err(data_tar_error(format!(
+                    "archive root entry {raw_path:?} is not a directory"
+                )));
+            }
+            require_zero_size("/", header.size, "archive root directory")?;
+            if archive_root_seen {
+                return Err(data_tar_error(
+                    "duplicate archive root directory is not representable",
+                ));
+            }
+            archive_root_seen = true;
+            continue;
+        }
         let raw_path = if directory_from_trailing_slash {
             raw_path.trim_end_matches('/')
         } else {
@@ -303,6 +320,15 @@ fn parse_reader(
 
     resolve_hardlinks(&mut entries)?;
     Ok(entries)
+}
+
+/// dpkg normalizes leading slash/current-directory components onto its
+/// extraction root. That root is container metadata, not one package-owned
+/// deployable path in Conary's selected-root payload model.
+fn is_archive_root_path(path: &str) -> bool {
+    let mut components = Path::new(path).components().peekable();
+    components.peek().is_some()
+        && components.all(|component| matches!(component, Component::RootDir | Component::CurDir))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/conary-core/src/packages/deb/payload/tests.rs
+++ b/crates/conary-core/src/packages/deb/payload/tests.rs
@@ -35,6 +35,52 @@ fn finish(builder: Builder<Vec<u8>>) -> Vec<u8> {
 }
 
 #[test]
+fn accepts_one_exact_archive_root_directory_as_container_metadata() {
+    let mut builder = Builder::new(Vec::new());
+    append(&mut builder, "./", EntryType::Directory, 0o755, &[], None);
+    append(
+        &mut builder,
+        "./usr/bin/tool",
+        EntryType::Regular,
+        0o755,
+        b"tool",
+        None,
+    );
+
+    let parsed = parse_package_files(&finish(builder)).unwrap();
+
+    assert_eq!(parsed.len(), 1);
+    assert_eq!(parsed[0].path, "/usr/bin/tool");
+    assert_eq!(parsed[0].content.as_ref().unwrap().size, 4);
+}
+
+#[test]
+fn archive_root_must_be_one_zero_sized_directory() {
+    let mut duplicate = Builder::new(Vec::new());
+    append(&mut duplicate, "./", EntryType::Directory, 0o755, &[], None);
+    append(&mut duplicate, "./", EntryType::Directory, 0o755, &[], None);
+    let error = parse_package_files(&finish(duplicate)).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("duplicate archive root directory"),
+        "{error}"
+    );
+
+    let mut regular = Builder::new(Vec::new());
+    append(
+        &mut regular,
+        ".",
+        EntryType::Regular,
+        0o755,
+        b"not-a-directory",
+        None,
+    );
+    let error = parse_package_files(&finish(regular)).unwrap_err();
+    assert!(error.to_string().contains("is not a directory"), "{error}");
+}
+
+#[test]
 fn parses_exact_posix_nodes_and_hardlink_identity() {
     let mut builder = Builder::new(Vec::new());
     builder.mode(HeaderMode::Complete);

--- a/crates/conary-core/tests/native_abi.rs
+++ b/crates/conary-core/tests/native_abi.rs
@@ -462,13 +462,12 @@ fn assert_conversion_preserves_native_entries(
         .package_payload()
         .expect("open package payload sources");
 
+    let checksum = conary_core::hash::Hash::parse_prefixed(
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    )
+    .expect("valid native ABI test checksum");
     let result = converter
-        .convert_payload(
-            &metadata,
-            payload.files(),
-            format,
-            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        )
+        .convert_payload(&metadata, payload.files(), format, &checksum)
         .unwrap_or_else(|error| panic!("convert {format} package: {error}"));
 
     let bundle = result


### PR DESCRIPTION
## Primary Issue

Refs #95

Design / Plan / Roadmap: `docs/modules/remi.md`, `docs/modules/ccs.md`, issue #86 release suite

## Problem And Outcome

The protected `remi-v0.8.3` deployment installed the expected binary, populated all five native repositories, and provisioned all three exact-profile signing authorities, but persisted zero conversions. Production logs exposed two systemic failures:

1. Remi's file checksum helper returned an untyped bare hexadecimal string while the current CCS lifecycle contract requires an algorithm-qualified source identity.
2. Ubuntu `data.tar` archives carry the exact root directory entry `./`; the DEB payload parser passed that container root through deployable-path sanitization and rejected the resulting empty path.

After this change, the native converter accepts a parsed `Hash`, rejects non-SHA-256 algorithms structurally, and serializes the canonical `sha256:<hex>` form only at manifest/database boundaries. The DEB parser follows dpkg's source-level root normalization: it accepts exactly one zero-sized directory root as container metadata, rejects duplicate/non-directory/payload-bearing roots, and never creates an empty deployable path. Remi `0.8.4` is the repair release candidate.

## Changes

- change `NativePackageConverter::convert_payload` to accept typed hash authority and fail closed on non-SHA-256 input
- keep Remi package and emitted-CCS checksums typed until persistence/manifest serialization
- update direct install, foreign cook, Remi, native ABI, and golden conversion callers
- model dpkg archive-root handling structurally without weakening general path sanitization
- add regressions for algorithm enforcement, canonical prefixed serialization, accepted root metadata, and rejected ambiguous roots
- bump Remi to `0.8.4` and record both production repairs

## Scope

- In scope: the universal checksum-representation failure and Ubuntu archive-root parser failure blocking production profile population
- Out of scope: package-specific RPM hardlink metadata failures and six isolated Arch parser failures observed after these systemic blockers; schema changes; legacy bare-checksum compatibility; manual conversion or skip lists

## Ownership / Boundary

- Owning subsystem: `remi` conversion workflow and `ccs` native/DEB conversion boundary
- Boundary changed or preserved: strengthen source checksums from ambiguous strings to typed SHA-256 authority; preserve selected-root path safety while treating dpkg's archive root as container metadata
- Persisted state or public surface impact: newly persisted conversion source/content hashes are canonical algorithm-qualified SHA-256 strings; Ubuntu conversion becomes operable; no schema change
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service code
- [x] Updated subsystem docs or maps when the "look here first" path changed (no path changed)
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs (issue remains open for immutable release/deployment and per-profile production proof)

```text
- bash scripts/agent-context.sh --feature remi
- bash scripts/agent-context.sh --feature ccs
- cargo test -p remi conversion
- cargo test -p remi
- cargo test -p conary-core ccs::convert
- cargo test -p conary-core packages::rpm
- cargo test -p conary-core packages::deb
- cargo test -p conary-core --test native_abi
- cargo test -p conary --test conversion_integration golden_conversion
- cargo test -p conary --test packaging_m4c
- cargo clippy --workspace --all-targets -- -D warnings
- bash scripts/check-doc-truth.sh
- bash scripts/test-doc-truth.sh
- bash scripts/test-agent-context.sh
- bash scripts/agent-context.sh --validate
- cargo fmt --all --check
- git diff --check
- real Ubuntu 26.04 `gcc-15-for-build 15.2.0-16ubuntu1` DEB converted to a signed CCS v2 artifact with the repaired local binary
```

## Review And Merge Notes

- Review focus: typed hash propagation, canonical serialization at persistence boundaries, exact dpkg archive-root grammar, and absence of a bare-string/root-path compatibility bypass
- User or developer impact: restores automatic signed CCS prewarming for Fedora/Arch and unblocks Ubuntu package parsing; intentionally breaks source callers that supply untyped checksum strings
- Required-check bypass: not used