### PR TITLE
feat(corpus): add typed result vocabulary for the just-works gate

### DIFF
--- a/apps/remi/src/bin/remi.rs
+++ b/apps/remi/src/bin/remi.rs
@@ -522,8 +522,13 @@ fn run_prewarm_command(args: PrewarmArgs) -> Result<()> {
 
         if !result.failed.is_empty() {
             println!("\nFailed packages:");
-            for (package, error) in &result.failed {
-                println!("  {}: {}", package, error);
+            for entry in &result.failed {
+                println!(
+                    "  {} [{}]: {}",
+                    entry.package,
+                    entry.failure.kind().as_str(),
+                    entry.failure.detail()
+                );
             }
         }
 

--- a/apps/remi/src/server/mod.rs
+++ b/apps/remi/src/server/mod.rs
@@ -62,7 +62,7 @@ pub use jobs::{ConversionJob, JobManager, JobStatus};
 pub use lite::{ProxyConfig, run_proxy};
 pub use metrics::{MetricsSnapshot, ServerMetrics};
 pub use negative_cache::NegativeCache;
-pub use prewarm::{PrewarmConfig, PrewarmResult, run_prewarm};
+pub use prewarm::{PrewarmConfig, PrewarmFailure, PrewarmResult, run_prewarm};
 pub use r2::R2Store;
 pub use routes::{create_admin_router, create_external_admin_router, create_router};
 pub use search::SearchEngine;

--- a/apps/remi/src/server/prewarm.rs
+++ b/apps/remi/src/server/prewarm.rs
@@ -6,6 +6,7 @@
 
 use crate::server::conversion::ConversionService;
 use anyhow::{Context, Result};
+use conary_core::corpus::ConversionFailure;
 use conary_core::db::models::{ConvertedPackage, RepositoryPackage};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -55,8 +56,21 @@ pub struct PrewarmResult {
     pub total_bytes: u64,
     /// List of converted package names
     pub converted: Vec<String>,
-    /// List of failed package names with errors
-    pub failed: Vec<(String, String)>,
+    /// Failed packages with their typed failure category.
+    ///
+    /// The category comes from the concrete error type, so prewarm results can
+    /// be aggregated by authority rather than by message wording. See
+    /// `conary_core::corpus` for the taxonomy.
+    pub failed: Vec<PrewarmFailure>,
+}
+
+/// One package that failed prewarm, with its typed reason.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrewarmFailure {
+    /// `name-version` of the package that failed.
+    pub package: String,
+    /// Typed category plus its human-readable diagnostic.
+    pub failure: ConversionFailure,
 }
 
 /// Popularity data for a package
@@ -191,9 +205,10 @@ async fn run_prewarm_with_permits(
             Err(e) => {
                 warn!("Failed to convert {} {}: {}", pkg.name, pkg.version, e);
                 result.packages_failed += 1;
-                result
-                    .failed
-                    .push((format!("{}-{}", pkg.name, pkg.version), e.to_string()));
+                result.failed.push(PrewarmFailure {
+                    package: format!("{}-{}", pkg.name, pkg.version),
+                    failure: ConversionFailure::classify(&e),
+                });
             }
         }
     }
@@ -386,7 +401,12 @@ mod tests {
             packages_failed: 1,
             total_bytes: 1024 * 1024,
             converted: vec!["nginx-1.24.0".to_string(), "curl-8.0.0".to_string()],
-            failed: vec![("broken-1.0.0".to_string(), "Download failed".to_string())],
+            failed: vec![PrewarmFailure {
+                package: "broken-1.0.0".to_string(),
+                failure: ConversionFailure::Publication {
+                    detail: "Download failed".to_string(),
+                },
+            }],
         };
 
         let json = serde_json::to_string_pretty(&result).unwrap();

