### PR TITLE
docs(release): record post-hard-cut suite proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ attach only a reviewed support bundle.
 ## Try It
 
 Download the pinned preview release from
-[v0.13.0](https://github.com/ConaryLabs/Conary/releases/tag/v0.13.0) after its
-release page publishes `SHA256SUMS`, verify the package checksum, and install it
-only on a VM or non-critical host. Release artifact expectations are tracked in
+[v0.13.0](https://github.com/ConaryLabs/Conary/releases/tag/v0.13.0), verify
+the package against its published `SHA256SUMS`, and install it only on a VM or
+non-critical host. Release artifact evidence is tracked in
 [docs/operations/release-artifact-matrix.md](docs/operations/release-artifact-matrix.md).
 
 Then choose a source whose package format differs from the host and run the
@@ -130,7 +130,10 @@ first when the command supports it.
   advisory metadata support.
 - Native transaction-history import is not implemented.
 - Non-x86_64 generation boot assets are still reserved.
-- SBOM/provenance sidecars are not published for every preview artifact yet.
+- The 0.13 schema hard cut is not readable by the 0.12 CCS self-update parser;
+  install the 0.13 native package fresh instead of attempting that in-place
+  update.
+- SBOM/provenance sidecars are not published for the current preview suite.
 
 ## Common Commands
 

--- a/docs/operations/external-tester-outreach.md
+++ b/docs/operations/external-tester-outreach.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-26
-revision: 4
+last_updated: 2026-07-27
+revision: 5
 status: postponed
 target_release: v0.13.0
 summary: Postponed multi-venue launch packet for the first cross-distro tester loop
@@ -11,23 +11,21 @@ summary: Postponed multi-venue launch packet for the first cross-distro tester l
 > **POSTPONED; NO NEW DATE IS ASSIGNED:** the current qualifying milestone is
 > 0/10. The two earlier supported-host reports remain useful adoption and
 > onboarding evidence, but neither installed a source package whose format
-> differed from the host's native format. Intended release `v0.13.0` remains a
-> candidate, not a published tester baseline. Do not publish the copy below
-> until the cross-distro implementation has exact artifact and deployment
-> proof and the external cached-history and venue-eligibility gates are closed.
+> differed from the host's native format. Release `v0.13.0` is now the
+> published and verified tester baseline. Do not publish the copy below until
+> the separate external cached-history and venue-eligibility gates are closed.
 
-`v0.13.0` is the intended release for this packet. Treat that tag and every
-link below as a candidate until the release artifact matrix records the
-published tag, checksums, signature, installed-binary proof, live deployment,
-and a successful cross-distro package loop. The maintainer assigns fresh dates
-only after those facts are durable, then posts manually and remains available
-to answer comments.
+`v0.13.0` is the pinned release for this packet. The release artifact matrix
+records its published tag, checksums, signature, installed-binary proof, live
+deployment, and released-package cross-distro lifecycle. The maintainer assigns
+fresh dates only after the remaining external gates close, then posts manually
+and remains available to answer comments.
 
 ## Show HN Submission
 
 - **Title:** `Show HN: Conary - install RPM, DEB, and Arch packages across distros`
 - **URL:** `https://github.com/ConaryLabs/Conary`
-- **Reschedule state:** TBD after release and external launch-gate clearance
+- **Reschedule state:** TBD after external launch-gate clearance
 
 Submit the repository URL, then add the following opening comment.
 
@@ -73,7 +71,7 @@ before mutation; there is no capability-approval bypass.
 Agent-assisted walkthrough, including download and checksum verification:
 https://github.com/ConaryLabs/Conary/blob/v0.13.0/docs/guides/agent-assisted-tester-loop.md
 
-Pinned release candidate:
+Pinned release:
 https://github.com/ConaryLabs/Conary/releases/tag/v0.13.0
 
 Privacy-safe feedback form:
@@ -118,7 +116,7 @@ https://github.com/ConaryLabs/Conary/blob/v0.13.0/docs/guides/agent-assisted-tes
 Repository:
 https://github.com/ConaryLabs/Conary
 
-Pinned release candidate:
+Pinned release:
 https://github.com/ConaryLabs/Conary/releases/tag/v0.13.0
 
 I'm interested both in product defects and in whether repo-owned instructions
@@ -153,7 +151,7 @@ pinned release checksum, inspect the complete dry-run, ask before every live
 mutation, keep a private transcript, and draft privacy-safe feedback:
 https://github.com/ConaryLabs/Conary/blob/v0.13.0/docs/guides/agent-assisted-tester-loop.md
 
-Repository and release candidate:
+Repository and pinned release:
 https://github.com/ConaryLabs/Conary
 https://github.com/ConaryLabs/Conary/releases/tag/v0.13.0
 
@@ -186,13 +184,13 @@ failed attempts are useful evidence.
   reports as non-qualifying historical evidence.
 - [x] Rewrite the venue copy around the cross-distro package loop.
 - [x] Retire the passed 2026-07-20 through 2026-07-22 dates.
-- [ ] Publish immutable `v0.13.0` with RPM, DEB, Arch, CCS, checksums, and the
+- [x] Publish immutable `v0.13.0` with RPM, DEB, Arch, CCS, checksums, and the
   required signature and installed-binary evidence.
-- [ ] Record exact cross-distro install/query/update-preview/remove proof for
+- [x] Record exact cross-distro install/query/update-preview/remove proof for
   the released binary on supported hosts.
-- [ ] Deploy the exact release sites and independently verify live status and
+- [x] Deploy the exact release sites and independently verify live status and
   body claims.
-- [ ] Update the release artifact matrix and milestone tracker with exact
+- [x] Update the release artifact matrix and milestone tracker with exact
   release, deployment, and Remi population evidence.
 - [ ] Obtain GitHub Support confirmation that cached pre-rewrite pull-request
   and commit views have been dereferenced.

--- a/docs/operations/release-artifact-matrix.md
+++ b/docs/operations/release-artifact-matrix.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-07-26
-revision: 18
-summary: Track the post-hard-cut release suite and the proof required before its artifacts become preview-supported
+last_updated: 2026-07-27
+revision: 19
+summary: Record the verified post-hard-cut release suite and its limited-preview evidence
 ---
 
 # Release Artifact Matrix
@@ -15,25 +15,120 @@ Remote Forge validation is paused until a KVM-capable runner replaces the old
 VPS host. Local QEMU/KVM evidence may support a preview row only when it names
 the absolute run date, distro, suite, and pass counts.
 
-## Current Release Target
+## Current Release Suite
 
-The issue #86 release suite targets `v0.13.0`, `remi-v0.8.0`,
-`conaryd-v0.7.0`, and `conary-test-v0.9.0` from one reviewed release commit.
-All four rows are **pending publication**. Their candidate URLs must not be
-treated as downloads until the corresponding GitHub release exists and its
-assets pass the evidence gate below.
+Issue #86 produced a split immutable lineage rather than pretending that four
+products published at different times came from one commit:
 
-The preceding release proof is available through Git history. It is not
-current artifact authority after the owned manifests move to this suite.
-External outreach remains postponed until the Conary and Remi rows are
-published, deployed where applicable, and independently verified.
+- `v0.13.0` and the current `remi-v0.8.5` peel to
+  `6f1429c362ac161f1ef817233e72ee9c9a031c11`;
+- `conaryd-v0.7.0` and `conary-test-v0.9.0` peel to
+  `a231276a900bbe8a8ccb6a0942f104cba2ab86b4`;
+- published Remi 0.8.0 through 0.8.4 releases remain immutable recovery
+  evidence, but none is current production authority.
 
-| Product | Artifact classes | Release workflow | Source authority | Candidate release URL | Required evidence | Preview support | Known caveats | Source-build fallback |
+Conary and Remi are deployed and independently identified below. Conary's
+published native-package lifecycle matrix remains the final preview-support
+gate. Broad outreach is still postponed even after that gate passes.
+
+| Product | Artifact classes | Release workflow | Source authority | Release URL | Required evidence | Preview support | Known caveats | Source-build fallback |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `conary` | binary, `.ccs`, `.rpm`, `.deb`, `.pkg.tar.zst` | `.github/workflows/release-build.yml`, `scripts/release.sh conary`, `scripts/release-matrix.sh` | pending reviewed commit and annotated `v0.13.0` tag | https://github.com/ConaryLabs/Conary/releases/tag/v0.13.0 | pending: terminal merge and release CI; exact tag/commit proof; complete asset inventory; independent checksums and GitHub digests; CCS signature verification; installed-binary identity and self-update; RPM/DEB/Arch package smoke; one exact cross-distro lifecycle loop; exact-tag site and Remi deployment proof; SBOM/provenance status | closed pending evidence | pre-alpha; use only on a disposable VM or non-critical host; no artifact is supported before this row records proof | `cargo build -p conary` |
-| `remi` | binary and deploy bundle | `.github/workflows/release-build.yml`, `scripts/release.sh remi`, `scripts/release-matrix.sh` | pending reviewed commit and annotated `remi-v0.8.0` tag | https://github.com/ConaryLabs/Conary/releases/tag/remi-v0.8.0 | pending: terminal release CI; exact tag/commit proof; independent checksums and GitHub digests; installed-binary identity; deployment snapshot/retirement/repopulation result; pre/post full health; public-route and exact CCS proof; signature status; SBOM/provenance status | closed pending evidence | deployment intentionally retires the previous schema epoch and must prove rollback safety; no detached binary signature is expected unless publication says otherwise | `cargo build -p remi` |
-| `conaryd` | binary and tarball | `.github/workflows/release-build.yml`, `scripts/release.sh conaryd`, `scripts/release-matrix.sh` | pending reviewed commit and annotated `conaryd-v0.7.0` tag | https://github.com/ConaryLabs/Conary/releases/tag/conaryd-v0.7.0 | pending: terminal release CI; exact tag/commit proof; asset inventory; independent checksums and GitHub digests; binary identity; signature status; SBOM/provenance status | release artifact only; no deployment | Forge staging remains paused; package jobs retain the CLI live-mutation acknowledgement boundary | `cargo build -p conaryd` |
-| `conary-test` | binary and tarball | `.github/workflows/release-build.yml`, `scripts/release.sh conary-test`, `scripts/release-matrix.sh` | pending reviewed commit and annotated `conary-test-v0.9.0` tag | https://github.com/ConaryLabs/Conary/releases/tag/conary-test-v0.9.0 | pending: terminal release CI; exact tag/commit proof; asset inventory; independent checksums and GitHub digests; binary identity and suite inventory; signature status; SBOM/provenance status | release artifact only; no deployment | QEMU/KVM suites require a capable local host while remote validation is paused | `cargo build -p conary-test` |
+| `conary` | binary, `.ccs`, `.rpm`, `.deb`, `.pkg.tar.zst` | `.github/workflows/release-build.yml`, `scripts/release.sh conary`, `scripts/release-matrix.sh` | annotated tag object `f8298522fd7fe95a4994184ae20c34cf64096818`, commit `6f1429c362ac161f1ef817233e72ee9c9a031c11` | https://github.com/ConaryLabs/Conary/releases/tag/v0.13.0 | exact publication, checksums, GitHub digests, detached signature, current binary/self-update, deployment, endpoint, site, SBOM, and provenance status recorded below; published native-package lifecycle run `30263948968` is in progress | closed until run `30263948968` passes | pre-alpha; disposable, snapshotted, or explicitly non-critical x86_64 Fedora 44, Ubuntu 26.04 LTS, and Arch hosts only; the intentional schema hard cut requires a fresh native-package install from 0.12 | `cargo build -p conary` |
+| `remi` | binary and deploy bundle | `.github/workflows/release-build.yml`, `scripts/release.sh remi`, `scripts/release-matrix.sh` | annotated tag object `1d9b8588fe01453bab20f1a7956e4aa9d6263702`, commit `6f1429c362ac161f1ef817233e72ee9c9a031c11` | https://github.com/ConaryLabs/Conary/releases/tag/remi-v0.8.5 | exact publication, checksums, installed identity, signature, protected deployment, current schema/source/signing state, conversions, full health, public converted CCS, SBOM, and provenance status recorded below | live operator service | conversion defects are explicit engineering work in #98, #99, and #102 through #105; unknown `/v1` paths currently receive the SPA fallback instead of an API 404 and are tracked in #67 | `cargo build -p remi` |
+| `conaryd` | binary and tarball | `.github/workflows/release-build.yml`, `scripts/release.sh conaryd`, `scripts/release-matrix.sh` | annotated tag object `381ee55cd051234dd78647ef5d7a8c3250c6b9df`, commit `a231276a900bbe8a8ccb6a0942f104cba2ab86b4` | https://github.com/ConaryLabs/Conary/releases/tag/conaryd-v0.7.0 | exact publication, three-asset inventory, matching independent/GitHub checksums, raw/tar identity, binary version, build-only routing, signature, SBOM, and provenance status recorded below | release artifact only; no deployment | Forge staging remains paused; package jobs retain the CLI live-mutation acknowledgement boundary | `cargo build -p conaryd` |
+| `conary-test` | binary and tarball | `.github/workflows/release-build.yml`, `scripts/release.sh conary-test`, `scripts/release-matrix.sh` | annotated tag object `6c4a8cb4bb2c6e89f359a8ceb89ac40a5ce06890`, commit `a231276a900bbe8a8ccb6a0942f104cba2ab86b4` | https://github.com/ConaryLabs/Conary/releases/tag/conary-test-v0.9.0 | exact publication, three-asset inventory, matching independent/GitHub checksums, raw/tar identity, binary version, suite inventory, build-only routing, signature, SBOM, and provenance status recorded below | release artifact only; no deployment | QEMU/KVM suites require a capable local host while remote validation is paused | `cargo build -p conary-test` |
+
+## Recorded Evidence
+
+### Conary 0.13.0
+
+- The release published at `2026-07-27T11:57:44Z`. Exact-tag
+  release-build run `30261256730` passed the workspace gate and all four
+  package builders.
+- Independent downloads found exactly seven assets. Their SHA-256 values
+  matched the GitHub REST digests:
+  - `SHA256SUMS`:
+    `ce67a7199f8adafec8d1a47a29d5b3ccd0c32068fff0804653251daa35d436c7`
+  - `conary-0.13.0-1-x86_64.pkg.tar.zst`:
+    `a2905964c1272ab0e7c963102429501fa4ab05a6b569b8b1d1f02b5be4e20997`
+  - `conary-0.13.0-1.fc44.x86_64.rpm`:
+    `f65adc8cad33e46c26d3aa6dcb0d47a89382857e5ece0f7fe6da7b787d4d76d8`
+  - `conary-0.13.0.ccs`:
+    `9f6bb7208aaf196a73a482d32aec918cb032857a002c85ecc40c51e4c44bd927`
+  - `conary-0.13.0.ccs.sig`:
+    `b47bde4d29394558dd0bd15554dc6e79f05776886f0c63807a0c3a644eb01a00`
+  - `conary_0.13.0-1_amd64.deb`:
+    `c67ea72ac8b8a3d061b6f0bf943fab1bb15258cfc7d6d3d0b0dea9bf2b472b9c`
+  - `metadata.json`:
+    `386f3ef51846d20186a6a42fda1dc14c8f0bda56db46ba57445974ec2ae26a90`
+- All five `SHA256SUMS` entries passed. Metadata names product `conary`,
+  version `0.13.0`, tag `v0.13.0`, live `release_bundle` deployment, and
+  `dry_run: false`. Extracted RPM and DEB binaries report `conary 0.13.0`;
+  the Arch package declares `conary 0.13.0-1 x86_64`.
+- The official 0.12 binary and embedded release key verified the detached
+  signature over the CCS digest. A copied released 0.13.0 RPM binary then
+  initialized an isolated database, reported itself current, forced a signed
+  download, verified and extracted the CCS, replaced only its copied binary,
+  and again reported `conary 0.13.0` and current.
+- The 0.12 binary intentionally cannot parse the current CCS component
+  manifest after the schema hard cut. This suite does not restore a legacy
+  parser: install the 0.13 native package fresh instead of claiming an
+  in-place 0.12-to-0.13 self-update.
+- Deploy job `deploy-conary` in run `30263948968` passed. The server's
+  `/conary/releases/latest` selects `0.13.0`; all seven deployed hashes match
+  the release; the self-update endpoint reports version `0.13.0`, the exact
+  CCS hash and size, and a signature. Both sites were built from the exact tag:
+  conary.io and its install guide serve `v0.13.0`, while an unknown route
+  returns the branded HTTP 404.
+- The three published-native-package lifecycle jobs in run `30263948968`
+  remain in progress. This row stays closed until all three and the aggregate
+  job pass.
+- No SBOM or provenance sidecars are published. The CCS has both its embedded
+  package authority and the separately verified release-digest signature.
+
+### Remi 0.8.5
+
+- Exact-tag release-build run `30259180128` passed, and the release published
+  at `2026-07-27T11:09:12Z`.
+- Independent downloads found exactly three assets whose SHA-256 values
+  matched GitHub: `metadata.json`
+  `e036548d3469a1ffd28d8687ffae1fb7b88662d7d284a7cbbe08015dc2f79bc8`,
+  raw binary
+  `ad949c026578bbadc8f45402d167b577f28fec5c3780839ac27c09d4718f008d`,
+  and tarball
+  `dfae67f91adc268009bd6f8e128ffd1f8103d82efe92d729da319e88bf3cc42a`.
+  Raw and tarred binaries are identical and report `remi 0.8.5`.
+- Protected deploy run `30260847616` passed. Independent inspection reports
+  schema epoch `conary-current-v1`, revision 21, five configured and populated
+  sources, 98,266 repository packages, exact signing profiles `arch`,
+  `fedora-44`, and `ubuntu-26.04`, and 2,368 current conversions at the final
+  release check.
+- Full public health passes 10/10. A Fedora `curl` request returns a converted,
+  native-free CCS artifact. No detached binary signature, SBOM, or provenance
+  sidecar is published for this release.
+
+### conaryd 0.7.0 and conary-test 0.9.0
+
+- Release-build runs `30225403876` and `30225404886` passed at their shared
+  immutable commit; deploy-routing runs `30226301835` and `30226177794`
+  selected `no-deploy-required`, as the matrix requires.
+- conaryd published at `2026-07-26T23:56:22Z`. Its metadata, raw binary, and
+  tarball hashes are respectively
+  `a9c902fad9dc9be09608a0d8e3e699fa7178d727822bc507d18bdc503b25d612`,
+  `3e1559b13386ddd1effedc96a1f083c200e1b3bed2d062135b5e687143c259b3`,
+  and `6bacb205a945150a6bfd4039370d54b5dc5a56599b63a4c51ac9e675fc5bf1f6`.
+  Independent downloads match GitHub, raw and tarred binaries are identical,
+  and the binary reports `conaryd 0.7.0`.
+- conary-test published at `2026-07-26T23:52:48Z`. Its metadata, raw binary,
+  and tarball hashes are respectively
+  `ba29e17684039588340e58c4363db1c38f064781f58c030c326952c75c8480f9`,
+  `1d8a4c7fa78c2e20955fd43c4e8c55ee263b768e8e743a19cbd657667feb5ecc`,
+  and `e1476e24c6aa78f079d5374590f034bcd26860be0da98c4fd15ef31a7204f967`.
+  Independent downloads match GitHub, raw and tarred binaries are identical,
+  the binary reports `conary-test 0.9.0`, and `list` exposes the native
+  cross-source lifecycle plus the complete owned suite inventory.
+- Neither build-only product publishes a detached signature, SBOM, or
+  provenance sidecar.
 
 Deploy-helper artifact publication uses CI-produced trust inputs as evidence:
 `conary-remi-deploy deploy-conary` verifies staged `SHA256SUMS` before

--- a/docs/operations/release-artifact-matrix.md
+++ b/docs/operations/release-artifact-matrix.md
@@ -28,12 +28,13 @@ products published at different times came from one commit:
   evidence, but none is current production authority.
 
 Conary and Remi are deployed and independently identified below. Conary's
-published native-package lifecycle matrix remains the final preview-support
-gate. Broad outreach is still postponed even after that gate passes.
+published native-package lifecycle matrix passed on all three supported hosts,
+so the bounded pre-alpha preview is open. Broad outreach remains separately
+postponed.
 
 | Product | Artifact classes | Release workflow | Source authority | Release URL | Required evidence | Preview support | Known caveats | Source-build fallback |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `conary` | binary, `.ccs`, `.rpm`, `.deb`, `.pkg.tar.zst` | `.github/workflows/release-build.yml`, `scripts/release.sh conary`, `scripts/release-matrix.sh` | annotated tag object `f8298522fd7fe95a4994184ae20c34cf64096818`, commit `6f1429c362ac161f1ef817233e72ee9c9a031c11` | https://github.com/ConaryLabs/Conary/releases/tag/v0.13.0 | exact publication, checksums, GitHub digests, detached signature, current binary/self-update, deployment, endpoint, site, SBOM, and provenance status recorded below; published native-package lifecycle run `30263948968` is in progress | closed until run `30263948968` passes | pre-alpha; disposable, snapshotted, or explicitly non-critical x86_64 Fedora 44, Ubuntu 26.04 LTS, and Arch hosts only; the intentional schema hard cut requires a fresh native-package install from 0.12 | `cargo build -p conary` |
+| `conary` | binary, `.ccs`, `.rpm`, `.deb`, `.pkg.tar.zst` | `.github/workflows/release-build.yml`, `scripts/release.sh conary`, `scripts/release-matrix.sh` | annotated tag object `f8298522fd7fe95a4994184ae20c34cf64096818`, commit `6f1429c362ac161f1ef817233e72ee9c9a031c11` | https://github.com/ConaryLabs/Conary/releases/tag/v0.13.0 | exact publication, checksums, GitHub digests, detached signature, current binary/self-update, deployment, endpoint, site, released-package lifecycle, SBOM, and provenance status recorded below | limited pre-alpha preview | disposable, snapshotted, or explicitly non-critical x86_64 Fedora 44, Ubuntu 26.04 LTS, and Arch hosts only; the intentional schema hard cut requires a fresh native-package install from 0.12 | `cargo build -p conary` |
 | `remi` | binary and deploy bundle | `.github/workflows/release-build.yml`, `scripts/release.sh remi`, `scripts/release-matrix.sh` | annotated tag object `1d9b8588fe01453bab20f1a7956e4aa9d6263702`, commit `6f1429c362ac161f1ef817233e72ee9c9a031c11` | https://github.com/ConaryLabs/Conary/releases/tag/remi-v0.8.5 | exact publication, checksums, installed identity, signature, protected deployment, current schema/source/signing state, conversions, full health, public converted CCS, SBOM, and provenance status recorded below | live operator service | conversion defects are explicit engineering work in #98, #99, and #102 through #105; unknown `/v1` paths currently receive the SPA fallback instead of an API 404 and are tracked in #67 | `cargo build -p remi` |
 | `conaryd` | binary and tarball | `.github/workflows/release-build.yml`, `scripts/release.sh conaryd`, `scripts/release-matrix.sh` | annotated tag object `381ee55cd051234dd78647ef5d7a8c3250c6b9df`, commit `a231276a900bbe8a8ccb6a0942f104cba2ab86b4` | https://github.com/ConaryLabs/Conary/releases/tag/conaryd-v0.7.0 | exact publication, three-asset inventory, matching independent/GitHub checksums, raw/tar identity, binary version, build-only routing, signature, SBOM, and provenance status recorded below | release artifact only; no deployment | Forge staging remains paused; package jobs retain the CLI live-mutation acknowledgement boundary | `cargo build -p conaryd` |
 | `conary-test` | binary and tarball | `.github/workflows/release-build.yml`, `scripts/release.sh conary-test`, `scripts/release-matrix.sh` | annotated tag object `6c4a8cb4bb2c6e89f359a8ceb89ac40a5ce06890`, commit `a231276a900bbe8a8ccb6a0942f104cba2ab86b4` | https://github.com/ConaryLabs/Conary/releases/tag/conary-test-v0.9.0 | exact publication, three-asset inventory, matching independent/GitHub checksums, raw/tar identity, binary version, suite inventory, build-only routing, signature, SBOM, and provenance status recorded below | release artifact only; no deployment | QEMU/KVM suites require a capable local host while remote validation is paused | `cargo build -p conary-test` |
@@ -80,9 +81,11 @@ gate. Broad outreach is still postponed even after that gate passes.
   CCS hash and size, and a signature. Both sites were built from the exact tag:
   conary.io and its install guide serve `v0.13.0`, while an unknown route
   returns the branded HTTP 404.
-- The three published-native-package lifecycle jobs in run `30263948968`
-  remain in progress. This row stays closed until all three and the aggregate
-  job pass.
+- Run `30263948968` completed successfully. Its immutable RPM, DEB, and Arch
+  packages installed through the native package managers on Fedora 44, Ubuntu
+  26.04 LTS, and Arch; each host passed the one owned Cartesian
+  native-cross-source lifecycle suite, and the aggregate
+  `release-artifact-proof` job passed.
 - No SBOM or provenance sidecars are published. The CCS has both its embedded
   package authority and the separately verified release-digest signature.
 

--- a/docs/roadmaps/development-roadmap.md
+++ b/docs/roadmaps/development-roadmap.md
@@ -1,8 +1,8 @@
 ---
-last_updated: 2026-07-25
-revision: 4
+last_updated: 2026-07-27
+revision: 5
 summary: Track Conary's cross-distro package milestone, ordered workstreams, evidence, blockers, and post-milestone horizons
-proof_baseline: "v0.12.0 at eb256b19b4f04ca1d03b6af39a2819d746d3a22a; release and issue-remediation proof complete"
+proof_baseline: "v0.13.0 and remi-v0.8.5 at 6f1429c362ac161f1ef817233e72ee9c9a031c11; post-hard-cut release, deployment, and three-distro artifact proof complete"
 current_milestone: first external tester loop
 active_workstream: W3 First External Tester Loop
 next_workstream: post-milestone work selected from tester evidence
@@ -90,16 +90,16 @@ the stated scope, not whether a workstream happens to be active.
 | CLI and core package operations | solid | Scope is the limited preview; external use and fresh combined proof matter more than new surface area. |
 | Adoption, unadoption, and native handoff | solid | Proof covers the current three-distro scope; the released Arch package initializes only its exact native profile and synchronizes Remi. |
 | Database, CAS, native parsing, and resolution | solid | Some advanced repository-policy abstractions and integration edges remain incomplete. |
-| Packaging, static repositories, trust, and self-update | solid | `v0.12.0` has exact tag, artifact hashes, signature, supported Arch-path, deployment, and real installed-binary self-update proof. No SBOM/provenance sidecars are published or planned. |
-| CCS conversion and native lifecycle authority | active hard switch | PR #61 replaces review/refusal-era scriptlet policy with exact RPM, Debian, and ALPM lifecycle transactions; release, deployment, and cross-distro matrix proof remain. |
+| Packaging, static repositories, trust, and self-update | solid | `v0.13.0` has exact tag, hashes, detached signature, current signed self-update, deployment, and native RPM/DEB/Arch installed-binary proof. The intentional 0.12 schema boundary requires a fresh native-package install. No SBOM/provenance sidecars are published or planned. |
+| CCS conversion and native lifecycle authority | active hard switch | The exact RPM, Debian, and ALPM lifecycle contract is released and deployed; current source-backed format defects are explicit work in #98, #99, and #102 through #105 rather than manual-review authority. |
 | Generation build and export | limited | Proven paths are x86_64; non-x86 assets, signed boot authority, and persistent-effect rollback remain later work. |
 | Model, source selection, and replatforming | limited | Some resolution deltas and builder inputs are not wired end to end. |
 | Bootstrap and self-hosting | limited | Rootful, chroot, fixture, and QEMU dependencies need repeatable current proof. |
-| Remi core and publication | solid | Operator-run limited-preview scope; distribution, cold-start readiness, and a wider stranger-operated path remain limited. |
+| Remi core and publication | solid | `remi-v0.8.5` is deployed on the current schema with five populated sources, exact signing profiles, fair prewarm, real conversions, and full public health; distribution and a wider stranger-operated path remain limited. |
 | conaryd package and query service | limited | Authorization is exact root/daemon/configured-group authority; restart semantics, resolver-backed dry-run proof, and deployment remain incomplete. |
 | Federation | experimental | Coordinator and fetch paths are not wired into serving; TLS identity documentation and enforcement do not yet agree. |
 | Advanced derivation, lock, and reproducibility flows | unfinished | Several interfaces exist without complete persisted inputs or update-path integration. |
-| External product readiness | unfinished | One organic tester completed the former adoption flow on Ubuntu 26.04 and Fedora 44 with verified release-package checksums; the revised cross-distro milestone is 0/10, the former 2026-07-20 through 2026-07-22 outreach slots passed without posts, and new outreach requires a released cross-distro matrix. |
+| External product readiness | unfinished | The `v0.13.0` released-package matrix is complete, but the revised cross-distro milestone remains 0/10. The former 2026-07-20 through 2026-07-22 outreach slots passed without posts; rescheduling still requires cached-history and current venue-eligibility clearance. |
 
 ## Workstreams
 
@@ -139,20 +139,20 @@ the stated scope, not whether a workstream happens to be active.
 - **Outcome:** Conary has external evidence that strangers can install and
   remove a package whose source format differs from the supported host's native
   format.
-- **Current truth:** the W3a publication and issue-remediation gate is complete
-  at immutable `v0.12.0`. It preserves the preceding exact SONAME, ELF-class,
-  and constraint-aware Arch fixes and adds safe in-root system-symlink
-  traversal plus usable installed-host support diagnostics. No broad external
-  venue post has been published. One organic external tester completed the
-  former adoption-led flow on Ubuntu 26.04 LTS and Fedora 44. Those reports
-  remain valid release/onboarding evidence but do not count toward the revised
-  cross-distro milestone, so the tracker is 0/10.
-  The former 2026-07-20 through 2026-07-22 outreach window passed without a
-  post. Issue #41's reported Artix host and Fedora-form source route remain
-  outside supported-scope proof and require the repaired bundle's source-selection,
-  source-pin, and repository evidence before classification.
-- **Execution status:** active; release remediation is complete, but broad
-  outreach and its replacement dates remain postponed.
+- **Current truth:** the post-hard-cut release gate is complete at immutable
+  `v0.13.0` with compatible production `remi-v0.8.5`. The released RPM, DEB,
+  and Arch packages passed the Cartesian source-format lifecycle on Fedora 44,
+  Ubuntu 26.04 LTS, and Arch. No broad external venue post has been published.
+  One organic external tester's former adoption-led Ubuntu and Fedora reports
+  remain valid onboarding evidence but do not count toward the revised
+  cross-distro milestone, so the tracker remains 0/10. The former 2026-07-20
+  through 2026-07-22 outreach window passed without a post. Issue #41's Artix
+  host and Fedora-form source route remain outside the supported host proof and
+  require exact source-selection, source-pin, and repository evidence before
+  classification.
+- **Execution status:** active; release, deployment, and published-package
+  proof are complete, while broad outreach and replacement dates remain
+  postponed.
 - **Dependencies:** GitHub Support must dereference the cached pull-request and
   commit views that still expose pre-rewrite history, and the maintainer must
   re-check each venue's current account/rule eligibility immediately before
@@ -160,47 +160,37 @@ the stated scope, not whether a workstream happens to be active.
 - **Next gate:** after GitHub Support confirms the cached history is no longer
   reachable and venue checks pass, assign a new staggered schedule. Then submit
   the refreshed Show HN packet, record its actual URL and timestamp, and
-  continue collecting privacy-safe reports toward the second unique qualifying
+  collect privacy-safe reports toward the first unique qualifying
   tester.
-- **Proof:** immutable `v0.12.0` was published at
-  `2026-07-23T21:39:20Z`; annotated tag object
-  `8411169b40d8523ee716518cb3dc3e51acddb019` peels to commit
-  `eb256b19b4f04ca1d03b6af39a2819d746d3a22a`. Remediation merge CI
-  `30041401268` and release-commit CI `30042990554` passed 11/11 jobs,
-  release-build `30043930486` passed, and exact-tag deploy-and-verify
-  `30047027525` passed. Seven assets are published; independent downloads
-  matched all five `SHA256SUMS` payloads and all seven REST digests, and the
-  official preceding binary verified the detached CCS signature. An isolated
-  schema-77 database completed a signed update from the official preceding
-  preview to `v0.12.0` and then reported itself current. The exact Arch package
-  binary initialized profile `arch`, synchronized 15,462 Arch-only Remi rows,
-  installed and
-  executed `htop 3.5.2-1-arch`, and removed all five files and the trove. In
-  the same isolated writable root it installed and removed a one-file probe
-  through `/usr/lib64 -> lib`, while a paired out-of-root symlink was rejected
-  without an outside write or trove. Host pacman inventory, linker cache,
-  installed Conary binary, and `/usr/lib64` stayed unchanged. This was exact
-  released-binary proof with live-host pacman evidence read-only, not native
-  `pacman -U` or a pristine VM. Support-bundle self-tests passed, and an
-  isolated bundle captured integrity, table, repository, and profile summaries
-  without including its database; this host had no installed root-owned
-  Conary database for a live cached-sudo success. Full Remi health passed
-  10/10, six public routes returned HTTP 200, and the deployed CCS matched
-  release hash
-  `c973fb654b67da0619d6837b34e2f5f78bbea90dfd9fb8de19b6edf9cbe9582a`,
-  size `16183371`, and signature. The preceding Fedora-form KVM result remains
-  a conaryOS regression baseline rather than literal stock Fedora native-PM
-  proof. No SBOM or provenance sidecars are published or planned. The
-  repository Welcome Discussion remains live at discussion 36, and issue 35
-  remains closed with its released-path proof; neither repository action
-  launches broad outreach. Issues 37 and 38 remain two supported-host attempts
-  by one unique tester. They are historical onboarding evidence, not
-  completions under the revised milestone. Each qualifying completion belongs
-  to a unique outsider and covers exactly `foreign artifact install ->
-  list/query -> update --dry-run -> remove` on a supported host with the pinned
-  release, where source and host native package formats differ. Record failed
-  attempts and triage every report as `fix-now`, `next-slice`,
-  `validated-no-action`, or `declined-with-reason` with an owner.
+- **Proof:** immutable `v0.13.0` published at `2026-07-27T11:57:44Z`;
+  annotated tag object `f8298522fd7fe95a4994184ae20c34cf64096818`
+  peels to `6f1429c362ac161f1ef817233e72ee9c9a031c11`. Exact-tag
+  release-build `30261256730` passed the workspace and four package builders.
+  Independent downloads found exactly seven assets, matched all five
+  `SHA256SUMS` entries and every GitHub digest, and verified the detached CCS
+  signature with the official preceding release key. A copied released 0.13
+  binary forced a signed update through the production channel and remained
+  `conary 0.13.0`; the incompatible 0.12 CCS parser is an intentional hard-cut
+  reinstall boundary, not a compatibility path. Deploy-and-proof run
+  `30263948968` passed: the server's exact seven files match the release,
+  conary.io serves the exact tag and a branded HTTP 404, and native RPM, DEB,
+  and Arch packages each installed and passed the owned Cartesian lifecycle on
+  their matching supported host. Current `remi-v0.8.5` tag object
+  `1d9b8588fe01453bab20f1a7956e4aa9d6263702` peels to the same commit;
+  release-build `30259180128` and protected deploy `30260847616` passed. Live
+  inspection reports schema revision 21, five populated sources, 98,266
+  repository packages, exact Arch/Fedora/Ubuntu signing profiles, 2,368
+  conversions, full health 10/10, and public converted CCS proof. conaryd
+  0.7.0 and conary-test 0.9.0 remain immutable build-only products from
+  `a231276a900bbe8a8ccb6a0942f104cba2ab86b4`. Exact hashes and complete
+  per-product evidence live in the release matrix. No SBOM or provenance
+  sidecars are published. The known conversion failures are owned by #98,
+  #99, and #102 through #105; the false-success unknown API fallback is owned
+  by #67 rather than hidden as release success. Issues 37 and 38 remain two
+  same-format onboarding attempts by one person and contribute zero qualifying
+  completions. Each future completion belongs to a unique outsider and covers
+  exactly `foreign artifact install -> list/query -> update --dry-run ->
+  remove` on a supported host where source and host formats differ.
 - **Limitations:** no qualifying completion for three weeks after launch
   triggers a maintainer review of venue reach, onboarding friction, and
   observed failures. A pivot still requires a reproducible systemic blocker;
@@ -322,8 +312,10 @@ checksum and CCS-signature verification, production deployment, official
 installed-binary self-update, compatible prewarmed Remi, rollback, and
 clean-host proof. W3 is now active; its earlier release proof gate was reopened
 for the supported `htop` SONAME repair and again for issue #41's path-safety
-and support-bundle defects. That remediation gate is closed with verified
-immutable `v0.12.0`. The 2026-07-20 through 2026-07-22 manual outreach window
-passed without a post and is now retired. Rescheduling waits for GitHub Support
-to dereference cached pre-rewrite pull-request and commit views and for the
-venue-specific eligibility checks. No replacement date is assigned yet.
+and support-bundle defects, then superseded by the post-hard-cut package
+authority suite. That release gate is closed with verified immutable
+`v0.13.0` and production `remi-v0.8.5`. The 2026-07-20 through 2026-07-22
+manual outreach window passed without a post and is now retired. Rescheduling
+waits for GitHub Support to dereference cached pre-rewrite pull-request and
+commit views and for the venue-specific eligibility checks. No replacement
+date is assigned yet.

--- a/docs/roadmaps/external-tester-milestone.md
+++ b/docs/roadmaps/external-tester-milestone.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-26
-revision: 4
+last_updated: 2026-07-27
+revision: 5
 status: active
 current_result: 0/10
 summary: Outcome tracker for Conary's first cross-distro external tester milestone
@@ -35,23 +35,30 @@ but does not count as a completion.
 
 ## Release Gate
 
-The pinned target is `v0.13.0`. It is not a tester release until
-`docs/operations/release-artifact-matrix.md` records all of the following:
+The pinned tester release is the verified immutable `v0.13.0` recorded in
+`docs/operations/release-artifact-matrix.md`. Its release gate is complete:
 
-- the published annotated tag, peeled commit, release time, and terminal CI;
-- all expected `conary-0.13.0` and `conary_0.13.0` assets with independently
-  verified checksums and matching GitHub digests;
-- CCS signature and installed-binary identity/self-update proof;
-- native RPM, DEB, and Arch package smoke proof;
-- at least one exact foreign-format install, query, update preview, and remove
-  loop using the released binary;
-- exact-tag Conary site deployment and compatible `remi-v0.8.0` production
-  deployment with full health and public artifact checks;
-- explicit signature, SBOM, and provenance status.
+- annotated tag object `f8298522fd7fe95a4994184ae20c34cf64096818`
+  peels to `6f1429c362ac161f1ef817233e72ee9c9a031c11`;
+- release-build run `30261256730` published the exact seven-asset suite, and
+  independent downloads matched all five checksum entries and every GitHub
+  digest;
+- the detached CCS signature, current 0.13 binary identity, signed forced
+  self-update, deployed release directory, and public self-update endpoint
+  agree;
+- the schema hard cut is explicit: install the 0.13 native package fresh
+  instead of attempting to self-update the incompatible 0.12 CCS parser;
+- deploy-and-proof run `30263948968` installed the immutable RPM, DEB, and
+  Arch packages natively and passed the Cartesian lifecycle on Fedora 44,
+  Ubuntu 26.04 LTS, and Arch;
+- exact-tag Conary sites serve 0.13.0 with a real branded 404, and compatible
+  `remi-v0.8.5` production passes full health with all five sources populated
+  and real conversions for every public profile;
+- signature, SBOM, and provenance statuses are explicit in the release matrix.
 
-Until that evidence is durable, the release link and all launch copy are
-candidates, the result remains 0/10, and outreach remains postponed. Do not
-substitute evidence from an earlier release.
+Release proof is not an external-user completion. The result therefore remains
+0/10, and broad outreach remains postponed by the separate cached-history and
+venue-eligibility gates.
 
 Supported tester hosts are x86_64 Fedora 44, Ubuntu 26.04 LTS, and Arch Linux.
 Use a disposable VM, snapshot, spare system, or other non-critical host.
@@ -62,7 +69,6 @@ No broad-outreach post has been published and no new date is assigned. The
 venue copy remains in `docs/operations/external-tester-outreach.md`. Fresh
 dates require:
 
-- complete `v0.13.0` and `remi-v0.8.0` release and deployment proof;
 - GitHub Support dereferencing of cached pre-rewrite history;
 - current venue-rule and posting-eligibility checks.
 


### PR DESCRIPTION
## Primary Issue

Refs #86

Design / Plan / Roadmap:

- `docs/operations/release-artifact-matrix.md`
- `docs/roadmaps/development-roadmap.md`
- `docs/roadmaps/external-tester-milestone.md`

## Problem And Outcome

The post-hard-cut products are published from a deliberately split immutable lineage, Remi 0.8.5 is deployed with real conversions, and Conary 0.13.0 is published, deployed, and proven through the immutable native-package matrix. Canonical release and public guidance still described candidate releases and an obsolete Remi 0.8.0 target.

This PR records exact tag, asset, checksum, signature, deployment, conversion, site, and self-update evidence without inventing backward compatibility at the intentional 0.12-to-0.13 schema boundary. After merge, the release matrix, milestone, roadmap, README, postponed outreach packet, and issue #86 will agree on one current baseline.

## Changes

- replace pending release rows with exact immutable lineage and independently verified evidence
- record the terminal RPM/DEB/Arch released-package lifecycle on Fedora 44, Ubuntu 26.04 LTS, and Arch
- publish the current Remi 0.8.5 production identity and real conversion totals
- make the 0.13 fresh-native-install boundary explicit after proving the current signed self-update path
- reconcile roadmap, tester gate, postponed outreach packet, and README installation guidance

## Scope

- In scope: durable release, deployment, public-site, tester, roadmap, and issue #86 closeout truth
- Out of scope: product behavior changes, broad outreach, and the separately tracked Remi unknown-API SPA fallback in #67

## Ownership / Boundary

- Owning subsystem: release construction, publication, deployment, and proof
- Boundary changed or preserved: documentation now follows exact published/deployed authority; no release or runtime boundary changes
- Persisted state or public surface impact: public release/support claims only
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed (no behavior change)
- [x] Ran affected-package verification directly when touching service or daemon code (not applicable)
- [x] Updated subsystem docs or maps when the "look here first" path changed (no path changed)
- [x] Ran the broader interaction gate required by the release ownership card
- [x] Updated the primary issue with the one acceptance criterion remaining until this PR merges

```text
- bash scripts/check-doc-truth.sh
- bash scripts/test-doc-truth.sh
- bash scripts/test-agent-context.sh
- bash scripts/agent-context.sh --validate
- bash scripts/check-release-matrix.sh
- bash scripts/test-release-matrix.sh
- bash scripts/test-remi-deploy-helper.sh
- bash scripts/test-deploy-sites.sh
- cargo fmt --check
- cargo test -p conary-core --example sign_hash
- cargo test -p conary --test release_ccs_manifest
- cargo test -p conary-test container::image
- git diff --check
```

Release and production proof:

```text
- release-build 30261256730: success
- deploy-and-verify 30263948968: success, including all three native-package lifecycle jobs and aggregate
- independent seven-asset inventory, SHA256SUMS, GitHub REST digest, metadata, package identity, and detached-signature proof
- isolated released 0.13 signed forced self-update and current check
- deployed seven-file hash parity and /conary/releases/latest -> 0.13.0
- public self-update metadata parity, conary.io v0.13.0, branded HTTP 404, and Remi full health 10/10
```

## Review And Merge Notes

- Review focus: exact lineage and evidence; honest hard-cut/self-update wording; no accidental outreach claim
- User or developer impact: users get one current preview identity and a correct fresh-install instruction
- Required-check bypass: not used