### PR TITLE
fix(remi): make serving readiness evidence bearing

### DIFF
--- a/.github/workflows/deploy-and-verify.yml
+++ b/.github/workflows/deploy-and-verify.yml
@@ -641,6 +641,17 @@ jobs:
           REMOTE_EOF
       - name: Verify remi health
         run: curl -fsS https://remi.conary.io/health >/dev/null
+      - name: Verify remi readiness
+        # /health is an unconditional liveness reply and proves only that the
+        # process is listening. /health/ready opens the database, requires the
+        # expected schema revision, and checks the serving directories and free
+        # space, failing closed when a probe cannot run. Deployment evidence
+        # needs the second, not the first.
+        run: |
+          set -euo pipefail
+          body=$(curl -fsS --max-time 30 https://remi.conary.io/health/ready)
+          echo "$body"
+          echo "$body" | jq -e '.ready == true' >/dev/null
 
   no-deploy-required:
     name: no-deploy-required

--- a/apps/remi/src/server/config.rs
+++ b/apps/remi/src/server/config.rs
@@ -150,6 +150,12 @@ pub struct StorageSection {
     /// Maximum cache size in bytes (e.g., "700GB", "1TB")
     #[serde(default)]
     pub max_cache_size: Option<String>,
+
+    /// Free space the serving root must have before readiness reports ready
+    /// (e.g., "10GB"). Readiness fails closed below this, and reports the
+    /// probe as unavailable when free space cannot be measured at all.
+    #[serde(default)]
+    pub readiness_min_free: Option<String>,
 }
 
 impl Default for StorageSection {
@@ -160,6 +166,7 @@ impl Default for StorageSection {
             eviction_min_age: default_eviction_min_age(),
             negative_cache_ttl: default_negative_cache_ttl(),
             max_cache_size: None,
+            readiness_min_free: None,
         }
     }
 }
@@ -763,6 +770,13 @@ impl RemiConfig {
         30
     }
 
+    fn readiness_min_free_bytes(&self) -> Result<u64> {
+        match self.storage.readiness_min_free {
+            Some(ref size_str) => parse_size(size_str),
+            None => Ok(crate::server::readiness::DEFAULT_MIN_FREE_BYTES),
+        }
+    }
+
     fn enable_bloom_filter(&self) -> bool {
         true
     }
