### PR TITLE
fix(paths): decide traversal on exact bytes, not character class

### DIFF
--- a/crates/conary-core/src/filesystem/mod.rs
+++ b/crates/conary-core/src/filesystem/mod.rs
@@ -15,8 +15,10 @@ pub mod durable;
 pub mod fsverity;
 pub mod path;
 pub mod selected_root;
+pub mod source_path;
 pub mod vfs;
 
 pub use cas::{CasStore, object_path};
 pub use path::{safe_join, sanitize_filename, sanitize_path};
+pub use source_path::{DeploymentPath, SourcePathBytes};
 pub use vfs::{NodeId, NodeKind, VfsNode, VfsStats, VfsTree};

--- a/crates/conary-core/src/filesystem/path.rs
+++ b/crates/conary-core/src/filesystem/path.rs
@@ -6,15 +6,21 @@
 //! sources (packages, repositories, etc.) to prevent path traversal attacks.
 
 use crate::error::{Error, Result};
-use std::path::{Component, Path, PathBuf};
+use crate::filesystem::source_path::SourcePathBytes;
+use std::path::{Path, PathBuf};
 
 /// Sanitize a path from an untrusted source
 ///
-/// This function:
-/// 1. Rejects paths containing `..` (parent directory) components
-/// 2. Skips `.` (current directory) components
-/// 3. Strips leading slashes to make the path relative
-/// 4. Returns an error for empty paths
+/// Delegates to [`SourcePathBytes`], which decides traversal by exact
+/// component comparison on bytes. This function:
+/// 1. Rejects paths containing an exact `..` component
+/// 2. Skips `.` components
+/// 3. Drops leading, trailing, and repeated separators, making the path relative
+/// 4. Rejects NUL bytes and paths with no deployable components
+///
+/// Character class is deliberately not consulted. Non-ASCII paths are valid in
+/// every source format Conary parses; a name is traversal only if it *is* `..`,
+/// not if it merely looks unusual.
 ///
 /// # Security
 ///
@@ -41,56 +47,25 @@ use std::path::{Component, Path, PathBuf};
 /// assert!(sanitize_path("usr/../../../etc/passwd").is_err());
 /// ```
 pub fn sanitize_path(path: impl AsRef<Path>) -> Result<PathBuf> {
-    let path = path.as_ref();
-    let path_str = path.to_string_lossy();
+    Ok(source_path_for(path.as_ref())
+        .to_deployment_path()?
+        .to_path_buf())
+}
 
-    // Reject null bytes -- these truncate paths at C API boundaries (open(), stat(), etc.)
-    if path_str.contains('\0') {
-        return Err(Error::PathTraversal("path contains null byte".to_string()));
-    }
+/// Recover the declared bytes of a path for validation.
+///
+/// On Unix this is exact. Validation is defined on bytes rather than on
+/// decoded text so that traversal is decided by component identity, not by how
+/// a path renders.
+#[cfg(unix)]
+fn source_path_for(path: &Path) -> SourcePathBytes {
+    use std::os::unix::ffi::OsStrExt;
+    SourcePathBytes::new(path.as_os_str().as_bytes().to_vec())
+}
 
-    // Reject non-ASCII paths from untrusted sources to avoid Unicode
-    // normalization edge cases on filesystems that treat homoglyphs as
-    // separators or normalize canonically equivalent forms.
-    if !path_str.is_ascii() {
-        return Err(Error::PathTraversal(
-            "path contains non-ASCII characters".to_string(),
-        ));
-    }
-
-    // Strip leading slashes to make relative
-    let relative = path_str.trim_start_matches('/');
-
-    let mut normalized = PathBuf::new();
-
-    for component in Path::new(relative).components() {
-        match component {
-            Component::Normal(c) => {
-                // Normal path component - keep it
-                normalized.push(c);
-            }
-            Component::CurDir => {
-                // "." - skip it
-            }
-            Component::ParentDir => {
-                // ".." - this is a path traversal attempt
-                return Err(Error::PathTraversal(path_str.to_string()));
-            }
-            Component::Prefix(_) | Component::RootDir => {
-                // Skip Windows prefixes and root markers
-                // (we already stripped leading slashes)
-            }
-        }
-    }
-
-    // Reject empty paths
-    if normalized.as_os_str().is_empty() {
-        return Err(Error::InvalidPath(
-            "Empty path after sanitization".to_string(),
-        ));
-    }
-
-    Ok(normalized)
+#[cfg(not(unix))]
+fn source_path_for(path: &Path) -> SourcePathBytes {
+    SourcePathBytes::new(path.to_string_lossy().as_bytes().to_vec())
 }
 
 /// Safely join a root path with an untrusted path
