### PR TITLE
fix(remi): prewarm source profiles fairly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [remi-v0.8.5] - 2026-07-27
+
+### Fixed
+- prewarm exact source profiles concurrently under the configured conversion
+  bound so a slow first profile cannot starve later profiles or deployment
+  proof (#100)
+
 ## [remi-v0.8.4] - 2026-07-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4857,7 +4857,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remi"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/apps/remi/Cargo.toml
+++ b/apps/remi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remi"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]

--- a/apps/remi/src/server/config.rs
+++ b/apps/remi/src/server/config.rs
@@ -714,6 +714,9 @@ impl RemiConfig {
         if self.prewarm.convert_top_n == 0 {
             anyhow::bail!("prewarm.convert_top_n must be greater than zero");
         }
+        if !(1..=128).contains(&self.conversion.max_concurrent) {
+            anyhow::bail!("conversion.max_concurrent must be in the range 1..=128");
+        }
         for route in &self.prewarm.distros {
             if conary_core::repository::supported_profiles::profile_for_remi_route(route).is_none()
             {

--- a/apps/remi/src/server/config/tests.rs
+++ b/apps/remi/src/server/config/tests.rs
@@ -48,6 +48,13 @@ fn prewarm_contract_rejects_invalid_interval_and_profile() {
 }
 
 #[test]
+fn conversion_contract_rejects_invalid_concurrency() {
+    let mut invalid_concurrency = RemiConfig::default();
+    invalid_concurrency.conversion.max_concurrent = 0;
+    assert!(invalid_concurrency.validate().is_err());
+}
+
+#[test]
 fn test_storage_dirs() {
     let config = RemiConfig::default();
     let dirs = config.storage_dirs();

--- a/apps/remi/src/server/mod.rs
+++ b/apps/remi/src/server/mod.rs
@@ -570,6 +570,10 @@ pub async fn run_server_from_config(remi_config: &RemiConfig) -> Result<()> {
         } else {
             Vec::new()
         };
+        let prewarm_conversion_permits = {
+            let state = state.read().await;
+            state.job_manager.semaphore()
+        };
         tracing::info!(
             "  Metadata refresh: enabled every {}s",
             refresh_interval.as_secs()
@@ -606,6 +610,7 @@ pub async fn run_server_from_config(remi_config: &RemiConfig) -> Result<()> {
                             );
                         }
                         let successful_profiles = successful_refresh_profile_ids(&batch);
+                        let mut eligible_jobs = Vec::new();
                         for job in &prewarm_jobs {
                             if !prewarm_route_refreshed(&job.distro, &successful_profiles) {
                                 tracing::warn!(
@@ -614,17 +619,25 @@ pub async fn run_server_from_config(remi_config: &RemiConfig) -> Result<()> {
                                 );
                                 continue;
                             }
-                            match prewarm::run_prewarm(job).await {
+                            eligible_jobs.push(job.clone());
+                        }
+                        for outcome in prewarm::run_prewarm_jobs(
+                            eligible_jobs,
+                            Arc::clone(&prewarm_conversion_permits),
+                        )
+                        .await
+                        {
+                            match outcome.result {
                                 Ok(result) => tracing::info!(
                                     "Post-refresh pre-warm for {}: {} converted, {} skipped, {} failed",
-                                    job.distro,
+                                    outcome.distro,
                                     result.packages_converted,
                                     result.packages_skipped,
                                     result.packages_failed
                                 ),
                                 Err(error) => tracing::warn!(
                                     "Post-refresh pre-warm for {} failed: {}",
-                                    job.distro,
+                                    outcome.distro,
                                     error
                                 ),
                             }

--- a/apps/remi/src/server/prewarm.rs
+++ b/apps/remi/src/server/prewarm.rs
@@ -10,7 +10,12 @@ use conary_core::db::models::{ConvertedPackage, RepositoryPackage};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use tokio::sync::Semaphore;
 use tracing::{debug, info, warn};
+
+mod scheduler;
+
+pub(crate) use scheduler::run_prewarm_jobs;
 
 /// Pre-warming configuration
 #[derive(Debug, Clone)]
@@ -65,6 +70,13 @@ pub struct PackagePopularity {
 
 /// Run pre-warming job
 pub async fn run_prewarm(config: &PrewarmConfig) -> Result<PrewarmResult> {
+    run_prewarm_with_permits(config, None).await
+}
+
+async fn run_prewarm_with_permits(
+    config: &PrewarmConfig,
+    conversion_permits: Option<&Semaphore>,
+) -> Result<PrewarmResult> {
     let source_profile =
         conary_core::repository::supported_profiles::profile_for_remi_route(&config.distro)
             .ok_or_else(|| {
@@ -143,6 +155,15 @@ pub async fn run_prewarm(config: &PrewarmConfig) -> Result<PrewarmResult> {
 
         info!("Converting {} {}...", pkg.name, pkg.version);
 
+        let _permit = match conversion_permits {
+            Some(permits) => Some(
+                permits
+                    .acquire()
+                    .await
+                    .map_err(|_| anyhow::anyhow!("conversion semaphore closed"))?,
+            ),
+            None => None,
+        };
         match conversion_service
             .convert_package_async(
                 &config.distro,

--- a/apps/remi/src/server/prewarm/scheduler.rs
+++ b/apps/remi/src/server/prewarm/scheduler.rs
@@ -1,0 +1,184 @@
+// apps/remi/src/server/prewarm/scheduler.rs
+//! Bounded, fair scheduling across exact source-profile prewarm jobs.
+
+use super::{PrewarmConfig, PrewarmResult, run_prewarm_with_permits};
+use anyhow::Result;
+use futures::future::join_all;
+use std::future::Future;
+use std::sync::Arc;
+use tokio::sync::Semaphore;
+
+/// Completed result for one configured prewarm route.
+#[derive(Debug)]
+pub(crate) struct PrewarmJobOutcome {
+    pub(crate) distro: String,
+    pub(crate) result: Result<PrewarmResult>,
+}
+
+/// Run every exact-profile prewarm job against the shared conversion budget.
+///
+/// All configured profiles begin together. Each profile retains its own top-N
+/// ordering and sequential conversion semantics, while every individual
+/// conversion acquires the same permit used by request-driven conversion.
+pub(crate) async fn run_prewarm_jobs(
+    jobs: Vec<PrewarmConfig>,
+    conversion_permits: Arc<Semaphore>,
+) -> Vec<PrewarmJobOutcome> {
+    run_prewarm_jobs_with(jobs, conversion_permits, |job, permits| async move {
+        run_prewarm_with_permits(&job, Some(permits.as_ref())).await
+    })
+    .await
+}
+
+async fn run_prewarm_jobs_with<Runner, RunFuture>(
+    jobs: Vec<PrewarmConfig>,
+    conversion_permits: Arc<Semaphore>,
+    runner: Runner,
+) -> Vec<PrewarmJobOutcome>
+where
+    Runner: Fn(PrewarmConfig, Arc<Semaphore>) -> RunFuture + Clone,
+    RunFuture: Future<Output = Result<PrewarmResult>>,
+{
+    join_all(jobs.into_iter().map(move |job| {
+        let runner = runner.clone();
+        let distro = job.distro.clone();
+        let conversion_permits = Arc::clone(&conversion_permits);
+        async move {
+            PrewarmJobOutcome {
+                distro,
+                result: runner(job, conversion_permits).await,
+            }
+        }
+    }))
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+    use tokio::sync::mpsc;
+
+    fn job(distro: &str) -> PrewarmConfig {
+        PrewarmConfig {
+            db_path: "unused.db".to_string(),
+            chunk_dir: "unused-chunks".to_string(),
+            cache_dir: "unused-cache".to_string(),
+            repository_keys_dir: None,
+            distro: distro.to_string(),
+            max_packages: 1000,
+            popularity_file: None,
+            pattern: None,
+            dry_run: false,
+        }
+    }
+
+    fn empty_result() -> PrewarmResult {
+        PrewarmResult {
+            packages_processed: 0,
+            packages_converted: 0,
+            packages_skipped: 0,
+            packages_failed: 0,
+            total_bytes: 0,
+            converted: Vec::new(),
+            failed: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn slow_first_profile_does_not_starve_later_profiles() {
+        let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+        let release_first = Arc::new(Semaphore::new(0));
+        let runner_release = Arc::clone(&release_first);
+        let conversion_permits = Arc::new(Semaphore::new(1));
+        let runner = move |job: PrewarmConfig, permits: Arc<Semaphore>| {
+            let started_tx = started_tx.clone();
+            let release_first = Arc::clone(&runner_release);
+            async move {
+                started_tx.send(job.distro.clone()).unwrap();
+                let _permit = permits.acquire().await.unwrap();
+                if job.distro == "arch" {
+                    let release = release_first.acquire().await.unwrap();
+                    release.forget();
+                }
+                Ok(empty_result())
+            }
+        };
+
+        let scheduler = tokio::spawn(run_prewarm_jobs_with(
+            vec![job("arch"), job("fedora"), job("ubuntu")],
+            conversion_permits,
+            runner,
+        ));
+
+        let started = tokio::time::timeout(Duration::from_secs(1), async {
+            let mut started = HashSet::new();
+            while started.len() < 3 {
+                started.insert(started_rx.recv().await.unwrap());
+            }
+            started
+        })
+        .await
+        .expect("all profiles should start while the first profile holds the only permit");
+
+        assert_eq!(
+            started,
+            ["arch", "fedora", "ubuntu"]
+                .into_iter()
+                .map(str::to_string)
+                .collect()
+        );
+        release_first.add_permits(1);
+        assert_eq!(scheduler.await.unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn profile_failure_is_reported_and_shared_concurrency_is_bounded() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let runner_active = Arc::clone(&active);
+        let runner_peak = Arc::clone(&peak);
+        let runner = move |job: PrewarmConfig, permits: Arc<Semaphore>| {
+            let active = Arc::clone(&runner_active);
+            let peak = Arc::clone(&runner_peak);
+            async move {
+                let _permit = permits.acquire().await.unwrap();
+                let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                peak.fetch_max(current, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                active.fetch_sub(1, Ordering::SeqCst);
+                if job.distro == "fedora" {
+                    anyhow::bail!("source failed");
+                }
+                Ok(empty_result())
+            }
+        };
+
+        let outcomes = run_prewarm_jobs_with(
+            vec![job("arch"), job("fedora"), job("ubuntu")],
+            Arc::new(Semaphore::new(2)),
+            runner,
+        )
+        .await;
+
+        assert_eq!(outcomes.len(), 3);
+        assert_eq!(peak.load(Ordering::SeqCst), 2);
+        assert!(
+            outcomes
+                .iter()
+                .any(|outcome| outcome.distro == "fedora" && outcome.result.is_err())
+        );
+        assert!(
+            outcomes
+                .iter()
+                .any(|outcome| outcome.distro == "arch" && outcome.result.is_ok())
+        );
+        assert!(
+            outcomes
+                .iter()
+                .any(|outcome| outcome.distro == "ubuntu" && outcome.result.is_ok())
+        );
+    }
+}

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-07-27
-revision: 9
+revision: 10
 summary: Document Remi source, signing, canonical-map, repository trust, conversion, publication, and serving authority
 ---
 
@@ -51,11 +51,15 @@ read-only deployment inspection. It snapshots a current database or retires an
 old schema epoch before replacement, so health failure can restore config,
 source authority, and SQLite state together. Startup reconciles the installed
 manifest before opening listeners, then immediately refreshes metadata and
-runs prewarm jobs. Multi-source refresh returns one typed result or failure per
-source. A source failure remains visible but cannot discard successful source
-commits or suppress prewarm for another exact profile. Prewarm eligibility
-comes only from the successful result's persisted `source_profile`; repository
-names, URLs, formats, and error text are not selectors.
+runs eligible exact-profile prewarm jobs concurrently under the configured
+conversion bound shared with request-driven conversions. Each profile preserves
+its own top-N ordering and sequential conversion semantics, while a slow first
+profile cannot starve the profiles after it. Multi-source refresh returns one
+typed result or failure per source. A source failure remains visible but cannot
+discard successful source commits or suppress prewarm for another exact
+profile. Prewarm eligibility comes only from the successful result's persisted
+`source_profile`; repository names, URLs, formats, and error text are not
+selectors.
 
 Both internal and external `POST /v1/admin/refresh` routes use the same response
 projection: HTTP 200 means every source completed or was current, 207 carries a
@@ -69,7 +73,9 @@ so concurrent completion order is not API order.
 `apps/remi/src/server/admin_service/refresh.rs` owns the batch state, typed
 per-source results, and bounded concurrent collection. `server/mod.rs` owns the
 exact-profile handoff from successful refresh results into configured prewarm
-jobs; HTTP handlers only publish events and project the shared batch.
+jobs; `apps/remi/src/server/prewarm/scheduler.rs` owns their bounded fair
+execution and complete outcome collection. HTTP handlers only publish events
+and project the shared batch.
 
 ## Durable Repository Signing Authority
 


### PR DESCRIPTION
## Primary Issue

Refs #100

Design / Plan / Roadmap: production conversion closeout in #95

## Problem And Outcome

Remi ran each configured prewarm profile's entire top-1,000 batch serially. During the `remi-v0.8.4` deployment, production logged only the Arch prewarm start and accumulated hundreds of Arch conversions while the configured Fedora and Ubuntu jobs had not started. That made the strict per-profile deployment gate depend on profile ordering and package cost rather than conversion correctness.

After this change, every successfully refreshed exact profile starts together. Each individual background conversion acquires the same semaphore permit as request-driven conversion, so total conversion work stays within the configured bound. Each profile keeps its own top-N order and sequential semantics; one profile's error is collected without suppressing peer outcomes.

## Changes

- add a focused exact-profile prewarm scheduler that awaits every profile outcome
- acquire and release the shared conversion permit around each individual prewarm conversion
- pass only successfully refreshed exact profiles into the fair scheduler
- validate `conversion.max_concurrent` against the deployment contract
- document the new scheduling ownership and bump Remi to 0.8.5
- add regression tests for first-profile starvation, shared concurrency, and failure isolation

## Scope

- In scope: post-refresh prewarm orchestration, shared conversion concurrency, configuration validation, Remi 0.8.5 release metadata, and subsystem truth
- Out of scope: package-format defects tracked in #98 and #99; changes to top-N selection; deployment-gate weakening; synthetic conversion rows

## Ownership / Boundary

- Owning subsystem: Remi publication, serving, and admin
- Boundary changed or preserved: `prewarm.rs` retains one-profile top-N conversion; new `prewarm/scheduler.rs` owns cross-profile fair orchestration; `server/mod.rs` remains the thin refresh-to-prewarm handoff
- Persisted state or public surface impact: no schema or row-shape change; scheduling produces the same current converted artifacts earlier and fairly; release version becomes 0.8.5
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code
- [x] Updated subsystem docs or maps when the "look here first" path changed
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs

```text
cargo test -p remi prewarm::scheduler
cargo test -p remi
cargo test -p conary --test conversion_integration golden_conversion
cargo test -p conary --test packaging_m4c
bash scripts/test-remi-deploy-helper.sh
cargo clippy --workspace --all-targets -- -D warnings
cargo fmt --check
bash scripts/check-doc-truth.sh
bash scripts/test-doc-truth.sh
bash scripts/test-agent-context.sh
bash scripts/agent-context.sh --validate
bash scripts/agent-context.sh --path apps/remi/src/server/prewarm/scheduler.rs
git diff --check
```

Local result: 575 Remi library tests, five Remi CLI tests, three CLI-help tests, all interaction gates, strict lint, formatting, documentation truth, and ownership routing passed.

## Review And Merge Notes

- Review focus: permit lifetime is one package conversion, all exact-profile futures start together, and every result remains observable
- User or developer impact: clean deployments can prove all configured profiles without waiting for an earlier profile's full batch
- Required-check bypass: not used