@@ -789,6 +803,7 @@ impl RemiConfig {
             max_concurrent_conversions: self.conversion.max_concurrent,
             cache_max_bytes: self.cache_max_bytes()?,
             chunk_ttl_days: self.chunk_ttl_days(),
+            readiness_min_free_bytes: self.readiness_min_free_bytes()?,
             enable_bloom_filter: self.enable_bloom_filter(),
             bloom_expected_chunks: self.bloom_expected_chunks(),
             upstream_url: None,

--- a/apps/remi/src/server/mod.rs
+++ b/apps/remi/src/server/mod.rs
@@ -43,6 +43,7 @@ mod prewarm;
 pub mod publication;
 pub mod r2;
 pub mod rate_limit;
+pub mod readiness;
 pub mod release_publish;
 pub mod repository_manifest;
 mod routes;
@@ -127,6 +128,8 @@ pub struct ServerConfig {
     pub cache_max_bytes: u64,
     /// Chunk TTL in days before LRU eviction
     pub chunk_ttl_days: u32,
+    /// Free bytes the serving root must have before readiness reports ready.
+    pub readiness_min_free_bytes: u64,
 
     // === Phase 0 additions ===
     /// Enable Bloom filter for fast negative lookups

--- a/apps/remi/src/server/readiness.rs
+++ b/apps/remi/src/server/readiness.rs
@@ -1,0 +1,381 @@
+// remi/src/server/readiness.rs
+
+//! Evidence-bearing readiness evaluation for Remi serving.
+//!
+//! Readiness answers one question: can this server actually answer requests?
+//! A probe that cannot establish its fact reports that as a failure, never as
+//! success.
+//!
+//! Deploy verification currently polls `/health`, which is an unconditional
+//! liveness reply and proves only that the process is listening. Pointing it at
+//! `/health/ready` is the remaining half of this work and is tracked on the
+//! owning issue; until then this endpoint is correct but unconsumed.
+//!
+//! The evaluation here is pure over its inputs so every failure mode is
+//! provable in a focused test. The route handler stays thin.
+
+use conary_core::db::schema::{SCHEMA_VERSION, SchemaCompatibility};
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+
+/// Free space a serving root must have before Remi reports ready.
+pub const DEFAULT_MIN_FREE_BYTES: u64 = 10 * 1024 * 1024 * 1024;
+
+/// Outcome of a single readiness probe.
+///
+/// `Unavailable` is deliberately distinct from `NotReady`: the first means the
+/// probe could not run and the fact is unknown, the second means the probe ran
+/// and the resource is genuinely unfit. They need different operator responses,
+/// and collapsing them is what allowed a failed disk probe to read as success.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum ProbeOutcome {
+    Ready,
+    NotReady { reason: String },
+    Unavailable { reason: String },
+}
+
+impl ProbeOutcome {
+    pub fn is_ready(&self) -> bool {
+        matches!(self, ProbeOutcome::Ready)
+    }
+
+    fn not_ready(reason: impl Into<String>) -> Self {
+        ProbeOutcome::NotReady {
+            reason: reason.into(),
+        }
+    }
+
+    fn unavailable(reason: impl Into<String>) -> Self {
+        ProbeOutcome::Unavailable {
+            reason: reason.into(),
+        }
+    }
+}
+
+/// Inputs the readiness evaluation needs, gathered from server configuration.
+#[derive(Debug, Clone)]
+pub struct ReadinessInputs {
+    pub db_path: PathBuf,
+    pub chunk_dir: PathBuf,
+    pub cache_dir: PathBuf,
+    pub min_free_bytes: u64,
+}
+
+/// Complete readiness report.
+///
+/// Field names state exactly what each probe established. `database` is not
+/// "the file is present"; it is "the database opened, answered a query, and
+/// carries the expected schema revision".
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ReadinessReport {
+    pub ready: bool,
+    pub database: ProbeOutcome,
+    pub chunk_dir: ProbeOutcome,
+    pub cache_dir: ProbeOutcome,
+    pub free_space: ProbeOutcome,
+    pub expected_schema_revision: i32,
+}
+
+impl ReadinessReport {
+    fn from_probes(
+        database: ProbeOutcome,
+        chunk_dir: ProbeOutcome,
+        cache_dir: ProbeOutcome,
+        free_space: ProbeOutcome,
+    ) -> Self {
+        let ready = database.is_ready()
+            && chunk_dir.is_ready()
+            && cache_dir.is_ready()
+            && free_space.is_ready();
+        Self {
+            ready,
+            database,
+            chunk_dir,
+            cache_dir,
+            free_space,
+            expected_schema_revision: SCHEMA_VERSION,
+        }
+    }
+}
+
+/// Evaluate readiness. Blocking: callers must run this off the async runtime.
+pub fn evaluate(inputs: &ReadinessInputs) -> ReadinessReport {
+    ReadinessReport::from_probes(
+        probe_database(&inputs.db_path),
+        probe_directory(&inputs.chunk_dir, "chunk directory"),
+        probe_directory(&inputs.cache_dir, "cache directory"),
+        probe_free_space(&inputs.chunk_dir, inputs.min_free_bytes),
+    )
+}
+
+/// Open the database read-only, run a query, and require the exact schema epoch.
+///
+/// A missing database reports `Fresh`, which is not ready: a server with no
+/// database cannot serve, regardless of whether its parent directory exists.
+fn probe_database(db_path: &Path) -> ProbeOutcome {
+    match conary_core::db::schema::inspect(db_path) {
+        Ok(SchemaCompatibility::Current) => ProbeOutcome::Ready,
+        Ok(SchemaCompatibility::Fresh) => {
+            ProbeOutcome::not_ready(format!("no initialized database at {}", db_path.display()))
+        }
+        Ok(SchemaCompatibility::RebuildRequired { observed }) => ProbeOutcome::not_ready(format!(
+            "database requires rebuild: expected epoch revision {SCHEMA_VERSION}, observed {observed}"
+        )),
+        Err(error) => {
+            ProbeOutcome::unavailable(format!("could not inspect {}: {error}", db_path.display()))
+        }
+    }
+}
+
+fn probe_directory(path: &Path, label: &str) -> ProbeOutcome {
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_dir() => ProbeOutcome::Ready,
+        Ok(_) => ProbeOutcome::not_ready(format!("{label} {} is not a directory", path.display())),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            ProbeOutcome::not_ready(format!("{label} {} does not exist", path.display()))
+        }
+        Err(error) => ProbeOutcome::unavailable(format!(
+            "could not stat {label} {}: {error}",
+            path.display()
+        )),
+    }
+}
+
+/// Report available free space beneath `path`.
+///
+/// A probe that cannot execute reports `Unavailable`. Returning success on
+/// `statvfs` failure is what let a broken disk probe pass readiness.
+fn probe_free_space(path: &Path, min_free_bytes: u64) -> ProbeOutcome {
+    match available_bytes(path) {
+        Ok(free) if free >= min_free_bytes => ProbeOutcome::Ready,
+        Ok(free) => ProbeOutcome::not_ready(format!(
+            "{} has {free} bytes free, below the required {min_free_bytes}",
+            path.display()
+        )),
+        Err(error) => ProbeOutcome::unavailable(format!(
+            "could not measure free space at {}: {error}",
+            path.display()
+        )),
+    }
+}
+
+#[cfg(unix)]
+fn available_bytes(path: &Path) -> Result<u64, String> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let path_cstr = CString::new(path.as_os_str().as_bytes())
+        .map_err(|error| format!("path is not representable for statvfs: {error}"))?;
+
+    // SAFETY: `stat` is zeroed and only read after statvfs reports success;
+    // `path_cstr` outlives the call and is NUL-terminated by construction.
+    let stat = unsafe {
+        let mut stat: libc::statvfs = std::mem::zeroed();
+        if libc::statvfs(path_cstr.as_ptr(), &mut stat) != 0 {
+            return Err(std::io::Error::last_os_error().to_string());
+        }
+        stat
+    };
+
+    #[allow(clippy::unnecessary_cast)]
+    let available = (stat.f_bavail as u64).checked_mul(stat.f_bsize as u64);
+    available.ok_or_else(|| "free-space calculation overflowed".to_string())
+}
+
+#[cfg(not(unix))]
+fn available_bytes(_path: &Path) -> Result<u64, String> {
+    Err("free-space measurement is not implemented on this platform".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use conary_core::db::schema;
+
+    fn inputs_for(dir: &Path) -> ReadinessInputs {
+        let db_path = dir.join("metadata/conary.db");
+        std::fs::create_dir_all(db_path.parent().expect("db parent")).expect("create metadata dir");
+        let chunk_dir = dir.join("chunks");
+        let cache_dir = dir.join("cache");
+        std::fs::create_dir_all(&chunk_dir).expect("create chunk dir");
+        std::fs::create_dir_all(&cache_dir).expect("create cache dir");
+        ReadinessInputs {
+            db_path,
+            chunk_dir,
+            cache_dir,
+            min_free_bytes: 0,
+        }
+    }
+
+    fn initialize_database(db_path: &Path) {
+        let conn = rusqlite::Connection::open(db_path).expect("open database");
+        schema::ensure_current(&conn).expect("initialize current schema");
+    }
+
+    #[test]
+    fn ready_when_database_directories_and_space_all_satisfy_their_probes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let inputs = inputs_for(dir.path());
+        initialize_database(&inputs.db_path);
+
+        let report = evaluate(&inputs);
+
+        assert!(report.ready, "expected ready, got {report:?}");
+        assert_eq!(report.database, ProbeOutcome::Ready);
+        assert_eq!(report.expected_schema_revision, SCHEMA_VERSION);
+    }
+
+    /// The exact defect this module replaces: the previous check accepted a
+    /// missing database whenever its parent directory existed, which on any
+    /// normal deployment is always true.
+    #[test]
+    fn not_ready_when_database_is_absent_but_its_parent_directory_exists() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let inputs = inputs_for(dir.path());
+
+        assert!(
+            inputs.db_path.parent().expect("db parent").is_dir(),
+            "the parent directory must exist for this regression to be meaningful"
+        );
+        assert!(!inputs.db_path.exists(), "the database must be absent");
+
+        let report = evaluate(&inputs);
+
+        assert!(!report.ready, "absent database must not report ready");
+        assert!(
+            matches!(report.database, ProbeOutcome::NotReady { .. }),
+            "expected NotReady, got {:?}",
+            report.database
+        );
+    }
+
+    #[test]
+    fn not_ready_when_database_carries_a_retired_schema_revision() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let inputs = inputs_for(dir.path());
+
+        let conn = rusqlite::Connection::open(&inputs.db_path).expect("open database");
+        conn.execute_batch(
+            "CREATE TABLE schema_version (version INTEGER NOT NULL);
+             INSERT INTO schema_version (version) VALUES (3);
+             CREATE TABLE converted_packages (id INTEGER PRIMARY KEY);",
+        )
+        .expect("write retired schema");
+        drop(conn);
+
+        let report = evaluate(&inputs);
+
+        assert!(!report.ready, "retired schema must not report ready");
+        match report.database {
+            ProbeOutcome::NotReady { ref reason } => {
+                assert!(
+                    reason.contains("rebuild"),
+                    "reason should name the rebuild requirement, got {reason}"
+                );
+            }
+            ref other => panic!("expected NotReady, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn database_probe_is_unavailable_when_the_file_cannot_be_opened() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let inputs = inputs_for(dir.path());
+        std::fs::write(&inputs.db_path, b"this is not a sqlite database")
+            .expect("write junk database");
+
+        let report = evaluate(&inputs);
+
+        assert!(!report.ready, "unreadable database must not report ready");
+        assert!(
+            matches!(
+                report.database,
+                ProbeOutcome::NotReady { .. } | ProbeOutcome::Unavailable { .. }
+            ),
+            "expected a failing outcome, got {:?}",
+            report.database
+        );
+    }
+
+    #[test]
+    fn not_ready_when_the_chunk_directory_is_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let inputs = inputs_for(dir.path());
+        initialize_database(&inputs.db_path);
+        std::fs::remove_dir(&inputs.chunk_dir).expect("remove chunk dir");
+
+        let report = evaluate(&inputs);
+
+        assert!(!report.ready);
+        assert!(matches!(report.chunk_dir, ProbeOutcome::NotReady { .. }));
+    }
+
+    #[test]
+    fn not_ready_when_the_cache_path_is_a_file_rather_than_a_directory() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let inputs = inputs_for(dir.path());
+        initialize_database(&inputs.db_path);
+        std::fs::remove_dir(&inputs.cache_dir).expect("remove cache dir");
+        std::fs::write(&inputs.cache_dir, b"not a directory").expect("write file at cache path");
+
+        let report = evaluate(&inputs);
+
+        assert!(!report.ready);
+        assert!(matches!(report.cache_dir, ProbeOutcome::NotReady { .. }));
+    }
+
+    /// Insufficient space is a genuine NotReady, distinct from a probe that
+    /// could not run at all.
+    #[test]
+    fn not_ready_when_free_space_is_below_the_configured_threshold() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut inputs = inputs_for(dir.path());
+        initialize_database(&inputs.db_path);
+        inputs.min_free_bytes = u64::MAX;
+
+        let report = evaluate(&inputs);
+
+        assert!(!report.ready, "insufficient space must not report ready");
+        match report.free_space {
+            ProbeOutcome::NotReady { ref reason } => {
+                assert!(
+                    reason.contains("below the required"),
+                    "reason should state the shortfall, got {reason}"
+                );
+            }
+            ref other => panic!("expected NotReady, got {other:?}"),
+        }
+    }
+
+    /// A probe that cannot execute must not read as success. The previous
+    /// implementation returned `true` on statvfs failure.
+    #[test]
+    fn free_space_probe_is_unavailable_when_the_path_cannot_be_measured() {
+        let missing = Path::new("/nonexistent-remi-readiness-probe-target");
+
+        let outcome = probe_free_space(missing, 0);
+
+        assert!(
+            matches!(outcome, ProbeOutcome::Unavailable { .. }),
+            "a failed probe must be Unavailable, got {outcome:?}"
+        );
+        assert!(!outcome.is_ready(), "a failed probe must never be ready");
+    }
+
+    #[test]
+    fn report_serializes_each_probe_state_distinctly() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let inputs = inputs_for(dir.path());
+
+        let json = serde_json::to_value(evaluate(&inputs)).expect("serialize report");
+
+        assert_eq!(json["ready"], serde_json::json!(false));
+        assert_eq!(json["database"]["state"], serde_json::json!("not_ready"));
+        assert_eq!(json["chunk_dir"]["state"], serde_json::json!("ready"));
+        assert!(
+            json["database"]["reason"].is_string(),
+            "a failing probe must carry a reason"
+        );
+    }
+}

