### PR TITLE
docs(agents): make defect discipline a binding contract rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,41 @@ contract, not a separate authority. Do not make an essential operation
 available only through ad hoc shell, interactive human judgment, or untyped
 free-form output, and do not weaken trust or approval boundaries for agents.
 
+## Defect Discipline
+
+Conary's product promise is that ordinary packages just work. A defect that is
+routed around rather than fixed is a promise that has not been kept, so treat
+the following as binding rather than aspirational.
+
+**Fix what you find.** When work uncovers a half-implementation, a duplicated
+authority, or a path that only works by luck, fix it or file it with the exact
+evidence. Do not build around it and leave it for the next person to rediscover.
+Scope discipline is real, and a finding outside the current slice belongs in an
+issue rather than in the slice; what is not acceptable is knowing and saying
+nothing.
+
+**A failure is evidence until it is explained.** Do not re-run a failing check
+hoping for a different result, and do not label a failure flaky, environmental,
+or unrelated without a specific reason that survives being checked. Two failures
+with different names may be one defect. An intermittent failure usually means
+the system is genuinely nondeterministic somewhere, which is itself the defect.
+Retrying until green converts a known failure into an unknown one.
+
+**Fix the cause, not the symptom.** Restoring a deleted value, widening a bound,
+or adding a special case makes a check pass without removing the condition that
+produced it. Ask what structure allowed the defect, and correct that. If the
+same fact is maintained in two places, the fix is one owner, not two updates.
+
+**Prove the property, not the instance.** A regression test that pins the exact
+input that failed will not catch the next instance of the same class. Where a
+contract exists between two components, test the contract: that everything one
+side can emit, the other admits.
+
+**Verification means the command ran.** Report the commands and their real
+output. Never describe an expected result as an observed one. When something
+could not be verified, say so plainly and name what remains unproven; a partial
+result reported accurately is worth more than an overstated one.
+
 ## Maintainability & Refactor Discipline
 
 Treat large files as review signals, not automatic failures. Planning has a


### PR DESCRIPTION
AGENTS.md already required typed authority, fail-closed behavior, and no heuristics as correctness authority. It said nothing about what to do when you *encounter* a defect — so the failure modes that actually produce broken releases were unstated.

Every rule here came from one incident today, on PR #120.

## The incident

A CCS change made the reader reject packages its own writer emits. The path from symptom to cause:

1. Two CI tests failed with **different names**. I read that as flakiness. It was one defect with two symptoms.
2. I reached for a **CI re-run**. That would have shipped the bug behind an eventual green.
3. The real cause was `components` dropped from a directory allowlist — *and* a second hand-maintained copy of that allowlist added alongside the existing one.
4. The obvious fix was re-adding the string. That would have left **three** copies of the same layout knowledge in place.
5. The regression escaped in the first place because the change proved writer and reader share one *budget* owner, while nothing proved they share one *layout* owner.

## The rules

| Rule | Traces to |
|---|---|
| **Fix what you find** — or file it with exact evidence; don't build around it | three duplicated copies |
| **A failure is evidence until explained** — don't re-run hoping for green; two failures with different names may be one defect | steps 1–2 |
| **Fix the cause, not the symptom** — if a fact lives in two places, the fix is one owner | step 4 |
| **Prove the property, not the instance** — test the contract between components, not the input that failed | step 5 |
| **Verification means the command ran** — report real output; say plainly what you could not verify | see below |

The scope caveat is explicit: a finding outside the current slice belongs in an issue, not in the slice. What's unacceptable is knowing and saying nothing.

The verification rule is stated because an agent describing an *expected* result as an *observed* one is indistinguishable from a passing run until someone checks. That's a failure mode worth naming in a repo where agent-assisted contribution is a first-class path.

## Verification

```
bash scripts/check-doc-truth.sh        passed
bash scripts/test-doc-truth.sh         passed
bash scripts/agent-context.sh --validate    passed (16 cards)
```

Docs only. No code, schema, or contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011y1e74GvvxzaDkyrxthYZB