@@ -302,10 +277,49 @@ mod tests {
         assert!(sanitize_path("./").is_err());
     }
 
+    /// Behavior change: non-ASCII paths are accepted.
+    ///
+    /// The previous rule rejected every non-ASCII path as traversal, which is
+    /// not a rule of ALPM, RPM, Debian, tar, or Linux, and rejected valid
+    /// repository packages across all three source formats.
     #[test]
-    fn test_sanitize_path_non_ascii_rejected() {
-        assert!(sanitize_path("usr/bin/cafe\u{301}").is_err());
-        assert!(sanitize_path("usr\u{ff0f}bin\u{ff0f}tool").is_err());
+    fn sanitize_path_accepts_valid_non_ascii_paths() {
+        assert_eq!(
+            sanitize_path("usr/bin/cafe\u{301}").unwrap(),
+            PathBuf::from("usr/bin/cafe\u{301}")
+        );
+        assert_eq!(
+            sanitize_path("usr/share/doc/n\u{f8}rsk.txt").unwrap(),
+            PathBuf::from("usr/share/doc/n\u{f8}rsk.txt")
+        );
+    }
+
+    /// A separator homoglyph is not a separator.
+    ///
+    /// U+FF0F FULLWIDTH SOLIDUS renders like `/` but is not the separator byte,
+    /// so `usr／bin／tool` is one ordinary component, not three. It cannot
+    /// escape a directory precisely because it does not split the path. The old
+    /// rule rejected it out of homoglyph anxiety; the correct answer is that
+    /// only the separator byte separates.
+    #[test]
+    fn separator_homoglyphs_are_ordinary_name_bytes_not_separators() {
+        let sanitized = sanitize_path("usr\u{ff0f}bin\u{ff0f}tool").expect("valid single component");
+
+        assert_eq!(sanitized, PathBuf::from("usr\u{ff0f}bin\u{ff0f}tool"));
+        assert_eq!(
+            sanitized.components().count(),
+            1,
+            "a fullwidth solidus must not split the path"
+        );
+    }
+
+    /// The security property is unchanged: traversal is still rejected, and
+    /// dressing it in non-ASCII does not get it through.
+    #[test]
+    fn traversal_is_still_rejected_regardless_of_character_class() {
+        assert!(sanitize_path("usr/\u{e9}t\u{e9}/../../etc/passwd").is_err());
+        assert!(sanitize_path("../etc/passwd").is_err());
+        assert!(sanitize_path("usr/\u{e9}t\u{e9}/file").is_ok());
     }
 
     #[test]

--- a/crates/conary-core/src/filesystem/path.rs
+++ b/crates/conary-core/src/filesystem/path.rs
@@ -303,7 +303,8 @@ mod tests {
     /// only the separator byte separates.
     #[test]
     fn separator_homoglyphs_are_ordinary_name_bytes_not_separators() {
-        let sanitized = sanitize_path("usr\u{ff0f}bin\u{ff0f}tool").expect("valid single component");
+        let sanitized =
+            sanitize_path("usr\u{ff0f}bin\u{ff0f}tool").expect("valid single component");
 
         assert_eq!(sanitized, PathBuf::from("usr\u{ff0f}bin\u{ff0f}tool"));
         assert_eq!(

--- a/crates/conary-core/src/filesystem/source_path.rs
+++ b/crates/conary-core/src/filesystem/source_path.rs
@@ -1,0 +1,397 @@
+// conary-core/src/filesystem/source_path.rs
+
+//! Byte-exact path authority for untrusted source-package archives.
+//!
+//! Archive paths are byte strings in a format-defined grammar. They are not
+//! `std::path::Path` values, and asking `Path` to parse them imports host
+//! filesystem conventions that the source format never promised. This module
+//! keeps the two apart: [`SourcePathBytes`] preserves exactly what the archive
+//! declared, and [`DeploymentPath`] is the validated relative form that may be
+//! materialized under a root.
+//!
+//! Traversal safety is decided by exact component comparison on bytes, never by
+//! how a path *looks*. The previous implementation rejected every non-ASCII
+//! path as traversal, which is not a rule of ALPM, RPM, Debian, tar, or Linux.
+//! It rejected valid repository packages — `aisleriot`, `aspell-nb`, `azure-cli`
+//! on Arch, and equally any RPM or Debian package with a non-ASCII path, since
+//! all three formats route through this authority. It also converted with
+//! `to_string_lossy` before deciding, destroying the very bytes a rejection
+//! would need to be diagnosed.
+//!
+//! # Scope boundary
+//!
+//! [`SourcePathBytes`] can hold any non-NUL byte sequence, but Conary persists
+//! paths as `TEXT`/`String` (`ccs/v2/schema.rs`, `packages/mod.rs`, the `files`
+//! table). Storing a non-UTF-8 path therefore requires a CCS schema and
+//! database decision that this module deliberately does not make. Until that
+//! decision exists, [`DeploymentPath::to_utf8`] is the persistence boundary and
+//! returns a typed error for non-UTF-8 input rather than lossily converting it.
+//! That keeps the failure explicit and attributable instead of silently
+//! corrupting a path.
+
+use crate::error::{Error, Result};
+use std::path::{Path, PathBuf};
+
+/// The path separator byte. Archive grammars define this exactly; it is not a
+/// host filesystem convention and does not vary by platform.
+const SEPARATOR: u8 = b'/';
+
+const CURRENT_DIR: &[u8] = b".";
+const PARENT_DIR: &[u8] = b"..";
+
+/// A path exactly as an archive declared it.
+///
+/// Lossless: no normalization, no case folding, no Unicode normalization, no
+/// lossy character replacement. Two paths that differ by a single byte remain
+/// distinguishable, which matters because a package may legitimately ship paths
+/// that are canonically equivalent under NFC/NFD but distinct as bytes.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SourcePathBytes(Vec<u8>);
+
+impl SourcePathBytes {
+    /// Record a declared path verbatim.
+    pub fn new(bytes: impl Into<Vec<u8>>) -> Self {
+        Self(bytes.into())
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Lossy rendering for diagnostics only.
+    ///
+    /// Never use this to make a decision. It exists so an error message can
+    /// show something readable for a path that is not valid UTF-8.
+    pub fn to_diagnostic_string(&self) -> String {
+        String::from_utf8_lossy(&self.0).into_owned()
+    }
+
+    /// Validate for materialization under a root.
+    ///
+    /// Splits on the separator byte only, then judges each component by exact
+    /// byte comparison:
+    ///
+    /// - a NUL byte anywhere is rejected, since it truncates the path at C API
+    ///   boundaries and would make the materialized path differ from the
+    ///   validated one
+    /// - empty components, produced by leading, trailing, or repeated
+    ///   separators, carry no meaning and are dropped
+    /// - `.` is dropped
+    /// - `..` is rejected outright rather than resolved, because resolving it
+    ///   against a root that contains symlinks does not mean what it appears to
+    /// - a path with no components left is rejected as undeployable
+    ///
+    /// Character class, script, and encoding are deliberately not consulted.
+    pub fn to_deployment_path(&self) -> Result<DeploymentPath> {
+        if self.0.contains(&0) {
+            return Err(Error::PathTraversal(format!(
+                "path contains a NUL byte: {}",
+                self.to_diagnostic_string()
+            )));
+        }
+
+        let mut components: Vec<Vec<u8>> = Vec::new();
+        for component in self.0.split(|byte| *byte == SEPARATOR) {
+            match component {
+                b"" | CURRENT_DIR => {}
+                PARENT_DIR => {
+                    return Err(Error::PathTraversal(format!(
+                        "path contains a parent-directory component: {}",
+                        self.to_diagnostic_string()
+                    )));
+                }
+                other => components.push(other.to_vec()),
+            }
+        }
+
+        if components.is_empty() {
+            return Err(Error::InvalidPath(format!(
+                "path has no deployable components: {}",
+                self.to_diagnostic_string()
+            )));
+        }
+
+        Ok(DeploymentPath { components })
+    }
+}
+
+impl From<&str> for SourcePathBytes {
+    fn from(value: &str) -> Self {
+        Self(value.as_bytes().to_vec())
+    }
+}
+
+/// A validated, relative path safe to join beneath a root.
+///
+/// Holding one of these means traversal validation already happened. It cannot
+/// be constructed except through [`SourcePathBytes::to_deployment_path`].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DeploymentPath {
+    components: Vec<Vec<u8>>,
+}
+
+impl DeploymentPath {
+    /// Components in order, each a non-empty byte string that is not `.` or `..`.
+    pub fn components(&self) -> impl Iterator<Item = &[u8]> {
+        self.components.iter().map(|component| component.as_slice())
+    }
+
+    pub fn component_count(&self) -> usize {
+        self.components.len()
+    }
+
+    /// Rejoin with the separator byte, byte-exact.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.components.join(&SEPARATOR)
+    }
+
+    /// The persistence boundary.
+    ///
+    /// Errors rather than converting lossily, because Conary persists paths as
+    /// text and a lossy conversion here would write a path that does not match
+    /// the artifact. See this module's scope note.
+    pub fn to_utf8(&self) -> Result<String> {
+        String::from_utf8(self.to_bytes()).map_err(|error| {
+            Error::InvalidPath(format!(
+                "path is not valid UTF-8 and cannot be persisted: {error}"
+            ))
+        })
+    }
+
+    /// Convert to a relative `PathBuf` for filesystem calls.
+    ///
+    /// Safe only after validation, which is why it lives on this type and not
+    /// on [`SourcePathBytes`].
+    #[cfg(unix)]
+    pub fn to_path_buf(&self) -> PathBuf {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let mut path = PathBuf::new();
+        for component in &self.components {
+            path.push(OsString::from_vec(component.clone()));
+        }
+        path
+    }
+
+    /// Non-Unix hosts have no byte-exact path representation, so this requires
+    /// UTF-8 rather than guessing an encoding.
+    #[cfg(not(unix))]
+    pub fn to_path_buf(&self) -> PathBuf {
+        PathBuf::from(
+            self.to_utf8()
+                .unwrap_or_else(|_| String::from_utf8_lossy(&self.to_bytes()).into_owned()),
+        )
+    }
+
+    /// Join beneath `root`. The result cannot escape by construction: every
+    /// component is a plain name, and `..` was rejected at validation.
+    pub fn join_under(&self, root: impl AsRef<Path>) -> PathBuf {
+        root.as_ref().join(self.to_path_buf())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn deploy(input: &str) -> Result<DeploymentPath> {
+        SourcePathBytes::from(input).to_deployment_path()
+    }
+
+    #[test]
+    fn ordinary_paths_keep_their_components_in_order() {
+        let path = deploy("usr/bin/foo").expect("valid path");
+
+        assert_eq!(path.component_count(), 3);
+        assert_eq!(path.to_bytes(), b"usr/bin/foo");
+        assert_eq!(path.to_utf8().unwrap(), "usr/bin/foo");
+    }
+
+    #[test]
+    fn leading_trailing_and_repeated_separators_are_dropped() {
+        for input in ["/usr/bin/foo", "usr/bin/foo/", "//usr//bin//foo//"] {
+            let path = deploy(input).unwrap_or_else(|_| panic!("{input} should be valid"));
+            assert_eq!(path.to_bytes(), b"usr/bin/foo", "input was {input}");
+        }
+    }
+
+    #[test]
+    fn current_directory_components_are_dropped() {
+        assert_eq!(deploy("./usr/./bin/foo").unwrap().to_bytes(), b"usr/bin/foo");
+    }
+
+    // -- Traversal safety, decided on exact components ----------------------
+
+    #[test]
+    fn parent_directory_components_are_rejected() {
+        for input in ["../etc/passwd", "usr/../../etc/passwd", "usr/bin/..", ".."] {
+            assert!(
+                deploy(input).is_err(),
+                "{input} must be rejected as traversal"
+            );
+        }
+    }
+
+    #[test]
+    fn nul_bytes_are_rejected() {
+        let path = SourcePathBytes::new(b"usr/bin/foo\0.txt".to_vec());
+
+        assert!(
+            path.to_deployment_path().is_err(),
+            "a NUL byte truncates the path at C API boundaries"
+        );
+    }
+
+    #[test]
+    fn paths_with_no_deployable_components_are_rejected() {
+        for input in ["", "/", "///", ".", "./."] {
+            assert!(deploy(input).is_err(), "{input} has nothing to deploy");
+        }
+    }
+
+    /// Names that merely *contain* dots are ordinary names. Only an exact `..`
+    /// component is traversal.
+    #[test]
+    fn names_containing_dots_are_not_traversal() {
+        for input in ["usr/lib/..foo", "usr/lib/foo..", "usr/lib/a..b", "usr/..."] {
+            assert!(
+                deploy(input).is_ok(),
+                "{input} is an ordinary name, not traversal"
+            );
+        }
+    }
+
+    // -- The defect this module replaces ------------------------------------
+
+    /// The previous authority rejected every non-ASCII path as traversal. These
+    /// are real repository packages named in issue #99.
+    #[test]
+    fn valid_non_ascii_paths_are_accepted_and_round_trip_byte_exactly() {
+        let cases = [
+            "usr/share/aisleriot/cards/fran\u{e7}ais.svg",
+            "usr/share/doc/aspell-nb/n\u{f8}rsk.txt",
+            "usr/lib/azure-cli/\u{6587}\u{4ef6}.py",
+            "usr/share/icons/\u{1f4e6}.png",
+        ];
+
+        for input in cases {
+            let path = deploy(input).unwrap_or_else(|error| {
+                panic!("{input} is a valid source path but was rejected: {error:?}")
+            });
+            assert_eq!(
+                path.to_utf8().unwrap(),
+                input.trim_start_matches('/'),
+                "{input} must round-trip byte-exactly"
+            );
+        }
+    }
+
+    /// Non-ASCII is orthogonal to traversal: a non-ASCII path with `..` is
+    /// still rejected, and an ASCII path without it is still accepted.
+    #[test]
+    fn character_class_does_not_decide_traversal() {
+        assert!(deploy("usr/\u{e9}t\u{e9}/../../etc/passwd").is_err());
+        assert!(deploy("usr/\u{e9}t\u{e9}/file").is_ok());
+        assert!(deploy("usr/ascii/../../etc/passwd").is_err());
+        assert!(deploy("usr/ascii/file").is_ok());
+    }
+
+    /// Canonically equivalent Unicode forms are distinct byte sequences and
+    /// must stay distinct. Normalizing here would merge two paths a package
+    /// may legitimately ship separately.
+    #[test]
+    fn unicode_normalization_is_not_applied() {
+        let precomposed = deploy("usr/share/\u{e9}").unwrap();
+        let decomposed = deploy("usr/share/e\u{301}").unwrap();
+
+        assert_ne!(
+            precomposed.to_bytes(),
+            decomposed.to_bytes(),
+            "NFC and NFD forms must remain distinct byte sequences"
+        );
+    }
+
+    // -- Byte-level authority beyond UTF-8 ----------------------------------
+
+    /// Structural validation is defined on bytes, so a non-UTF-8 path is
+    /// judged for traversal without needing to be decodable.
+    #[test]
+    fn non_utf8_paths_are_structurally_validated_without_decoding() {
+        let valid = SourcePathBytes::new(vec![b'u', b's', b'r', b'/', 0xff, 0xfe]);
+        let traversal = SourcePathBytes::new(vec![0xff, b'/', b'.', b'.', b'/', b'x']);
+
+        let deployed = valid.to_deployment_path().expect("structurally valid");
+        assert_eq!(deployed.component_count(), 2);
+        assert!(
+            traversal.to_deployment_path().is_err(),
+            "traversal is caught on bytes, not on decoded text"
+        );
+    }
+
+    /// The persistence boundary is explicit: non-UTF-8 fails loudly here rather
+    /// than being lossily written into a TEXT column.
+    #[test]
+    fn non_utf8_paths_fail_at_the_persistence_boundary_rather_than_corrupting() {
+        let path = SourcePathBytes::new(vec![b'u', b's', b'r', b'/', 0xff])
+            .to_deployment_path()
+            .expect("structurally valid");
+
+        let error = path.to_utf8().expect_err("must not persist lossily");
+        assert!(
+            format!("{error:?}").contains("UTF-8"),
+            "the error must name the reason, got {error:?}"
+        );
+        assert_eq!(
+            path.to_bytes(),
+            vec![b'u', b's', b'r', b'/', 0xff],
+            "the lossless bytes survive the failed projection"
+        );
+    }
+
+    #[test]
+    fn diagnostics_never_decide_anything_but_stay_readable() {
+        let path = SourcePathBytes::new(vec![b'a', 0xff, b'b']);
+
+        let rendered = path.to_diagnostic_string();
+
+        assert!(rendered.contains('a') && rendered.contains('b'));
+        assert_eq!(
+            path.as_bytes(),
+            &[b'a', 0xff, b'b'],
+            "rendering must not mutate the authority"
+        );
+    }
+
+    // -- Joining ------------------------------------------------------------
+
+    #[test]
+    fn joining_stays_under_the_root() {
+        let root = Path::new("/target/root");
+        let joined = deploy("/usr/bin/foo").unwrap().join_under(root);
+
+        assert_eq!(joined, Path::new("/target/root/usr/bin/foo"));
+        assert!(joined.starts_with(root));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn joining_preserves_non_utf8_component_bytes() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let path = SourcePathBytes::new(vec![b'u', b's', b'r', b'/', 0xff])
+            .to_deployment_path()
+            .unwrap();
+
+        let joined = path.join_under("/root");
+
+        assert!(
+            joined.as_os_str().as_bytes().ends_with(&[0xff]),
+            "the raw byte must survive into the filesystem path"
+        );
+    }
+}

--- a/crates/conary-core/src/filesystem/source_path.rs
+++ b/crates/conary-core/src/filesystem/source_path.rs
@@ -222,7 +222,10 @@ mod tests {
 
     #[test]
     fn current_directory_components_are_dropped() {
-        assert_eq!(deploy("./usr/./bin/foo").unwrap().to_bytes(), b"usr/bin/foo");
+        assert_eq!(
+            deploy("./usr/./bin/foo").unwrap().to_bytes(),
+            b"usr/bin/foo"
+        );
     }
 
     // -- Traversal safety, decided on exact components ----------------------

--- a/crates/conary-core/src/packages/archive_utils.rs
+++ b/crates/conary-core/src/packages/archive_utils.rs
@@ -1,7 +1,7 @@
 // conary-core/src/packages/archive_utils.rs
 
 use crate::error::Result;
-use crate::filesystem::path::sanitize_path;
+use crate::filesystem::source_path::SourcePathBytes;
 pub use crate::packages::common::MAX_EXTRACTION_FILE_SIZE;
 use tracing::warn;
 
@@ -14,15 +14,19 @@ pub fn is_regular_file_mode(mode: u32) -> bool {
     (mode & S_IFMT) == S_IFREG
 }
 
-/// Normalize archive entry path to absolute form with security sanitization
+/// Normalize an archive entry path to absolute form with traversal validation.
+///
+/// Shared by the RPM, Debian, and ALPM payload parsers, so a change here
+/// affects every source format.
+///
+/// Validation happens on the declared bytes: traversal is decided by exact
+/// component comparison, not by character class. The UTF-8 requirement comes
+/// last and belongs to persistence rather than to safety — Conary stores paths
+/// as text, so a path that cannot be represented there fails explicitly instead
+/// of being lossily converted into one that does not match the artifact.
 pub fn normalize_path(path: &str) -> Result<String> {
-    let sanitized = sanitize_path(path)?;
-    let s = sanitized.to_string_lossy();
-    if s.starts_with('/') {
-        Ok(s.to_string())
-    } else {
-        Ok(format!("/{}", s))
-    }
+    let deployment = SourcePathBytes::from(path).to_deployment_path()?;
+    Ok(format!("/{}", deployment.to_utf8()?))
 }
 
 /// Check if file size exceeds limit, warn if so


### PR DESCRIPTION
Refs #99 — this is slice **99a** of three. 99b (libarchive xattr grammar) and 99c (declared resource budgets) stay open on the parent.

## Problem

The shared path authority rejected **every non-ASCII path as traversal**:

```rust
if !path_str.is_ascii() {
    return Err(Error::PathTraversal("path contains non-ASCII characters"));
}
```

That is not a rule of ALPM, RPM, Debian, tar, or Linux. It is an invented character policy of exactly the class `AGENTS.md` prohibits from deciding mutation authority.

**It was never ALPM-specific.** `packages/archive_utils.rs::normalize_path` routes all three source formats through this function — confirmed callers in `packages/arch.rs`, `packages/deb.rs`, `packages/arch/payload.rs`, `packages/deb/payload.rs`, `packages/rpm/payload/header.rs`, and `packages/rpm/payload/stream.rs`. Valid RPM and Debian packages with non-ASCII paths were being rejected too, not just `aisleriot`, `aspell-nb`, and `azure-cli` on Arch. #99 was widened accordingly.

Two further defects in the same function: it called `to_string_lossy()` *before* deciding, destroying the bytes a rejection would need to be diagnosed; and it used `std::path::Path::components()` to parse an untrusted archive grammar, importing host filesystem conventions the source format never promised.

## Change

New `filesystem/source_path.rs` with two types:

- **`SourcePathBytes`** — the path exactly as the archive declared it. No normalization, case folding, Unicode normalization, or lossy replacement.
- **`DeploymentPath`** — the validated relative form, constructible *only* through validation, so holding one is proof the check ran.

Validation splits on the separator **byte** and judges components by exact byte comparison: NUL anywhere rejected, empty and `.` dropped, `..` rejected outright rather than resolved (resolving it against a root containing symlinks does not mean what it appears to), and a path with nothing left is undeployable. Character class is never consulted, so `..foo`, `foo..`, `a..b`, and `...` stay ordinary names while `..` does not.

## The one behavior change worth reviewing

**A separator homoglyph is now an ordinary name byte.** `usr／bin／tool` (U+FF0F FULLWIDTH SOLIDUS) is one component, not three.

It renders like `/` but is not the separator byte, so it cannot split a path and therefore cannot escape a directory. The old rule rejected it out of homoglyph anxiety; the correct answer is that only the separator separates. Covered by `separator_homoglyphs_are_ordinary_name_bytes_not_separators`.

The security property is unchanged and directly tested: `usr/été/../../etc/passwd` is still rejected, `usr/été/file` is accepted, and dressing traversal in non-ASCII does not get it through.

## Scope boundary I did not cross

`SourcePathBytes` holds any non-NUL bytes and validates structurally **without decoding**, so non-UTF-8 paths are still checked for traversal. But Conary persists paths as `TEXT`/`String` (`ccs/v2/schema.rs:156`, `packages/mod.rs:246`, the `files` table), so storing a non-UTF-8 path needs a CCS schema and database decision.

`DeploymentPath::to_utf8()` is therefore the persistence boundary and **errors** rather than converting lossily — a lossy write would persist a path that does not match the artifact. The lossless bytes survive the failed projection.

#99 explicitly instructs that such a decision "must be made explicitly before implementation rather than hidden behind a compatibility string," so this slice leaves it open and documented rather than pretending the types go deeper than they do.

## Verification

Run on the 12-core dev host:

```
cargo test -p conary-core --lib      3028 passed; 0 failed
cargo clippy -p conary-core --all-targets -- -D warnings    clean
cargo fmt --check                    clean
```

Breakdown across the affected surfaces: `filesystem::` 102 passed (15 new `source_path` tests), `packages::` 216 passed, `ccs::` 396 passed. Zero regressions — which is the real evidence that widening the fix beyond ALPM did not disturb RPM or Debian parsing. rustc 1.97.1, matching CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011y1e74GvvxzaDkyrxthYZB