--- a/apps/remi/src/server/routes.rs
+++ b/apps/remi/src/server/routes.rs
@@ -21,6 +21,7 @@ use crate::server::handlers::{
     jobs, models, oci, openapi, packages, profiles, recipes, search, seeds, self_update, sparse,
     tuf,
 };
+use crate::server::readiness::{self, ReadinessInputs};
 use crate::server::security::RateLimiter;
 use crate::server::{ServerConfig, ServerState};
 use axum::{

--- a/apps/remi/src/server/routes/public.rs
+++ b/apps/remi/src/server/routes/public.rs
@@ -203,84 +203,47 @@ async fn health_check() -> &'static str {
     "OK"
 }
 
+/// Report whether this server can actually answer requests.
+///
+/// Every probe fails closed: an absent database, a wrong schema revision, a
+/// missing directory, insufficient free space, or a probe that could not run at
+/// all all produce 503. Deploy verification and the release pipeline consume
+/// this endpoint, so it must never report readiness it has not established.
+/// The evaluation itself lives in `server::readiness`, where each failure mode
+/// is covered by a focused test.
 async fn readiness_check(
     axum::extract::State(state): axum::extract::State<Arc<RwLock<ServerState>>>,
 ) -> Response {
-    let (db_path, chunk_dir, cache_dir) = {
+    let inputs = {
         let state_guard = state.read().await;
         let config = &state_guard.config;
-        (
-            config.db_path.clone(),
-            config.chunk_dir.clone(),
-            config.cache_dir.clone(),
-        )
-    };
-
-    let result = tokio::task::spawn_blocking(move || {
-        let db_ok = db_path.exists() || db_path.parent().is_some_and(|p| p.exists() && p.is_dir());
-        let chunk_dir_ok = chunk_dir.exists() && chunk_dir.is_dir();
-        let cache_dir_ok = cache_dir.exists() && cache_dir.is_dir();
-        let disk_ok = check_disk_space(&chunk_dir, 10 * 1024 * 1024 * 1024);
-        (db_ok, chunk_dir_ok, cache_dir_ok, disk_ok)
-    })
-    .await;
-
-    let (db_ok, chunk_dir_ok, cache_dir_ok, disk_ok) = match result {
-        Ok(checks) => checks,
-        Err(_) => {
-            return (StatusCode::INTERNAL_SERVER_ERROR, "Readiness check failed").into_response();
+        ReadinessInputs {
+            db_path: config.db_path.clone(),
+            chunk_dir: config.chunk_dir.clone(),
+            cache_dir: config.cache_dir.clone(),
+            min_free_bytes: config.readiness_min_free_bytes,
         }
     };
 
-    if db_ok && chunk_dir_ok && cache_dir_ok && disk_ok {
-        (StatusCode::OK, "READY").into_response()
+    // Probes open a database and stat filesystems; keep them off the runtime.
+    let report = match tokio::task::spawn_blocking(move || readiness::evaluate(&inputs)).await {
+        Ok(report) => report,
+        Err(error) => {
+            // The probe task itself failed, so readiness is unknown. Unknown is
+            // not ready.
+            tracing::error!("readiness probe task failed: {error}");
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "readiness probe did not complete",
+            )
+                .into_response();
+        }
+    };
+
+    if report.ready {
+        (StatusCode::OK, Json(report)).into_response()
     } else {
-        let details = ReadinessDetails {
-            ready: false,
-            db_accessible: db_ok,
-            chunk_dir_ok,
-            cache_dir_ok,
-            disk_space_ok: disk_ok,
-        };
-        (StatusCode::SERVICE_UNAVAILABLE, Json(details)).into_response()
-    }
-}
-
-#[derive(Serialize)]
-struct ReadinessDetails {
-    ready: bool,
-    db_accessible: bool,
-    chunk_dir_ok: bool,
-    cache_dir_ok: bool,
-    disk_space_ok: bool,
-}
-
-fn check_disk_space(path: &std::path::Path, min_bytes: u64) -> bool {
-    #[cfg(unix)]
-    {
-        use std::ffi::CString;
-        use std::os::unix::ffi::OsStrExt;
-
-        let path_cstr = match CString::new(path.as_os_str().as_bytes()) {
-            Ok(s) => s,
-            Err(_) => return true,
-        };
-
-        unsafe {
-            let mut stat: libc::statvfs = std::mem::zeroed();
-            if libc::statvfs(path_cstr.as_ptr(), &mut stat) == 0 {
-                #[allow(clippy::unnecessary_cast)]
-                let free_bytes = stat.f_bavail as u64 * stat.f_bsize as u64;
-                return free_bytes >= min_bytes;
-            }
-        }
-        true
-    }
-
-    #[cfg(not(unix))]
-    {
-        let _ = (path, min_bytes);
-        true
+        (StatusCode::SERVICE_UNAVAILABLE, Json(report)).into_response()
     }
 }
 

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -46,6 +46,16 @@ expressions are not source, parser, or trust authority. A configured native
 parser or trust failure is an error for that source; it does not silently retry
 the URL as another metadata format or continue unsigned.
 
+`apps/remi/src/server/readiness.rs` owns serving readiness. `/health` is an
+unconditional liveness reply and proves only that the process is listening;
+`/health/ready` is the evidence-bearing one. It opens the database read-only,
+requires the expected schema revision, and checks the serving directories and
+configured free-space floor. A probe that cannot run reports `unavailable`
+rather than success, so an unmeasurable resource never reads as ready. Deploy
+verification and `scripts/remi-health.sh` assert `ready == true` from that
+endpoint; liveness alone is not deployment evidence. The free-space floor is
+`storage.readiness_min_free`, defaulting to 10 GiB.
+
 `apps/remi/src/deployment.rs` owns recoverable config/schema transitions and
 read-only deployment inspection. It snapshots a current database or retires an
 old schema epoch before replacement, so health failure can restore config,

--- a/scripts/remi-health.sh
+++ b/scripts/remi-health.sh
@@ -91,6 +91,10 @@ echo ""
 # ── Smoke checks (always run) ────────────────────────────────────────────
 echo "=== Core Endpoints ==="
 check "health"           "$ENDPOINT/health"
+# /health is an unconditional liveness reply. Readiness is the evidence-bearing
+# one: it opens the database, requires the expected schema revision, and checks
+# the serving directories and free space, failing closed when a probe cannot run.
+check_contains "readiness" "$ENDPOINT/health/ready" '"ready":true'
 check "stats overview"   "$ENDPOINT/v1/stats/overview"
 
 echo ""


### PR DESCRIPTION
Closes #107.

## Problem

`GET /health/ready` returned `READY` on a server with no database and a failed disk probe. Three independent fail-open paths in `readiness_check` and `check_disk_space`:

1. **Absent database passed.** The check was `db_path.exists() || db_path.parent().is_some_and(|p| p.exists() && p.is_dir())`. The right-hand disjunct means a missing database satisfies readiness whenever its parent directory exists — which on any normal deployment is always true, so the check could not fail for the condition it named.
2. **Failed probe passed.** `check_disk_space` returned `true` when `statvfs` returned non-zero *and* when `CString::new` rejected the path. A probe that could not run was reported as one that succeeded.
3. **The database was never opened.** Readiness asserted nothing about schema revision, table presence, or query capability, so a present but corrupt database passed.

The reported `db_accessible` and `disk_space_ok` fields did not carry the meaning their names claimed.

## Correction to the issue's framing

The issue body said this endpoint is consumed by deploy verification, so a false pass became deployment evidence. **That was wrong**, and the correction is recorded [on the issue](https://github.com/ConaryLabs/Conary/issues/107#issuecomment-5093918980). Nothing consumed `/health/ready` — it appeared only in its own route registration.

What deploy verification *does* consume is `/health`:

```rust
async fn health_check() -> &'static str { "OK" }
```

An unconditional liveness reply. Release deployment was verified by confirming the process was listening, which proves nothing about serving capability. Fixing readiness alone would have left that gap untouched, so this PR covers both halves — which is what the issue's "deploy helper and release pipeline consume the corrected endpoint" criterion already required.

## Change

**`apps/remi/src/server/readiness.rs`** (new) holds the evaluation, pure over its inputs so every failure mode is provable in a focused test. The route handler stays thin.

`ProbeOutcome` distinguishes `NotReady` (the probe ran; the resource is unfit) from `Unavailable` (the probe could not run). They need different operator responses, and collapsing them is precisely what let a broken disk probe pass.

- **Database** — opens read-only via `schema::inspect`, which runs a query and requires the exact schema epoch. A missing database reports `Fresh`, which is not ready.
- **Directories** — distinguishes missing, not-a-directory, and unstattable.
- **Free space** — `statvfs` failure and path-encoding failure are `Unavailable`; below-threshold is `NotReady`. Multiplication is checked for overflow.

The threshold moves to `storage.readiness_min_free` (default 10 GiB) instead of a literal in the handler.

**Consumers** — `deploy-and-verify.yml` and `scripts/remi-health.sh` now assert `ready == true` from `/health/ready` alongside the existing liveness check. `/health` stays unconditional; that is correct for a liveness probe, and the defect was using it as deployment evidence rather than its own behavior.

Production has 215 GB free on `/conary`, checked read-only before wiring this in, so the stricter assertion will not break the release pipeline.

## Verification

```
cargo test -p remi          584 + 5 + 3 passed, 0 failed
cargo clippy -p remi --all-targets -- -D warnings    clean
cargo fmt --check           clean
bash scripts/check-doc-truth.sh                      passed
```

Nine focused tests cover each fail-open path independently, including `not_ready_when_database_is_absent_but_its_parent_directory_exists`, which asserts the parent directory exists so the regression stays meaningful, and `free_space_probe_is_unavailable_when_the_path_cannot_be_measured`.

Run on rustc 1.97.1 to match CI. Worth noting for other contributors: on 1.96.0 the workspace has a pre-existing `clippy::nonminimal_bool` error in `crates/conary-core/src/boot_runtime/bootloader/bootctl/parser.rs` that does not fire on 1.97.1. That file is untouched here; the repo pins no toolchain, so local clippy needs a current stable to be trustworthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011y1e74GvvxzaDkyrxthYZB