--- a/crates/conary-core/src/corpus/aggregate.rs
+++ b/crates/conary-core/src/corpus/aggregate.rs
@@ -1,0 +1,360 @@
+// conary-core/src/corpus/aggregate.rs
+
+//! Aggregation of corpus case results.
+//!
+//! Every tally is keyed by a typed discriminant: a [`ConversionStage`] and a
+//! [`FailureKind`], plus an `incident_id` for unclassified failures that is
+//! itself derived from the error's type chain. No key is derived from a
+//! failure's human-readable detail, so rephrasing a message cannot split one
+//! bucket into two or merge two distinct defects into one.
+//!
+//! This is enforced structurally rather than by convention: the key types are
+//! `Copy` enums and the aggregation functions never read `detail()`.
+
+use super::failure::FailureKind;
+use super::{ConversionStage, CorpusCaseResult, CorpusOutcome};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Failures grouped by category within one stage.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FailureTally {
+    pub kind: FailureKind,
+    pub count: usize,
+    /// Distinct incident ids seen for unclassified failures, sorted.
+    ///
+    /// Empty for every classified category. A growing list here means the
+    /// underlying errors are too coarse to report on.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub incident_ids: Vec<String>,
+}
+
+/// One stage's failure profile.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StageTally {
+    pub stage: ConversionStage,
+    pub failures: Vec<FailureTally>,
+    pub total: usize,
+}
+
+/// Aggregate report over a set of cases.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorpusAggregate {
+    pub cases: usize,
+    pub completed: usize,
+    pub failed: usize,
+    pub skipped: usize,
+    /// Stages that recorded at least one failure, in execution order.
+    pub stages: Vec<StageTally>,
+    /// Cases whose failure could not be attributed to a typed category.
+    ///
+    /// This is a gate signal in its own right: the corpus cannot claim a clean
+    /// typed result while any case lands here.
+    pub unclassified: usize,
+}
+
+impl CorpusAggregate {
+    /// Whether every case completed its declared journey.
+    pub fn all_completed(&self) -> bool {
+        self.failed == 0 && self.completed == self.cases
+    }
+}
+
+/// Aggregate cases by typed stage and failure category.
+///
+/// Keys come from enum discriminants only. Case ordering does not affect the
+/// result: stages sort by execution order and categories by their stable code.
+pub fn aggregate_cases(cases: &[CorpusCaseResult]) -> CorpusAggregate {
+    let mut completed = 0usize;
+    let mut skipped = 0usize;
+    let mut unclassified = 0usize;
+
+    // Keyed by typed discriminants, never by any human-readable text.
+    let mut buckets: BTreeMap<ConversionStage, BTreeMap<FailureKind, (usize, Vec<String>)>> =
+        BTreeMap::new();
+
+    for case in cases {
+        match &case.final_outcome {
+            CorpusOutcome::Completed => completed += 1,
+            CorpusOutcome::Skipped { .. } => skipped += 1,
+            CorpusOutcome::Failed { stage, failure } => {
+                let kind = failure.kind();
+                if kind == FailureKind::InternalUnclassified {
+                    unclassified += 1;
+                }
+
+                let entry = buckets
+                    .entry(*stage)
+                    .or_default()
+                    .entry(kind)
+                    .or_insert_with(|| (0, Vec::new()));
+                entry.0 += 1;
+
+                if let super::ConversionFailure::InternalUnclassified { incident_id, .. } = failure
+                    && !entry.1.contains(incident_id)
+                {
+                    entry.1.push(incident_id.clone());
+                }
+            }
+        }
+    }
+
+    let stages = buckets
+        .into_iter()
+        .map(|(stage, kinds)| {
+            let mut total = 0usize;
+            let failures = kinds
+                .into_iter()
+                .map(|(kind, (count, mut incident_ids))| {
+                    total += count;
+                    incident_ids.sort();
+                    FailureTally {
+                        kind,
+                        count,
+                        incident_ids,
+                    }
+                })
+                .collect();
+            StageTally {
+                stage,
+                failures,
+                total,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let failed = stages.iter().map(|stage| stage.total).sum();
+
+    CorpusAggregate {
+        cases: cases.len(),
+        completed,
+        failed,
+        skipped,
+        stages,
+        unclassified,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{
+        ConversionFailure, SourceArtifactIdentity, SourceProfileIdentity, StageResult,
+        TargetCapabilitySnapshot,
+    };
+    use super::*;
+
+    fn case_failing_with(stage: ConversionStage, failure: ConversionFailure) -> CorpusCaseResult {
+        CorpusCaseResult::from_stages(
+            SourceProfileIdentity {
+                profile: "arch".into(),
+                format: "alpm".into(),
+            },
+            SourceArtifactIdentity {
+                name: "btop".into(),
+                version: "1.4.0-1".into(),
+                architecture: Some("x86_64".into()),
+                digest: "d3983ae27b3e6e470bc33fd060a29c2e9a4a0c5a363ea76a07dd4ce300709c9c".into(),
+            },
+            TargetCapabilitySnapshot {
+                profile: "fedora-44".into(),
+                architecture: "x86_64".into(),
+                init_system: "systemd".into(),
+                capabilities: Vec::new(),
+            },
+            vec![StageResult::failed(stage, failure)],
+        )
+    }
+
+    fn passing_case() -> CorpusCaseResult {
+        CorpusCaseResult::from_stages(
+            SourceProfileIdentity {
+                profile: "arch".into(),
+                format: "alpm".into(),
+            },
+            SourceArtifactIdentity {
+                name: "curl".into(),
+                version: "8.0.0-1".into(),
+                architecture: Some("x86_64".into()),
+                digest: "abc".into(),
+            },
+            TargetCapabilitySnapshot {
+                profile: "fedora-44".into(),
+                architecture: "x86_64".into(),
+                init_system: "systemd".into(),
+                capabilities: Vec::new(),
+            },
+            vec![StageResult::passed(ConversionStage::Installation)],
+        )
+    }
+
+    #[test]
+    fn cases_tally_by_stage_and_category() {
+        let cases = vec![
+            passing_case(),
+            case_failing_with(
+                ConversionStage::NativeParse,
+                ConversionFailure::SourceMetadata {
+                    detail: "inode metadata disagreement".into(),
+                },
+            ),
+            case_failing_with(
+                ConversionStage::NativeParse,
+                ConversionFailure::SourceMetadata {
+                    detail: "a completely different sentence".into(),
+                },
+            ),
+            case_failing_with(
+                ConversionStage::CcsVerification,
+                ConversionFailure::CcsAuthority {
+                    detail: "manifest exceeds budget".into(),
+                },
+            ),
+        ];
+
+        let report = aggregate_cases(&cases);
+
+        assert_eq!(report.cases, 4);
+        assert_eq!(report.completed, 1);
+        assert_eq!(report.failed, 3);
+        assert!(!report.all_completed());
+        assert_eq!(report.stages.len(), 2);
+
+        let parse = &report.stages[0];
+        assert_eq!(parse.stage, ConversionStage::NativeParse);
+        assert_eq!(parse.total, 2);
+        assert_eq!(parse.failures[0].kind, FailureKind::SourceMetadata);
+        assert_eq!(
+            parse.failures[0].count, 2,
+            "two differently worded failures of one category are one bucket"
+        );
+    }
+
+    /// The rule this module exists to enforce.
+    #[test]
+    fn differing_detail_text_does_not_split_a_bucket() {
+        let cases = vec![
+            case_failing_with(
+                ConversionStage::NativeParse,
+                ConversionFailure::SourceArchive {
+                    detail: "truncated stream at entry 41".into(),
+                },
+            ),
+            case_failing_with(
+                ConversionStage::NativeParse,
+                ConversionFailure::SourceArchive {
+                    detail: "wholly unrelated phrasing".into(),
+                },
+            ),
+        ];
+
+        let report = aggregate_cases(&cases);
+
+        assert_eq!(report.stages.len(), 1);
+        assert_eq!(report.stages[0].failures.len(), 1);
+        assert_eq!(report.stages[0].failures[0].count, 2);
+    }
+
+    /// The converse: identical wording must not merge distinct categories.
+    #[test]
+    fn identical_detail_text_does_not_merge_distinct_categories() {
+        let shared = "conversion failed".to_string();
+        let cases = vec![
+            case_failing_with(
+                ConversionStage::NativeParse,
+                ConversionFailure::SourceArchive {
+                    detail: shared.clone(),
+                },
+            ),
+            case_failing_with(
+                ConversionStage::NativeParse,
+                ConversionFailure::ResourceBudget { detail: shared },
+            ),
+        ];
+
+        let report = aggregate_cases(&cases);
+
+        assert_eq!(
+            report.stages[0].failures.len(),
+            2,
+            "same wording across two categories must stay two buckets"
+        );
+    }
+
+    #[test]
+    fn unclassified_failures_are_counted_and_carry_their_incident_ids() {
+        let cases = vec![
+            case_failing_with(
+                ConversionStage::Publication,
+                ConversionFailure::InternalUnclassified {
+                    incident_id: "a1b2c3d4e5f60718".into(),
+                    detail: "opaque".into(),
+                },
+            ),
+            case_failing_with(
+                ConversionStage::Publication,
+                ConversionFailure::InternalUnclassified {
+                    incident_id: "a1b2c3d4e5f60718".into(),
+                    detail: "opaque but worded differently".into(),
+                },
+            ),
+        ];
+
+        let report = aggregate_cases(&cases);
+
+        assert_eq!(report.unclassified, 2);
+        let tally = &report.stages[0].failures[0];
+        assert_eq!(tally.kind, FailureKind::InternalUnclassified);
+        assert_eq!(tally.count, 2);
+        assert_eq!(
+            tally.incident_ids,
+            vec!["a1b2c3d4e5f60718".to_string()],
+            "one shared incident id is recorded once"
+        );
+    }
+
+    #[test]
+    fn skipped_cases_are_neither_passes_nor_failures() {
+        let mut skipped = passing_case();
+        skipped.final_outcome = CorpusOutcome::Skipped {
+            reason: "fixture unavailable on this target".into(),
+        };
+
+        let report = aggregate_cases(&[skipped]);
+
+        assert_eq!(report.skipped, 1);
+        assert_eq!(report.completed, 0);
+        assert_eq!(report.failed, 0);
+        assert!(
+            !report.all_completed(),
+            "a skipped case must not satisfy the gate"
+        );
+    }
+
+    #[test]
+    fn stages_report_in_execution_order_regardless_of_case_order() {
+        let cases = vec![
+            case_failing_with(
+                ConversionStage::Rollback,
+                ConversionFailure::Transaction { detail: "x".into() },
+            ),
+            case_failing_with(
+                ConversionStage::ArtifactDownload,
+                ConversionFailure::Publication { detail: "y".into() },
+            ),
+        ];
+
+        let report = aggregate_cases(&cases);
+
+        assert_eq!(report.stages[0].stage, ConversionStage::ArtifactDownload);
+        assert_eq!(report.stages[1].stage, ConversionStage::Rollback);
+    }
+
+    #[test]
+    fn an_all_passing_corpus_reports_clean() {
+        let report = aggregate_cases(&[passing_case(), passing_case()]);
+
+        assert!(report.all_completed());
+        assert_eq!(report.unclassified, 0);
+        assert!(report.stages.is_empty());
+    }
+}

--- a/crates/conary-core/src/corpus/failure.rs
+++ b/crates/conary-core/src/corpus/failure.rs
@@ -1,0 +1,372 @@
+// conary-core/src/corpus/failure.rs
+
+//! Typed conversion-failure taxonomy for corpus reporting.
+//!
+//! The governing rule is that a failure's category comes from the concrete
+//! error type that produced it, never from the wording of its message. Human
+//! text stays attached as a diagnostic and is never a classifier, so rephrasing
+//! an error cannot move a case between buckets or change a gate result.
+//!
+//! Classification walks an `anyhow` cause chain and downcasts each link. An
+//! error whose concrete type carries no category maps to
+//! [`ConversionFailure::InternalUnclassified`] with a deterministic incident id
+//! derived from the type chain. That is a visible, countable defect rather than
+//! a guess: a rising unclassified count means the underlying errors are too
+//! coarse to report on, which is the condition the source-authority work exists
+//! to remove.
+
+use crate::error::Error;
+use serde::{Deserialize, Serialize};
+
+/// Why a case failed, categorized by the authority that rejected it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ConversionFailure {
+    /// Signature, key, or repository-authentication authority rejected the input.
+    Trust { detail: String },
+    /// The source archive container itself was unreadable or malformed.
+    SourceArchive { detail: String },
+    /// Archive framing was readable but its declared metadata was rejected.
+    SourceMetadata { detail: String },
+    /// A source semantic exists that Conary does not yet model exactly.
+    ///
+    /// This is a required implementation defect, never a permanent unsupported
+    /// class or a human-review queue.
+    UnsupportedSemantic { detail: String },
+    /// A declared or observed resource bound was exceeded.
+    ResourceBudget { detail: String },
+    /// Generated CCS authority failed its own structural or signing contract.
+    CcsAuthority { detail: String },
+    /// Publication or serving rejected an otherwise valid artifact.
+    Publication { detail: String },
+    /// Transaction planning, mutation, or rollback failed.
+    Transaction { detail: String },
+    /// No concrete type in the chain carries a category.
+    ///
+    /// `incident_id` is derived from the chain's type names, so the same
+    /// unclassified error type always produces the same id. That makes these
+    /// aggregate into countable buckets and correlate with logs without any
+    /// message-text comparison.
+    InternalUnclassified { incident_id: String, detail: String },
+}
+
+/// Stable machine-readable category code.
+///
+/// Reports, aggregation keys, and wire payloads use this. It is deliberately
+/// separate from the human `detail`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureKind {
+    Trust,
+    SourceArchive,
+    SourceMetadata,
+    UnsupportedSemantic,
+    ResourceBudget,
+    CcsAuthority,
+    Publication,
+    Transaction,
+    InternalUnclassified,
+}
+
+impl FailureKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            FailureKind::Trust => "trust",
+            FailureKind::SourceArchive => "source_archive",
+            FailureKind::SourceMetadata => "source_metadata",
+            FailureKind::UnsupportedSemantic => "unsupported_semantic",
+            FailureKind::ResourceBudget => "resource_budget",
+            FailureKind::CcsAuthority => "ccs_authority",
+            FailureKind::Publication => "publication",
+            FailureKind::Transaction => "transaction",
+            FailureKind::InternalUnclassified => "internal_unclassified",
+        }
+    }
+
+    /// Every category, for exhaustive report scaffolding.
+    pub const ALL: [FailureKind; 9] = [
+        FailureKind::Trust,
+        FailureKind::SourceArchive,
+        FailureKind::SourceMetadata,
+        FailureKind::UnsupportedSemantic,
+        FailureKind::ResourceBudget,
+        FailureKind::CcsAuthority,
+        FailureKind::Publication,
+        FailureKind::Transaction,
+        FailureKind::InternalUnclassified,
+    ];
+}
+
+impl ConversionFailure {
+    pub fn kind(&self) -> FailureKind {
+        match self {
+            ConversionFailure::Trust { .. } => FailureKind::Trust,
+            ConversionFailure::SourceArchive { .. } => FailureKind::SourceArchive,
+            ConversionFailure::SourceMetadata { .. } => FailureKind::SourceMetadata,
+            ConversionFailure::UnsupportedSemantic { .. } => FailureKind::UnsupportedSemantic,
+            ConversionFailure::ResourceBudget { .. } => FailureKind::ResourceBudget,
+            ConversionFailure::CcsAuthority { .. } => FailureKind::CcsAuthority,
+            ConversionFailure::Publication { .. } => FailureKind::Publication,
+            ConversionFailure::Transaction { .. } => FailureKind::Transaction,
+            ConversionFailure::InternalUnclassified { .. } => FailureKind::InternalUnclassified,
+        }
+    }
+
+    /// Human-readable diagnostic. Never a classifier.
+    pub fn detail(&self) -> &str {
+        match self {
+            ConversionFailure::Trust { detail }
+            | ConversionFailure::SourceArchive { detail }
+            | ConversionFailure::SourceMetadata { detail }
+            | ConversionFailure::UnsupportedSemantic { detail }
+            | ConversionFailure::ResourceBudget { detail }
+            | ConversionFailure::CcsAuthority { detail }
+            | ConversionFailure::Publication { detail }
+            | ConversionFailure::Transaction { detail }
+            | ConversionFailure::InternalUnclassified { detail, .. } => detail,
+        }
+    }
+
+    /// Classify a typed `conary-core` error by its variant.
+    ///
+    /// Variants that cannot be attributed to one authority stay unclassified
+    /// rather than being resolved by inspecting their message. `ParseError`, for
+    /// example, is raised by both archive framing and metadata decoding, so it
+    /// is deliberately not forced into either bucket here.
+    pub fn from_core_error(error: &Error) -> Self {
+        let detail = error.to_string();
+        match error {
+            Error::GpgVerificationFailed(_) => ConversionFailure::Trust { detail },
+            Error::ChecksumMismatch { .. } => ConversionFailure::SourceArchive { detail },
+            Error::DownloadError(_) | Error::HttpStatus { .. } | Error::TimeoutError(_) => {
+                ConversionFailure::Publication { detail }
+            }
+            Error::VersionParse(_) | Error::VersionComparison(_) => {
+                ConversionFailure::SourceMetadata { detail }
+            }
+            Error::NotImplemented(_) | Error::Capability(_) => {
+                ConversionFailure::UnsupportedSemantic { detail }
+            }
+            Error::PathTraversal(_) | Error::InvalidPath(_) => {
+                ConversionFailure::SourceMetadata { detail }
+            }
+            Error::ConflictError(_)
+            | Error::ResolutionError(_)
+            | Error::ScriptletExecution { .. }
+            | Error::TriggerError(_)
+            | Error::RecoveryFailed(_) => ConversionFailure::Transaction { detail },
+            other => ConversionFailure::InternalUnclassified {
+                incident_id: incident_id_for(&[core_variant_name(other)]),
+                detail,
+            },
+        }
+    }
+
+    /// Classify an `anyhow` error by walking its cause chain and downcasting.
+    ///
+    /// Only concrete types are inspected. The first link carrying a category
+    /// wins, so context wrapping does not hide the originating authority.
+    pub fn classify(error: &anyhow::Error) -> Self {
+        for cause in error.chain() {
+            if let Some(core) = cause.downcast_ref::<Error>() {
+                let classified = ConversionFailure::from_core_error(core);
+                if classified.kind() != FailureKind::InternalUnclassified {
+                    return classified;
+                }
+            }
+        }
+
+        // Nothing in the chain carries a category. Record the chain's concrete
+        // type names so identical failures aggregate together and can be found
+        // in logs, without ever comparing message text.
+        let type_names: Vec<&'static str> = error
+            .chain()
+            .map(|cause| {
+                cause
+                    .downcast_ref::<Error>()
+                    .map(core_variant_name)
+                    .unwrap_or("opaque")
+            })
+            .collect();
+
+        ConversionFailure::InternalUnclassified {
+            incident_id: incident_id_for(&type_names),
+            detail: error.to_string(),
+        }
+    }
+}
+
+/// Variant name of a core error. Structural, not its rendered message.
+fn core_variant_name(error: &Error) -> &'static str {
+    match error {
+        Error::Database(_) => "Database",
+        Error::Io(_) => "Io",
+        Error::IoError(_) => "IoError",
+        Error::InitError(_) => "InitError",
+        Error::MissingId(_) => "MissingId",
+        Error::VersionParse(_) => "VersionParse",
+        Error::VersionComparison(_) => "VersionComparison",
+        Error::HashError(_) => "HashError",
+        Error::ConfigError(_) => "ConfigError",
+        Error::DatabaseNotFound(_) => "DatabaseNotFound",
+        Error::DownloadError(_) => "DownloadError",
+        Error::HttpStatus { .. } => "HttpStatus",
+        Error::ConflictError(_) => "ConflictError",
+        Error::AmbiguousPackageSelection { .. } => "AmbiguousPackageSelection",
+        Error::ChecksumMismatch { .. } => "ChecksumMismatch",
+        Error::ParseError(_) => "ParseError",
+        Error::DeltaError(_) => "DeltaError",
+        Error::GpgVerificationFailed(_) => "GpgVerificationFailed",
+        Error::ScriptletExecution { .. } => "ScriptletExecution",
+        Error::TriggerError(_) => "TriggerError",
+        Error::AlreadyExists(_) => "AlreadyExists",
+        Error::InvalidPath(_) => "InvalidPath",
+        Error::PathTraversal(_) => "PathTraversal",
+        Error::NotFound(_) => "NotFound",
+        Error::RecoveryFailed(_) => "RecoveryFailed",
+        Error::TimeoutError(_) => "TimeoutError",
+        Error::ResolutionError(_) => "ResolutionError",
+        Error::NotImplemented(_) => "NotImplemented",
+        Error::Json(_) => "Json",
+        Error::Capability(_) => "Capability",
+        _ => "Other",
+    }
+}
+
+/// Deterministic short id over a chain of type names.
+fn incident_id_for(type_names: &[&str]) -> String {
+    let joined = type_names.join(">");
+    crate::hash::sha256(joined.as_bytes())[..16].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn core_variants_map_to_their_owning_authority() {
+        assert_eq!(
+            ConversionFailure::from_core_error(&Error::GpgVerificationFailed("k".into())).kind(),
+            FailureKind::Trust
+        );
+        assert_eq!(
+            ConversionFailure::from_core_error(&Error::NotImplemented("x".into())).kind(),
+            FailureKind::UnsupportedSemantic
+        );
+        assert_eq!(
+            ConversionFailure::from_core_error(&Error::PathTraversal("p".into())).kind(),
+            FailureKind::SourceMetadata
+        );
+        assert_eq!(
+            ConversionFailure::from_core_error(&Error::ResolutionError("r".into())).kind(),
+            FailureKind::Transaction
+        );
+    }
+
+    /// The central invariant: wording is a diagnostic, never a classifier.
+    #[test]
+    fn rewording_an_error_cannot_change_its_category() {
+        let first = ConversionFailure::from_core_error(&Error::GpgVerificationFailed(
+            "signature from unknown key".into(),
+        ));
+        let second = ConversionFailure::from_core_error(&Error::GpgVerificationFailed(
+            "totally different wording here".into(),
+        ));
+
+        assert_eq!(first.kind(), second.kind());
+        assert_ne!(
+            first.detail(),
+            second.detail(),
+            "the diagnostic must still differ, proving the category ignored it"
+        );
+    }
+
+    /// A message that reads like another category must not be reclassified.
+    #[test]
+    fn message_text_resembling_another_category_does_not_move_the_bucket() {
+        let misleading =
+            ConversionFailure::from_core_error(&Error::ResolutionError("trust failure".into()));
+
+        assert_eq!(
+            misleading.kind(),
+            FailureKind::Transaction,
+            "classification must follow the variant, not the words in the message"
+        );
+    }
+
+    #[test]
+    fn classify_finds_the_category_through_context_wrapping() {
+        let wrapped = anyhow::Error::from(Error::GpgVerificationFailed("bad sig".into()))
+            .context("while converting package")
+            .context("while running prewarm");
+
+        assert_eq!(
+            ConversionFailure::classify(&wrapped).kind(),
+            FailureKind::Trust,
+            "context layers must not hide the originating authority"
+        );
+    }
+
+    #[test]
+    fn opaque_errors_are_unclassified_rather_than_guessed() {
+        let opaque = anyhow::anyhow!("something went wrong in an untyped path");
+
+        let failure = ConversionFailure::classify(&opaque);
+
+        assert_eq!(failure.kind(), FailureKind::InternalUnclassified);
+        match failure {
+            ConversionFailure::InternalUnclassified { incident_id, .. } => {
+                assert_eq!(incident_id.len(), 16);
+            }
+            other => panic!("expected InternalUnclassified, got {other:?}"),
+        }
+    }
+
+    /// Unclassified failures must aggregate, so the id depends on the type
+    /// chain and not on the message.
+    #[test]
+    fn identical_unclassified_type_chains_share_one_incident_id() {
+        let first = ConversionFailure::classify(&anyhow::anyhow!("first wording"));
+        let second = ConversionFailure::classify(&anyhow::anyhow!("second wording entirely"));
+
+        match (first, second) {
+            (
+                ConversionFailure::InternalUnclassified {
+                    incident_id: a,
+                    detail: da,
+                },
+                ConversionFailure::InternalUnclassified {
+                    incident_id: b,
+                    detail: db,
+                },
+            ) => {
+                assert_eq!(a, b, "same type chain must share an incident id");
+                assert_ne!(da, db, "details must still differ");
+            }
+            other => panic!("expected two unclassified failures, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn failure_kind_codes_are_stable_and_unique() {
+        let mut codes: Vec<&str> = FailureKind::ALL.iter().map(|k| k.as_str()).collect();
+        let total = codes.len();
+        codes.sort_unstable();
+        codes.dedup();
+        assert_eq!(codes.len(), total, "category codes must be unique");
+        assert_eq!(FailureKind::Trust.as_str(), "trust");
+    }
+
+    #[test]
+    fn failures_round_trip_through_serde_by_category_code() {
+        let failure = ConversionFailure::SourceArchive {
+            detail: "truncated payload stream".into(),
+        };
+
+        let json = serde_json::to_value(&failure).expect("serialize");
+        assert_eq!(json["kind"], serde_json::json!("source_archive"));
+
+        let restored: ConversionFailure = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(restored, failure);
+    }
+}

--- a/crates/conary-core/src/corpus/mod.rs
+++ b/crates/conary-core/src/corpus/mod.rs
@@ -1,0 +1,385 @@
+// conary-core/src/corpus/mod.rs
+
+//! Typed result vocabulary for the just-works corpus gate.
+//!
+//! The corpus proves that ordinary packages complete an ordinary user journey
+//! across the supported source/target matrix. This module owns how that proof
+//! is *reported*, not how it is run: the stages a case passes through, the
+//! typed reason it stopped, and the identities that make a result attributable.
+//!
+//! It exists so gate results aggregate by typed stage and category rather than
+//! by error-message text. Aggregating by wording makes a rephrased error look
+//! like a new failure class and two distinct defects look like one, which is
+//! not a basis for release decisions.
+//!
+//! The vocabulary lives in `conary-core` because it is shared by the CLI, Remi,
+//! and the `conary-test` runner. See [`failure`] for the classification rule.
+
+mod aggregate;
+mod failure;
+
+pub use aggregate::{FailureTally, StageTally, aggregate_cases};
+pub use failure::{ConversionFailure, FailureKind};
+
+use serde::{Deserialize, Serialize};
+
+/// One stage of the user journey a corpus case walks.
+///
+/// Ordering matches execution order, so `StageResult` sequences are directly
+/// comparable and the first failing stage is the earliest one recorded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConversionStage {
+    RepositoryAuthentication,
+    ArtifactDownload,
+    PackageSignatureVerification,
+    NativeParse,
+    CcsProjection,
+    CcsSigning,
+    CcsVerification,
+    Publication,
+    Resolution,
+    TransactionPreflight,
+    Installation,
+    Update,
+    Removal,
+    Rollback,
+}
+
+impl ConversionStage {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ConversionStage::RepositoryAuthentication => "repository_authentication",
+            ConversionStage::ArtifactDownload => "artifact_download",
+            ConversionStage::PackageSignatureVerification => "package_signature_verification",
+            ConversionStage::NativeParse => "native_parse",
+            ConversionStage::CcsProjection => "ccs_projection",
+            ConversionStage::CcsSigning => "ccs_signing",
+            ConversionStage::CcsVerification => "ccs_verification",
+            ConversionStage::Publication => "publication",
+            ConversionStage::Resolution => "resolution",
+            ConversionStage::TransactionPreflight => "transaction_preflight",
+            ConversionStage::Installation => "installation",
+            ConversionStage::Update => "update",
+            ConversionStage::Removal => "removal",
+            ConversionStage::Rollback => "rollback",
+        }
+    }
+
+    /// Every stage in execution order.
+    pub const ALL: [ConversionStage; 14] = [
+        ConversionStage::RepositoryAuthentication,
+        ConversionStage::ArtifactDownload,
+        ConversionStage::PackageSignatureVerification,
+        ConversionStage::NativeParse,
+        ConversionStage::CcsProjection,
+        ConversionStage::CcsSigning,
+        ConversionStage::CcsVerification,
+        ConversionStage::Publication,
+        ConversionStage::Resolution,
+        ConversionStage::TransactionPreflight,
+        ConversionStage::Installation,
+        ConversionStage::Update,
+        ConversionStage::Removal,
+        ConversionStage::Rollback,
+    ];
+}
+
+/// Which configured upstream feed the artifact came from.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SourceProfileIdentity {
+    /// Exact configured profile id, e.g. `fedora-44`.
+    pub profile: String,
+    /// Source package format the profile's parser owns.
+    pub format: String,
+}
+
+/// The exact artifact under test, pinned by digest.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SourceArtifactIdentity {
+    pub name: String,
+    pub version: String,
+    pub architecture: Option<String>,
+    /// SHA-256 of the source artifact. A result without this is not evidence.
+    pub digest: String,
+}
+
+/// Typed host capabilities the case ran against.
+///
+/// Deliberately capability facts rather than a distro name, matching the
+/// lifecycle contract: the target exposes capabilities, it does not select
+/// behavior by identity.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TargetCapabilitySnapshot {
+    /// Target profile id used for reporting attribution.
+    pub profile: String,
+    pub architecture: String,
+    pub init_system: String,
+    /// Additional typed capability facts recorded for this run.
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+}
+
+/// Outcome of one stage.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum StageOutcome {
+    Passed,
+    Failed {
+        failure: ConversionFailure,
+    },
+    /// Not reached because an earlier stage failed.
+    NotReached,
+    /// Deliberately not part of this case's declared journey.
+    NotApplicable {
+        reason: String,
+    },
+}
+
+/// One stage's recorded result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StageResult {
+    pub stage: ConversionStage,
+    #[serde(flatten)]
+    pub outcome: StageOutcome,
+}
+
+impl StageResult {
+    pub fn passed(stage: ConversionStage) -> Self {
+        Self {
+            stage,
+            outcome: StageOutcome::Passed,
+        }
+    }
+
+    pub fn failed(stage: ConversionStage, failure: ConversionFailure) -> Self {
+        Self {
+            stage,
+            outcome: StageOutcome::Failed { failure },
+        }
+    }
+
+    pub fn not_reached(stage: ConversionStage) -> Self {
+        Self {
+            stage,
+            outcome: StageOutcome::NotReached,
+        }
+    }
+
+    pub fn failure(&self) -> Option<&ConversionFailure> {
+        match &self.outcome {
+            StageOutcome::Failed { failure } => Some(failure),
+            _ => None,
+        }
+    }
+}
+
+/// Final disposition of a case.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum CorpusOutcome {
+    /// Every declared stage passed.
+    Completed,
+    /// A stage failed. The stage and category are the aggregation key.
+    Failed {
+        stage: ConversionStage,
+        failure: ConversionFailure,
+    },
+    /// The case did not run. Not a pass and not a failure of the code.
+    Skipped { reason: String },
+}
+
+/// One corpus case: an exact artifact against an exact target.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorpusCaseResult {
+    pub source_profile: SourceProfileIdentity,
+    pub source_artifact: SourceArtifactIdentity,
+    pub target_profile: TargetCapabilitySnapshot,
+    pub stage_results: Vec<StageResult>,
+    pub final_outcome: CorpusOutcome,
+}
+
+impl CorpusCaseResult {
+    /// Build a result from the stages actually walked.
+    ///
+    /// The outcome is derived from the first failing stage rather than passed
+    /// in separately, so a result cannot claim success while carrying a failed
+    /// stage.
+    pub fn from_stages(
+        source_profile: SourceProfileIdentity,
+        source_artifact: SourceArtifactIdentity,
+        target_profile: TargetCapabilitySnapshot,
+        stage_results: Vec<StageResult>,
+    ) -> Self {
+        let final_outcome = stage_results
+            .iter()
+            .find_map(|result| {
+                result.failure().map(|failure| CorpusOutcome::Failed {
+                    stage: result.stage,
+                    failure: failure.clone(),
+                })
+            })
+            .unwrap_or(CorpusOutcome::Completed);
+
+        Self {
+            source_profile,
+            source_artifact,
+            target_profile,
+            stage_results,
+            final_outcome,
+        }
+    }
+
+    pub fn completed(&self) -> bool {
+        matches!(self.final_outcome, CorpusOutcome::Completed)
+    }
+
+    /// The stage and category this case failed at, if any.
+    pub fn failure_key(&self) -> Option<(ConversionStage, FailureKind)> {
+        match &self.final_outcome {
+            CorpusOutcome::Failed { stage, failure } => Some((*stage, failure.kind())),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn profile() -> SourceProfileIdentity {
+        SourceProfileIdentity {
+            profile: "fedora-44".into(),
+            format: "rpm".into(),
+        }
+    }
+
+    fn artifact() -> SourceArtifactIdentity {
+        SourceArtifactIdentity {
+            name: "2ping".into(),
+            version: "4.5.1-24.fc44".into(),
+            architecture: Some("noarch".into()),
+            digest: "cf48a9380416daf02e934cbddd15d5356b3b6ea6b5f0824187074b66dd0fe14a".into(),
+        }
+    }
+
+    fn target() -> TargetCapabilitySnapshot {
+        TargetCapabilitySnapshot {
+            profile: "arch".into(),
+            architecture: "x86_64".into(),
+            init_system: "systemd".into(),
+            capabilities: vec!["posix-acl".into()],
+        }
+    }
+
+    #[test]
+    fn a_case_with_every_stage_passing_completes() {
+        let stages = vec![
+            StageResult::passed(ConversionStage::NativeParse),
+            StageResult::passed(ConversionStage::CcsProjection),
+            StageResult::passed(ConversionStage::Installation),
+        ];
+
+        let case = CorpusCaseResult::from_stages(profile(), artifact(), target(), stages);
+
+        assert!(case.completed());
+        assert_eq!(case.failure_key(), None);
+    }
+
+    /// A result must not be able to claim success while carrying a failed
+    /// stage, so the outcome is derived rather than supplied.
+    #[test]
+    fn a_failed_stage_forces_a_failed_outcome() {
+        let stages = vec![
+            StageResult::passed(ConversionStage::NativeParse),
+            StageResult::failed(
+                ConversionStage::CcsVerification,
+                ConversionFailure::CcsAuthority {
+                    detail: "manifest exceeds declared budget".into(),
+                },
+            ),
+            StageResult::not_reached(ConversionStage::Installation),
+        ];
+
+        let case = CorpusCaseResult::from_stages(profile(), artifact(), target(), stages);
+
+        assert!(!case.completed());
+        assert_eq!(
+            case.failure_key(),
+            Some((ConversionStage::CcsVerification, FailureKind::CcsAuthority))
+        );
+    }
+
+    #[test]
+    fn the_earliest_failing_stage_owns_the_outcome() {
+        let stages = vec![
+            StageResult::failed(
+                ConversionStage::PackageSignatureVerification,
+                ConversionFailure::Trust {
+                    detail: "unknown signing subkey".into(),
+                },
+            ),
+            StageResult::failed(
+                ConversionStage::NativeParse,
+                ConversionFailure::SourceArchive {
+                    detail: "truncated".into(),
+                },
+            ),
+        ];
+
+        let case = CorpusCaseResult::from_stages(profile(), artifact(), target(), stages);
+
+        assert_eq!(
+            case.failure_key(),
+            Some((
+                ConversionStage::PackageSignatureVerification,
+                FailureKind::Trust
+            )),
+            "the first failure in execution order is the attributable one"
+        );
+    }
+
+    #[test]
+    fn stage_codes_are_stable_and_unique() {
+        let mut codes: Vec<&str> = ConversionStage::ALL.iter().map(|s| s.as_str()).collect();
+        let total = codes.len();
+        codes.sort_unstable();
+        codes.dedup();
+        assert_eq!(codes.len(), total, "stage codes must be unique");
+        assert_eq!(
+            ConversionStage::ALL.len(),
+            14,
+            "the journey has fourteen stages"
+        );
+    }
+
+    #[test]
+    fn stages_order_by_execution_sequence() {
+        assert!(ConversionStage::RepositoryAuthentication < ConversionStage::NativeParse);
+        assert!(ConversionStage::Installation < ConversionStage::Rollback);
+    }
+
+    #[test]
+    fn a_case_round_trips_through_serde() {
+        let case = CorpusCaseResult::from_stages(
+            profile(),
+            artifact(),
+            target(),
+            vec![StageResult::failed(
+                ConversionStage::NativeParse,
+                ConversionFailure::SourceMetadata {
+                    detail: "inode metadata disagreement".into(),
+                },
+            )],
+        );
+
+        let json = serde_json::to_string(&case).expect("serialize");
+        let restored: CorpusCaseResult = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(restored, case);
+        assert_eq!(
+            restored.failure_key(),
+            Some((ConversionStage::NativeParse, FailureKind::SourceMetadata))
+        );
+    }
+}

--- a/crates/conary-core/src/lib.rs
+++ b/crates/conary-core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod components;
 pub mod compression;
 pub mod config_transaction;
 pub mod container;
+pub mod corpus;
 pub mod db;
 pub mod delta;
 pub mod dependencies;


### PR DESCRIPTION
Refs #110. This is the schema half only — the runner, fixture selection, and the 3×3 matrix stay open on the umbrella issue.

## Why now

The roadmap records this as a deliberate ordering exception: the typed schema lands *before* the other W4 slices close, so each reports against it. Retrofitting typed results onto five finished fixes costs more than defining the vocabulary once, and without it the W4 gate has nothing to report in but message text.

Remi's prewarm result currently keeps failed package identity plus `e.to_string()`. That is fine for logs and unusable as gate authority — rephrasing an error looks like a new failure class, and two unrelated defects that happen to share wording look like one.

## What this adds

`conary_core::corpus`, owning how corpus proof is *reported* rather than how it is run. It lives in `conary-core` because the CLI, Remi, and `conary-test` all need the same vocabulary.

- **`ConversionStage`** — the fourteen journey stages, ordered by execution, so the first failing stage is the attributable one.
- **`ConversionFailure` / `FailureKind`** — nine categories named for the authority that rejected the input. Each carries a human `detail` that is explicitly never a classifier.
- **`CorpusCaseResult`** — source profile, digest-pinned artifact identity, target capability snapshot, per-stage results. The final outcome is *derived* from the first failing stage rather than passed in, so a result cannot claim success while carrying a failed stage.
- **`aggregate_cases`** — tallies keyed only on enum discriminants.

## How classification avoids message text

`ConversionFailure::classify` walks an `anyhow` cause chain and `downcast_ref`s each link, so context wrapping cannot hide the originating authority and no decision ever reads a string. There is existing precedent for this at `conversion/lookup.rs:216`.

Variants that genuinely span two authorities are left unclassified rather than forced into a bucket. `Error::ParseError` is raised by both archive framing and metadata decoding, and the only way to separate them today would be to inspect the message — which is the thing being prohibited.

Unclassifiable errors become `InternalUnclassified` with an incident id hashed from the chain's **concrete type names**. Identical type chains share an id and aggregate together while their details still differ. That count is itself a gate signal: it measures how much of the codebase still raises errors too coarse to report on, which is exactly what W5 and W6 exist to fix. It goes down as those land.

## Remi prewarm wiring

`PrewarmResult.failed` becomes `Vec<PrewarmFailure>` carrying a typed category. Classification happens at the call site where the error is still typed, rather than after `to_string()` has erased it — that call was the exact point the type was being discarded. The prewarm CLI now prints the category alongside the diagnostic. Pre-alpha hard cut: the tuple shape is replaced, not aliased.

## Verification

```
cargo test -p conary-core corpus::        21 passed
cargo test -p remi --lib prewarm          13 passed
cargo clippy -p conary-core -p remi --all-targets -- -D warnings    clean
cargo fmt --check                          clean
bash scripts/check-doc-truth.sh            passed
```

Three tests encode the rule directly: rewording an error cannot change its category, a message that *reads* like another category does not move buckets, and identical wording across two categories does not merge them. Run on rustc 1.97.1 to match CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011y1e74GvvxzaDkyrxthYZB