### PR TITLE
fix(ccs): replace the fixed authority ceiling with a shared structural budget

### DIFF
--- a/crates/conary-core/src/ccs/archive_layout.rs
+++ b/crates/conary-core/src/ccs/archive_layout.rs
@@ -1,0 +1,173 @@
+// conary-core/src/ccs/archive_layout.rs
+
+//! The directory layout a CCS v2 archive is allowed to contain.
+//!
+//! One owner for the layout vocabulary. The writer emits these names, and both
+//! the streaming verifier and the archive reader admit exactly this set, so a
+//! package the writer produces is reader-admissible by construction rather than
+//! by separate hand-maintained lists happening to agree.
+//!
+//! They did not agree. Two copies of this rule previously existed, and when the
+//! structural budget work added a second reader it dropped `components` from
+//! one of them, so any package carrying a component directory failed
+//! verification while its own writer had just emitted it. That is the exact
+//! writer-versus-reader disagreement the budget owner was introduced to
+//! prevent, reproduced one layer up. Hence: one owner here too.
+//!
+//! Membership is returned as a `bool` rather than a `Result` because the two
+//! readers carry different error types. Each caller states its own failure.
+
+/// Component payload directory.
+pub const COMPONENTS_DIR: &str = "components";
+
+/// Content-addressed object directory.
+pub const OBJECTS_DIR: &str = "objects";
+
+/// Whether `path` is a directory entry the CCS v2 layout defines.
+///
+/// Accepts the two top-level directories and the two-hex-character fan-out
+/// directories beneath `objects/`. Anything else is rejected: an unrecognized
+/// directory in a signed archive is unaccounted-for structure, not a harmless
+/// extra.
+pub fn is_known_directory(path: &str) -> bool {
+    if path == COMPONENTS_DIR || path == OBJECTS_DIR {
+        return true;
+    }
+
+    matches!(
+        path.strip_prefix(concat!("objects", "/")),
+        Some(prefix) if prefix.len() == 2 && is_lower_hex(prefix)
+    )
+}
+
+/// Whether every byte is a lowercase hexadecimal digit.
+///
+/// Case matters: object fan-out directories are emitted lowercase, so accepting
+/// uppercase would admit two spellings of one address.
+pub fn is_lower_hex(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+/// The component name a `components/<name>.json` entry declares, if the path is
+/// a well-formed component entry.
+///
+/// Returns `None` for anything else so callers can use it as a match guard. A
+/// name may not be empty or contain a separator: `components/a/b.json` names no
+/// component and must not be admitted as one.
+pub fn component_entry_name(path: &str) -> Option<&str> {
+    let name = path
+        .strip_prefix(COMPONENTS_DIR)?
+        .strip_prefix('/')?
+        .strip_suffix(".json")?;
+
+    (!name.is_empty() && !name.contains('/')).then_some(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn both_top_level_directories_are_known() {
+        assert!(is_known_directory(COMPONENTS_DIR));
+        assert!(is_known_directory(OBJECTS_DIR));
+    }
+
+    /// The regression that motivated this module: `components` was dropped from
+    /// one of two copies of this rule, so writer output failed its own reader.
+    #[test]
+    fn components_is_admitted_because_the_writer_emits_it() {
+        assert!(
+            is_known_directory("components"),
+            "the writer emits a components directory; the reader must admit it"
+        );
+    }
+
+    #[test]
+    fn object_fanout_directories_are_known() {
+        for path in ["objects/00", "objects/ab", "objects/9f", "objects/ff"] {
+            assert!(is_known_directory(path), "{path} should be known");
+        }
+    }
+
+    #[test]
+    fn malformed_object_fanout_is_rejected() {
+        for path in [
+            "objects/A0",
+            "objects/abc",
+            "objects/a",
+            "objects/",
+            "objects/zz",
+            "objects/ab/cd",
+        ] {
+            assert!(!is_known_directory(path), "{path} should be rejected");
+        }
+    }
+
+    #[test]
+    fn unrelated_directories_are_rejected() {
+        for path in ["", "manifest", "component", "objects2", "../objects"] {
+            assert!(!is_known_directory(path), "{path} should be rejected");
+        }
+    }
+
+    /// Closes the gap that let the regression through: #103 proved writer and
+    /// reader share one *budget* owner, but nothing proved they share one
+    /// *layout* owner. Every directory the writer can emit must be admitted.
+    #[test]
+    fn every_directory_the_writer_emits_is_reader_admissible() {
+        let writer_emits = [
+            COMPONENTS_DIR,
+            OBJECTS_DIR,
+            "objects/00",
+            "objects/0f",
+            "objects/ff",
+        ];
+
+        for path in writer_emits {
+            assert!(
+                is_known_directory(path),
+                "the writer emits {path:?}; a reader that rejects it makes its own output unreadable"
+            );
+        }
+    }
+
+    #[test]
+    fn component_entries_yield_their_declared_name() {
+        assert_eq!(
+            component_entry_name("components/runtime.json"),
+            Some("runtime")
+        );
+        assert_eq!(component_entry_name("components/dev.json"), Some("dev"));
+    }
+
+    #[test]
+    fn malformed_component_entries_name_nothing() {
+        for path in [
+            "components/.json",
+            "components/a/b.json",
+            "components/runtime.txt",
+            "components/runtime",
+            "components.json",
+            "objects/runtime.json",
+            "components/",
+        ] {
+            assert_eq!(
+                component_entry_name(path),
+                None,
+                "{path} names no component"
+            );
+        }
+    }
+
+    #[test]
+    fn lower_hex_rejects_uppercase_and_empty() {
+        assert!(is_lower_hex("0f"));
+        assert!(!is_lower_hex("0F"));
+        assert!(!is_lower_hex(""));
+        assert!(!is_lower_hex("g0"));
+    }
+}

--- a/crates/conary-core/src/ccs/archive_reader.rs
+++ b/crates/conary-core/src/ccs/archive_reader.rs
@@ -2,10 +2,13 @@
 
 //! Explicitly untrusted CCS v2 archive inspection.
 //!
-//! This module decodes the current archive grammar and applies structural
-//! bounds. It does not establish package trust. Mutation and publication
-//! callers must pass the result through `ccs::verify::verify_package`.
+//! This module decodes the current archive grammar and applies the canonical
+//! structural budget in `crate::ccs::budget`. It owns no limits of its own, so
+//! anything the authoring writer emits is admissible here. It does not
+//! establish package trust: mutation and publication callers must pass the
+//! result through `ccs::verify::verify_package`.
 
+use crate::ccs::budget::{AuthorityCensus, BudgetDimension, CCS_BUDGET};
 use crate::ccs::builder::ComponentData;
 use crate::ccs::manifest::CcsManifest;
 use crate::ccs::v2::AuthorityDocumentV2;
@@ -17,11 +20,6 @@ use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 use tar::Archive;
-
-const MAX_ENTRY_SIZE: u64 = 512 * 1024 * 1024;
-const MAX_TOTAL_EXTRACTION_SIZE: u64 = 4 * 1024 * 1024 * 1024;
-const MAX_MANIFEST_SIZE: u64 = 16 * 1024 * 1024;
-const MAX_COMPONENT_SIZE: u64 = 64 * 1024 * 1024;
 
 /// Structurally decoded CCS v2 data that has not been authenticated.
 ///
@@ -35,6 +33,8 @@ pub struct UntrustedCcsArchive {
     pub v2_authority: AuthorityDocumentV2,
     /// Exact archived authority bytes used by signature verification.
     pub v2_manifest_raw: Vec<u8>,
+    /// Structural census the shared budget measured for this authority.
+    pub census: AuthorityCensus,
     /// Raw build-attestation JSON, when present.
     pub v2_build_attestation_raw: Option<String>,
     /// Raw foreign-conversion-boundary JSON, when present.
@@ -47,15 +47,30 @@ pub struct UntrustedCcsArchive {
     pub toml_raw: Option<Vec<u8>>,
     /// Raw package signature JSON. Verification requires this field.
     pub signature_raw: Option<String>,
-    /// Untrusted component projections keyed by exact component name.
+    /// Component view derived from the decoded authority.
     pub components: HashMap<String, ComponentData>,
-    /// Content objects keyed by their exact lowercase SHA-256 digest.
-    pub blobs: HashMap<String, Vec<u8>>,
 }
 
 /// Structurally inspect a CCS v2 archive without granting trust.
 pub fn inspect_untrusted_ccs_archive<R: Read>(reader: R) -> anyhow::Result<UntrustedCcsArchive> {
-    inspect_untrusted_ccs_archive_with_limits(reader, MAX_TOTAL_EXTRACTION_SIZE)
+    let mut archive = Archive::new(GzDecoder::new(reader));
+    let mut state = InspectionState::default();
+    let mut entries_seen = 0_u64;
+
+    for entry in archive.entries()? {
+        entries_seen += 1;
+        CCS_BUDGET.admit_archive_entry(entries_seen)?;
+        let mut entry = entry?;
+        let path = canonical_entry_path(&entry)?;
+
+        if entry.header().entry_type().is_dir() {
+            require_known_directory(&path)?;
+            continue;
+        }
+        state.read_regular_entry(&mut entry, &path)?;
+    }
+
+    state.finish()
 }
 
 /// Identify the exact current CCS v2 archive contract independently of name.
@@ -67,43 +82,290 @@ pub fn has_current_ccs_archive_contract(path: impl AsRef<Path>) -> anyhow::Resul
         return Ok(false);
     }
 
-    let decoder = GzDecoder::new(File::open(path)?).take(MAX_TOTAL_EXTRACTION_SIZE + 1);
-    let mut archive = Archive::new(decoder);
-    let mut entries_seen = 0_usize;
+    let mut archive = Archive::new(GzDecoder::new(File::open(path)?));
+    let mut entries_seen = 0_u64;
     for entry in archive.entries()? {
         entries_seen += 1;
-        crate::compression::check_archive_entry_limit(entries_seen, "CCS package")?;
+        CCS_BUDGET.admit_archive_entry(entries_seen)?;
         let mut entry = entry?;
-        let path = entry.path()?;
-        if path != Path::new("MANIFEST") && path != Path::new("./MANIFEST") {
+        if canonical_entry_path(&entry)? != "MANIFEST" {
             continue;
         }
-        if !entry.header().entry_type().is_file() || entry.size() > MAX_MANIFEST_SIZE {
+        if !entry.header().entry_type().is_file() {
             return Ok(false);
         }
-        let raw = read_entry(&mut entry, MAX_MANIFEST_SIZE, "MANIFEST")?;
-        return match cbor_format_version(&raw)? {
-            2 => Ok(true),
-            1 => anyhow::bail!(
-                "CCS v1 archive authority is unsupported; rebuild the package as signed CCS v2"
-            ),
-            version => {
-                anyhow::bail!("unsupported CCS MANIFEST format_version {version}; expected 2")
-            }
-        };
+        if entry.header().size()? > CCS_BUDGET.max_authority_bytes() {
+            return Ok(false);
+        }
+        let raw = read_bounded(
+            &mut entry,
+            CCS_BUDGET.max_authority_bytes(),
+            BudgetDimension::AuthorityBytes,
+            "MANIFEST",
+        )?;
+        return require_format_version_2(&raw).map(|()| true);
     }
     Ok(false)
 }
 
-fn cbor_format_version(raw: &[u8]) -> anyhow::Result<u64> {
+#[derive(Default)]
+struct InspectionState {
+    authority: Option<AuthorityDocumentV2>,
+    census: AuthorityCensus,
+    manifest_raw: Option<Vec<u8>>,
+    toml_raw: Option<Vec<u8>>,
+    signature_raw: Option<String>,
+    attestation_raw: Option<String>,
+    boundary_raw: Option<String>,
+    attestation: Option<crate::ccs::attestation::BuildAttestationEnvelope>,
+    boundary: Option<crate::ccs::attestation::ForeignConversionBoundary>,
+    metadata_bytes: u64,
+    payload_bytes: u64,
+    payload_objects: u64,
+    objects_seen: std::collections::BTreeSet<String>,
+}
+
+impl InspectionState {
+    /// Read one non-directory entry.
+    ///
+    /// `MANIFEST` must arrive before any other archived file, so every later
+    /// ceiling is derived from this package's own signed census rather than
+    /// from a global guess.
+    fn read_regular_entry<R: Read>(
+        &mut self,
+        entry: &mut tar::Entry<'_, R>,
+        path: &str,
+    ) -> anyhow::Result<()> {
+        require_regular(entry, path)?;
+        if path == "MANIFEST" {
+            return self.read_authority(entry);
+        }
+        let census = self.census_or_bail()?;
+
+        match path {
+            "MANIFEST.toml" => {
+                let ceiling = CCS_BUDGET.debug_projection_bytes_ceiling(&census)?;
+                let raw = self.read_metadata(
+                    entry,
+                    ceiling,
+                    BudgetDimension::DebugProjectionBytes,
+                    "MANIFEST.toml",
+                )?;
+                set_once(&mut self.toml_raw, raw, "MANIFEST.toml")
+            }
+            "MANIFEST.sig" => {
+                let raw = self.read_metadata(
+                    entry,
+                    CCS_BUDGET.signature_bytes_ceiling(),
+                    BudgetDimension::SignatureBytes,
+                    "MANIFEST.sig",
+                )?;
+                let raw = String::from_utf8(raw).context("CCS MANIFEST.sig is not valid UTF-8")?;
+                set_once(&mut self.signature_raw, raw, "MANIFEST.sig")
+            }
+            "MANIFEST.attestation.json" => {
+                let raw = self.read_metadata(
+                    entry,
+                    CCS_BUDGET.attestation_bytes_ceiling(),
+                    BudgetDimension::AttestationBytes,
+                    "MANIFEST.attestation.json",
+                )?;
+                let raw = String::from_utf8(raw)
+                    .context("CCS MANIFEST.attestation.json is not valid UTF-8")?;
+                self.attestation = Some(
+                    serde_json::from_str(&raw).context("invalid CCS MANIFEST.attestation.json")?,
+                );
+                set_once(&mut self.attestation_raw, raw, "MANIFEST.attestation.json")
+            }
+            "MANIFEST.conversion-boundary.json" => {
+                let raw = self.read_metadata(
+                    entry,
+                    CCS_BUDGET.attestation_bytes_ceiling(),
+                    BudgetDimension::AttestationBytes,
+                    "MANIFEST.conversion-boundary.json",
+                )?;
+                let raw = String::from_utf8(raw)
+                    .context("CCS MANIFEST.conversion-boundary.json is not valid UTF-8")?;
+                self.boundary = Some(
+                    serde_json::from_str(&raw)
+                        .context("invalid CCS MANIFEST.conversion-boundary.json")?,
+                );
+                set_once(
+                    &mut self.boundary_raw,
+                    raw,
+                    "MANIFEST.conversion-boundary.json",
+                )
+            }
+            _ if path.starts_with("objects/") => self.read_object(entry, path, &census),
+            _ => anyhow::bail!("unknown CCS archive entry {path:?}"),
+        }
+    }
+
+    fn read_authority<R: Read>(&mut self, entry: &mut tar::Entry<'_, R>) -> anyhow::Result<()> {
+        if self.manifest_raw.is_some() {
+            anyhow::bail!("CCS archive contains duplicate MANIFEST entries");
+        }
+        let ceiling = CCS_BUDGET.max_authority_bytes();
+        CCS_BUDGET.admit_control_bytes(
+            BudgetDimension::AuthorityBytes,
+            "MANIFEST",
+            entry.header().size()?,
+            ceiling,
+        )?;
+        let raw = read_bounded(entry, ceiling, BudgetDimension::AuthorityBytes, "MANIFEST")?;
+        require_format_version_2(&raw)?;
+        let authority = CCS_BUDGET.decode_authority(&raw)?;
+        let census = crate::ccs::v2::authority_census(&authority)
+            .map_err(|error| anyhow::anyhow!("invalid CCS v2 MANIFEST: {error}"))?;
+        CCS_BUDGET.admit_encoded_authority(&census, raw.len() as u64)?;
+        self.metadata_bytes = raw.len() as u64;
+        self.census = census;
+        self.authority = Some(authority);
+        self.manifest_raw = Some(raw);
+        Ok(())
+    }
+
+    fn read_object<R: Read>(
+        &mut self,
+        entry: &mut tar::Entry<'_, R>,
+        path: &str,
+        census: &AuthorityCensus,
+    ) -> anyhow::Result<()> {
+        let hash = canonical_object_hash(path)?;
+        let declared = entry.header().size()?;
+        CCS_BUDGET.admit_control_bytes(
+            BudgetDimension::PayloadObjectBytes,
+            path,
+            declared,
+            CCS_BUDGET.max_payload_object_bytes,
+        )?;
+        self.payload_objects += 1;
+        CCS_BUDGET.admit_control_bytes(
+            BudgetDimension::PayloadObjectCount,
+            "objects",
+            self.payload_objects,
+            census.payload_objects,
+        )?;
+        self.payload_bytes = self
+            .payload_bytes
+            .checked_add(declared)
+            .context("CCS payload size arithmetic overflow")?;
+        CCS_BUDGET.admit_control_bytes(
+            BudgetDimension::TotalPayloadBytes,
+            "objects",
+            self.payload_bytes,
+            census.payload_bytes,
+        )?;
+        if !self.objects_seen.insert(hash.clone()) {
+            anyhow::bail!("CCS archive contains duplicate object {hash}");
+        }
+
+        // Hash the object as it streams. Untrusted inspection never retains
+        // payload bytes, so it introduces no whole-package buffering.
+        let mut hasher = crate::hash::Hasher::new(crate::hash::HashAlgorithm::Sha256);
+        let mut buffer = vec![0_u8; 64 * 1024];
+        let mut read_bytes = 0_u64;
+        loop {
+            let read = entry.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            read_bytes += read as u64;
+            hasher.update(&buffer[..read]);
+        }
+        if read_bytes != declared {
+            anyhow::bail!("CCS object {hash} declares {declared} bytes but carries {read_bytes}");
+        }
+        let actual = hasher.finalize().value;
+        if actual != hash {
+            anyhow::bail!("CCS object path hash mismatch: expected {hash}, got {actual}");
+        }
+        Ok(())
+    }
+
+    fn read_metadata<R: Read>(
+        &mut self,
+        entry: &mut tar::Entry<'_, R>,
+        ceiling: u64,
+        dimension: BudgetDimension,
+        label: &str,
+    ) -> anyhow::Result<Vec<u8>> {
+        CCS_BUDGET.admit_control_bytes(dimension, label, entry.header().size()?, ceiling)?;
+        let raw = read_bounded(entry, ceiling, dimension, label)?;
+        self.metadata_bytes = self
+            .metadata_bytes
+            .checked_add(raw.len() as u64)
+            .context("CCS metadata-size arithmetic overflow")?;
+        CCS_BUDGET.admit_control_bytes(
+            BudgetDimension::MetadataBytes,
+            "control documents",
+            self.metadata_bytes,
+            CCS_BUDGET.metadata_bytes_ceiling(&self.census)?,
+        )?;
+        Ok(raw)
+    }
+
+    fn census_or_bail(&self) -> anyhow::Result<AuthorityCensus> {
+        if self.authority.is_none() {
+            anyhow::bail!(
+                "CCS archive must carry its MANIFEST authority before every other archived file"
+            );
+        }
+        Ok(self.census.clone())
+    }
+
+    fn finish(self) -> anyhow::Result<UntrustedCcsArchive> {
+        let authority = self
+            .authority
+            .context("CCS package is missing required current v2 MANIFEST authority")?;
+        let manifest_raw = self
+            .manifest_raw
+            .context("CCS package is missing required current v2 MANIFEST bytes")?;
+
+        if let Some(expected) = &authority.provenance.foreign_conversion_boundary_hash {
+            let boundary = self.boundary.as_ref().context(
+                "v2 foreign conversion boundary hash present but MANIFEST.conversion-boundary.json is missing",
+            )?;
+            let actual = crate::ccs::attestation::canonical_json_hash(boundary)?;
+            if &actual != expected {
+                anyhow::bail!(
+                    "v2 foreign conversion boundary hash mismatch: expected {expected}, got {actual}"
+                );
+            }
+        }
+
+        Ok(UntrustedCcsArchive {
+            manifest: install_manifest_projection(&authority),
+            components: crate::ccs::v2::component_view::components(&authority),
+            census: self.census,
+            v2_authority: authority,
+            v2_manifest_raw: manifest_raw,
+            v2_build_attestation_raw: self.attestation_raw,
+            v2_foreign_conversion_boundary_raw: self.boundary_raw,
+            v2_build_attestation: self.attestation,
+            v2_foreign_conversion_boundary: self.boundary,
+            toml_raw: self.toml_raw,
+            signature_raw: self.signature_raw,
+        })
+    }
+}
+
+fn require_format_version_2(raw: &[u8]) -> anyhow::Result<()> {
     #[derive(Deserialize)]
     struct Header {
         format_version: u64,
     }
 
-    ciborium::from_reader::<Header, _>(raw)
-        .map(|header| header.format_version)
-        .map_err(|error| anyhow::anyhow!("invalid CCS CBOR MANIFEST header: {error}"))
+    let header: Header =
+        ciborium::de::from_reader_with_recursion_limit(raw, CCS_BUDGET.max_cbor_nesting_depth)
+            .map_err(|error| anyhow::anyhow!("invalid CCS CBOR MANIFEST header: {error}"))?;
+    match header.format_version {
+        2 => Ok(()),
+        1 => anyhow::bail!(
+            "CCS v1 archive authority is unsupported; rebuild the package as signed CCS v2"
+        ),
+        version => anyhow::bail!("unsupported CCS MANIFEST format_version {version}; expected 2"),
+    }
 }
 
 fn install_manifest_projection(authority: &AuthorityDocumentV2) -> CcsManifest {
@@ -122,26 +384,62 @@ fn install_manifest_projection(authority: &AuthorityDocumentV2) -> CcsManifest {
     manifest
 }
 
-fn read_entry<R: Read>(entry: &mut R, declared_limit: u64, label: &str) -> anyhow::Result<Vec<u8>> {
+fn read_bounded<R: Read>(
+    entry: &mut R,
+    ceiling: u64,
+    dimension: BudgetDimension,
+    label: &str,
+) -> anyhow::Result<Vec<u8>> {
     let mut bytes = Vec::new();
     entry
-        .take(declared_limit + 1)
+        .take(ceiling.saturating_add(1))
         .read_to_end(&mut bytes)
         .with_context(|| format!("read CCS {label}"))?;
-    if bytes.len() as u64 > declared_limit {
-        anyhow::bail!("CCS {label} exceeds maximum size {declared_limit}");
-    }
+    CCS_BUDGET.admit_control_bytes(dimension, label, bytes.len() as u64, ceiling)?;
     Ok(bytes)
 }
 
-fn require_regular(entry: &tar::Entry<'_, impl Read>, label: &str) -> anyhow::Result<()> {
+fn set_once<T>(slot: &mut Option<T>, value: T, label: &str) -> anyhow::Result<()> {
+    if slot.replace(value).is_some() {
+        anyhow::bail!("CCS archive contains duplicate {label} entries");
+    }
+    Ok(())
+}
+
+fn require_regular<R: Read>(entry: &tar::Entry<'_, R>, label: &str) -> anyhow::Result<()> {
     if !entry.header().entry_type().is_file() {
         anyhow::bail!("CCS {label} must be a regular file");
     }
     Ok(())
 }
 
-fn canonical_entry_path(entry: &tar::Entry<'_, impl Read>) -> anyhow::Result<String> {
+fn require_known_directory(path: &str) -> anyhow::Result<()> {
+    if path == "objects" {
+        return Ok(());
+    }
+    if let Some(prefix) = path.strip_prefix("objects/")
+        && prefix.len() == 2
+        && is_lower_hex(prefix)
+    {
+        return Ok(());
+    }
+    anyhow::bail!("unknown CCS archive directory {path:?}")
+}
+
+fn canonical_object_hash(path: &str) -> anyhow::Result<String> {
+    let object = path
+        .strip_prefix("objects/")
+        .context("invalid CCS object path")?;
+    let Some((prefix, suffix)) = object.split_once('/') else {
+        anyhow::bail!("invalid CCS object path {object:?}");
+    };
+    if prefix.len() != 2 || suffix.len() != 62 || !is_lower_hex(prefix) || !is_lower_hex(suffix) {
+        anyhow::bail!("invalid canonical CCS SHA-256 object path {object:?}");
+    }
+    Ok(format!("{prefix}{suffix}"))
+}
+
+fn canonical_entry_path<R: Read>(entry: &tar::Entry<'_, R>) -> anyhow::Result<String> {
     let path = entry.path()?;
     let path = path
         .to_str()
@@ -155,341 +453,6 @@ fn is_lower_hex(value: &str) -> bool {
         .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
 }
 
-fn inspect_untrusted_ccs_archive_with_limits<R: Read>(
-    reader: R,
-    total_extraction_limit: u64,
-) -> anyhow::Result<UntrustedCcsArchive> {
-    let decoder = GzDecoder::new(reader).take(total_extraction_limit + 1);
-    let mut archive = Archive::new(decoder);
-    let mut manifest_raw = None;
-    let mut authority = None;
-    let mut toml_raw = None;
-    let mut signature_raw = None;
-    let mut attestation_raw = None;
-    let mut boundary_raw = None;
-    let mut attestation = None;
-    let mut boundary = None;
-    let mut components = HashMap::new();
-    let mut blobs = HashMap::new();
-    let mut total_bytes = 0_u64;
-    let mut entries_seen = 0_usize;
-
-    for entry in archive.entries()? {
-        entries_seen += 1;
-        crate::compression::check_archive_entry_limit(entries_seen, "CCS package")?;
-        let mut entry = entry?;
-        let entry_size = entry.header().size()?;
-        if entry_size > MAX_ENTRY_SIZE {
-            anyhow::bail!("CCS archive entry exceeds maximum size: {entry_size} bytes");
-        }
-        total_bytes = total_bytes
-            .checked_add(entry_size)
-            .context("CCS archive total extraction size overflow")?;
-        if total_bytes > total_extraction_limit {
-            anyhow::bail!("CCS archive total extraction size exceeds limit");
-        }
-
-        let path = canonical_entry_path(&entry)?;
-        if entry.header().entry_type().is_dir() {
-            if path.is_empty()
-                || path == "."
-                || path == "components"
-                || path == "objects"
-                || path.starts_with("objects/")
-            {
-                continue;
-            }
-            anyhow::bail!("unknown CCS archive directory {path:?}");
-        }
-
-        match path.as_str() {
-            "MANIFEST" => {
-                require_regular(&entry, "MANIFEST")?;
-                if manifest_raw.is_some() {
-                    anyhow::bail!("CCS archive contains duplicate MANIFEST entries");
-                }
-                let raw = read_entry(&mut entry, MAX_MANIFEST_SIZE, "MANIFEST")?;
-                let version = cbor_format_version(&raw)?;
-                if version != 2 {
-                    if version == 1 {
-                        anyhow::bail!(
-                            "CCS v1 archive authority is unsupported; rebuild the package as signed CCS v2"
-                        );
-                    }
-                    anyhow::bail!("unsupported CCS MANIFEST format_version {version}; expected 2");
-                }
-                authority = Some(
-                    AuthorityDocumentV2::from_cbor(&raw)
-                        .map_err(|error| anyhow::anyhow!("invalid CCS v2 MANIFEST: {error}"))?,
-                );
-                manifest_raw = Some(raw);
-            }
-            "MANIFEST.toml" => {
-                require_regular(&entry, "MANIFEST.toml")?;
-                if toml_raw.is_some() {
-                    anyhow::bail!("CCS archive contains duplicate MANIFEST.toml entries");
-                }
-                toml_raw = Some(read_entry(&mut entry, MAX_MANIFEST_SIZE, "MANIFEST.toml")?);
-            }
-            "MANIFEST.sig" => {
-                require_regular(&entry, "MANIFEST.sig")?;
-                if signature_raw.is_some() {
-                    anyhow::bail!("CCS archive contains duplicate MANIFEST.sig entries");
-                }
-                signature_raw = Some(
-                    String::from_utf8(read_entry(&mut entry, MAX_MANIFEST_SIZE, "MANIFEST.sig")?)
-                        .context("CCS MANIFEST.sig is not valid UTF-8")?,
-                );
-            }
-            "MANIFEST.attestation.json" => {
-                require_regular(&entry, "MANIFEST.attestation.json")?;
-                if attestation_raw.is_some() {
-                    anyhow::bail!(
-                        "CCS archive contains duplicate MANIFEST.attestation.json entries"
-                    );
-                }
-                let raw = String::from_utf8(read_entry(
-                    &mut entry,
-                    MAX_MANIFEST_SIZE,
-                    "MANIFEST.attestation.json",
-                )?)
-                .context("CCS MANIFEST.attestation.json is not valid UTF-8")?;
-                attestation = Some(
-                    serde_json::from_str(&raw).context("invalid CCS MANIFEST.attestation.json")?,
-                );
-                attestation_raw = Some(raw);
-            }
-            "MANIFEST.conversion-boundary.json" => {
-                require_regular(&entry, "MANIFEST.conversion-boundary.json")?;
-                if boundary_raw.is_some() {
-                    anyhow::bail!(
-                        "CCS archive contains duplicate MANIFEST.conversion-boundary.json entries"
-                    );
-                }
-                let raw = String::from_utf8(read_entry(
-                    &mut entry,
-                    MAX_MANIFEST_SIZE,
-                    "MANIFEST.conversion-boundary.json",
-                )?)
-                .context("CCS MANIFEST.conversion-boundary.json is not valid UTF-8")?;
-                boundary = Some(
-                    serde_json::from_str(&raw)
-                        .context("invalid CCS MANIFEST.conversion-boundary.json")?,
-                );
-                boundary_raw = Some(raw);
-            }
-            _ if path.starts_with("components/") && path.ends_with(".json") => {
-                require_regular(&entry, "component")?;
-                let name = path
-                    .strip_prefix("components/")
-                    .and_then(|path| path.strip_suffix(".json"))
-                    .context("invalid CCS component path")?;
-                if name.is_empty() || name.contains('/') {
-                    anyhow::bail!("invalid CCS component path {path:?}");
-                }
-                let raw = read_entry(&mut entry, MAX_COMPONENT_SIZE, "component")?;
-                let component: ComponentData =
-                    serde_json::from_slice(&raw).context("invalid CCS component JSON")?;
-                if component.name != name {
-                    anyhow::bail!(
-                        "CCS component path {path:?} disagrees with component name {:?}",
-                        component.name
-                    );
-                }
-                if components
-                    .insert(component.name.clone(), component)
-                    .is_some()
-                {
-                    anyhow::bail!("CCS archive contains duplicate component {name:?}");
-                }
-            }
-            _ if path.starts_with("objects/") => {
-                require_regular(&entry, "object")?;
-                let object = path
-                    .strip_prefix("objects/")
-                    .context("invalid CCS object path")?;
-                let Some((prefix, suffix)) = object.split_once('/') else {
-                    anyhow::bail!("invalid CCS object path {object:?}");
-                };
-                if prefix.len() != 2
-                    || suffix.len() != 62
-                    || !is_lower_hex(prefix)
-                    || !is_lower_hex(suffix)
-                {
-                    anyhow::bail!("invalid canonical CCS SHA-256 object path {object:?}");
-                }
-                let hash = format!("{prefix}{suffix}");
-                let bytes = read_entry(&mut entry, MAX_ENTRY_SIZE, "object")?;
-                let actual = crate::hash::sha256(&bytes);
-                if actual != hash {
-                    anyhow::bail!("CCS object path hash mismatch: expected {hash}, got {actual}");
-                }
-                if blobs.insert(hash.clone(), bytes).is_some() {
-                    anyhow::bail!("CCS archive contains duplicate object {hash}");
-                }
-            }
-            _ => anyhow::bail!("unknown CCS archive entry {path:?}"),
-        }
-    }
-
-    let authority =
-        authority.context("CCS package is missing required current v2 MANIFEST authority")?;
-    let manifest_raw =
-        manifest_raw.context("CCS package is missing required current v2 MANIFEST bytes")?;
-
-    if let Some(expected) = &authority.provenance.foreign_conversion_boundary_hash {
-        let boundary = boundary.as_ref().context(
-            "v2 foreign conversion boundary hash present but MANIFEST.conversion-boundary.json is missing",
-        )?;
-        let actual = crate::ccs::attestation::canonical_json_hash(boundary)?;
-        if &actual != expected {
-            anyhow::bail!(
-                "v2 foreign conversion boundary hash mismatch: expected {expected}, got {actual}"
-            );
-        }
-    }
-
-    Ok(UntrustedCcsArchive {
-        manifest: install_manifest_projection(&authority),
-        v2_authority: authority,
-        v2_manifest_raw: manifest_raw,
-        v2_build_attestation_raw: attestation_raw,
-        v2_foreign_conversion_boundary_raw: boundary_raw,
-        v2_build_attestation: attestation,
-        v2_foreign_conversion_boundary: boundary,
-        toml_raw,
-        signature_raw,
-        components,
-        blobs,
-    })
-}
-
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::ccs::builder::write_v2_ccs_package;
-    use crate::ccs::signing::SigningKeyPair;
-    use flate2::Compression;
-    use flate2::write::GzEncoder;
-    use std::io::Write;
-    use tar::Builder;
-
-    fn current_package() -> (tempfile::TempDir, std::path::PathBuf) {
-        let temp = tempfile::tempdir().unwrap();
-        let path = temp.path().join("current.ccs");
-        let authority = crate::ccs::v2::test_support::package_authority_with_one_file("current");
-        let payloads = crate::ccs::v2::test_support::one_file_payloads_for_tests();
-        write_v2_ccs_package(
-            &authority,
-            &payloads,
-            &path,
-            &SigningKeyPair::generate(),
-            None,
-            None,
-            None,
-        )
-        .unwrap();
-        (temp, path)
-    }
-
-    fn append<W: Write>(builder: &mut Builder<W>, path: &str, bytes: &[u8]) {
-        let mut header = tar::Header::new_gnu();
-        header.set_size(bytes.len() as u64);
-        header.set_mode(0o644);
-        header.set_cksum();
-        builder.append_data(&mut header, path, bytes).unwrap();
-    }
-
-    #[test]
-    fn inspection_is_explicitly_untrusted_and_v2_only() {
-        let (_temp, path) = current_package();
-        let archive = inspect_untrusted_ccs_archive(File::open(&path).unwrap()).unwrap();
-
-        assert_eq!(archive.v2_authority.identity.name, "current");
-        assert_eq!(archive.manifest.package.name, "current");
-        assert!(archive.signature_raw.is_some());
-        assert!(!archive.blobs.is_empty());
-        assert!(has_current_ccs_archive_contract(path).unwrap());
-    }
-
-    #[test]
-    fn current_contract_detection_rejects_v1() {
-        let temp = tempfile::tempdir().unwrap();
-        let path = temp.path().join("v1.ccs");
-        let mut manifest = Vec::new();
-        ciborium::into_writer(
-            &serde_json::json!({
-                "format_version": 1,
-                "name": "retired-v1-fixture",
-            }),
-            &mut manifest,
-        )
-        .unwrap();
-        {
-            let output = std::fs::File::create(&path).unwrap();
-            let encoder = GzEncoder::new(output, Compression::default());
-            let mut builder = Builder::new(encoder);
-            append(&mut builder, "MANIFEST", &manifest);
-            builder.into_inner().unwrap().finish().unwrap();
-        }
-
-        let error = inspect_untrusted_ccs_archive(File::open(&path).unwrap()).unwrap_err();
-        assert!(
-            error
-                .to_string()
-                .contains("CCS v1 archive authority is unsupported")
-        );
-        let error = has_current_ccs_archive_contract(path).unwrap_err();
-        assert!(
-            error
-                .to_string()
-                .contains("CCS v1 archive authority is unsupported")
-        );
-    }
-
-    #[test]
-    fn inspection_rejects_noncanonical_object_paths() {
-        let authority = crate::ccs::v2::test_support::package_authority_with_one_file("bad-object");
-        let raw = authority.to_cbor().unwrap();
-        let mut bytes = Vec::new();
-        {
-            let encoder = GzEncoder::new(&mut bytes, Compression::default());
-            let mut builder = Builder::new(encoder);
-            append(&mut builder, "MANIFEST", &raw);
-            append(&mut builder, "objects/not-a-digest", b"payload");
-            builder.into_inner().unwrap().finish().unwrap();
-        }
-
-        let error = inspect_untrusted_ccs_archive(std::io::Cursor::new(bytes)).unwrap_err();
-        assert!(error.to_string().contains("invalid CCS object path"));
-    }
-
-    #[test]
-    fn inspection_rejects_duplicate_manifest_authority() {
-        let authority = crate::ccs::v2::test_support::package_authority_with_one_file("duplicate");
-        let raw = authority.to_cbor().unwrap();
-        let mut bytes = Vec::new();
-        {
-            let encoder = GzEncoder::new(&mut bytes, Compression::default());
-            let mut builder = Builder::new(encoder);
-            append(&mut builder, "MANIFEST", &raw);
-            append(&mut builder, "./MANIFEST", &raw);
-            builder.into_inner().unwrap().finish().unwrap();
-        }
-
-        let error = inspect_untrusted_ccs_archive(std::io::Cursor::new(bytes)).unwrap_err();
-        assert!(error.to_string().contains("duplicate MANIFEST"));
-    }
-
-    #[test]
-    fn inspection_enforces_cumulative_extraction_limit() {
-        let (_temp, path) = current_package();
-        let error =
-            inspect_untrusted_ccs_archive_with_limits(File::open(path).unwrap(), 32).unwrap_err();
-        assert!(
-            error.to_string().contains("extraction size")
-                || error.to_string().contains("unexpected end of file")
-                || error.to_string().contains("failed to read")
-        );
-    }
-}
+#[path = "archive_reader/tests.rs"]
+mod tests;

--- a/crates/conary-core/src/ccs/archive_reader.rs
+++ b/crates/conary-core/src/ccs/archive_reader.rs
@@ -8,6 +8,7 @@
 //! establish package trust: mutation and publication callers must pass the
 //! result through `ccs::verify::verify_package`.
 
+use crate::ccs::archive_layout::is_lower_hex;
 use crate::ccs::budget::{AuthorityCensus, BudgetDimension, CCS_BUDGET};
 use crate::ccs::builder::ComponentData;
 use crate::ccs::manifest::CcsManifest;
@@ -414,13 +415,7 @@ fn require_regular<R: Read>(entry: &tar::Entry<'_, R>, label: &str) -> anyhow::R
 }
 
 fn require_known_directory(path: &str) -> anyhow::Result<()> {
-    if path == "objects" {
-        return Ok(());
-    }
-    if let Some(prefix) = path.strip_prefix("objects/")
-        && prefix.len() == 2
-        && is_lower_hex(prefix)
-    {
+    if crate::ccs::archive_layout::is_known_directory(path) {
         return Ok(());
     }
     anyhow::bail!("unknown CCS archive directory {path:?}")
@@ -445,12 +440,6 @@ fn canonical_entry_path<R: Read>(entry: &tar::Entry<'_, R>) -> anyhow::Result<St
         .to_str()
         .context("CCS archive entry path is not valid UTF-8")?;
     Ok(path.strip_prefix("./").unwrap_or(path).to_string())
-}
-
-fn is_lower_hex(value: &str) -> bool {
-    value
-        .bytes()
-        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
 }
 
 #[cfg(test)]

--- a/crates/conary-core/src/ccs/archive_reader/tests.rs
+++ b/crates/conary-core/src/ccs/archive_reader/tests.rs
@@ -1,0 +1,172 @@
+// conary-core/src/ccs/archive_reader/tests.rs
+
+use super::*;
+use crate::ccs::builder::write_v2_ccs_package;
+use crate::ccs::signing::SigningKeyPair;
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use std::io::Write;
+use tar::Builder;
+
+fn current_package() -> (tempfile::TempDir, std::path::PathBuf) {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("current.ccs");
+    let authority = crate::ccs::v2::test_support::package_authority_with_one_file("current");
+    let payloads = crate::ccs::v2::test_support::one_file_payloads_for_tests();
+    write_v2_ccs_package(
+        &authority,
+        &payloads,
+        &path,
+        &SigningKeyPair::generate(),
+        None,
+        None,
+        None,
+    )
+    .unwrap();
+    (temp, path)
+}
+
+fn append<W: Write>(builder: &mut Builder<W>, path: &str, bytes: &[u8]) {
+    let mut header = tar::Header::new_gnu();
+    header.set_size(bytes.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    builder.append_data(&mut header, path, bytes).unwrap();
+}
+
+fn entry(path: &str, content: Vec<u8>) -> (String, Vec<u8>) {
+    (path.to_string(), content)
+}
+
+fn archive_of(entries: &[(String, Vec<u8>)]) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    {
+        let encoder = GzEncoder::new(&mut bytes, Compression::default());
+        let mut builder = Builder::new(encoder);
+        for (path, content) in entries {
+            append(&mut builder, path, content);
+        }
+        builder.into_inner().unwrap().finish().unwrap();
+    }
+    bytes
+}
+
+#[test]
+fn inspection_is_explicitly_untrusted_and_v2_only() {
+    let (_temp, path) = current_package();
+    let archive = inspect_untrusted_ccs_archive(File::open(&path).unwrap()).unwrap();
+
+    assert_eq!(archive.v2_authority.identity.name, "current");
+    assert_eq!(archive.manifest.package.name, "current");
+    assert!(archive.signature_raw.is_some());
+    assert_eq!(archive.census.files, 1);
+    assert!(has_current_ccs_archive_contract(path).unwrap());
+}
+
+#[test]
+fn current_contract_detection_rejects_v1() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("v1.ccs");
+    let mut manifest = Vec::new();
+    ciborium::into_writer(
+        &serde_json::json!({
+            "format_version": 1,
+            "name": "retired-v1-fixture",
+        }),
+        &mut manifest,
+    )
+    .unwrap();
+    std::fs::write(&path, archive_of(&[entry("MANIFEST", manifest)])).unwrap();
+
+    let error = inspect_untrusted_ccs_archive(File::open(&path).unwrap()).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("CCS v1 archive authority is unsupported")
+    );
+    let error = has_current_ccs_archive_contract(path).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("CCS v1 archive authority is unsupported")
+    );
+}
+
+#[test]
+fn inspection_rejects_noncanonical_object_paths() {
+    let authority = crate::ccs::v2::test_support::package_authority_with_one_file("bad-object");
+    let bytes = archive_of(&[
+        entry("MANIFEST", authority.to_cbor().unwrap()),
+        entry("objects/not-a-digest", b"payload".to_vec()),
+    ]);
+
+    let error = inspect_untrusted_ccs_archive(std::io::Cursor::new(bytes)).unwrap_err();
+    assert!(error.to_string().contains("invalid CCS object path"));
+}
+
+#[test]
+fn inspection_rejects_duplicate_manifest_authority() {
+    let authority = crate::ccs::v2::test_support::package_authority_with_one_file("duplicate");
+    let raw = authority.to_cbor().unwrap();
+    let bytes = archive_of(&[entry("MANIFEST", raw.clone()), entry("./MANIFEST", raw)]);
+
+    let error = inspect_untrusted_ccs_archive(std::io::Cursor::new(bytes)).unwrap_err();
+    assert!(error.to_string().contains("duplicate MANIFEST"));
+}
+
+#[test]
+fn inspection_requires_authority_before_every_other_archived_file() {
+    let authority = crate::ccs::v2::test_support::package_authority_with_one_file("ordered");
+    let bytes = archive_of(&[
+        entry("MANIFEST.sig", b"{}".to_vec()),
+        entry("MANIFEST", authority.to_cbor().unwrap()),
+    ]);
+
+    let error = inspect_untrusted_ccs_archive(std::io::Cursor::new(bytes)).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("must carry its MANIFEST authority before"),
+        "{error:#}"
+    );
+}
+
+#[test]
+fn inspection_rejects_unsigned_and_oversized_payload_objects() {
+    let authority = crate::ccs::v2::test_support::package_authority_with_one_file("payload-bounds");
+    let unsigned = b"not in signed authority".to_vec();
+    let hash = crate::hash::sha256(&unsigned);
+    let bytes = archive_of(&[
+        entry("MANIFEST", authority.to_cbor().unwrap()),
+        entry(&format!("objects/{}/{}", &hash[..2], &hash[2..]), unsigned),
+    ]);
+
+    let error = inspect_untrusted_ccs_archive(std::io::Cursor::new(bytes)).unwrap_err();
+    assert!(
+        error.to_string().contains("total-payload-bytes")
+            || error.to_string().contains("payload-object-count"),
+        "{error:#}"
+    );
+}
+
+#[test]
+fn inspection_rejects_a_hostile_declared_authority_length_before_allocation() {
+    // The declared tar length is refused against the derived decoder-memory
+    // ceiling, so no allocation proportional to the declaration happens.
+    let ceiling = CCS_BUDGET.max_authority_bytes();
+    let mut header = tar::Header::new_gnu();
+    header.set_size(ceiling + 1);
+    header.set_mode(0o644);
+    header.set_cksum();
+
+    let error = CCS_BUDGET
+        .admit_control_bytes(
+            BudgetDimension::AuthorityBytes,
+            "MANIFEST",
+            header.size().unwrap(),
+            ceiling,
+        )
+        .unwrap_err();
+    assert_eq!(error.dimension, BudgetDimension::AuthorityBytes);
+    assert_eq!(error.limit, ceiling);
+}

--- a/crates/conary-core/src/ccs/budget.rs
+++ b/crates/conary-core/src/ccs/budget.rs
@@ -1,0 +1,779 @@
+// conary-core/src/ccs/budget.rs
+
+//! The single canonical structural and operator-resource budget for CCS v2.
+//!
+//! Both ends of the format share this owner. Authoring preflight admits the
+//! authority it is about to sign, and untrusted inspection plus signature-first
+//! verification admit the authority they decode. There is no second table of
+//! limits, so the writer cannot construct a package the reader refuses.
+//!
+//! Budgeting is structural, not one guessed serialized-byte ceiling. Counts,
+//! per-item string lengths, install-path depth, aggregate variable-length
+//! pools, payload objects, and CBOR nesting are each an explicit dimension
+//! with its own typed diagnostic. Byte ceilings are *derived* from those
+//! dimensions: the global ceiling bounds decoder memory before allocation, and
+//! the census ceiling bounds the exact document a specific package may occupy.
+
+use super::v2::schema::{
+    AuthorityDocumentV2, FileAuthorityV2, LifecycleAuthorityV2, PackageKindV2,
+};
+use crate::payload::PayloadNodeKind;
+
+#[cfg(test)]
+#[path = "budget/tests.rs"]
+mod tests;
+
+/// Exact CBOR cost of one `FileAuthorityV2` record excluding its variable
+/// length authority (install path, component name, link target, xattrs).
+///
+/// A minimal regular-file record measures 238 bytes and the widest variant with
+/// maximal scalars and config semantics measures 323.
+/// `file_authority_fixed_bytes_is_an_upper_bound` proves this constant bounds
+/// every node variant the schema admits.
+const FILE_AUTHORITY_FIXED_BYTES: u64 = 384;
+
+/// CBOR cost of the document map itself once every section is accounted for.
+const AUTHORITY_ENVELOPE_BYTES: u64 = 4096;
+
+/// The archived signature document has a fixed shape: algorithm, base64
+/// Ed25519 signature, base64 public key, optional key id and timestamp.
+const SIGNATURE_DOCUMENT_BYTES: u64 = 8 * 1024;
+
+/// How much larger the TOML rendering of one record may be than its CBOR form.
+const DEBUG_PROJECTION_TEXT_EXPANSION: u64 = 4;
+
+/// Fixed table headers and comments the TOML projection always writes.
+const DEBUG_PROJECTION_ENVELOPE_BYTES: u64 = 64 * 1024;
+
+/// Every structurally independent way a CCS package can exceed its budget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BudgetDimension {
+    FileCount,
+    ComponentCount,
+    ConfigCount,
+    ProvideCount,
+    RequirementCount,
+    RelationCount,
+    LifecycleEntryCount,
+    PathBytes,
+    PathDepth,
+    NameBytes,
+    LinkTargetBytes,
+    XattrCount,
+    XattrNameBytes,
+    XattrValueBytes,
+    ScriptBodyBytes,
+    TotalPathBytes,
+    TotalXattrBytes,
+    NonPayloadAuthorityBytes,
+    AuthorityBytes,
+    DebugProjectionBytes,
+    AttestationBytes,
+    SignatureBytes,
+    MetadataBytes,
+    PayloadObjectCount,
+    PayloadObjectBytes,
+    TotalPayloadBytes,
+    ArchiveEntryCount,
+    CborNestingDepth,
+    Arithmetic,
+}
+
+impl BudgetDimension {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::FileCount => "file-count",
+            Self::ComponentCount => "component-count",
+            Self::ConfigCount => "config-count",
+            Self::ProvideCount => "provide-count",
+            Self::RequirementCount => "requirement-count",
+            Self::RelationCount => "relation-count",
+            Self::LifecycleEntryCount => "lifecycle-entry-count",
+            Self::PathBytes => "path-bytes",
+            Self::PathDepth => "path-depth",
+            Self::NameBytes => "name-bytes",
+            Self::LinkTargetBytes => "link-target-bytes",
+            Self::XattrCount => "xattr-count",
+            Self::XattrNameBytes => "xattr-name-bytes",
+            Self::XattrValueBytes => "xattr-value-bytes",
+            Self::ScriptBodyBytes => "script-body-bytes",
+            Self::TotalPathBytes => "total-path-bytes",
+            Self::TotalXattrBytes => "total-xattr-bytes",
+            Self::NonPayloadAuthorityBytes => "non-payload-authority-bytes",
+            Self::AuthorityBytes => "authority-bytes",
+            Self::DebugProjectionBytes => "debug-projection-bytes",
+            Self::AttestationBytes => "attestation-bytes",
+            Self::SignatureBytes => "signature-bytes",
+            Self::MetadataBytes => "metadata-bytes",
+            Self::PayloadObjectCount => "payload-object-count",
+            Self::PayloadObjectBytes => "payload-object-bytes",
+            Self::TotalPayloadBytes => "total-payload-bytes",
+            Self::ArchiveEntryCount => "archive-entry-count",
+            Self::CborNestingDepth => "cbor-nesting-depth",
+            Self::Arithmetic => "arithmetic",
+        }
+    }
+}
+
+impl std::fmt::Display for BudgetDimension {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A typed refusal naming the exact dimension, location, observation, and limit.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("CCS structural budget {dimension} exceeded at {field}: {observed} exceeds limit {limit}")]
+pub struct BudgetError {
+    pub dimension: BudgetDimension,
+    pub field: String,
+    pub observed: u64,
+    pub limit: u64,
+}
+
+impl BudgetError {
+    fn new(
+        dimension: BudgetDimension,
+        field: impl Into<String>,
+        observed: u64,
+        limit: u64,
+    ) -> Self {
+        Self {
+            dimension,
+            field: field.into(),
+            observed,
+            limit,
+        }
+    }
+
+    fn overflow(field: impl Into<String>) -> Self {
+        Self {
+            dimension: BudgetDimension::Arithmetic,
+            field: field.into(),
+            observed: u64::MAX,
+            limit: u64::MAX,
+        }
+    }
+}
+
+type BudgetResult<T> = Result<T, BudgetError>;
+
+fn admit(
+    dimension: BudgetDimension,
+    field: impl Into<String>,
+    observed: u64,
+    limit: u64,
+) -> BudgetResult<()> {
+    if observed > limit {
+        return Err(BudgetError::new(dimension, field, observed, limit));
+    }
+    Ok(())
+}
+
+fn sum(field: &str, values: impl IntoIterator<Item = u64>) -> BudgetResult<u64> {
+    values.into_iter().try_fold(0_u64, |total, value| {
+        total
+            .checked_add(value)
+            .ok_or_else(|| BudgetError::overflow(field))
+    })
+}
+
+fn product(field: &str, left: u64, right: u64) -> BudgetResult<u64> {
+    left.checked_mul(right)
+        .ok_or_else(|| BudgetError::overflow(field))
+}
+
+/// Exact structural measurement of one decoded authority document.
+///
+/// The census is what makes writer and reader agree: authoring measures the
+/// document it is about to sign, verification measures the document it decoded,
+/// and both compare against the same derived ceiling.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AuthorityCensus {
+    pub files: u64,
+    pub components: u64,
+    pub config_entries: u64,
+    pub payload_objects: u64,
+    pub payload_bytes: u64,
+    pub path_bytes: u64,
+    pub xattr_bytes: u64,
+    pub name_bytes: u64,
+    /// Exact encoded size of every signed section other than the file array.
+    pub non_payload_authority_bytes: u64,
+}
+
+/// The canonical CCS v2 budget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CcsStructuralBudget {
+    pub max_files: u64,
+    pub max_components: u64,
+    pub max_config_entries: u64,
+    pub max_provides: u64,
+    pub max_requirement_groups: u64,
+    pub max_relation_groups: u64,
+    pub max_lifecycle_entries: u64,
+    pub max_path_bytes: u64,
+    pub max_path_components: u64,
+    pub max_name_bytes: u64,
+    pub max_link_target_bytes: u64,
+    pub max_xattrs_per_node: u64,
+    pub max_xattr_name_bytes: u64,
+    pub max_xattr_value_bytes: u64,
+    pub max_script_body_bytes: u64,
+    pub max_total_path_bytes: u64,
+    pub max_total_xattr_bytes: u64,
+    pub max_non_payload_authority_bytes: u64,
+    pub max_attestation_bytes: u64,
+    pub max_payload_object_bytes: u64,
+    pub max_total_payload_bytes: u64,
+    pub max_cbor_nesting_depth: usize,
+}
+
+/// The budget every CCS producer and consumer in this workspace uses.
+pub const CCS_BUDGET: CcsStructuralBudget = CcsStructuralBudget::DEFAULT;
+
+impl CcsStructuralBudget {
+    pub const DEFAULT: Self = Self {
+        // Payload node count. The largest ordinary distribution packages
+        // measured here sit near 60,000 nodes.
+        max_files: 1 << 20,
+        max_components: 1024,
+        max_config_entries: 1 << 20,
+        max_provides: 1 << 16,
+        max_requirement_groups: 1 << 16,
+        max_relation_groups: 1 << 16,
+        max_lifecycle_entries: 1 << 16,
+        // POSIX PATH_MAX and a depth well beyond any real install tree.
+        max_path_bytes: 4096,
+        max_path_components: 128,
+        max_name_bytes: 1024,
+        max_link_target_bytes: 4096,
+        max_xattrs_per_node: 256,
+        max_xattr_name_bytes: 255,
+        max_xattr_value_bytes: 64 * 1024,
+        max_script_body_bytes: 4 * 1024 * 1024,
+        // Aggregate variable-length pools. These, not a per-document byte
+        // guess, are what bound decoder memory for a maximal package.
+        max_total_path_bytes: 128 * 1024 * 1024,
+        max_total_xattr_bytes: 64 * 1024 * 1024,
+        max_non_payload_authority_bytes: 128 * 1024 * 1024,
+        max_attestation_bytes: 4 * 1024 * 1024,
+        max_payload_object_bytes: 512 * 1024 * 1024,
+        max_total_payload_bytes: 64 * 1024 * 1024 * 1024,
+        max_cbor_nesting_depth: 64,
+    };
+
+    /// Decoder-memory ceiling for signed authority, derived from the structural
+    /// dimensions above rather than chosen as a serialized-byte constant.
+    ///
+    /// A reader applies this before reading a declared MANIFEST entry, so a
+    /// hostile length declaration fails before allocation. The much tighter
+    /// [`Self::authority_bytes_ceiling`] then applies to the decoded census.
+    pub fn max_authority_bytes(&self) -> u64 {
+        let files = product(
+            "max_authority_bytes",
+            self.max_files,
+            FILE_AUTHORITY_FIXED_BYTES,
+        )
+        .unwrap_or(u64::MAX);
+        sum(
+            "max_authority_bytes",
+            [
+                AUTHORITY_ENVELOPE_BYTES,
+                files,
+                self.max_total_path_bytes,
+                self.max_total_xattr_bytes,
+                self.max_non_payload_authority_bytes,
+            ],
+        )
+        .unwrap_or(u64::MAX)
+    }
+
+    /// Exact ceiling this specific package's authority may occupy.
+    pub fn authority_bytes_ceiling(&self, census: &AuthorityCensus) -> BudgetResult<u64> {
+        let files = product(
+            "authority_bytes_ceiling",
+            census.files,
+            FILE_AUTHORITY_FIXED_BYTES,
+        )?;
+        sum(
+            "authority_bytes_ceiling",
+            [
+                AUTHORITY_ENVELOPE_BYTES,
+                files,
+                census.path_bytes,
+                census.xattr_bytes,
+                census.name_bytes,
+                census.non_payload_authority_bytes,
+            ],
+        )
+    }
+
+    /// The diagnostic TOML projection is a text rendering of authority the
+    /// package already declares, so its ceiling scales with the same census.
+    ///
+    /// Text keys, quoting, and table headers cost more per record than CBOR, so
+    /// the projection is allowed a bounded expansion over the authority
+    /// ceiling. It is still structural: a package that declares little
+    /// authority may not ship a large projection.
+    pub fn debug_projection_bytes_ceiling(&self, census: &AuthorityCensus) -> BudgetResult<u64> {
+        let authority = self.authority_bytes_ceiling(census)?;
+        let expanded = product(
+            "debug_projection_bytes_ceiling",
+            authority,
+            DEBUG_PROJECTION_TEXT_EXPANSION,
+        )?;
+        sum(
+            "debug_projection_bytes_ceiling",
+            [expanded, DEBUG_PROJECTION_ENVELOPE_BYTES],
+        )
+    }
+
+    /// Archive entries a maximal CCS package may contain.
+    ///
+    /// One object per unique payload digest, the two-hex fanout directories,
+    /// the `objects` root, and the control documents. CCS owns this bound
+    /// instead of the generic foreign-archive entry guard, so the writer and
+    /// reader cannot disagree about how many entries are admissible.
+    pub fn max_archive_entries(&self) -> u64 {
+        self.max_files.saturating_add(256 + 1 + 8)
+    }
+
+    pub fn admit_archive_entry(&self, entries_seen: u64) -> BudgetResult<()> {
+        admit(
+            BudgetDimension::ArchiveEntryCount,
+            "archive entries",
+            entries_seen,
+            self.max_archive_entries(),
+        )
+    }
+
+    pub fn signature_bytes_ceiling(&self) -> u64 {
+        SIGNATURE_DOCUMENT_BYTES
+    }
+
+    pub fn attestation_bytes_ceiling(&self) -> u64 {
+        self.max_attestation_bytes
+    }
+
+    /// Aggregate ceiling on every control document in one archive.
+    pub fn metadata_bytes_ceiling(&self, census: &AuthorityCensus) -> BudgetResult<u64> {
+        let authority = self.authority_bytes_ceiling(census)?;
+        let projection = self.debug_projection_bytes_ceiling(census)?;
+        sum(
+            "metadata_bytes_ceiling",
+            [
+                authority,
+                projection,
+                self.signature_bytes_ceiling(),
+                self.attestation_bytes_ceiling(),
+                self.attestation_bytes_ceiling(),
+            ],
+        )
+    }
+
+    /// Admit a declared or observed control-document length.
+    pub fn admit_control_bytes(
+        &self,
+        dimension: BudgetDimension,
+        field: &str,
+        observed: u64,
+        limit: u64,
+    ) -> BudgetResult<()> {
+        admit(dimension, field, observed, limit)
+    }
+
+    /// Decode signed authority under the nesting-depth bound.
+    ///
+    /// `ciborium` refuses a declared nesting depth beyond the limit before it
+    /// descends, so a hostile depth declaration costs no allocation.
+    pub fn decode_authority(&self, raw: &[u8]) -> anyhow::Result<AuthorityDocumentV2> {
+        admit(
+            BudgetDimension::AuthorityBytes,
+            "MANIFEST",
+            raw.len() as u64,
+            self.max_authority_bytes(),
+        )?;
+        ciborium::de::from_reader_with_recursion_limit(raw, self.max_cbor_nesting_depth)
+            .map_err(|error| anyhow::anyhow!("invalid CCS v2 MANIFEST: {error}"))
+    }
+
+    /// Measure and admit a decoded authority document against every dimension.
+    ///
+    /// This is the one function authoring preflight and verification share.
+    pub fn admit_authority(
+        &self,
+        authority: &AuthorityDocumentV2,
+    ) -> BudgetResult<AuthorityCensus> {
+        let mut census = AuthorityCensus::default();
+
+        self.admit_identity_strings(authority, &mut census)?;
+        self.admit_sections(authority, &mut census)?;
+
+        census.components = authority.components.len() as u64;
+        admit(
+            BudgetDimension::ComponentCount,
+            "components",
+            census.components,
+            self.max_components,
+        )?;
+        for name in authority.components.keys() {
+            self.admit_name(name, "components")?;
+            census.name_bytes = sum("components", [census.name_bytes, name.len() as u64])?;
+        }
+
+        if let PackageKindV2::Package(data) = &authority.kind {
+            census.files = data.files.len() as u64;
+            admit(
+                BudgetDimension::FileCount,
+                "kind.package.files",
+                census.files,
+                self.max_files,
+            )?;
+            let mut payload_objects = std::collections::BTreeSet::new();
+            for file in &data.files {
+                self.admit_file(file, &mut census, &mut payload_objects)?;
+            }
+            census.payload_objects = payload_objects.len() as u64;
+            admit(
+                BudgetDimension::PayloadObjectCount,
+                "kind.package.files.content",
+                census.payload_objects,
+                self.max_files,
+            )?;
+
+            census.config_entries = data.config.len() as u64;
+            admit(
+                BudgetDimension::ConfigCount,
+                "kind.package.config",
+                census.config_entries,
+                self.max_config_entries,
+            )?;
+            for config in &data.config {
+                self.admit_path(&config.path, "kind.package.config.path")?;
+                census.path_bytes = sum(
+                    "kind.package.config.path",
+                    [census.path_bytes, config.path.len() as u64],
+                )?;
+            }
+        }
+
+        admit(
+            BudgetDimension::TotalPathBytes,
+            "kind.package.files.path",
+            census.path_bytes,
+            self.max_total_path_bytes,
+        )?;
+        admit(
+            BudgetDimension::TotalXattrBytes,
+            "kind.package.files.node.xattrs",
+            census.xattr_bytes,
+            self.max_total_xattr_bytes,
+        )?;
+        admit(
+            BudgetDimension::TotalPayloadBytes,
+            "kind.package.files.content.size",
+            census.payload_bytes,
+            self.max_total_payload_bytes,
+        )?;
+        Ok(census)
+    }
+
+    /// Prove a serialized authority document fits the ceiling its own structure
+    /// derives. Authoring runs this on the bytes it is about to sign and
+    /// verification runs it on the exact archived bytes.
+    pub fn admit_encoded_authority(
+        &self,
+        census: &AuthorityCensus,
+        encoded_len: u64,
+    ) -> BudgetResult<()> {
+        admit(
+            BudgetDimension::AuthorityBytes,
+            "MANIFEST",
+            encoded_len,
+            self.authority_bytes_ceiling(census)?,
+        )
+    }
+
+    fn admit_identity_strings(
+        &self,
+        authority: &AuthorityDocumentV2,
+        census: &mut AuthorityCensus,
+    ) -> BudgetResult<()> {
+        for (field, value) in [
+            ("identity.name", Some(authority.identity.name.as_str())),
+            (
+                "identity.version",
+                Some(authority.identity.version.as_str()),
+            ),
+            (
+                "identity.release",
+                Some(authority.identity.release.as_str()),
+            ),
+            (
+                "identity.architecture",
+                authority.identity.architecture.as_deref(),
+            ),
+            ("identity.platform", authority.identity.platform.as_deref()),
+        ] {
+            let Some(value) = value else { continue };
+            self.admit_name(value, field)?;
+            census.name_bytes = sum(field, [census.name_bytes, value.len() as u64])?;
+        }
+        Ok(())
+    }
+
+    /// Measure every signed section other than the payload file array exactly.
+    ///
+    /// These sections are count-bounded first, so encoding them to obtain an
+    /// exact byte census is itself bounded work.
+    fn admit_sections(
+        &self,
+        authority: &AuthorityDocumentV2,
+        census: &mut AuthorityCensus,
+    ) -> BudgetResult<()> {
+        admit(
+            BudgetDimension::ProvideCount,
+            "provides",
+            authority.provides.len() as u64,
+            self.max_provides,
+        )?;
+        admit(
+            BudgetDimension::RequirementCount,
+            "requirements",
+            authority.requirements.len() as u64,
+            self.max_requirement_groups,
+        )?;
+        admit(
+            BudgetDimension::RelationCount,
+            "relations",
+            authority.relations.len() as u64,
+            self.max_relation_groups,
+        )?;
+        self.admit_lifecycle(&authority.lifecycle)?;
+
+        let mut bytes = 0_u64;
+        for (field, encoded) in [
+            ("identity", encoded_len(&authority.identity, "identity")?),
+            ("provides", encoded_len(&authority.provides, "provides")?),
+            (
+                "requirements",
+                encoded_len(&authority.requirements, "requirements")?,
+            ),
+            ("relations", encoded_len(&authority.relations, "relations")?),
+            (
+                "capabilities",
+                encoded_len(&authority.capabilities, "capabilities")?,
+            ),
+            (
+                "components",
+                encoded_len(&authority.components, "components")?,
+            ),
+            ("lifecycle", encoded_len(&authority.lifecycle, "lifecycle")?),
+            (
+                "provenance",
+                encoded_len(&authority.provenance, "provenance")?,
+            ),
+        ] {
+            bytes = sum(field, [bytes, encoded])?;
+        }
+        admit(
+            BudgetDimension::NonPayloadAuthorityBytes,
+            "authority sections",
+            bytes,
+            self.max_non_payload_authority_bytes,
+        )?;
+        census.non_payload_authority_bytes = bytes;
+        Ok(())
+    }
+
+    fn admit_lifecycle(&self, lifecycle: &LifecycleAuthorityV2) -> BudgetResult<()> {
+        let native_entries = lifecycle
+            .native_lifecycle
+            .as_ref()
+            .map_or(0, |bundle| bundle.entries.len() as u64);
+        let entries = sum(
+            "lifecycle",
+            [
+                lifecycle.users.len() as u64,
+                lifecycle.groups.len() as u64,
+                lifecycle.directories.len() as u64,
+                lifecycle.services.len() as u64,
+                lifecycle.systemd.len() as u64,
+                lifecycle.tmpfiles.len() as u64,
+                lifecycle.sysctl.len() as u64,
+                lifecycle.alternatives.len() as u64,
+                lifecycle.script_capabilities.len() as u64,
+                native_entries,
+            ],
+        )?;
+        admit(
+            BudgetDimension::LifecycleEntryCount,
+            "lifecycle",
+            entries,
+            self.max_lifecycle_entries,
+        )?;
+        for (field, script) in [
+            ("lifecycle.post_install", lifecycle.post_install.as_ref()),
+            ("lifecycle.pre_remove", lifecycle.pre_remove.as_ref()),
+        ] {
+            let Some(script) = script else { continue };
+            admit(
+                BudgetDimension::ScriptBodyBytes,
+                field,
+                script.body.len() as u64,
+                self.max_script_body_bytes,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn admit_file(
+        &self,
+        file: &FileAuthorityV2,
+        census: &mut AuthorityCensus,
+        payload_objects: &mut std::collections::BTreeSet<String>,
+    ) -> BudgetResult<()> {
+        self.admit_path(&file.path, "kind.package.files.path")?;
+        self.admit_name(&file.component, "kind.package.files.component")?;
+        census.path_bytes = sum(
+            "kind.package.files.path",
+            [census.path_bytes, file.path.len() as u64],
+        )?;
+        census.name_bytes = sum(
+            "kind.package.files.component",
+            [census.name_bytes, file.component.len() as u64],
+        )?;
+
+        match &file.node.kind {
+            PayloadNodeKind::Symlink { target } => {
+                self.admit_link_target(target, "kind.package.files.node.kind.target")?;
+                census.path_bytes = sum(
+                    "kind.package.files.node",
+                    [census.path_bytes, target.len() as u64],
+                )?;
+            }
+            PayloadNodeKind::Hardlink { target, identity } => {
+                self.admit_link_target(target, "kind.package.files.node.kind.target")?;
+                self.admit_link_target(identity, "kind.package.files.node.kind.identity")?;
+                census.path_bytes = sum(
+                    "kind.package.files.node",
+                    [
+                        census.path_bytes,
+                        target.len() as u64,
+                        identity.len() as u64,
+                    ],
+                )?;
+            }
+            PayloadNodeKind::Regular {
+                hardlink_identity: Some(identity),
+            } => {
+                self.admit_link_target(identity, "kind.package.files.node.kind.hardlink_identity")?;
+                census.path_bytes = sum(
+                    "kind.package.files.node",
+                    [census.path_bytes, identity.len() as u64],
+                )?;
+            }
+            _ => {}
+        }
+
+        admit(
+            BudgetDimension::XattrCount,
+            "kind.package.files.node.xattrs",
+            file.node.xattrs.len() as u64,
+            self.max_xattrs_per_node,
+        )?;
+        for (name, value) in &file.node.xattrs {
+            admit(
+                BudgetDimension::XattrNameBytes,
+                "kind.package.files.node.xattrs",
+                name.len() as u64,
+                self.max_xattr_name_bytes,
+            )?;
+            admit(
+                BudgetDimension::XattrValueBytes,
+                "kind.package.files.node.xattrs",
+                value.len() as u64,
+                self.max_xattr_value_bytes,
+            )?;
+            census.xattr_bytes = sum(
+                "kind.package.files.node.xattrs",
+                [census.xattr_bytes, name.len() as u64, value.len() as u64],
+            )?;
+        }
+
+        if let Some(content) = &file.content {
+            admit(
+                BudgetDimension::PayloadObjectBytes,
+                "kind.package.files.content.size",
+                content.size,
+                self.max_payload_object_bytes,
+            )?;
+            if payload_objects.insert(content.sha256.clone()) {
+                census.payload_bytes = sum(
+                    "kind.package.files.content.size",
+                    [census.payload_bytes, content.size],
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    fn admit_path(&self, path: &str, field: &str) -> BudgetResult<()> {
+        admit(
+            BudgetDimension::PathBytes,
+            field,
+            path.len() as u64,
+            self.max_path_bytes,
+        )?;
+        let depth = path.split('/').filter(|part| !part.is_empty()).count() as u64;
+        admit(
+            BudgetDimension::PathDepth,
+            field,
+            depth,
+            self.max_path_components,
+        )
+    }
+
+    fn admit_name(&self, name: &str, field: &str) -> BudgetResult<()> {
+        admit(
+            BudgetDimension::NameBytes,
+            field,
+            name.len() as u64,
+            self.max_name_bytes,
+        )
+    }
+
+    fn admit_link_target(&self, target: &str, field: &str) -> BudgetResult<()> {
+        admit(
+            BudgetDimension::LinkTargetBytes,
+            field,
+            target.len() as u64,
+            self.max_link_target_bytes,
+        )
+    }
+}
+
+fn encoded_len<T: serde::Serialize>(value: &T, field: &str) -> BudgetResult<u64> {
+    let mut counter = ByteCounter::default();
+    ciborium::into_writer(value, &mut counter).map_err(|_| BudgetError::overflow(field))?;
+    Ok(counter.bytes)
+}
+
+/// Counts encoded bytes without retaining them, so measuring a section never
+/// duplicates the document.
+#[derive(Default)]
+struct ByteCounter {
+    bytes: u64,
+}
+
+impl std::io::Write for ByteCounter {
+    fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+        self.bytes = self.bytes.saturating_add(data.len() as u64);
+        Ok(data.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}

--- a/crates/conary-core/src/ccs/budget/tests.rs
+++ b/crates/conary-core/src/ccs/budget/tests.rs
@@ -1,0 +1,419 @@
+// conary-core/src/ccs/budget/tests.rs
+
+use super::*;
+use crate::ccs::v2::schema::{
+    ComponentAuthorityV2, ConfigAuthorityV2, ConfigSemanticsV2, ConflictPolicyV2,
+    LifecycleScriptExecutionV2, LifecycleScriptV2, PackageDataV2,
+};
+use crate::payload::{PayloadContentAuthority, PayloadIdentity, PayloadNode, PayloadTimestamp};
+use std::collections::BTreeMap;
+
+fn package_data(authority: &mut AuthorityDocumentV2) -> &mut PackageDataV2 {
+    let PackageKindV2::Package(data) = &mut authority.kind else {
+        panic!("fixture must be a package");
+    };
+    data
+}
+
+fn file_at(path: &str) -> FileAuthorityV2 {
+    FileAuthorityV2 {
+        path: path.to_string(),
+        node: PayloadNode::regular(0o644),
+        content: Some(PayloadContentAuthority {
+            sha256: crate::hash::sha256(path.as_bytes()),
+            size: 4096,
+        }),
+        component: "main".to_string(),
+        config: None,
+        conflict: ConflictPolicyV2::Error,
+    }
+}
+
+fn with_files(name: &str, count: usize, path_of: impl Fn(usize) -> String) -> AuthorityDocumentV2 {
+    let mut authority = AuthorityDocumentV2::empty_package_for_tests(name);
+    authority.components.insert(
+        "main".to_string(),
+        ComponentAuthorityV2 {
+            name: "main".to_string(),
+            default: true,
+            file_count: count as u32,
+            total_size: 0,
+        },
+    );
+    let files = (0..count).map(|index| file_at(&path_of(index))).collect();
+    package_data(&mut authority).files = files;
+    authority
+}
+
+#[test]
+fn a_package_far_past_the_retired_sixteen_mebibyte_ceiling_is_admissible() {
+    // The retired fixed ceiling refused an ordinary package at roughly 52,000
+    // payload nodes. Structural budgeting admits it, and the encoded document
+    // fits the ceiling its own census derives.
+    let authority = with_files("large", 80_000, |index| {
+        format!(
+            "/usr/lib/python3.14/site-packages/large_collection/plugins/modules/module_{index:06}.py"
+        )
+    });
+
+    let census = CCS_BUDGET.admit_authority(&authority).unwrap();
+    let encoded = authority.to_cbor().unwrap();
+
+    assert_eq!(census.files, 80_000);
+    assert!(
+        encoded.len() as u64 > 16 * 1024 * 1024,
+        "fixture must exercise the retired ceiling: {} bytes",
+        encoded.len()
+    );
+    CCS_BUDGET
+        .admit_encoded_authority(&census, encoded.len() as u64)
+        .unwrap();
+}
+
+#[test]
+fn file_authority_fixed_bytes_is_an_upper_bound() {
+    // Every node variant, with its variable-length authority accounted for
+    // separately, must fit the constant the derived ceiling multiplies.
+    let variants = [
+        crate::payload::PayloadNodeKind::Regular {
+            hardlink_identity: None,
+        },
+        crate::payload::PayloadNodeKind::Directory,
+        crate::payload::PayloadNodeKind::Symlink {
+            target: String::new(),
+        },
+        crate::payload::PayloadNodeKind::Hardlink {
+            target: String::new(),
+            identity: String::new(),
+        },
+        crate::payload::PayloadNodeKind::BlockDevice {
+            major: u64::MAX,
+            minor: u64::MAX,
+        },
+        crate::payload::PayloadNodeKind::CharacterDevice {
+            major: u64::MAX,
+            minor: u64::MAX,
+        },
+        crate::payload::PayloadNodeKind::Fifo,
+        crate::payload::PayloadNodeKind::Socket,
+    ];
+
+    for kind in variants {
+        let file = FileAuthorityV2 {
+            path: String::new(),
+            node: PayloadNode {
+                kind,
+                mode: u32::MAX,
+                user: PayloadIdentity::Numeric { id: u64::MAX },
+                group: PayloadIdentity::Numeric { id: u64::MAX },
+                mtime: PayloadTimestamp {
+                    seconds: i64::MIN,
+                    nanoseconds: u32::MAX,
+                },
+                xattrs: BTreeMap::new(),
+            },
+            content: Some(PayloadContentAuthority {
+                sha256: "f".repeat(64),
+                size: u64::MAX,
+            }),
+            component: String::new(),
+            config: Some(ConfigSemanticsV2 {
+                noreplace: true,
+                ghost: true,
+                remove_on_upgrade: true,
+            }),
+            conflict: ConflictPolicyV2::Replace,
+        };
+        let encoded = encoded_len(&file, "file").unwrap();
+        assert!(
+            encoded <= FILE_AUTHORITY_FIXED_BYTES,
+            "{encoded} exceeds the fixed per-file allowance"
+        );
+    }
+}
+
+#[test]
+fn every_structural_dimension_fails_one_over_its_own_limit() {
+    let budget = CCS_BUDGET;
+
+    // File count.
+    let authority = with_files("files", (budget.max_files + 1) as usize, |index| {
+        format!("/f{index}")
+    });
+    // Building a real 1M-file fixture is wasteful; assert against the
+    // dimension directly for the count-only limits.
+    drop(authority);
+    assert_eq!(
+        admit(
+            BudgetDimension::FileCount,
+            "kind.package.files",
+            budget.max_files + 1,
+            budget.max_files
+        )
+        .unwrap_err()
+        .dimension,
+        BudgetDimension::FileCount
+    );
+
+    // Path length.
+    let mut authority = with_files("path", 1, |_| {
+        format!("/{}", "a".repeat(CCS_BUDGET.max_path_bytes as usize))
+    });
+    assert_eq!(
+        CCS_BUDGET
+            .admit_authority(&authority)
+            .unwrap_err()
+            .dimension,
+        BudgetDimension::PathBytes
+    );
+
+    // Path depth.
+    authority = with_files("depth", 1, |_| {
+        "/a".repeat(CCS_BUDGET.max_path_components as usize + 1)
+    });
+    assert_eq!(
+        CCS_BUDGET
+            .admit_authority(&authority)
+            .unwrap_err()
+            .dimension,
+        BudgetDimension::PathDepth
+    );
+
+    // Component name length.
+    authority = with_files("component", 1, |index| format!("/f{index}"));
+    package_data(&mut authority).files[0].component =
+        "c".repeat(CCS_BUDGET.max_name_bytes as usize + 1);
+    assert_eq!(
+        CCS_BUDGET
+            .admit_authority(&authority)
+            .unwrap_err()
+            .dimension,
+        BudgetDimension::NameBytes
+    );
+
+    // Symlink target length.
+    authority = with_files("link", 1, |index| format!("/f{index}"));
+    package_data(&mut authority).files[0].node.kind = crate::payload::PayloadNodeKind::Symlink {
+        target: "t".repeat(CCS_BUDGET.max_link_target_bytes as usize + 1),
+    };
+    assert_eq!(
+        CCS_BUDGET
+            .admit_authority(&authority)
+            .unwrap_err()
+            .dimension,
+        BudgetDimension::LinkTargetBytes
+    );
+
+    // Xattr count, name, and value.
+    authority = with_files("xattr", 1, |index| format!("/f{index}"));
+    let xattrs = &mut package_data(&mut authority).files[0].node.xattrs;
+    for index in 0..=CCS_BUDGET.max_xattrs_per_node {
+        xattrs.insert(format!("user.x{index}"), vec![0_u8; 4]);
+    }
+    assert_eq!(
+        CCS_BUDGET
+            .admit_authority(&authority)
+            .unwrap_err()
+            .dimension,
+        BudgetDimension::XattrCount
+    );
+
+    authority = with_files("xattr-name", 1, |index| format!("/f{index}"));
+    package_data(&mut authority).files[0].node.xattrs.insert(
+        "n".repeat(CCS_BUDGET.max_xattr_name_bytes as usize + 1),
+        vec![0_u8; 4],
+    );
+    assert_eq!(
+        CCS_BUDGET
+            .admit_authority(&authority)
+            .unwrap_err()
+            .dimension,
+        BudgetDimension::XattrNameBytes
+    );
+
+    authority = with_files("xattr-value", 1, |index| format!("/f{index}"));
+    package_data(&mut authority).files[0].node.xattrs.insert(
+        "user.big".to_string(),
+        vec![0_u8; CCS_BUDGET.max_xattr_value_bytes as usize + 1],
+    );
+    assert_eq!(
+        CCS_BUDGET
+            .admit_authority(&authority)
+            .unwrap_err()
+            .dimension,
+        BudgetDimension::XattrValueBytes
+    );
+
+    // Component count.
+    authority = with_files("components", 1, |index| format!("/f{index}"));
+    for index in 0..=CCS_BUDGET.max_components {
+        authority.components.insert(
+            format!("c{index}"),
+            ComponentAuthorityV2 {
+                name: format!("c{index}"),
+                default: false,
+                file_count: 0,
+                total_size: 0,
+            },
+        );
+    }
+    assert_eq!(
+        CCS_BUDGET
+            .admit_authority(&authority)
+            .unwrap_err()
+            .dimension,
+        BudgetDimension::ComponentCount
+    );
+
+    // Payload object size.
+    authority = with_files("object", 1, |index| format!("/f{index}"));
+    package_data(&mut authority).files[0]
+        .content
+        .as_mut()
+        .unwrap()
+        .size = CCS_BUDGET.max_payload_object_bytes + 1;
+    assert_eq!(
+        CCS_BUDGET
+            .admit_authority(&authority)
+            .unwrap_err()
+            .dimension,
+        BudgetDimension::PayloadObjectBytes
+    );
+
+    // Lifecycle script body.
+    authority = with_files("script", 1, |index| format!("/f{index}"));
+    authority.lifecycle.post_install = Some(LifecycleScriptV2 {
+        interpreter: "/bin/sh".to_string(),
+        body: "x".repeat(CCS_BUDGET.max_script_body_bytes as usize + 1),
+        capabilities: Vec::new(),
+        reversible: None,
+        execution: LifecycleScriptExecutionV2::SandboxedTargetRoot,
+    });
+    assert_eq!(
+        CCS_BUDGET
+            .admit_authority(&authority)
+            .unwrap_err()
+            .dimension,
+        BudgetDimension::ScriptBodyBytes
+    );
+}
+
+#[test]
+fn near_limit_values_on_each_dimension_stay_admissible() {
+    let mut authority = with_files("near-limit", 4, |index| format!("/near/{index}"));
+    package_data(&mut authority).files[0].path =
+        format!("/{}", "a".repeat(CCS_BUDGET.max_path_bytes as usize - 1));
+    package_data(&mut authority).files[1].node.kind = crate::payload::PayloadNodeKind::Symlink {
+        target: "t".repeat(CCS_BUDGET.max_link_target_bytes as usize),
+    };
+    package_data(&mut authority).files[1].content = None;
+    let widest_component = "c".repeat(CCS_BUDGET.max_name_bytes as usize);
+    package_data(&mut authority).files[2].component = widest_component.clone();
+    authority.components.insert(
+        widest_component.clone(),
+        ComponentAuthorityV2 {
+            name: widest_component,
+            default: false,
+            file_count: 1,
+            total_size: 4096,
+        },
+    );
+    let xattrs = &mut package_data(&mut authority).files[3].node.xattrs;
+    for index in 0..CCS_BUDGET.max_xattrs_per_node {
+        xattrs.insert(format!("user.x{index}"), vec![0_u8; 8]);
+    }
+    package_data(&mut authority).config = vec![ConfigAuthorityV2 {
+        path: "/etc/near-limit.conf".to_string(),
+        semantics: ConfigSemanticsV2 {
+            noreplace: true,
+            ghost: false,
+            remove_on_upgrade: false,
+        },
+    }];
+
+    let census = CCS_BUDGET.admit_authority(&authority).unwrap();
+
+    assert_eq!(census.files, 4);
+    assert_eq!(census.config_entries, 1);
+    CCS_BUDGET
+        .admit_encoded_authority(&census, authority.to_cbor().unwrap().len() as u64)
+        .unwrap();
+}
+
+#[test]
+fn hostile_cbor_depth_and_length_declarations_fail_before_allocation() {
+    // A declared nesting depth beyond the bound is refused while decoding the
+    // header, not after descending it.
+    let mut deep = Vec::new();
+    for _ in 0..CCS_BUDGET.max_cbor_nesting_depth + 8 {
+        deep.push(0x81); // one-element array
+    }
+    deep.push(0x00);
+    let error = CCS_BUDGET.decode_authority(&deep).unwrap_err();
+    assert!(format!("{error:#}").contains("MANIFEST"), "{error:#}");
+
+    // A hostile declared length is refused before any read.
+    let error = CCS_BUDGET
+        .decode_authority(&[])
+        .expect_err("empty authority is not decodable");
+    assert!(format!("{error:#}").contains("MANIFEST"), "{error:#}");
+
+    let over = CCS_BUDGET.max_authority_bytes() + 1;
+    let error = CCS_BUDGET
+        .admit_control_bytes(
+            BudgetDimension::AuthorityBytes,
+            "MANIFEST",
+            over,
+            CCS_BUDGET.max_authority_bytes(),
+        )
+        .unwrap_err();
+    assert_eq!(error.observed, over);
+}
+
+#[test]
+fn padded_authority_is_refused_against_its_own_census_ceiling() {
+    // A document may not be larger than the structure it declares, so an
+    // attacker cannot pad a ten-file package up to the global ceiling.
+    let authority = with_files("padded", 10, |index| format!("/usr/bin/f{index}"));
+    let census = CCS_BUDGET.admit_authority(&authority).unwrap();
+    let ceiling = CCS_BUDGET.authority_bytes_ceiling(&census).unwrap();
+
+    assert!(ceiling < CCS_BUDGET.max_authority_bytes());
+    let error = CCS_BUDGET
+        .admit_encoded_authority(&census, ceiling + 1)
+        .unwrap_err();
+    assert_eq!(error.dimension, BudgetDimension::AuthorityBytes);
+}
+
+#[test]
+fn arithmetic_overflow_fails_closed() {
+    let mut authority = with_files("overflow", 2, |index| format!("/f{index}"));
+    let files = &mut package_data(&mut authority).files;
+    files[0].content.as_mut().unwrap().size = u64::MAX;
+    files[1].content.as_mut().unwrap().size = u64::MAX;
+
+    let error = CCS_BUDGET.admit_authority(&authority).unwrap_err();
+
+    assert_eq!(error.dimension, BudgetDimension::PayloadObjectBytes);
+    assert_eq!(
+        sum("probe", [u64::MAX, 1]).unwrap_err().dimension,
+        BudgetDimension::Arithmetic
+    );
+    assert_eq!(
+        product("probe", u64::MAX, 2).unwrap_err().dimension,
+        BudgetDimension::Arithmetic
+    );
+}
+
+#[test]
+fn derived_ceilings_are_stated_in_terms_of_structural_dimensions() {
+    let budget = CCS_BUDGET;
+    let expected = AUTHORITY_ENVELOPE_BYTES
+        + budget.max_files * FILE_AUTHORITY_FIXED_BYTES
+        + budget.max_total_path_bytes
+        + budget.max_total_xattr_bytes
+        + budget.max_non_payload_authority_bytes;
+
+    assert_eq!(budget.max_authority_bytes(), expected);
+    assert_eq!(budget.max_archive_entries(), budget.max_files + 256 + 1 + 8);
+}

--- a/crates/conary-core/src/ccs/budget/tests.rs
+++ b/crates/conary-core/src/ccs/budget/tests.rs
@@ -344,10 +344,9 @@ fn near_limit_values_on_each_dimension_stay_admissible() {
 fn hostile_cbor_depth_and_length_declarations_fail_before_allocation() {
     // A declared nesting depth beyond the bound is refused while decoding the
     // header, not after descending it.
-    let mut deep = Vec::new();
-    for _ in 0..CCS_BUDGET.max_cbor_nesting_depth + 8 {
-        deep.push(0x81); // one-element array
-    }
+    // Each 0x81 is a one-element array header, so a run of them declares
+    // nesting deeper than the bound allows.
+    let mut deep = vec![0x81u8; CCS_BUDGET.max_cbor_nesting_depth + 8];
     deep.push(0x00);
     let error = CCS_BUDGET.decode_authority(&deep).unwrap_err();
     assert!(format!("{error:#}").contains("MANIFEST"), "{error:#}");

--- a/crates/conary-core/src/ccs/builder.rs
+++ b/crates/conary-core/src/ccs/builder.rs
@@ -56,7 +56,7 @@ pub enum BuilderError {
 }
 
 /// A file entry in a CCS package
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct FileEntry {
     /// Installation path (absolute)
@@ -76,7 +76,7 @@ pub struct FileEntry {
 }
 
 /// Component data in a built package
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ComponentData {
     pub name: String,

--- a/crates/conary-core/src/ccs/builder/package_writer.rs
+++ b/crates/conary-core/src/ccs/builder/package_writer.rs
@@ -79,68 +79,63 @@ fn write_v2_ccs_package_with_open<'a>(
     foreign_conversion_boundary: Option<&crate::ccs::attestation::ForeignConversionBoundary>,
     mut open_payload: impl FnMut(&str) -> Result<Box<dyn std::io::Read + 'a>>,
 ) -> Result<()> {
-    use crate::ccs::builder::{ComponentData, FileEntry};
+    use crate::ccs::budget::CCS_BUDGET;
     use crate::ccs::v2::schema::PackageKindV2;
     use flate2::Compression;
     use flate2::write::GzEncoder;
-    use std::collections::BTreeMap;
     use tar::Builder;
 
-    crate::ccs::v2::validation::validate_authority_structure(authority)
-        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    // Authoring preflight and verification share one structural-budget owner,
+    // so a package this writer emits is admissible to the reader by
+    // construction rather than by coincidence.
+    let census =
+        crate::ccs::v2::authority_census(authority).map_err(|error| anyhow::anyhow!("{error}"))?;
     let temp_dir = tempfile::tempdir()?;
     let manifest_cbor = authority.to_cbor()?;
+    CCS_BUDGET.admit_encoded_authority(&census, manifest_cbor.len() as u64)?;
     fs::write(temp_dir.path().join("MANIFEST"), &manifest_cbor)?;
     if let Some(debug_toml) = debug_toml {
+        CCS_BUDGET.admit_control_bytes(
+            crate::ccs::budget::BudgetDimension::DebugProjectionBytes,
+            "MANIFEST.toml",
+            debug_toml.len() as u64,
+            CCS_BUDGET.debug_projection_bytes_ceiling(&census)?,
+        )?;
         fs::write(temp_dir.path().join("MANIFEST.toml"), debug_toml)?;
     }
     if let Some(build_attestation) = build_attestation {
-        fs::write(
-            temp_dir.path().join("MANIFEST.attestation.json"),
-            serde_json::to_string_pretty(build_attestation)?,
-        )?;
+        let encoded = serde_json::to_string_pretty(build_attestation)?;
+        admit_attestation_document(&encoded, "MANIFEST.attestation.json")?;
+        fs::write(temp_dir.path().join("MANIFEST.attestation.json"), encoded)?;
     }
     if let Some(foreign_conversion_boundary) = foreign_conversion_boundary {
+        let encoded = serde_json::to_string_pretty(foreign_conversion_boundary)?;
+        admit_attestation_document(&encoded, "MANIFEST.conversion-boundary.json")?;
         fs::write(
             temp_dir.path().join("MANIFEST.conversion-boundary.json"),
-            serde_json::to_string_pretty(foreign_conversion_boundary)?,
+            encoded,
         )?;
     }
     let signature = signing_key.sign(&manifest_cbor);
-    fs::write(
-        temp_dir.path().join("MANIFEST.sig"),
-        serde_json::to_string_pretty(&signature)?,
+    let signature_document = serde_json::to_string_pretty(&signature)?;
+    CCS_BUDGET.admit_control_bytes(
+        crate::ccs::budget::BudgetDimension::SignatureBytes,
+        "MANIFEST.sig",
+        signature_document.len() as u64,
+        CCS_BUDGET.signature_bytes_ceiling(),
     )?;
+    fs::write(temp_dir.path().join("MANIFEST.sig"), signature_document)?;
 
     let PackageKindV2::Package(data) = &authority.kind else {
         anyhow::bail!("M4a v2 writer only writes package payloads");
     };
-    let mut components: BTreeMap<String, ComponentData> = authority
-        .components
-        .keys()
-        .map(|name| {
-            (
-                name.clone(),
-                ComponentData {
-                    name: name.clone(),
-                    files: Vec::new(),
-                    hash: String::new(),
-                    size: 0,
-                },
-            )
-        })
-        .collect();
 
     let objects_dir = temp_dir.path().join("objects");
     let object_store = crate::filesystem::CasStore::new(&objects_dir)?;
     for file in &data.files {
-        let entry = FileEntry {
-            path: file.path.clone(),
-            node: file.node.clone(),
-            content: file.content.clone(),
-            component: file.component.clone(),
-            chunks: None,
-        };
+        if !authority.components.contains_key(&file.component) {
+            anyhow::bail!("missing component {}", file.component);
+        }
         if file.node.kind.is_regular() {
             let content = file.content.as_ref().with_context(|| {
                 format!(
@@ -158,23 +153,6 @@ fn write_v2_ccs_package_with_open<'a>(
                     )
                 })?;
         }
-        let component = components
-            .get_mut(&file.component)
-            .with_context(|| format!("missing component {}", file.component))?;
-        component.size += file.content.as_ref().map_or(0, |content| content.size);
-        component.files.push(entry);
-    }
-
-    let components_dir = temp_dir.path().join("components");
-    fs::create_dir_all(&components_dir)?;
-    for (name, component) in &mut components {
-        component.hash = crate::hash::sha256_prefixed(
-            &crate::ccs::attestation::canonical_json_bytes(&component.files)?,
-        );
-        fs::write(
-            components_dir.join(format!("{name}.json")),
-            serde_json::to_vec_pretty(component)?,
-        )?;
     }
 
     let output_file = fs::File::create(output_path)?;
@@ -186,6 +164,19 @@ fn write_v2_ccs_package_with_open<'a>(
         .unwrap_or(1_704_067_200);
     append_dir_with_mtime(&mut archive, temp_dir.path(), "", timestamp)?;
     archive.into_inner()?.finish()?;
+    Ok(())
+}
+
+/// Admit one attestation-class control document against the shared budget.
+fn admit_attestation_document(encoded: &str, label: &str) -> Result<()> {
+    use crate::ccs::budget::{BudgetDimension, CCS_BUDGET};
+
+    CCS_BUDGET.admit_control_bytes(
+        BudgetDimension::AttestationBytes,
+        label,
+        encoded.len() as u64,
+        CCS_BUDGET.attestation_bytes_ceiling(),
+    )?;
     Ok(())
 }
 
@@ -371,10 +362,43 @@ mod tests {
         .unwrap();
         assert_eq!(contents.v2_authority.identity.name, "hello-v2");
         assert_eq!(contents.components["main"].files.len(), 1);
+        assert_eq!(contents.census.files, 1);
+        assert_eq!(contents.census.payload_objects, 1);
+    }
+
+    #[test]
+    fn writer_emits_no_duplicated_component_projection() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("no-projection.ccs");
+        let authority = crate::ccs::v2::test_support::package_authority_with_one_file("nodup");
+        let payloads = crate::ccs::v2::test_support::one_file_payloads_for_tests();
+        let key = crate::ccs::signing::SigningKeyPair::generate();
+        write_v2_ccs_package(&authority, &payloads, &path, &key, None, None, None).unwrap();
+
+        let mut archive =
+            tar::Archive::new(flate2::read::GzDecoder::new(fs::File::open(&path).unwrap()));
+        let entries = archive
+            .entries()
+            .unwrap()
+            .map(|entry| {
+                let entry = entry.unwrap();
+                (
+                    entry.path().unwrap().display().to_string(),
+                    entry.header().entry_type().is_file(),
+                )
+            })
+            .collect::<Vec<_>>();
+
         assert!(
-            contents
-                .blobs
-                .contains_key(&crate::hash::sha256(b"hello world\n"))
+            !entries
+                .iter()
+                .any(|(path, _)| path.starts_with("components")),
+            "{entries:?}"
         );
+        let (first_file, _) = entries
+            .iter()
+            .find(|(_, is_file)| *is_file)
+            .expect("archive carries files");
+        assert_eq!(first_file, "MANIFEST", "{entries:?}");
     }
 }

--- a/crates/conary-core/src/ccs/builder/package_writer.rs
+++ b/crates/conary-core/src/ccs/builder/package_writer.rs
@@ -392,7 +392,7 @@ mod tests {
         assert!(
             !entries
                 .iter()
-                .any(|(path, _)| path.starts_with("components")),
+                .any(|(path, _)| path.starts_with(crate::ccs::archive_layout::COMPONENTS_DIR)),
             "{entries:?}"
         );
         let (first_file, _) = entries

--- a/crates/conary-core/src/ccs/inspector.rs
+++ b/crates/conary-core/src/ccs/inspector.rs
@@ -32,12 +32,10 @@ impl UntrustedPackageInspection {
 
         let contents = inspect_untrusted_ccs_archive(file)?;
 
-        // Collect files from components (spec says files live in components/*.json)
-        let files: Vec<FileEntry> = contents
-            .components
-            .values()
-            .flat_map(|c| c.files.clone())
-            .collect();
+        // Files come from the signed authority. The archive no longer carries a
+        // duplicated `components/*.json` copy of the same records.
+        let files: Vec<FileEntry> =
+            crate::ccs::v2::component_view::file_entries(&contents.v2_authority);
 
         Ok(Self {
             manifest: contents.manifest,

--- a/crates/conary-core/src/ccs/mod.rs
+++ b/crates/conary-core/src/ccs/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod archive_reader;
 pub mod attestation;
+pub mod budget;
 pub mod builder;
 pub mod chunking;
 pub mod convert;
@@ -30,6 +31,7 @@ pub mod signing;
 pub mod v2;
 pub mod verify;
 
+pub use budget::{AuthorityCensus, BudgetDimension, BudgetError, CCS_BUDGET, CcsStructuralBudget};
 pub use builder::{BuildResult, BuilderError, CcsBuilder, ChunkStats, ComponentData, FileEntry};
 pub use chunking::{Chunk, ChunkStore, ChunkedFile, Chunker, DeltaStats, StoreStats};
 pub use convert::{ConversionOptions, ConversionResult, NativePackageConverter};

--- a/crates/conary-core/src/ccs/mod.rs
+++ b/crates/conary-core/src/ccs/mod.rs
@@ -9,6 +9,7 @@
 //! - Package installation (via PackageFormat trait)
 //! - Declarative hook execution
 
+pub mod archive_layout;
 pub mod archive_reader;
 pub mod attestation;
 pub mod budget;

--- a/crates/conary-core/src/ccs/v2/component_view.rs
+++ b/crates/conary-core/src/ccs/v2/component_view.rs
@@ -1,0 +1,129 @@
+// conary-core/src/ccs/v2/component_view.rs
+
+//! Component and file views derived from signed CCS v2 authority.
+//!
+//! The archive used to carry a `components/<name>.json` copy of every file
+//! record. That projection duplicated the signed file array in a second
+//! encoding, roughly doubling archive metadata, and it could add no authority
+//! because verification had to prove it matched the MANIFEST exactly. The
+//! signed authority is now the sole owner, and every component view is derived
+//! from it here.
+
+use super::schema::{AuthorityDocumentV2, PackageKindV2};
+use crate::ccs::builder::{ComponentData, FileEntry};
+use std::collections::HashMap;
+
+/// Project every signed payload node into the shared builder file view.
+pub fn file_entries(authority: &AuthorityDocumentV2) -> Vec<FileEntry> {
+    let PackageKindV2::Package(data) = &authority.kind else {
+        return Vec::new();
+    };
+    data.files
+        .iter()
+        .map(|file| FileEntry {
+            path: file.path.clone(),
+            node: file.node.clone(),
+            content: file.content.clone(),
+            component: file.component.clone(),
+            chunks: None,
+        })
+        .collect()
+}
+
+/// Derive the component view from signed authority.
+///
+/// Every component named in signed authority appears, including one that owns
+/// no payload node, and each file lands in exactly the component its signed
+/// record names.
+pub fn components(authority: &AuthorityDocumentV2) -> HashMap<String, ComponentData> {
+    let mut components = authority
+        .components
+        .keys()
+        .map(|name| {
+            (
+                name.clone(),
+                ComponentData {
+                    name: name.clone(),
+                    files: Vec::new(),
+                    hash: String::new(),
+                    size: 0,
+                },
+            )
+        })
+        .collect::<HashMap<String, ComponentData>>();
+
+    for file in file_entries(authority) {
+        let component = components
+            .entry(file.component.clone())
+            .or_insert_with(|| ComponentData {
+                name: file.component.clone(),
+                files: Vec::new(),
+                hash: String::new(),
+                size: 0,
+            });
+        component.size += file.content.as_ref().map_or(0, |content| content.size);
+        component.files.push(file);
+    }
+
+    for component in components.values_mut() {
+        component.hash = component_hash(&component.files);
+    }
+    components
+}
+
+/// Stable content hash of one component's derived file view.
+///
+/// This is the same canonical-JSON digest the deleted `components/<name>.json`
+/// projection carried, so inspection output did not change when the duplicated
+/// projection was removed from the archive grammar.
+pub fn component_hash(files: &[FileEntry]) -> String {
+    crate::hash::sha256_prefixed(
+        &crate::ccs::attestation::canonical_json_bytes(&files.to_vec())
+            .expect("FileEntry carries only serializable authority"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ccs::v2::schema::ComponentAuthorityV2;
+
+    #[test]
+    fn derived_components_cover_signed_names_including_empty_ones() {
+        let mut authority = AuthorityDocumentV2::package_for_tests("derived");
+        authority.components.insert(
+            "docs".to_string(),
+            ComponentAuthorityV2 {
+                name: "docs".to_string(),
+                default: false,
+                file_count: 0,
+                total_size: 0,
+            },
+        );
+
+        let components = components(&authority);
+
+        assert_eq!(components.len(), 2);
+        assert!(components["docs"].files.is_empty());
+        assert_eq!(components["main"].files.len(), 1);
+        assert_eq!(components["main"].size, 12);
+        assert!(components["main"].hash.starts_with("sha256:"));
+        assert!(components["docs"].hash.starts_with("sha256:"));
+    }
+
+    #[test]
+    fn derived_file_view_preserves_exact_signed_payload_authority() {
+        let authority = AuthorityDocumentV2::package_for_tests("derived-files");
+        let PackageKindV2::Package(data) = &authority.kind else {
+            panic!("fixture should be a package");
+        };
+
+        let files = file_entries(&authority);
+
+        assert_eq!(files.len(), data.files.len());
+        assert_eq!(files[0].path, data.files[0].path);
+        assert_eq!(files[0].node, data.files[0].node);
+        assert_eq!(files[0].content, data.files[0].content);
+        assert_eq!(files[0].component, data.files[0].component);
+    }
+}

--- a/crates/conary-core/src/ccs/v2/diagnostics.rs
+++ b/crates/conary-core/src/ccs/v2/diagnostics.rs
@@ -12,6 +12,7 @@ pub enum V2DiagnosticCode {
     ComponentAuthorityMismatch,
     IdentityUnstable,
     ConversionNotNative,
+    StructuralBudgetExceeded,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/conary-core/src/ccs/v2/mod.rs
+++ b/crates/conary-core/src/ccs/v2/mod.rs
@@ -2,6 +2,7 @@
 //! CCS v2 native package authority.
 
 pub mod authoring;
+pub mod component_view;
 pub mod debug_projection;
 pub mod diagnostics;
 pub mod identity;
@@ -26,3 +27,4 @@ pub use schema::{
     ProvidedCapabilityV2,
 };
 pub use validation::validate_authority;
+pub use validation::{authority_census, validate_authority_structure};

--- a/crates/conary-core/src/ccs/v2/schema.rs
+++ b/crates/conary-core/src/ccs/v2/schema.rs
@@ -408,8 +408,13 @@ impl AuthorityDocumentV2 {
         Ok(buf)
     }
 
-    pub fn from_cbor(bytes: &[u8]) -> Result<Self, ciborium::de::Error<std::io::Error>> {
-        ciborium::from_reader(bytes)
+    /// Decode signed authority under the canonical structural budget.
+    ///
+    /// There is no unbounded decode entry point: every consumer goes through
+    /// `crate::ccs::budget`, so a hostile nesting depth or declared length
+    /// fails before allocation.
+    pub fn from_cbor(bytes: &[u8]) -> anyhow::Result<Self> {
+        crate::ccs::budget::CCS_BUDGET.decode_authority(bytes)
     }
 
     #[cfg(test)]

--- a/crates/conary-core/src/ccs/v2/validation.rs
+++ b/crates/conary-core/src/ccs/v2/validation.rs
@@ -5,21 +5,52 @@ mod identity;
 
 use super::diagnostics::{V2Diagnostic, V2DiagnosticCode, V2ValidationError};
 use super::schema::*;
+use crate::ccs::budget::{AuthorityCensus, CCS_BUDGET};
 use config::{validate_config_authority, validate_package_policy};
 use identity::{validate_identity, validate_provides};
 
 pub fn validate_authority(authority: &AuthorityDocumentV2) -> Result<(), V2ValidationError> {
-    validate_authority_common(authority)
+    validate_authority_common(authority).map(|_| ())
 }
 
 pub fn validate_authority_structure(
     authority: &AuthorityDocumentV2,
 ) -> Result<(), V2ValidationError> {
+    validate_authority_common(authority).map(|_| ())
+}
+
+/// Validate and return the structural census the shared budget measured.
+///
+/// Authoring uses the census to prove the bytes it is about to sign fit the
+/// ceiling those exact bytes derive; verification uses it to prove the archived
+/// bytes do. Neither side owns a private limit table.
+pub fn authority_census(
+    authority: &AuthorityDocumentV2,
+) -> Result<AuthorityCensus, V2ValidationError> {
     validate_authority_common(authority)
 }
 
-fn validate_authority_common(authority: &AuthorityDocumentV2) -> Result<(), V2ValidationError> {
+fn validate_authority_common(
+    authority: &AuthorityDocumentV2,
+) -> Result<AuthorityCensus, V2ValidationError> {
     let mut diagnostics = Vec::new();
+
+    // The shared structural budget runs first: a document that declares
+    // hostile counts, lengths, or depth is refused before any other pass walks
+    // it, and the same admission runs in authoring preflight and verification.
+    let census = match CCS_BUDGET.admit_authority(authority) {
+        Ok(census) => census,
+        Err(error) => {
+            return Err(V2ValidationError {
+                diagnostics: vec![V2Diagnostic::error(
+                    V2DiagnosticCode::StructuralBudgetExceeded,
+                    error.to_string(),
+                    Some(error.field.clone()),
+                    "keep signed authority inside the canonical CCS structural budget",
+                )],
+            });
+        }
+    };
 
     if authority.format_version != FORMAT_VERSION_V2 {
         diagnostics.push(V2Diagnostic::error(
@@ -125,7 +156,7 @@ fn validate_authority_common(authority: &AuthorityDocumentV2) -> Result<(), V2Va
     }
 
     if diagnostics.is_empty() {
-        Ok(())
+        Ok(census)
     } else {
         Err(V2ValidationError { diagnostics })
     }

--- a/crates/conary-core/src/ccs/verify/stream.rs
+++ b/crates/conary-core/src/ccs/verify/stream.rs
@@ -3,6 +3,7 @@
 //! Signature-first streaming verification of trusted CCS archives.
 
 use super::{PackageSignature, TrustPolicy, VerifyError};
+use crate::ccs::archive_layout::is_lower_hex;
 use crate::ccs::budget::{AuthorityCensus, BudgetDimension, CCS_BUDGET};
 use crate::ccs::builder::ComponentData;
 use crate::ccs::v2::schema::{AuthorityDocumentV2, PackageKindV2};
@@ -42,6 +43,11 @@ struct MetadataState {
     debug_toml: Option<Vec<u8>>,
     attestation: Option<String>,
     conversion_boundary: Option<String>,
+    /// Components the archive carried, keyed by name.
+    ///
+    /// Collected while streaming and reconciled against the signed authority
+    /// once it is authenticated, the same way the object set is.
+    components: HashMap<String, ComponentData>,
 }
 
 struct AuthenticatedMetadata {
@@ -127,7 +133,14 @@ pub(super) fn verify_archive(path: &Path, policy: &TrustPolicy) -> Result<Stream
         .into());
     }
     let payload = payload_from_authority(&authenticated.authority, &object_sources)?;
+    // Components are derived from the signed authority, which is the source of
+    // truth. Archive component entries are still parsed and validated on the
+    // way past — name agreement, duplicates, and size budget — so a malformed
+    // one fails closed rather than being skipped. Their payload is not the
+    // component source: a package may legitimately carry no component entries
+    // while its authority declares components.
     let components = crate::ccs::v2::component_view::components(&authenticated.authority);
+
     Ok(StreamVerifiedArchive {
         authority: authenticated.authority,
         signature: authenticated.signature,
@@ -266,6 +279,41 @@ fn read_metadata_entry(
                 path,
             )?;
             set_once(&mut state.conversion_boundary, value, path)
+        }
+        _ if crate::ccs::archive_layout::component_entry_name(path).is_some() => {
+            // The signed authority owns the component set; this arm proves the
+            // archive agrees with it. The structural-budget rewrite dropped
+            // this arm entirely, so the reader rejected component entries its
+            // own writer emits.
+            let name = crate::ccs::archive_layout::component_entry_name(path)
+                .expect("component name checked by the guard")
+                .to_string();
+
+            let raw = read_metadata_control(
+                entry,
+                state,
+                CCS_BUDGET.metadata_bytes_ceiling(&census)?,
+                BudgetDimension::MetadataBytes,
+                path,
+            )?;
+            let component: ComponentData =
+                serde_json::from_slice(&raw).context("invalid CCS component JSON")?;
+
+            if component.name != name.as_str() {
+                return Err(VerifyError::PackageError(format!(
+                    "CCS component path {path:?} disagrees with component name {:?}",
+                    component.name
+                ))
+                .into());
+            }
+
+            if state.components.insert(name.clone(), component).is_some() {
+                return Err(VerifyError::PackageError(format!(
+                    "CCS archive contains duplicate component {name:?}"
+                ))
+                .into());
+            }
+            Ok(())
         }
         _ => Err(VerifyError::PackageError(format!("unknown CCS archive entry {path:?}")).into()),
     }
@@ -542,22 +590,10 @@ fn finish_archive(archive: Archive<ArchiveDecoder>) -> Result<()> {
 }
 
 fn require_known_directory(path: &str) -> Result<()> {
-    if path == "objects" {
-        return Ok(());
-    }
-    if let Some(prefix) = path.strip_prefix("objects/")
-        && prefix.len() == 2
-        && is_lower_hex(prefix)
-    {
+    if crate::ccs::archive_layout::is_known_directory(path) {
         return Ok(());
     }
     Err(VerifyError::PackageError(format!("unknown CCS archive directory {path:?}")).into())
-}
-
-fn is_lower_hex(value: &str) -> bool {
-    value
-        .bytes()
-        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
 }
 
 #[cfg(test)]

--- a/crates/conary-core/src/ccs/verify/stream.rs
+++ b/crates/conary-core/src/ccs/verify/stream.rs
@@ -3,6 +3,7 @@
 //! Signature-first streaming verification of trusted CCS archives.
 
 use super::{PackageSignature, TrustPolicy, VerifyError};
+use crate::ccs::budget::{AuthorityCensus, BudgetDimension, CCS_BUDGET};
 use crate::ccs::builder::ComponentData;
 use crate::ccs::v2::schema::{AuthorityDocumentV2, PackageKindV2};
 use crate::filesystem::CasStore;
@@ -11,15 +12,12 @@ use crate::packages::payload::{
 };
 use anyhow::{Context, Result};
 use flate2::bufread::GzDecoder;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::{Component, Path};
 use tar::Archive;
 
-const MAX_CONTROL_SIZE: u64 = 16 * 1024 * 1024;
-const MAX_COMPONENT_SIZE: u64 = 64 * 1024 * 1024;
-const MAX_METADATA_TOTAL_SIZE: u64 = 128 * 1024 * 1024;
 const EXPECTED_TAR_TRAILING_ZERO_BYTES: u64 = 512;
 
 type ArchiveDecoder = GzDecoder<BufReader<File>>;
@@ -38,12 +36,12 @@ pub(super) struct StreamVerifiedArchive {
 #[derive(Default)]
 struct MetadataState {
     bytes_read: u64,
+    census: Option<AuthorityCensus>,
     manifest: Option<Vec<u8>>,
     signature: Option<String>,
     debug_toml: Option<Vec<u8>>,
     attestation: Option<String>,
     conversion_boundary: Option<String>,
-    components: HashMap<String, ComponentData>,
 }
 
 struct AuthenticatedMetadata {
@@ -65,11 +63,11 @@ pub(super) fn verify_archive(path: &Path, policy: &TrustPolicy) -> Result<Stream
     let mut object_store = None;
     let mut object_sources = HashMap::new();
     let mut objects_started = false;
-    let mut entries_seen = 0_usize;
+    let mut entries_seen = 0_u64;
 
     for entry in archive.entries()? {
         entries_seen += 1;
-        crate::compression::check_archive_entry_limit(entries_seen, "CCS package")?;
+        CCS_BUDGET.admit_archive_entry(entries_seen)?;
         let mut entry = entry?;
         let path = canonical_entry_path(&entry)?;
         let is_object = path.starts_with("objects/");
@@ -129,13 +127,14 @@ pub(super) fn verify_archive(path: &Path, policy: &TrustPolicy) -> Result<Stream
         .into());
     }
     let payload = payload_from_authority(&authenticated.authority, &object_sources)?;
+    let components = crate::ccs::v2::component_view::components(&authenticated.authority);
     Ok(StreamVerifiedArchive {
         authority: authenticated.authority,
         signature: authenticated.signature,
         build_attestation: authenticated.build_attestation,
         foreign_conversion_boundary: authenticated.foreign_conversion_boundary,
         debug_toml: metadata.debug_toml,
-        components: metadata.components,
+        components,
         payload,
         files_checked: authenticated.files_checked,
     })
@@ -157,7 +156,6 @@ fn authenticate_metadata(
         metadata.conversion_boundary.as_deref(),
         policy,
     )?;
-    verify_components(&verified.authority, &metadata.components)?;
     let (expected_objects, files_checked) = expected_objects(&verified.authority)?;
     Ok(AuthenticatedMetadata {
         authority: verified.authority,
@@ -206,161 +204,98 @@ fn expected_objects(authority: &AuthorityDocumentV2) -> Result<(BTreeMap<String,
     Ok((objects, package.files.len()))
 }
 
-fn verify_components(
-    authority: &AuthorityDocumentV2,
-    components: &HashMap<String, ComponentData>,
-) -> Result<()> {
-    let signed_names = authority.components.keys().collect::<BTreeSet<_>>();
-    let archived_names = components.keys().collect::<BTreeSet<_>>();
-    if signed_names != archived_names {
-        return Err(VerifyError::PayloadInvalid(format!(
-            "signed component set {signed_names:?} disagrees with archived set {archived_names:?}"
-        ))
-        .into());
-    }
-    let PackageKindV2::Package(package) = &authority.kind else {
-        return Ok(());
-    };
-    let signed_files = package
-        .files
-        .iter()
-        .map(|file| ((file.component.as_str(), file.path.as_str()), file))
-        .collect::<HashMap<_, _>>();
-    let mut archived_files = HashSet::new();
-    for (name, component) in components {
-        let signed = authority
-            .components
-            .get(name)
-            .expect("component sets are equal");
-        let file_count = u32::try_from(component.files.len()).map_err(|_| {
-            VerifyError::PayloadInvalid(format!("component {name:?} file count exceeds u32"))
-        })?;
-        let total_size = component.files.iter().try_fold(0_u64, |total, file| {
-            total.checked_add(file.content.as_ref().map_or(0, |content| content.size))
-        });
-        let total_size = total_size.ok_or_else(|| {
-            VerifyError::PayloadInvalid(format!("component {name:?} size overflows u64"))
-        })?;
-        if file_count != signed.file_count || total_size != signed.total_size {
-            return Err(VerifyError::PayloadInvalid(format!(
-                "component {name:?} summary disagrees with signed authority"
-            ))
-            .into());
-        }
-        let actual_hash = crate::hash::sha256_prefixed(
-            &crate::ccs::attestation::canonical_json_bytes(&component.files)?,
-        );
-        if component.hash != actual_hash {
-            return Err(VerifyError::PayloadInvalid(format!(
-                "component {name:?} projection hash mismatch"
-            ))
-            .into());
-        }
-        for file in &component.files {
-            if file.chunks.is_some() {
-                return Err(VerifyError::PayloadInvalid(format!(
-                    "component file {} uses retired chunk projection",
-                    file.path
-                ))
-                .into());
-            }
-            let key = (name.as_str(), file.path.as_str());
-            if !archived_files.insert(key) {
-                return Err(VerifyError::PayloadInvalid(format!(
-                    "component {name:?} repeats file {}",
-                    file.path
-                ))
-                .into());
-            }
-            let source = signed_files.get(&key).ok_or_else(|| {
-                VerifyError::PayloadInvalid(format!(
-                    "v2 archive carries unsigned file {} in component {name}",
-                    file.path
-                ))
-            })?;
-            if file.node != source.node
-                || file.content != source.content
-                || file.component != source.component
-            {
-                return Err(VerifyError::PayloadInvalid(format!(
-                    "v2 file authority mismatch for {} in component {name}",
-                    file.path
-                ))
-                .into());
-            }
-        }
-    }
-    if archived_files.len() != signed_files.len() {
-        return Err(VerifyError::PayloadInvalid(
-            "one or more signed files are missing from component projections".to_string(),
-        )
-        .into());
-    }
-    Ok(())
-}
-
+/// Read one control document.
+///
+/// `MANIFEST` must be the first archived file. Reading it first gives every
+/// later ceiling a census derived from this package's own signed structure
+/// instead of a global byte guess.
 fn read_metadata_entry(
     entry: &mut tar::Entry<'_, ArchiveDecoder>,
     path: &str,
     state: &mut MetadataState,
 ) -> Result<()> {
     require_regular(entry, path)?;
+    if path == "MANIFEST" {
+        return read_authority_entry(entry, state);
+    }
+    let census = state.census.clone().ok_or_else(|| {
+        VerifyError::PackageError(
+            "CCS archive must carry its MANIFEST authority before every other archived file"
+                .to_string(),
+        )
+    })?;
+
     match path {
-        "MANIFEST" => {
-            let value = read_metadata_control(entry, state, MAX_CONTROL_SIZE, path)?;
-            set_once(&mut state.manifest, value, path)
-        }
         "MANIFEST.sig" => {
-            let value = read_metadata_utf8(entry, state, MAX_CONTROL_SIZE, path)?;
+            let value = read_metadata_utf8(
+                entry,
+                state,
+                CCS_BUDGET.signature_bytes_ceiling(),
+                BudgetDimension::SignatureBytes,
+                path,
+            )?;
             set_once(&mut state.signature, value, path)
         }
         "MANIFEST.toml" => {
-            let value = read_metadata_control(entry, state, MAX_CONTROL_SIZE, path)?;
+            let ceiling = CCS_BUDGET.debug_projection_bytes_ceiling(&census)?;
+            let value = read_metadata_control(
+                entry,
+                state,
+                ceiling,
+                BudgetDimension::DebugProjectionBytes,
+                path,
+            )?;
             set_once(&mut state.debug_toml, value, path)
         }
         "MANIFEST.attestation.json" => {
-            let value = read_metadata_utf8(entry, state, MAX_CONTROL_SIZE, path)?;
+            let value = read_metadata_utf8(
+                entry,
+                state,
+                CCS_BUDGET.attestation_bytes_ceiling(),
+                BudgetDimension::AttestationBytes,
+                path,
+            )?;
             set_once(&mut state.attestation, value, path)
         }
         "MANIFEST.conversion-boundary.json" => {
-            let value = read_metadata_utf8(entry, state, MAX_CONTROL_SIZE, path)?;
+            let value = read_metadata_utf8(
+                entry,
+                state,
+                CCS_BUDGET.attestation_bytes_ceiling(),
+                BudgetDimension::AttestationBytes,
+                path,
+            )?;
             set_once(&mut state.conversion_boundary, value, path)
-        }
-        _ if path.starts_with("components/") && path.ends_with(".json") => {
-            let name = path
-                .strip_prefix("components/")
-                .and_then(|value| value.strip_suffix(".json"))
-                .context("invalid CCS component path")?;
-            if name.is_empty() || name.contains('/') {
-                return Err(VerifyError::PackageError(format!(
-                    "invalid CCS component path {path:?}"
-                ))
-                .into());
-            }
-            let raw = read_metadata_control(entry, state, MAX_COMPONENT_SIZE, path)?;
-            let component: ComponentData =
-                serde_json::from_slice(&raw).context("invalid CCS component JSON")?;
-            if component.name != name {
-                return Err(VerifyError::PackageError(format!(
-                    "CCS component path {path:?} disagrees with component name {:?}",
-                    component.name
-                ))
-                .into());
-            }
-            if state
-                .components
-                .insert(component.name.clone(), component)
-                .is_some()
-            {
-                return Err(VerifyError::PackageError(format!(
-                    "CCS archive contains duplicate component {name:?}"
-                ))
-                .into());
-            }
-            Ok(())
         }
         _ => Err(VerifyError::PackageError(format!("unknown CCS archive entry {path:?}")).into()),
     }
+}
+
+/// Read, decode, and structurally admit the signed authority document.
+fn read_authority_entry(
+    entry: &mut tar::Entry<'_, ArchiveDecoder>,
+    state: &mut MetadataState,
+) -> Result<()> {
+    if state.manifest.is_some() {
+        return Err(VerifyError::PackageError(
+            "CCS archive contains duplicate MANIFEST entries".to_string(),
+        )
+        .into());
+    }
+    let raw = read_metadata_control(
+        entry,
+        state,
+        CCS_BUDGET.max_authority_bytes(),
+        BudgetDimension::AuthorityBytes,
+        "MANIFEST",
+    )?;
+    let authority = CCS_BUDGET.decode_authority(&raw)?;
+    let census = crate::ccs::v2::authority_census(&authority)
+        .map_err(|error| VerifyError::PackageError(format!("invalid CCS v2 MANIFEST: {error}")))?;
+    CCS_BUDGET.admit_encoded_authority(&census, raw.len() as u64)?;
+    state.census = Some(census);
+    state.manifest = Some(raw);
+    Ok(())
 }
 
 fn read_object(
@@ -452,7 +387,7 @@ fn payload_from_authority(
 fn read_control(entry: &mut impl Read, limit: u64, label: &str) -> Result<Vec<u8>> {
     let mut bytes = Vec::new();
     entry
-        .take(limit + 1)
+        .take(limit.saturating_add(1))
         .read_to_end(&mut bytes)
         .with_context(|| format!("read CCS {label}"))?;
     if bytes.len() as u64 > limit {
@@ -467,15 +402,13 @@ fn read_metadata_control(
     entry: &mut tar::Entry<'_, ArchiveDecoder>,
     state: &mut MetadataState,
     limit: u64,
+    dimension: BudgetDimension,
     label: &str,
 ) -> Result<Vec<u8>> {
-    let declared = entry.header().size()?;
-    if declared > limit {
-        return Err(
-            VerifyError::PackageError(format!("CCS {label} exceeds maximum size {limit}")).into(),
-        );
-    }
-    reserve_metadata_budget(&mut state.bytes_read, declared)?;
+    // Refuse the declared length before reading a byte, so a hostile size
+    // declaration costs no allocation.
+    CCS_BUDGET.admit_control_bytes(dimension, label, entry.header().size()?, limit)?;
+    reserve_metadata_budget(state, entry.header().size()?)?;
     read_control(entry, limit, label)
 }
 
@@ -483,23 +416,36 @@ fn read_metadata_utf8(
     entry: &mut tar::Entry<'_, ArchiveDecoder>,
     state: &mut MetadataState,
     limit: u64,
+    dimension: BudgetDimension,
     label: &str,
 ) -> Result<String> {
-    String::from_utf8(read_metadata_control(entry, state, limit, label)?)
-        .with_context(|| format!("CCS {label} is not valid UTF-8"))
+    String::from_utf8(read_metadata_control(
+        entry, state, limit, dimension, label,
+    )?)
+    .with_context(|| format!("CCS {label} is not valid UTF-8"))
 }
 
-fn reserve_metadata_budget(total: &mut u64, declared: u64) -> Result<()> {
-    let next = total
+/// Bound every control document in one archive together.
+///
+/// Before the authority is decoded the only admissible control document is
+/// `MANIFEST` itself; afterwards the aggregate ceiling is derived from that
+/// package's own census.
+fn reserve_metadata_budget(state: &mut MetadataState, declared: u64) -> Result<()> {
+    let ceiling = match &state.census {
+        Some(census) => CCS_BUDGET.metadata_bytes_ceiling(census)?,
+        None => CCS_BUDGET.max_authority_bytes(),
+    };
+    let next = state
+        .bytes_read
         .checked_add(declared)
         .context("CCS metadata-size arithmetic overflow")?;
-    if next > MAX_METADATA_TOTAL_SIZE {
-        return Err(VerifyError::PackageError(format!(
-            "CCS aggregate metadata exceeds maximum size {MAX_METADATA_TOTAL_SIZE}"
-        ))
-        .into());
-    }
-    *total = next;
+    CCS_BUDGET.admit_control_bytes(
+        BudgetDimension::MetadataBytes,
+        "control documents",
+        next,
+        ceiling,
+    )?;
+    state.bytes_read = next;
     Ok(())
 }
 
@@ -596,7 +542,7 @@ fn finish_archive(archive: Archive<ArchiveDecoder>) -> Result<()> {
 }
 
 fn require_known_directory(path: &str) -> Result<()> {
-    if path == "components" || path == "objects" {
+    if path == "objects" {
         return Ok(());
     }
     if let Some(prefix) = path.strip_prefix("objects/")
@@ -832,10 +778,19 @@ mod tests {
         output.write_all(&bytes[..bytes.len() / 2]).unwrap();
         assert!(verify_archive(&truncated, &policy).is_err());
 
-        let mut total = MAX_METADATA_TOTAL_SIZE;
-        let error = reserve_metadata_budget(&mut total, 1).unwrap_err();
-        assert!(format!("{error:#}").contains("aggregate metadata"));
-        assert_eq!(total, MAX_METADATA_TOTAL_SIZE);
+        // The aggregate control-document ceiling is derived from this
+        // package's own census, so padding is refused without allocation.
+        let authority = crate::ccs::v2::test_support::package_authority_with_one_file("stream");
+        let census = crate::ccs::v2::authority_census(&authority).unwrap();
+        let ceiling = CCS_BUDGET.metadata_bytes_ceiling(&census).unwrap();
+        let mut state = MetadataState {
+            census: Some(census),
+            bytes_read: ceiling,
+            ..MetadataState::default()
+        };
+        let error = reserve_metadata_budget(&mut state, 1).unwrap_err();
+        assert!(format!("{error:#}").contains("metadata-bytes"), "{error:#}");
+        assert_eq!(state.bytes_read, ceiling);
     }
 
     #[test]

--- a/docs/modules/ccs.md
+++ b/docs/modules/ccs.md
@@ -46,6 +46,9 @@ CcsBuilder::new(manifest, source_dir)
 | `CcsPackage` | package.rs | Parsed .ccs file ready for installation via PackageFormat trait |
 | CCS package projection | package/v2_projection.rs | Project verified signed v2 authority into install-time package data |
 | `AuthorityDocumentV2` | v2/schema.rs | Signed CCS v2 native package authority |
+| `CcsStructuralBudget` | budget.rs | Single owner of every CCS structural and operator-resource limit; authoring preflight and verification both admit against it |
+| `AuthorityCensus` | budget.rs | Exact structural measurement of one authority document; derives that package's byte ceilings |
+| Component view | v2/component_view.rs | Derives component and file views from signed authority instead of a duplicated archive projection |
 | `ComponentType` | components/types.rs | Closed typed names for standard component metadata; never inferred from payload paths |
 | `SigningKeyPair` | signing.rs | Ed25519 key generation, signing, file I/O |
 | `PackageSignature` | signing.rs | Embedded signature with algorithm, key_id, timestamp |
@@ -321,9 +324,21 @@ install-time authority. `MANIFEST.toml` may be present for source/debug
 visibility, but TOML-only install behavior is not native authority. The
 implementation lives under `crates/conary-core/src/ccs/v2/`. CCS v2 is the
 sole native package contract: the repository has no v1 writer, parser,
-projection, fixture factory, or compatibility path. `MANIFEST.toml` and
-component JSON are checked projections only; malformed, unsupported, or
-unsigned authority never falls back to them.
+projection, fixture factory, or compatibility path. `MANIFEST.toml` is a
+checked projection only; malformed, unsupported, or unsigned authority never
+falls back to it. The archive carries no `components/*.json` copy of the signed
+file records: component views are derived from authority in
+`v2/component_view.rs`.
+
+### Structural Budget
+
+`crates/conary-core/src/ccs/budget.rs` owns every CCS limit. There is no fixed
+serialized-byte ceiling on `MANIFEST`: limits are structural counts, per-item
+string and depth bounds, aggregate variable-length pools, payload-object
+bounds, and CBOR nesting depth, and byte ceilings are derived from them. The
+writer admits the authority it is about to sign through the same
+`admit_authority` call verification uses, so a package this repository emits is
+readable by construction. `docs/specs/ccs-format-v2.md` owns the contract.
 
 Configuration authority is exact per path. Each `[[config.files]]` declaration
 and its signed v2 projection carries `noreplace`, `ghost`, and

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -569,8 +569,10 @@ packages, install CCS packages, and preserve their exact lifecycle ABIs.
 
 **Start here:** `crates/conary-core/src/ccs/`;
 `crates/conary-core/src/payload.rs`;
+`crates/conary-core/src/ccs/budget.rs`;
 `crates/conary-core/src/ccs/v2/`;
 `crates/conary-core/src/ccs/v2/authoring.rs`;
+`crates/conary-core/src/ccs/v2/component_view.rs`;
 `crates/conary-core/src/ccs/v2/debug_projection.rs`;
 `crates/conary-core/src/repository/supported_profiles/`;
 `crates/conary-core/src/ccs/archive_reader.rs`;
@@ -660,7 +662,10 @@ metadata, scriptlet sandboxing (`crates/conary-core/src/scriptlet/mod.rs`,
 `docs/specs/ccs-format-v2.md`;
 `docs/specs/foreign-package-lifecycle-contracts.md`.
 
-**Focused proof:** `cargo test -p conary-core ccs::v2`;
+**Focused proof:** `cargo test -p conary-core ccs::budget`;
+`cargo test -p conary-core ccs::v2`;
+`cargo test -p conary-core ccs::archive_reader`;
+`cargo test -p conary-core ccs::verify`;
 `cargo test -p conary-core filesystem::cas`;
 `cargo test -p conary-core packages::rpm::payload`;
 `cargo test -p conary-core --lib lifecycle_helpers`;
@@ -685,9 +690,13 @@ crosses Remi publication;
 `docs/specs/static-repo-format-v1.md`; `docs/llms/subsystem-map.md`; the primary
 issue and draft pull request while the change is still in flight.
 
-**Safety notes:** start in `crates/conary-core/src/ccs/v2/` for v2 authority,
-validation, diagnostics, archive reading, debug projection, and content
-identity. Use `archive_reader.rs` and `package.rs` only as
+**Safety notes:** `crates/conary-core/src/ccs/budget.rs` is the sole owner of
+every CCS structural and operator-resource limit. Do not add a limit constant
+to a reader, writer, or archive path: add a dimension to the budget so
+authoring preflight and verification stay one owner and the writer cannot emit
+a package the reader refuses. Start in `crates/conary-core/src/ccs/v2/` for v2
+authority, validation, diagnostics, archive reading, debug projection, and
+content identity. Use `archive_reader.rs` and `package.rs` only as
 version-routing/adaptation surfaces. CCS v2 package and lifecycle authority is
 source-independent and must not contain a destination distro gate; transaction
 planning resolves it against typed host capabilities. Debug TOML is never

--- a/docs/specs/ccs-format-v2.md
+++ b/docs/specs/ccs-format-v2.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-07-27
-revision: 4
+revision: 5
 summary: Canonical signed CCS v2 authority, archive, payload, and trust contract
 ---
 
@@ -25,13 +25,23 @@ A package is a gzip-compressed tar archive. Its accepted entries are:
 | `MANIFEST.toml` | optional regular file | diagnostic projection only; its digest must match signed authority when present |
 | `MANIFEST.attestation.json` | optional regular file | build-attestation envelope bound by signed provenance |
 | `MANIFEST.conversion-boundary.json` | optional regular file | foreign-conversion boundary bound by signed provenance |
-| `components/<name>.json` | one per signed component | diagnostic payload index checked exactly against signed component summaries |
 | `objects/<aa>/<62 lowercase hex>` | one per signed regular-file digest | content-addressed payload bytes |
 
-The reader rejects duplicate authority, signatures, projections, components,
-or objects; unknown files and directories; non-canonical object paths; archive
-path escapes; oversized entries; extraction-limit overflow; object/hash
-disagreement; and any entry type not admitted for its path.
+`MANIFEST` is the first archived file. Directory entries may precede it; no
+other regular file may. Reading authority first lets every later ceiling be
+derived from this package's own signed structure instead of a global guess.
+
+There is no `components/<name>.json` entry. That projection re-encoded every
+signed file record in JSON, measured at 1.8x the CBOR authority it duplicated,
+and it could add no authority because verification had to prove it matched the
+`MANIFEST` exactly. Component views are derived from signed authority by
+`crates/conary-core/src/ccs/v2/component_view.rs`.
+
+The reader rejects duplicate authority, signatures, projections, or objects;
+unknown files and directories; authority that does not arrive first;
+non-canonical object paths; archive path escapes; object/hash disagreement; any
+entry type not admitted for its path; and every structural-budget violation
+below.
 
 Tar ordering, timestamps, ownership, and compression are transport details.
 Writers emit deterministic ordering and normalized timestamps. They never
@@ -103,10 +113,53 @@ regular-file content authority.
 For regular files, the archive contains exactly one object at the canonical
 path derived from the lowercase digest. Verification recomputes every digest
 and size, rejects missing or unreferenced objects, and proves that every
-component projection has the signed name, file count, and byte total.
+component summary has the signed name, file count, and byte total.
 
-`MANIFEST.toml` and `components/*.json` are readable projections. A projection
-may help inspection, but it can neither add nor replace install behavior.
+`MANIFEST.toml` is a readable projection. A projection may help inspection, but
+it can neither add nor replace install behavior.
+
+## Structural Budget
+
+`crates/conary-core/src/ccs/budget.rs` is the single owner of every CCS limit.
+Authoring preflight and verification both call `admit_authority`, so the writer
+cannot emit a package the reader refuses. There is no separate reader-side
+limit table and no fixed serialized-byte ceiling on `MANIFEST`.
+
+The budget states explicit dimensions, each with its own typed diagnostic:
+
+- counts: payload nodes, payload objects, components, config declarations,
+  provides, requirement groups, relation groups, lifecycle entries, and archive
+  entries;
+- per-item lengths: install-path bytes and path-component depth, identifier
+  bytes, link-target bytes, xattr count, xattr name and value bytes, and
+  lifecycle script body bytes;
+- aggregate pools: total path bytes, total xattr bytes, total non-payload
+  authority bytes, and total payload bytes;
+- per-object and decoder limits: payload object bytes and CBOR nesting depth.
+
+Byte ceilings are derived from those dimensions rather than chosen:
+
+- `max_authority_bytes()` bounds decoder memory before allocation. It is the
+  envelope plus `max_files` times the fixed per-record cost plus the aggregate
+  pools. A reader refuses a declared `MANIFEST` length above it before reading
+  a byte.
+- `authority_bytes_ceiling(census)` bounds the exact document one package may
+  occupy, computed from that package's measured structure, so a package that
+  declares little authority cannot ship a padded document.
+- `debug_projection_bytes_ceiling`, `signature_bytes_ceiling`,
+  `attestation_bytes_ceiling`, and `metadata_bytes_ceiling` bound the remaining
+  control documents from the same census.
+
+Every ceiling uses checked arithmetic; an overflow is a typed refusal, not a
+wrap. Hostile CBOR depth or length declarations, excessive counts, oversized
+strings, truncated authority, duplicate authority, unsigned or duplicated
+objects, and decompression bombs all fail before large allocation or any
+persistence.
+
+Untrusted inspection never retains payload bytes: it stream-hashes each object
+against its canonical path and discards it. Verification streams objects into
+the payload spool with their signed sizes. Neither path buffers whole-package
+payload.
 
 ## Signatures And Trust
 
@@ -180,6 +233,7 @@ Git history is the only source for the removed pre-alpha implementation.
 Focused verification for this contract is:
 
 ```bash
+cargo test -p conary-core ccs::budget
 cargo test -p conary-core ccs::v2
 cargo test -p conary-core ccs::archive_reader
 cargo test -p conary-core ccs::verify


### PR DESCRIPTION
Closes #103.

## Problem

The CCS v2 writer could emit a validly signed `MANIFEST` that the CCS v2 reader immediately refused. Two independent fixed ceilings existed — `MAX_MANIFEST_SIZE` in `archive_reader.rs` and `MAX_CONTROL_SIZE` in `verify/stream.rs`, both 16 MiB. Foreign conversion writes the package and then correctly performs immediate authority verification, so large ordinary packages failed against our own format by construction. Reproduced deterministically on `ansible` and `aws-sdk-cpp`.

## Approach

The issue lists raising the constant as an explicit non-goal, so it isn't raised — it's **deleted**. A new `ccs::budget` module owns explicit structural and resource bounds, and **writer and reader consume the same owner**, which is what makes the writer structurally incapable of producing something the reader rejects:

- `builder/package_writer.rs` calls `CCS_BUDGET.admit_encoded_authority(...)`, `admit_control_bytes(...)`, `debug_projection_bytes_ceiling(...)`, `signature_bytes_ceiling()`
- `archive_reader.rs` calls `CCS_BUDGET.admit_archive_entry(...)`, `max_authority_bytes()`, `debug_projection_bytes_ceiling(...)`

Bounds are dimensional rather than one serialized-byte guess — `AuthorityCensus` and `BudgetDimension` carry entry counts, nesting depth, and per-section ceilings, so limits track the authority's actual shape.

## Hostile input

Bounds are enforced *before* allocation, not after. Covered by `hostile_cbor_depth_and_length_declarations_fail_before_allocation`: a declared nesting depth beyond the bound is refused while decoding the header rather than after descending it, and a hostile declared length is refused before any read.

## Deletion

`MAX_MANIFEST_SIZE` and `MAX_CONTROL_SIZE` are removed rather than aliased, per the pre-alpha hard-cut rule. The only surviving `16 * 1024 * 1024` in the CCS tree is inside a test asserting that an authority now *legitimately* exceeds the former ceiling.

`archive_reader.rs` was decomposed into a directory alongside its module, and `docs/specs/ccs-format-v2.md` is updated since this is a format contract change.

## Verification

Run on the 12-core dev host:

```
cargo test -p conary-core --lib      3024 passed; 0 failed
cargo clippy -p conary-core --all-targets -- -D warnings    clean
cargo fmt --check                    clean
```

rustc 1.97.1, matching CI.

**Not verified here:** the pinned `ansible` and `aws-sdk-cpp` fixtures require a hosted Remi conversion run, which this change cannot perform. The issue's acceptance criterion that both convert, sign, verify, and reopen without package-specific behavior therefore remains open and should be confirmed against hosted Remi before this is treated as closing the production class.

## Provenance

Implemented by a subagent working from #103, then stopped mid-run when local disk I/O saturated. I harvested, verified, and completed it — including one clippy `same_item_push` fix. The `wip` commit in the history is the harvest point and is labelled unverified at that time; everything after it is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011y1e74GvvxzaDkyrxthYZB