### PR TITLE
fix(budget): derive archive decode bounds from the structural owner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,3 +136,9 @@ incremental = true
 [profile.dev]
 # Faster builds in development
 incremental = true
+
+# Multi-gigabyte streaming parser regressions exercise the real SHA-256
+# integrity path. Optimize that dependency in tests so bounded-memory proofs do
+# not turn debug hashing into a CI-duration bottleneck.
+[profile.test.package.sha2]
+opt-level = 3

--- a/apps/conary/src/commands/install/native_events/debian_runtime/lifecycle_bridge.rs
+++ b/apps/conary/src/commands/install/native_events/debian_runtime/lifecycle_bridge.rs
@@ -11,7 +11,7 @@ use conary_core::packages::deb::debconf::{
     DebconfEngine, DebconfExecution, DebconfSession, DebconfSessionPolicy, DebconfState,
     DebconfTemplateLoadError, DebconfTemplateLoader,
 };
-use conary_core::packages::deb::templates::{MAX_DEBCONF_TEMPLATES_SIZE, parse};
+use conary_core::packages::deb::templates::parse;
 use conary_core::packages::native_abi::DebconfTemplateRecord;
 use conary_core::scriptlet::{
     LifecycleBridgeConfig, LifecycleBridgeEndpoint, LifecycleBridgeHandler,
@@ -279,21 +279,22 @@ impl DebconfTemplateLoader for SelectedRootTemplateLoader {
         if !metadata.is_file() {
             return Err(Self::open_error("selected-root path is not a regular file"));
         }
-        if metadata.len() > MAX_DEBCONF_TEMPLATES_SIZE {
+        let max_templates_size = conary_core::ccs::CCS_BUDGET.max_metadata_bytes;
+        if metadata.len() > max_templates_size {
             return Err(Self::open_error(format!(
-                "template file is {} bytes; maximum is {MAX_DEBCONF_TEMPLATES_SIZE}",
+                "template file is {} bytes; maximum is {max_templates_size}",
                 metadata.len()
             )));
         }
 
         let mut body = Vec::with_capacity(metadata.len() as usize);
         file.by_ref()
-            .take(MAX_DEBCONF_TEMPLATES_SIZE + 1)
+            .take(max_templates_size + 1)
             .read_to_end(&mut body)
             .map_err(|error| Self::open_error(format!("cannot read template file: {error}")))?;
-        if body.len() as u64 > MAX_DEBCONF_TEMPLATES_SIZE {
+        if body.len() as u64 > max_templates_size {
             return Err(Self::open_error(format!(
-                "template file grew beyond the {MAX_DEBCONF_TEMPLATES_SIZE}-byte maximum"
+                "template file grew beyond the {max_templates_size}-byte maximum"
             )));
         }
         parse(&body)

--- a/apps/conary/src/commands/install/native_events/debian_runtime/lifecycle_bridge/tests.rs
+++ b/apps/conary/src/commands/install/native_events/debian_runtime/lifecycle_bridge/tests.rs
@@ -237,11 +237,12 @@ fn selected_root_loader_distinguishes_parse_failure() {
 }
 
 #[test]
-fn selected_root_loader_rejects_the_sixteen_mib_plus_one_boundary() {
+fn selected_root_loader_rejects_the_metadata_budget_plus_one_boundary() {
     let root = tempfile::tempdir().unwrap();
     let path = root.path().join("templates");
     let file = std::fs::File::create(&path).unwrap();
-    file.set_len(MAX_DEBCONF_TEMPLATES_SIZE + 1).unwrap();
+    file.set_len(conary_core::ccs::CCS_BUDGET.max_metadata_bytes + 1)
+        .unwrap();
     let mut loader = SelectedRootTemplateLoader::new(root.path()).unwrap();
 
     let error = loader.load(b"/templates").unwrap_err();

--- a/crates/conary-core/src/ccs/budget.rs
+++ b/crates/conary-core/src/ccs/budget.rs
@@ -13,6 +13,9 @@
 //! with its own typed diagnostic. Byte ceilings are *derived* from those
 //! dimensions: the global ceiling bounds decoder memory before allocation, and
 //! the census ceiling bounds the exact document a specific package may occupy.
+//! Source-package decoders consume [`ArchiveDecodeBounds`], which derives
+//! payload, metadata, entry-count, decompressed-stream, and spool limits from
+//! this same owner instead of maintaining a second package-parser limit table.
 
 use super::v2::schema::{
     AuthorityDocumentV2, FileAuthorityV2, LifecycleAuthorityV2, PackageKindV2,
@@ -45,6 +48,20 @@ const DEBUG_PROJECTION_TEXT_EXPANSION: u64 = 4;
 /// Fixed table headers and comments the TOML projection always writes.
 const DEBUG_PROJECTION_ENVELOPE_BYTES: u64 = 64 * 1024;
 
+/// One tar entry contributes one 512-byte header and at most 511 bytes of
+/// alignment padding. The extra byte also covers the terminal block envelope.
+const ARCHIVE_ENTRY_ENVELOPE_BYTES: u64 = 2 * 512;
+
+/// One payload object may occupy the package's entire payload allowance.
+///
+/// Authoring, conversion, chunking, CAS ingestion, and package writing all
+/// consume reopenable sources with fixed-size buffers; none of those active
+/// paths retain one complete payload object.
+const MAX_TOTAL_PAYLOAD_BYTES: u64 = 64 * 1024 * 1024 * 1024;
+
+/// Control-plane repository and source-package metadata is decoded in memory.
+const MAX_METADATA_BYTES: u64 = 512 * 1024 * 1024;
+
 /// Every structurally independent way a CCS package can exceed its budget.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BudgetDimension {
@@ -75,6 +92,7 @@ pub enum BudgetDimension {
     PayloadObjectBytes,
     TotalPayloadBytes,
     ArchiveEntryCount,
+    DecompressedStreamBytes,
     CborNestingDepth,
     Arithmetic,
 }
@@ -109,6 +127,7 @@ impl BudgetDimension {
             Self::PayloadObjectBytes => "payload-object-bytes",
             Self::TotalPayloadBytes => "total-payload-bytes",
             Self::ArchiveEntryCount => "archive-entry-count",
+            Self::DecompressedStreamBytes => "decompressed-stream-bytes",
             Self::CborNestingDepth => "cbor-nesting-depth",
             Self::Arithmetic => "arithmetic",
         }
@@ -202,6 +221,100 @@ pub struct AuthorityCensus {
     pub non_payload_authority_bytes: u64,
 }
 
+/// Source-archive limits derived from [`CcsStructuralBudget`].
+///
+/// The values are a projection of the canonical owner, not an independently
+/// configurable table. Format decoders carry this projection so every refusal
+/// retains the exact [`BudgetDimension`] that was exceeded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ArchiveDecodeBounds {
+    pub max_archive_entries: u64,
+    pub max_payload_object_bytes: u64,
+    pub max_total_payload_bytes: u64,
+    pub max_metadata_bytes: u64,
+    pub max_decompressed_stream_bytes: u64,
+}
+
+impl ArchiveDecodeBounds {
+    pub fn admit_archive_entry(&self, field: &str, entries_seen: u64) -> BudgetResult<()> {
+        admit(
+            BudgetDimension::ArchiveEntryCount,
+            field,
+            entries_seen,
+            self.max_archive_entries,
+        )
+    }
+
+    pub fn admit_payload_object(&self, field: &str, declared: u64) -> BudgetResult<()> {
+        admit(
+            BudgetDimension::PayloadObjectBytes,
+            field,
+            declared,
+            self.max_payload_object_bytes,
+        )
+    }
+
+    pub fn add_payload_bytes(&self, field: &str, current: u64, declared: u64) -> BudgetResult<u64> {
+        self.admit_payload_object(field, declared)?;
+        let observed = sum(field, [current, declared])?;
+        admit(
+            BudgetDimension::TotalPayloadBytes,
+            field,
+            observed,
+            self.max_total_payload_bytes,
+        )?;
+        Ok(observed)
+    }
+
+    pub fn add_metadata_bytes(
+        &self,
+        field: &str,
+        current: u64,
+        declared: u64,
+    ) -> BudgetResult<u64> {
+        let observed = sum(field, [current, declared])?;
+        admit(
+            BudgetDimension::MetadataBytes,
+            field,
+            observed,
+            self.max_metadata_bytes,
+        )?;
+        Ok(observed)
+    }
+
+    pub fn admit_metadata_bytes(&self, field: &str, observed: u64) -> BudgetResult<()> {
+        admit(
+            BudgetDimension::MetadataBytes,
+            field,
+            observed,
+            self.max_metadata_bytes,
+        )
+    }
+
+    pub fn admit_decompressed_stream_bytes(&self, field: &str, observed: u64) -> BudgetResult<()> {
+        admit(
+            BudgetDimension::DecompressedStreamBytes,
+            field,
+            observed,
+            self.max_decompressed_stream_bytes,
+        )
+    }
+
+    pub fn admit_spool_reservation(
+        &self,
+        field: &str,
+        required: u64,
+        available: u64,
+    ) -> BudgetResult<()> {
+        admit(
+            BudgetDimension::TotalPayloadBytes,
+            field,
+            required,
+            available,
+        )
+    }
+}
+
 /// The canonical CCS v2 budget.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CcsStructuralBudget {
@@ -226,6 +339,7 @@ pub struct CcsStructuralBudget {
     pub max_attestation_bytes: u64,
     pub max_payload_object_bytes: u64,
     pub max_total_payload_bytes: u64,
+    pub max_metadata_bytes: u64,
     pub max_cbor_nesting_depth: usize,
 }
 
@@ -258,10 +372,37 @@ impl CcsStructuralBudget {
         max_total_xattr_bytes: 64 * 1024 * 1024,
         max_non_payload_authority_bytes: 128 * 1024 * 1024,
         max_attestation_bytes: 4 * 1024 * 1024,
-        max_payload_object_bytes: 512 * 1024 * 1024,
-        max_total_payload_bytes: 64 * 1024 * 1024 * 1024,
+        max_payload_object_bytes: MAX_TOTAL_PAYLOAD_BYTES,
+        max_total_payload_bytes: MAX_TOTAL_PAYLOAD_BYTES,
+        max_metadata_bytes: MAX_METADATA_BYTES,
         max_cbor_nesting_depth: 64,
     };
+
+    /// Derive the complete source-archive decode budget from this owner.
+    ///
+    /// The decompressed-stream ceiling is structural: declared payload plus
+    /// one bounded header/alignment envelope for every admissible entry. Exact
+    /// per-entry, cumulative payload, entry-count, and metadata checks remain
+    /// authoritative; this outer ceiling bounds bytes that are only framing.
+    pub fn archive_decode_bounds(&self) -> BudgetResult<ArchiveDecodeBounds> {
+        let max_archive_entries = self.max_archive_entries();
+        let archive_envelope = product(
+            "archive decompressed stream envelope",
+            max_archive_entries,
+            ARCHIVE_ENTRY_ENVELOPE_BYTES,
+        )?;
+        let max_decompressed_stream_bytes = sum(
+            "archive decompressed stream",
+            [self.max_total_payload_bytes, archive_envelope],
+        )?;
+        Ok(ArchiveDecodeBounds {
+            max_archive_entries,
+            max_payload_object_bytes: self.max_payload_object_bytes,
+            max_total_payload_bytes: self.max_total_payload_bytes,
+            max_metadata_bytes: self.max_metadata_bytes,
+            max_decompressed_stream_bytes,
+        })
+    }
 
     /// Decoder-memory ceiling for signed authority, derived from the structural
     /// dimensions above rather than chosen as a serialized-byte constant.

--- a/crates/conary-core/src/ccs/budget/tests.rs
+++ b/crates/conary-core/src/ccs/budget/tests.rs
@@ -474,6 +474,37 @@ fn archive_decode_dimensions_fail_one_over_with_typed_diagnostics() {
 }
 
 #[test]
+fn archive_decode_dimensions_admit_their_exact_limits() {
+    let bounds = CCS_BUDGET.archive_decode_bounds().unwrap();
+
+    bounds
+        .admit_archive_entry("near-limit archive", bounds.max_archive_entries)
+        .unwrap();
+    assert_eq!(
+        bounds
+            .add_payload_bytes("near-limit payload", 0, bounds.max_total_payload_bytes,)
+            .unwrap(),
+        bounds.max_total_payload_bytes
+    );
+    bounds
+        .admit_metadata_bytes("near-limit metadata", bounds.max_metadata_bytes)
+        .unwrap();
+    bounds
+        .admit_decompressed_stream_bytes(
+            "near-limit decompressed stream",
+            bounds.max_decompressed_stream_bytes,
+        )
+        .unwrap();
+    bounds
+        .admit_spool_reservation(
+            "near-limit spool",
+            bounds.max_total_payload_bytes,
+            bounds.max_total_payload_bytes,
+        )
+        .unwrap();
+}
+
+#[test]
 fn archive_decode_derivation_overflow_is_typed() {
     let budget = CcsStructuralBudget {
         max_files: u64::MAX,

--- a/crates/conary-core/src/ccs/budget/tests.rs
+++ b/crates/conary-core/src/ccs/budget/tests.rs
@@ -415,4 +415,71 @@ fn derived_ceilings_are_stated_in_terms_of_structural_dimensions() {
 
     assert_eq!(budget.max_authority_bytes(), expected);
     assert_eq!(budget.max_archive_entries(), budget.max_files + 256 + 1 + 8);
+
+    let archive = budget.archive_decode_bounds().unwrap();
+    assert_eq!(
+        archive.max_payload_object_bytes,
+        archive.max_total_payload_bytes
+    );
+    assert_eq!(archive.max_metadata_bytes, 512 * 1024 * 1024);
+    assert_eq!(
+        archive.max_decompressed_stream_bytes,
+        archive.max_total_payload_bytes
+            + archive.max_archive_entries * ARCHIVE_ENTRY_ENVELOPE_BYTES
+    );
+}
+
+#[test]
+fn archive_decode_dimensions_fail_one_over_with_typed_diagnostics() {
+    let bounds = CCS_BUDGET.archive_decode_bounds().unwrap();
+
+    let entry_error = bounds
+        .admit_archive_entry("test archive entries", bounds.max_archive_entries + 1)
+        .unwrap_err();
+    assert_eq!(entry_error.dimension, BudgetDimension::ArchiveEntryCount);
+    assert_eq!(entry_error.field, "test archive entries");
+
+    let object_error = bounds
+        .admit_payload_object("test payload object", bounds.max_payload_object_bytes + 1)
+        .unwrap_err();
+    assert_eq!(object_error.dimension, BudgetDimension::PayloadObjectBytes);
+
+    let total_error = bounds
+        .add_payload_bytes("test cumulative payload", bounds.max_total_payload_bytes, 1)
+        .unwrap_err();
+    assert_eq!(total_error.dimension, BudgetDimension::TotalPayloadBytes);
+
+    let metadata_error = bounds
+        .admit_metadata_bytes("test metadata", bounds.max_metadata_bytes + 1)
+        .unwrap_err();
+    assert_eq!(metadata_error.dimension, BudgetDimension::MetadataBytes);
+
+    let stream_error = bounds
+        .admit_decompressed_stream_bytes(
+            "test decompressed stream",
+            bounds.max_decompressed_stream_bytes + 1,
+        )
+        .unwrap_err();
+    assert_eq!(
+        stream_error.dimension,
+        BudgetDimension::DecompressedStreamBytes
+    );
+
+    let spool_error = bounds
+        .admit_spool_reservation("test payload spool", 1025, 1024)
+        .unwrap_err();
+    assert_eq!(spool_error.dimension, BudgetDimension::TotalPayloadBytes);
+    assert_eq!(spool_error.observed, 1025);
+    assert_eq!(spool_error.limit, 1024);
+}
+
+#[test]
+fn archive_decode_derivation_overflow_is_typed() {
+    let budget = CcsStructuralBudget {
+        max_files: u64::MAX,
+        ..CCS_BUDGET
+    };
+    let error = budget.archive_decode_bounds().unwrap_err();
+    assert_eq!(error.dimension, BudgetDimension::Arithmetic);
+    assert_eq!(error.field, "archive decompressed stream envelope");
 }

--- a/crates/conary-core/src/ccs/mod.rs
+++ b/crates/conary-core/src/ccs/mod.rs
@@ -32,7 +32,10 @@ pub mod signing;
 pub mod v2;
 pub mod verify;
 
-pub use budget::{AuthorityCensus, BudgetDimension, BudgetError, CCS_BUDGET, CcsStructuralBudget};
+pub use budget::{
+    ArchiveDecodeBounds, AuthorityCensus, BudgetDimension, BudgetError, CCS_BUDGET,
+    CcsStructuralBudget,
+};
 pub use builder::{BuildResult, BuilderError, CcsBuilder, ChunkStats, ComponentData, FileEntry};
 pub use chunking::{Chunk, ChunkStore, ChunkedFile, Chunker, DeltaStats, StoreStats};
 pub use convert::{ConversionOptions, ConversionResult, NativePackageConverter};

--- a/crates/conary-core/src/compression/mod.rs
+++ b/crates/conary-core/src/compression/mod.rs
@@ -27,9 +27,6 @@ pub enum CompressionError {
     )]
     DecompressionBomb { format: &'static str, limit: u64 },
 
-    #[error("Archive {archive} exceeds {limit} entries (possible archive bomb)")]
-    ArchiveEntryLimit { archive: &'static str, limit: usize },
-
     #[error("Unsupported compression format: {0}")]
     UnsupportedFormat(String),
 }
@@ -165,33 +162,7 @@ pub fn create_decoder_limited<'a, R: Read + 'a>(
     limit: u64,
 ) -> Result<Box<dyn Read + 'a>, CompressionError> {
     let decoder = create_decoder(reader, format)?;
-    Ok(Box::new(decoder.take(limit + 1)))
-}
-
-/// Decompress a byte slice to a Vec
-///
-/// Convenience function that detects format from magic bytes and decompresses.
-pub fn decompress_auto(data: &[u8]) -> Result<Vec<u8>, CompressionError> {
-    let format = CompressionFormat::from_magic_bytes(data);
-    decompress(data, format)
-}
-
-/// Maximum decompressed output size (2 GiB) to guard against decompression bombs.
-pub const MAX_DECOMPRESS_SIZE: u64 = 2 * 1024 * 1024 * 1024;
-
-/// Tighter decompression budget for repository metadata and similar control-plane content.
-pub const MAX_METADATA_DECOMPRESS_SIZE: u64 = 512 * 1024 * 1024;
-
-/// Maximum number of entries allowed in a single archive traversal.
-pub const MAX_ARCHIVE_ENTRIES: usize = 500_000;
-
-/// Decompress a byte slice using the specified format.
-///
-/// Output is capped at `MAX_DECOMPRESS_SIZE` bytes to prevent decompression bombs.
-/// Returns an error if the decompressed output exceeds the limit rather than
-/// silently truncating.
-pub fn decompress(data: &[u8], format: CompressionFormat) -> Result<Vec<u8>, CompressionError> {
-    decompress_with_limit(data, format, MAX_DECOMPRESS_SIZE)
+    Ok(Box::new(decoder.take(limit.saturating_add(1))))
 }
 
 /// Decompress a byte slice with an explicit output limit.
@@ -223,6 +194,44 @@ pub fn decompress_auto_with_limit(data: &[u8], limit: u64) -> Result<Vec<u8>, Co
     decompress_with_limit(data, format, limit)
 }
 
+/// Decode bounded in-memory metadata through the shared structural owner.
+pub fn decompress_metadata_auto(data: &[u8], field: &str) -> crate::error::Result<Vec<u8>> {
+    let format = CompressionFormat::from_magic_bytes(data);
+    let bounds = crate::ccs::CCS_BUDGET.archive_decode_bounds()?;
+    decompress_metadata_with_bounds(data, format, field, &bounds)
+}
+
+/// Decode bounded in-memory metadata with an explicit compression format.
+pub fn decompress_metadata(
+    data: &[u8],
+    format: CompressionFormat,
+    field: &str,
+) -> crate::error::Result<Vec<u8>> {
+    let bounds = crate::ccs::CCS_BUDGET.archive_decode_bounds()?;
+    decompress_metadata_with_bounds(data, format, field, &bounds)
+}
+
+fn decompress_metadata_with_bounds(
+    data: &[u8],
+    format: CompressionFormat,
+    field: &str,
+    bounds: &crate::ccs::ArchiveDecodeBounds,
+) -> crate::error::Result<Vec<u8>> {
+    match decompress_with_limit(data, format, bounds.max_metadata_bytes) {
+        Ok(output) => {
+            bounds.admit_metadata_bytes(field, output.len() as u64)?;
+            Ok(output)
+        }
+        Err(CompressionError::DecompressionBomb { .. }) => {
+            bounds.admit_metadata_bytes(field, bounds.max_metadata_bytes.saturating_add(1))?;
+            unreachable!("one-over metadata admission always refuses")
+        }
+        Err(error) => Err(crate::error::Error::ParseError(format!(
+            "failed to decompress {field}: {error}"
+        ))),
+    }
+}
+
 /// Create a decompressing reader, auto-detecting format from data
 ///
 /// Reads the first few bytes to detect the compression format, then returns
@@ -234,20 +243,6 @@ pub fn create_decoder_auto(data: &[u8]) -> Result<Box<dyn Read + '_>, Compressio
 }
 
 /// Reject archives with pathologically large entry counts.
-pub fn check_archive_entry_limit(
-    entries_seen: usize,
-    archive: &'static str,
-) -> Result<(), CompressionError> {
-    if entries_seen > MAX_ARCHIVE_ENTRIES {
-        Err(CompressionError::ArchiveEntryLimit {
-            archive,
-            limit: MAX_ARCHIVE_ENTRIES,
-        })
-    } else {
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -331,7 +326,8 @@ mod tests {
     #[test]
     fn test_decompress_none() {
         let data = b"hello world";
-        let result = decompress(data, CompressionFormat::None).unwrap();
+        let result =
+            decompress_with_limit(data, CompressionFormat::None, data.len() as u64).unwrap();
         assert_eq!(result, data);
     }
 
@@ -342,19 +338,38 @@ mod tests {
             0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0xcb, 0x48, 0xcd, 0xc9,
             0xc9, 0x07, 0x00, 0x86, 0xa6, 0x10, 0x36, 0x05, 0x00, 0x00, 0x00,
         ];
-        let result = decompress(gzip_data, CompressionFormat::Gzip).unwrap();
+        let result = decompress_with_limit(gzip_data, CompressionFormat::Gzip, 1024).unwrap();
         assert_eq!(result, b"hello");
     }
 
     #[test]
-    fn test_decompress_auto() {
+    fn metadata_decode_uses_the_typed_metadata_dimension() {
         // Minimal gzip of "hello"
         let gzip_data: &[u8] = &[
             0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0xcb, 0x48, 0xcd, 0xc9,
             0xc9, 0x07, 0x00, 0x86, 0xa6, 0x10, 0x36, 0x05, 0x00, 0x00, 0x00,
         ];
-        let result = decompress_auto(gzip_data).unwrap();
-        assert_eq!(result, b"hello");
+        let bounds = crate::ccs::ArchiveDecodeBounds {
+            max_archive_entries: 1,
+            max_payload_object_bytes: 4,
+            max_total_payload_bytes: 4,
+            max_metadata_bytes: 4,
+            max_decompressed_stream_bytes: 1024,
+        };
+        let error = decompress_metadata_with_bounds(
+            gzip_data,
+            CompressionFormat::Gzip,
+            "test repository metadata",
+            &bounds,
+        )
+        .unwrap_err();
+        let crate::error::Error::Budget(error) = error else {
+            panic!("expected typed budget refusal");
+        };
+        assert_eq!(error.dimension, crate::ccs::BudgetDimension::MetadataBytes);
+        assert_eq!(error.field, "test repository metadata");
+        assert_eq!(error.observed, 5);
+        assert_eq!(error.limit, 4);
     }
 
     #[test]
@@ -370,18 +385,6 @@ mod tests {
             CompressionError::DecompressionBomb {
                 format: "gzip",
                 limit: 512
-            }
-        ));
-    }
-
-    #[test]
-    fn test_check_archive_entry_limit_rejects_too_many_entries() {
-        let err = check_archive_entry_limit(MAX_ARCHIVE_ENTRIES + 1, "test archive").unwrap_err();
-        assert!(matches!(
-            err,
-            CompressionError::ArchiveEntryLimit {
-                archive: "test archive",
-                limit: MAX_ARCHIVE_ENTRIES,
             }
         ));
     }

--- a/crates/conary-core/src/compression/mod.rs
+++ b/crates/conary-core/src/compression/mod.rs
@@ -242,7 +242,6 @@ pub fn create_decoder_auto(data: &[u8]) -> Result<Box<dyn Read + '_>, Compressio
     create_decoder(data, format)
 }
 
-/// Reject archives with pathologically large entry counts.
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/conary-core/src/error.rs
+++ b/crates/conary-core/src/error.rs
@@ -113,6 +113,10 @@ pub enum Error {
     #[error("Parse error: {0}")]
     ParseError(String),
 
+    /// Structural or operator-resource budget refusal.
+    #[error(transparent)]
+    Budget(#[from] crate::ccs::BudgetError),
+
     /// Delta operation error
     #[error("Delta operation failed: {0}")]
     DeltaError(String),

--- a/crates/conary-core/src/packages/arch.rs
+++ b/crates/conary-core/src/packages/arch.rs
@@ -13,6 +13,7 @@ pub(crate) use alpm_hook::{
     targets_match as alpm_hook_targets_match,
 };
 
+use crate::ccs::{ArchiveDecodeBounds, CCS_BUDGET};
 use crate::compression::{self, CompressionFormat};
 use crate::db::models::Trove;
 use crate::error::{Error, Result};
@@ -53,22 +54,30 @@ pub struct ArchPackage {
 
 /// Arch package metadata files that should be skipped during extraction
 const ARCH_METADATA_FILES: &[&str] = &[".PKGINFO", ".MTREE", ".BUILDINFO", ".INSTALL"];
-const MAX_ARCH_CONTROL_SIZE: u64 = 16 * 1024 * 1024;
 
-fn read_control_entry<R: Read>(entry: &mut tar::Entry<'_, R>, label: &str) -> Result<Vec<u8>> {
-    if entry.size() > MAX_ARCH_CONTROL_SIZE {
+fn read_control_entry<R: Read>(
+    entry: &mut tar::Entry<'_, R>,
+    label: &str,
+    bounds: &ArchiveDecodeBounds,
+    metadata_bytes: &mut u64,
+) -> Result<Vec<u8>> {
+    let declared = entry.size();
+    *metadata_bytes =
+        bounds.add_metadata_bytes("ALPM control metadata", *metadata_bytes, declared)?;
+    let mut content = Vec::with_capacity(
+        usize::try_from(declared)
+            .map_err(|_| Error::ParseError(format!("ALPM {label} exceeds addressable memory")))?,
+    );
+    let mut limited = entry.take(declared.saturating_add(1));
+    limited
+        .read_to_end(&mut content)
+        .map_err(|error| Error::ParseError(format!("read ALPM {label}: {error}")))?;
+    let actual = content.len() as u64;
+    if actual != declared {
         return Err(Error::ParseError(format!(
-            "ALPM {label} is {} bytes; maximum is {MAX_ARCH_CONTROL_SIZE}",
-            entry.size()
+            "ALPM {label} declares {declared} bytes but yields {actual}"
         )));
     }
-    let mut content =
-        Vec::with_capacity(usize::try_from(entry.size()).map_err(|_| {
-            Error::ParseError(format!("ALPM {label} cannot be represented in memory"))
-        })?);
-    entry
-        .read_to_end(&mut content)
-        .map_err(|error| Error::InitError(format!("Failed to read {label}: {error}")))?;
     Ok(content)
 }
 
@@ -91,16 +100,44 @@ impl ArchPackage {
     }
 
     /// Open and decompress the package archive
-    fn open_archive(path: &str) -> Result<Archive<Box<dyn Read>>> {
+    fn open_archive(path: &str, bounds: &ArchiveDecodeBounds) -> Result<Archive<Box<dyn Read>>> {
         let mut file = File::open(path)
             .map_err(|e| Error::InitError(format!("Failed to open package file: {}", e)))?;
 
         let format = Self::detect_compression(&mut file)?;
         let reader =
-            compression::create_decoder_limited(file, format, compression::MAX_DECOMPRESS_SIZE)
+            compression::create_decoder_limited(file, format, bounds.max_decompressed_stream_bytes)
                 .map_err(|e| Error::InitError(format!("Failed to create decoder: {}", e)))?;
 
         Ok(Archive::new(reader))
+    }
+
+    fn required_payload_spool_bytes(path: &str, bounds: &ArchiveDecodeBounds) -> Result<u64> {
+        let mut archive = Self::open_archive(path, bounds)?;
+        let mut entries_seen = 0_u64;
+        let mut required = 0_u64;
+        for entry in archive
+            .entries()
+            .map_err(|error| Error::ParseError(format!("read ALPM archive: {error}")))?
+        {
+            entries_seen += 1;
+            bounds.admit_archive_entry("ALPM archive entries", entries_seen)?;
+            let entry =
+                entry.map_err(|error| Error::ParseError(format!("read ALPM entry: {error}")))?;
+            let path_bytes = entry.path_bytes();
+            let path = std::str::from_utf8(path_bytes.as_ref()).map_err(|error| {
+                Error::ParseError(format!("ALPM archive path is not UTF-8: {error}"))
+            })?;
+            if ARCH_METADATA_FILES.contains(&path) {
+                continue;
+            }
+            required = bounds.add_payload_bytes(
+                "ALPM declared payload bytes",
+                required,
+                payload::declared_spool_bytes(&entry),
+            )?;
+        }
+        Ok(required)
     }
 
     /// Parse .PKGINFO file content
@@ -382,22 +419,26 @@ impl PackageFormat for ArchPackage {
     fn parse(path: &str) -> Result<Self> {
         debug!("Parsing Arch package: {}", path);
 
-        // Single-pass: decompress once and extract all metadata + file list
-        let mut archive = Self::open_archive(path)?;
+        let bounds = CCS_BUDGET.archive_decode_bounds()?;
+        // The first pass reserves exact declared regular payload bytes before
+        // the second pass can create any spool file.
+        let required_spool_bytes = Self::required_payload_spool_bytes(path, &bounds)?;
+        let payload_spool = PayloadSpool::new(required_spool_bytes)?;
+        let mut archive = Self::open_archive(path, &bounds)?;
         let mut pkginfo_content = None;
         let mut install_bytes = None;
         let mut alpm_hook_bytes: Vec<(String, Vec<u8>)> = Vec::new();
         let mut payload_entries = Vec::new();
-        let payload_spool = PayloadSpool::new(0)?;
-        let mut entries_seen = 0usize;
+        let mut entries_seen = 0_u64;
+        let mut declared_payload_bytes = 0_u64;
+        let mut metadata_bytes = 0_u64;
 
         for entry in archive
             .entries()
             .map_err(|e| Error::InitError(format!("Failed to read archive: {}", e)))?
         {
             entries_seen += 1;
-            compression::check_archive_entry_limit(entries_seen, "Arch package archive")
-                .map_err(|e| Error::InitError(format!("Failed to read archive: {}", e)))?;
+            bounds.admit_archive_entry("ALPM archive entries", entries_seen)?;
             let mut entry =
                 entry.map_err(|e| Error::InitError(format!("Failed to read entry: {}", e)))?;
 
@@ -409,32 +450,63 @@ impl PackageFormat for ArchPackage {
 
             match entry_path.as_str() {
                 ".PKGINFO" => {
-                    let content = read_control_entry(&mut entry, ".PKGINFO")?;
+                    let content =
+                        read_control_entry(&mut entry, ".PKGINFO", &bounds, &mut metadata_bytes)?;
                     let content = String::from_utf8(content).map_err(|error| {
                         Error::ParseError(format!(".PKGINFO is not UTF-8: {error}"))
                     })?;
                     pkginfo_content = Some(content);
                 }
                 ".INSTALL" => {
-                    install_bytes = Some(read_control_entry(&mut entry, ".INSTALL")?);
+                    install_bytes = Some(read_control_entry(
+                        &mut entry,
+                        ".INSTALL",
+                        &bounds,
+                        &mut metadata_bytes,
+                    )?);
                 }
                 name if ARCH_METADATA_FILES.contains(&name) => {
-                    // Skip other metadata files (.MTREE, .BUILDINFO)
+                    metadata_bytes = bounds.add_metadata_bytes(
+                        "ALPM control metadata",
+                        metadata_bytes,
+                        entry.size(),
+                    )?;
                 }
                 _ => {
-                    let parsed = payload::parse_entry(&mut entry, &payload_spool, entries_seen)?;
+                    declared_payload_bytes = bounds.add_payload_bytes(
+                        "ALPM declared payload bytes",
+                        declared_payload_bytes,
+                        payload::declared_spool_bytes(&entry),
+                    )?;
+                    let entry_index = usize::try_from(entries_seen).map_err(|_| {
+                        Error::ParseError("ALPM entry index exceeds usize".to_string())
+                    })?;
+                    let parsed = payload::parse_entry(&mut entry, &payload_spool, entry_index)?;
                     // Only the package-owned system hook directory is
                     // source-package ABI. `/etc/pacman.d/hooks` belongs to
                     // the selected target's explicit Conary hook policy.
-                    if alpm_hook::is_package_hook_path(parsed.path())
-                        && let Some(content) =
-                            parsed.read_regular_content_bounded(MAX_ARCH_CONTROL_SIZE)?
-                    {
-                        alpm_hook_bytes.push((parsed.path().to_string(), content));
+                    if alpm_hook::is_package_hook_path(parsed.path()) {
+                        let declared = parsed.regular_content_size().unwrap_or(0);
+                        metadata_bytes = bounds.add_metadata_bytes(
+                            "ALPM hook metadata",
+                            metadata_bytes,
+                            declared,
+                        )?;
+                        if let Some(content) =
+                            parsed.read_regular_content_bounded(bounds.max_metadata_bytes)?
+                        {
+                            alpm_hook_bytes.push((parsed.path().to_string(), content));
+                        }
                     }
                     payload_entries.push(parsed);
                 }
             }
+        }
+        if declared_payload_bytes != required_spool_bytes {
+            return Err(Error::ParseError(format!(
+                "ALPM archive changed between reservation and payload passes: reserved \
+                 {required_spool_bytes} bytes, observed {declared_payload_bytes}"
+            )));
         }
         let payload = PackagePayload::new(payload::resolve_hardlinks(payload_entries)?);
         let files = payload

--- a/crates/conary-core/src/packages/arch/payload/mod.rs
+++ b/crates/conary-core/src/packages/arch/payload/mod.rs
@@ -33,6 +33,12 @@ impl ArchivePayloadEntry {
         &self.path
     }
 
+    pub(super) fn regular_content_size(&self) -> Option<u64> {
+        self.content_authority
+            .as_ref()
+            .map(|authority| authority.size)
+    }
+
     pub(super) fn read_regular_content_bounded(&self, limit: u64) -> Result<Option<Vec<u8>>> {
         if !self.node.kind.is_regular() {
             return Ok(None);
@@ -59,6 +65,14 @@ impl ArchivePayloadEntry {
             .open()?
             .read_to_end(&mut content)?;
         Ok(Some(content))
+    }
+}
+
+pub(super) fn declared_spool_bytes<R: Read>(entry: &Entry<'_, R>) -> u64 {
+    match entry.header().entry_type() {
+        EntryType::Regular | EntryType::Continuous | EntryType::GNUSparse => entry.size(),
+        EntryType::Link if entry.size() != 0 => entry.size(),
+        _ => 0,
     }
 }
 
@@ -471,8 +485,9 @@ fn spool_content<R: Read>(
     let mut hasher = Hasher::new(HashAlgorithm::Sha256);
     let mut copied = 0_u64;
     let mut buffer = [0_u8; PAYLOAD_IO_BUFFER_SIZE];
+    let mut limited = entry.take(size.saturating_add(1));
     loop {
-        let read = entry.read(&mut buffer).map_err(|error| {
+        let read = limited.read(&mut buffer).map_err(|error| {
             Error::ParseError(format!("read ALPM payload node {path}: {error}"))
         })?;
         if read == 0 {

--- a/crates/conary-core/src/packages/arch/payload/mod.rs
+++ b/crates/conary-core/src/packages/arch/payload/mod.rs
@@ -482,10 +482,24 @@ fn spool_content<R: Read>(
     crate::packages::payload::ensure_available_space(spool.root(), size)?;
     let output_path = spool.indexed_path(index);
     let mut output = File::create(&output_path)?;
+    let sha256 = copy_declared_payload(entry, &mut output, size, path)?;
+    output.sync_all()?;
+    Ok((
+        PayloadContentAuthority { sha256, size },
+        spool.source(output_path),
+    ))
+}
+
+fn copy_declared_payload(
+    reader: &mut dyn Read,
+    writer: &mut dyn Write,
+    size: u64,
+    path: &str,
+) -> Result<String> {
     let mut hasher = Hasher::new(HashAlgorithm::Sha256);
     let mut copied = 0_u64;
     let mut buffer = [0_u8; PAYLOAD_IO_BUFFER_SIZE];
-    let mut limited = entry.take(size.saturating_add(1));
+    let mut limited = reader.take(size.saturating_add(1));
     loop {
         let read = limited.read(&mut buffer).map_err(|error| {
             Error::ParseError(format!("read ALPM payload node {path}: {error}"))
@@ -502,7 +516,7 @@ fn spool_content<R: Read>(
             )));
         }
         hasher.update(&buffer[..read]);
-        output.write_all(&buffer[..read])?;
+        writer.write_all(&buffer[..read])?;
     }
     if copied != size {
         return Err(Error::ParseError(format!(
@@ -510,14 +524,7 @@ fn spool_content<R: Read>(
             copied
         )));
     }
-    output.sync_all()?;
-    Ok((
-        PayloadContentAuthority {
-            sha256: hasher.finalize().value,
-            size,
-        },
-        spool.source(output_path),
-    ))
+    Ok(hasher.finalize().value)
 }
 
 fn require_empty_entry<R: Read>(entry: &Entry<'_, R>, path: &str) -> Result<()> {
@@ -595,6 +602,25 @@ mod tests {
             parsed.push(parse_entry(&mut entry, &spool, index)?);
         }
         PackagePayload::new(resolve_hardlinks(parsed)?).to_extracted_in_memory()
+    }
+
+    #[test]
+    fn declared_payload_copy_rejects_shorter_and_longer_bodies() {
+        let mut output = Vec::new();
+        let error =
+            copy_declared_payload(&mut Cursor::new(b"ab"), &mut output, 3, "/short").unwrap_err();
+        assert!(matches!(&error, Error::ParseError(_)));
+        assert!(error.to_string().contains("declares 3 bytes but yields 2"));
+
+        output.clear();
+        let error =
+            copy_declared_payload(&mut Cursor::new(b"abcd"), &mut output, 3, "/long").unwrap_err();
+        assert!(matches!(&error, Error::ParseError(_)));
+        assert!(
+            error
+                .to_string()
+                .contains("declares 3 bytes but yields at least 4")
+        );
     }
 
     #[test]

--- a/crates/conary-core/src/packages/archive_utils.rs
+++ b/crates/conary-core/src/packages/archive_utils.rs
@@ -2,8 +2,6 @@
 
 use crate::error::Result;
 use crate::filesystem::source_path::SourcePathBytes;
-pub use crate::packages::common::MAX_EXTRACTION_FILE_SIZE;
-use tracing::warn;
 
 pub const S_IFMT: u32 = 0o170000;
 pub const S_IFREG: u32 = 0o100000;
@@ -27,16 +25,6 @@ pub fn is_regular_file_mode(mode: u32) -> bool {
 pub fn normalize_path(path: &str) -> Result<String> {
     let deployment = SourcePathBytes::from(path).to_deployment_path()?;
     Ok(format!("/{}", deployment.to_utf8()?))
-}
-
-/// Check if file size exceeds limit, warn if so
-pub fn check_file_size(path: &str, size: u64) -> bool {
-    if size > MAX_EXTRACTION_FILE_SIZE {
-        warn!("Skipping oversized file: {} ({} bytes)", path, size);
-        false
-    } else {
-        true
-    }
 }
 
 /// Get file metadata (size and mode) from the filesystem.

--- a/crates/conary-core/src/packages/common.rs
+++ b/crates/conary-core/src/packages/common.rs
@@ -14,9 +14,6 @@ use crate::repository::dependency_model::{DebianMultiArch, RepositoryRequirement
 use crate::repository::versioning::VersionScheme;
 use std::path::{Path, PathBuf};
 
-/// Maximum size for a single file during package extraction (512 MB).
-pub const MAX_EXTRACTION_FILE_SIZE: u64 = 512 * 1024 * 1024;
-
 /// Common metadata shared by all package formats
 ///
 /// This struct contains the core fields that every package format provides.

--- a/crates/conary-core/src/packages/cpio.rs
+++ b/crates/conary-core/src/packages/cpio.rs
@@ -1,6 +1,6 @@
 // conary-core/src/packages/cpio.rs
 
-use crate::compression::{MAX_ARCHIVE_ENTRIES, MAX_DECOMPRESS_SIZE};
+use crate::ccs::CCS_BUDGET;
 use std::io::{self, Read};
 
 /// CPIO New ASCII Format (newc) header size
@@ -9,11 +9,6 @@ const HEADER_SIZE: usize = 110;
 const MAGIC_NEWC: &[u8] = b"070701";
 /// Magic string for CRC format
 const MAGIC_CRC: &[u8] = b"070702";
-/// Maximum allowed filename length in bytes (4 KiB)
-const MAX_NAME_SIZE: u64 = 4096;
-/// Maximum allowed file content size in bytes (512 MB)
-const MAX_FILE_SIZE: u64 = 512 * 1024 * 1024;
-
 /// Extracted CPIO entry metadata
 #[derive(Debug, Clone)]
 pub struct CpioEntry {
@@ -34,23 +29,40 @@ pub struct CpioEntry {
 /// A reader for CPIO (New ASCII) archives
 pub struct CpioReader<R: Read> {
     reader: R,
-    entries_seen: usize,
+    entries_seen: u64,
     total_content_size: u64,
-    max_entries: usize,
+    max_entries: u64,
+    max_name_size: u64,
+    max_file_size: u64,
     max_total_content_size: u64,
 }
 
 impl<R: Read> CpioReader<R> {
-    pub fn new(reader: R) -> Self {
-        Self::with_limits(reader, MAX_ARCHIVE_ENTRIES, MAX_DECOMPRESS_SIZE)
+    pub fn new(reader: R) -> crate::error::Result<Self> {
+        let bounds = CCS_BUDGET.archive_decode_bounds()?;
+        Ok(Self::with_limits(
+            reader,
+            bounds.max_archive_entries,
+            CCS_BUDGET.max_path_bytes.saturating_add(1),
+            bounds.max_payload_object_bytes,
+            bounds.max_total_payload_bytes,
+        ))
     }
 
-    fn with_limits(reader: R, max_entries: usize, max_total_content_size: u64) -> Self {
+    fn with_limits(
+        reader: R,
+        max_entries: u64,
+        max_name_size: u64,
+        max_file_size: u64,
+        max_total_content_size: u64,
+    ) -> Self {
         Self {
             reader,
             entries_seen: 0,
             total_content_size: 0,
             max_entries,
+            max_name_size,
+            max_file_size,
             max_total_content_size,
         }
     }
@@ -108,10 +120,13 @@ impl<R: Read> CpioReader<R> {
         let check = parse_hex_u32(102, 8)?;
 
         // Guard against unreasonable filename sizes
-        if namesize == 0 || namesize > MAX_NAME_SIZE {
+        if namesize == 0 || namesize > self.max_name_size {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("CPIO entry name size {namesize} is outside 1..={MAX_NAME_SIZE}"),
+                format!(
+                    "CPIO entry name size {namesize} is outside 1..={}",
+                    self.max_name_size
+                ),
             ));
         }
 
@@ -173,10 +188,13 @@ impl<R: Read> CpioReader<R> {
         }
 
         // Guard against unreasonable file content sizes
-        if filesize > MAX_FILE_SIZE {
+        if filesize > self.max_file_size {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("CPIO entry file size {filesize} exceeds maximum {MAX_FILE_SIZE}"),
+                format!(
+                    "CPIO entry file size {filesize} exceeds maximum {}",
+                    self.max_file_size
+                ),
             ));
         }
 
@@ -284,7 +302,7 @@ mod tests {
     fn reject_oversized_name() {
         // namesize = 0x2000 = 8192 > MAX_NAME_SIZE (4096)
         let data = make_header("00002000", "00000000");
-        let mut reader = CpioReader::new(data.as_slice());
+        let mut reader = CpioReader::new(data.as_slice()).unwrap();
         let err = reader.next_entry().unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
         assert!(
@@ -295,11 +313,17 @@ mod tests {
 
     #[test]
     fn reject_oversized_file_content() {
-        // namesize = 2 (one char + NUL), filesize = 0xFFFFFFFF (~4 GiB, > MAX_FILE_SIZE)
+        // Exercise a one-over file bound without allocating its declared body.
         let mut data = make_header("00000002", "FFFFFFFF");
         // Append filename "a\0" (2 bytes) + 2 bytes padding to align to 4
         data.extend_from_slice(b"a\0\0\0");
-        let mut reader = CpioReader::new(data.as_slice());
+        let mut reader = CpioReader::with_limits(
+            data.as_slice(),
+            u64::MAX,
+            CCS_BUDGET.max_path_bytes + 1,
+            u64::from(u32::MAX) - 1,
+            u64::MAX,
+        );
         let err = reader.next_entry().unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
         assert!(
@@ -316,7 +340,7 @@ mod tests {
         data.extend_from_slice(b"hello\0");
         // file content "abc" = 3 bytes + 1 byte padding
         data.extend_from_slice(b"abc\0");
-        let mut reader = CpioReader::new(data.as_slice());
+        let mut reader = CpioReader::new(data.as_slice()).unwrap();
         let entry = reader.next_entry().unwrap().unwrap();
         assert_eq!(entry.0.name, "hello");
         assert_eq!(entry.0.size, 3);
@@ -346,7 +370,7 @@ mod tests {
         append_entry(&mut data, "two", b"b");
         append_entry(&mut data, "TRAILER!!!", b"");
 
-        let mut reader = CpioReader::with_limits(data.as_slice(), 1, u64::MAX);
+        let mut reader = CpioReader::with_limits(data.as_slice(), 1, u64::MAX, u64::MAX, u64::MAX);
         assert!(reader.next_entry().unwrap().is_some());
         let err = reader.next_entry().unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
@@ -363,7 +387,7 @@ mod tests {
         append_entry(&mut data, "two", b"def");
         append_entry(&mut data, "TRAILER!!!", b"");
 
-        let mut reader = CpioReader::with_limits(data.as_slice(), usize::MAX, 5);
+        let mut reader = CpioReader::with_limits(data.as_slice(), u64::MAX, u64::MAX, u64::MAX, 5);
         assert!(reader.next_entry().unwrap().is_some());
         let err = reader.next_entry().unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);

--- a/crates/conary-core/src/packages/cpio.rs
+++ b/crates/conary-core/src/packages/cpio.rs
@@ -1,6 +1,7 @@
 // conary-core/src/packages/cpio.rs
 
-use crate::ccs::CCS_BUDGET;
+use crate::ccs::{ArchiveDecodeBounds, CCS_BUDGET};
+use crate::error::{Error, Result};
 use std::io::{self, Read};
 
 /// CPIO New ASCII Format (newc) header size
@@ -31,78 +32,63 @@ pub struct CpioReader<R: Read> {
     reader: R,
     entries_seen: u64,
     total_content_size: u64,
-    max_entries: u64,
     max_name_size: u64,
-    max_file_size: u64,
-    max_total_content_size: u64,
+    bounds: ArchiveDecodeBounds,
 }
 
 impl<R: Read> CpioReader<R> {
-    pub fn new(reader: R) -> crate::error::Result<Self> {
+    pub fn new(reader: R) -> Result<Self> {
         let bounds = CCS_BUDGET.archive_decode_bounds()?;
-        Ok(Self::with_limits(
+        Ok(Self::with_bounds(
             reader,
-            bounds.max_archive_entries,
+            bounds,
             CCS_BUDGET.max_path_bytes.saturating_add(1),
-            bounds.max_payload_object_bytes,
-            bounds.max_total_payload_bytes,
         ))
     }
 
-    fn with_limits(
-        reader: R,
-        max_entries: u64,
-        max_name_size: u64,
-        max_file_size: u64,
-        max_total_content_size: u64,
-    ) -> Self {
+    fn with_bounds(reader: R, bounds: ArchiveDecodeBounds, max_name_size: u64) -> Self {
         Self {
             reader,
             entries_seen: 0,
             total_content_size: 0,
-            max_entries,
             max_name_size,
-            max_file_size,
-            max_total_content_size,
+            bounds,
         }
     }
 
     /// Read the next entry from the CPIO archive
     /// Returns Ok(None) if end of archive (TRAILER!!!)
-    pub fn next_entry(&mut self) -> io::Result<Option<(CpioEntry, Vec<u8>)>> {
+    pub fn next_entry(&mut self) -> Result<Option<(CpioEntry, Vec<u8>)>> {
         // Read fixed header
         let mut header_buf = [0u8; HEADER_SIZE];
         if let Err(e) = self.reader.read_exact(&mut header_buf) {
             if e.kind() == io::ErrorKind::UnexpectedEof {
                 return Ok(None);
             }
-            return Err(e);
+            return Err(e.into());
         }
 
         // Verify magic
         let magic = &header_buf[0..6];
         if magic != MAGIC_NEWC && magic != MAGIC_CRC {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("Invalid CPIO magic: {:?}", String::from_utf8_lossy(magic)),
-            ));
+            return Err(cpio_parse(format!(
+                "invalid magic {:?}",
+                String::from_utf8_lossy(magic)
+            )));
         }
 
         // Parse hex fields into u64 to avoid silent truncation on malformed headers
-        let parse_hex = |start: usize, len: usize| -> io::Result<u64> {
+        let parse_hex = |start: usize, len: usize| -> Result<u64> {
             let s = std::str::from_utf8(&header_buf[start..start + len])
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-            u64::from_str_radix(s, 16).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+                .map_err(|error| cpio_parse(format!("header field is not ASCII: {error}")))?;
+            u64::from_str_radix(s, 16)
+                .map_err(|error| cpio_parse(format!("header field is not hexadecimal: {error}")))
         };
 
-        let parse_hex_u32 = |start: usize, len: usize| -> io::Result<u32> {
+        let parse_hex_u32 = |start: usize, len: usize| -> Result<u32> {
             let val = parse_hex(start, len)?;
-            u32::try_from(val).map_err(|_| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("CPIO header field value {val:#x} overflows u32"),
-                )
-            })
+            u32::try_from(val)
+                .map_err(|_| cpio_parse(format!("header field value {val:#x} overflows u32")))
         };
 
         let ino = parse_hex_u32(6, 8)?;
@@ -121,13 +107,10 @@ impl<R: Read> CpioReader<R> {
 
         // Guard against unreasonable filename sizes
         if namesize == 0 || namesize > self.max_name_size {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "CPIO entry name size {namesize} is outside 1..={}",
-                    self.max_name_size
-                ),
-            ));
+            return Err(cpio_parse(format!(
+                "entry name size {namesize} is outside 1..={}",
+                self.max_name_size
+            )));
         }
 
         // Read filename (including trailing NUL)
@@ -135,87 +118,47 @@ impl<R: Read> CpioReader<R> {
         self.reader.read_exact(&mut name_buf)?;
 
         if name_buf.last() != Some(&0) || name_buf[..name_buf.len() - 1].contains(&0) {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "CPIO entry name must contain exactly one trailing NUL",
+            return Err(cpio_parse(
+                "entry name must contain exactly one trailing NUL",
             ));
         }
         let name = std::str::from_utf8(&name_buf[..name_buf.len() - 1])
-            .map_err(|error| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("CPIO entry name is not UTF-8: {error}"),
-                )
-            })?
+            .map_err(|error| cpio_parse(format!("entry name is not UTF-8: {error}")))?
             .to_string();
 
         // Check for trailer
         if name == "TRAILER!!!" {
             if filesize != 0 {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "CPIO TRAILER!!! entry must have zero size",
-                ));
+                return Err(cpio_parse("TRAILER!!! entry must have zero size"));
             }
             return Ok(None);
         }
 
-        self.entries_seen += 1;
-        if self.entries_seen > self.max_entries {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("CPIO entry count exceeds maximum {}", self.max_entries),
-            ));
-        }
+        self.entries_seen = self
+            .entries_seen
+            .checked_add(1)
+            .ok_or_else(|| cpio_parse("entry count overflows u64"))?;
+        self.bounds
+            .admit_archive_entry("CPIO archive entries", self.entries_seen)?;
 
         // Skip padding after filename (align to 4 bytes)
-        let header_plus_name = HEADER_SIZE.checked_add(namesize as usize).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                "CPIO header + name size arithmetic overflow",
-            )
-        })?;
+        let header_plus_name = HEADER_SIZE
+            .checked_add(namesize as usize)
+            .ok_or_else(|| cpio_parse("header + name size arithmetic overflow"))?;
         let pad = (4 - (header_plus_name % 4)) % 4;
         if pad > 0 {
             let mut skip = [0u8; 3];
             self.reader.read_exact(&mut skip[..pad])?;
             if skip[..pad].iter().any(|byte| *byte != 0) {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "CPIO filename padding must be zero",
-                ));
+                return Err(cpio_parse("filename padding must be zero"));
             }
         }
 
-        // Guard against unreasonable file content sizes
-        if filesize > self.max_file_size {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "CPIO entry file size {filesize} exceeds maximum {}",
-                    self.max_file_size
-                ),
-            ));
-        }
-
-        self.total_content_size =
-            self.total_content_size
-                .checked_add(filesize)
-                .ok_or_else(|| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        "CPIO cumulative content size overflow",
-                    )
-                })?;
-        if self.total_content_size > self.max_total_content_size {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "CPIO cumulative content size {} exceeds maximum {}",
-                    self.total_content_size, self.max_total_content_size
-                ),
-            ));
-        }
+        self.total_content_size = self.bounds.add_payload_bytes(
+            "CPIO declared payload bytes",
+            self.total_content_size,
+            filesize,
+        )?;
 
         // Read file content
         let mut content = vec![0u8; filesize as usize];
@@ -225,16 +168,12 @@ impl<R: Read> CpioReader<R> {
                 .iter()
                 .fold(0_u32, |sum, byte| sum.wrapping_add(u32::from(*byte)));
             if actual != check {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("CPIO CRC mismatch: expected {check:#x}, got {actual:#x}"),
-                ));
+                return Err(cpio_parse(format!(
+                    "CRC mismatch: expected {check:#x}, got {actual:#x}"
+                )));
             }
         } else if check != 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "CPIO newc checksum field must be zero",
-            ));
+            return Err(cpio_parse("newc checksum field must be zero"));
         }
 
         // Skip padding after content (align to 4 bytes)
@@ -243,10 +182,7 @@ impl<R: Read> CpioReader<R> {
             let mut skip = [0u8; 3];
             self.reader.read_exact(&mut skip[..pad])?;
             if skip[..pad].iter().any(|byte| *byte != 0) {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "CPIO content padding must be zero",
-                ));
+                return Err(cpio_parse("content padding must be zero"));
             }
         }
 
@@ -268,6 +204,10 @@ impl<R: Read> CpioReader<R> {
             content,
         )))
     }
+}
+
+fn cpio_parse(message: impl Into<String>) -> Error {
+    Error::ParseError(format!("invalid CPIO archive: {}", message.into()))
 }
 
 #[cfg(test)]
@@ -304,7 +244,7 @@ mod tests {
         let data = make_header("00002000", "00000000");
         let mut reader = CpioReader::new(data.as_slice()).unwrap();
         let err = reader.next_entry().unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(matches!(&err, Error::ParseError(_)));
         assert!(
             err.to_string().contains("name size"),
             "unexpected error: {err}"
@@ -317,19 +257,24 @@ mod tests {
         let mut data = make_header("00000002", "FFFFFFFF");
         // Append filename "a\0" (2 bytes) + 2 bytes padding to align to 4
         data.extend_from_slice(b"a\0\0\0");
-        let mut reader = CpioReader::with_limits(
+        let mut reader = CpioReader::with_bounds(
             data.as_slice(),
-            u64::MAX,
+            ArchiveDecodeBounds {
+                max_payload_object_bytes: u64::from(u32::MAX) - 1,
+                ..CCS_BUDGET.archive_decode_bounds().unwrap()
+            },
             CCS_BUDGET.max_path_bytes + 1,
-            u64::from(u32::MAX) - 1,
-            u64::MAX,
         );
         let err = reader.next_entry().unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
-        assert!(
-            err.to_string().contains("file size"),
-            "unexpected error: {err}"
+        let Error::Budget(error) = err else {
+            panic!("expected typed payload-object refusal");
+        };
+        assert_eq!(
+            error.dimension,
+            crate::ccs::BudgetDimension::PayloadObjectBytes
         );
+        assert_eq!(error.observed, u64::from(u32::MAX));
+        assert_eq!(error.limit, u64::from(u32::MAX) - 1);
     }
 
     #[test]
@@ -370,14 +315,25 @@ mod tests {
         append_entry(&mut data, "two", b"b");
         append_entry(&mut data, "TRAILER!!!", b"");
 
-        let mut reader = CpioReader::with_limits(data.as_slice(), 1, u64::MAX, u64::MAX, u64::MAX);
+        let mut reader = CpioReader::with_bounds(
+            data.as_slice(),
+            ArchiveDecodeBounds {
+                max_archive_entries: 1,
+                ..CCS_BUDGET.archive_decode_bounds().unwrap()
+            },
+            u64::MAX,
+        );
         assert!(reader.next_entry().unwrap().is_some());
         let err = reader.next_entry().unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
-        assert!(
-            err.to_string().contains("entry count"),
-            "unexpected error: {err}"
+        let Error::Budget(error) = err else {
+            panic!("expected typed archive-entry refusal");
+        };
+        assert_eq!(
+            error.dimension,
+            crate::ccs::BudgetDimension::ArchiveEntryCount
         );
+        assert_eq!(error.observed, 2);
+        assert_eq!(error.limit, 1);
     }
 
     #[test]
@@ -387,13 +343,25 @@ mod tests {
         append_entry(&mut data, "two", b"def");
         append_entry(&mut data, "TRAILER!!!", b"");
 
-        let mut reader = CpioReader::with_limits(data.as_slice(), u64::MAX, u64::MAX, u64::MAX, 5);
+        let mut reader = CpioReader::with_bounds(
+            data.as_slice(),
+            ArchiveDecodeBounds {
+                max_payload_object_bytes: 3,
+                max_total_payload_bytes: 5,
+                ..CCS_BUDGET.archive_decode_bounds().unwrap()
+            },
+            u64::MAX,
+        );
         assert!(reader.next_entry().unwrap().is_some());
         let err = reader.next_entry().unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
-        assert!(
-            err.to_string().contains("cumulative"),
-            "unexpected error: {err}"
+        let Error::Budget(error) = err else {
+            panic!("expected typed cumulative-payload refusal");
+        };
+        assert_eq!(
+            error.dimension,
+            crate::ccs::BudgetDimension::TotalPayloadBytes
         );
+        assert_eq!(error.observed, 6);
+        assert_eq!(error.limit, 5);
     }
 }

--- a/crates/conary-core/src/packages/deb.rs
+++ b/crates/conary-core/src/packages/deb.rs
@@ -4,6 +4,7 @@
 //!
 //! Parses .deb packages, which are AR archives containing control and data tarballs
 
+use crate::ccs::{ArchiveDecodeBounds, CCS_BUDGET};
 use crate::compression::{self, CompressionFormat};
 use crate::db::models::Trove;
 use crate::error::{Error, Result};
@@ -52,9 +53,6 @@ const CONTROL_TAR_NAMES: &[&str] = &[
 
 const DATA_TAR_NAMES: &[&str] = &["data.tar.gz", "data.tar.xz", "data.tar.zst", "data.tar"];
 
-/// Maximum size for bounded control metadata within a DEB archive (16 MiB).
-pub(super) const MAX_DEB_CONTROL_MEMBER_SIZE: u64 = 16 * 1024 * 1024;
-
 /// Results of single-pass control tarball extraction
 #[derive(Default)]
 struct ControlTarContents {
@@ -66,6 +64,49 @@ struct ControlTarContents {
     config_files: Vec<ConfigFileInfo>,
     /// Whether the package-level debconf templates member was already seen.
     templates_seen: bool,
+}
+
+fn copy_declared_entry(
+    reader: &mut impl Read,
+    writer: &mut impl Write,
+    declared: u64,
+    label: &str,
+) -> Result<()> {
+    let mut limited = reader.take(declared.saturating_add(1));
+    let mut actual = 0_u64;
+    let mut buffer = [0_u8; PAYLOAD_IO_BUFFER_SIZE];
+    loop {
+        let read = limited
+            .read(&mut buffer)
+            .map_err(|error| Error::ParseError(format!("read {label}: {error}")))?;
+        if read == 0 {
+            break;
+        }
+        actual = actual
+            .checked_add(read as u64)
+            .ok_or_else(|| Error::ParseError(format!("{label} size overflows u64")))?;
+        if actual > declared {
+            return Err(Error::ParseError(format!(
+                "{label} declares {declared} bytes but yields at least {actual}"
+            )));
+        }
+        writer.write_all(&buffer[..read])?;
+    }
+    if actual != declared {
+        return Err(Error::ParseError(format!(
+            "{label} declares {declared} bytes but yields {actual}"
+        )));
+    }
+    Ok(())
+}
+
+fn read_declared_entry(reader: &mut impl Read, declared: u64, label: &str) -> Result<Vec<u8>> {
+    let mut content = Vec::with_capacity(
+        usize::try_from(declared)
+            .map_err(|_| Error::ParseError(format!("{label} exceeds addressable memory")))?,
+    );
+    copy_declared_entry(reader, &mut content, declared, label)?;
+    Ok(content)
 }
 
 /// Debian package representation
@@ -148,9 +189,12 @@ impl DebPackage {
     }
 
     /// Create a decompressor for tar data using magic byte detection
-    fn create_tar_decoder<'a>(tar_data: &'a [u8]) -> Result<Box<dyn Read + 'a>> {
+    fn create_tar_decoder<'a>(
+        tar_data: &'a [u8],
+        bounds: &ArchiveDecodeBounds,
+    ) -> Result<Box<dyn Read + 'a>> {
         let format = CompressionFormat::from_magic_bytes(tar_data);
-        compression::create_decoder_limited(tar_data, format, compression::MAX_DECOMPRESS_SIZE)
+        compression::create_decoder_limited(tar_data, format, bounds.max_metadata_bytes)
             .map_err(|e| Error::InitError(format!("Failed to create decoder: {}", e)))
     }
 
@@ -292,53 +336,37 @@ impl DebPackage {
 
     /// Single-pass extraction of control and data tarballs from the AR archive.
     fn extract_ar_members(path: &str) -> Result<(Vec<u8>, ReopenablePayload)> {
+        let bounds = CCS_BUDGET.archive_decode_bounds()?;
         let file = File::open(path)
             .map_err(|e| Error::InitError(format!("Failed to open DEB file: {}", e)))?;
         let mut archive = ar::Archive::new(file);
         let mut control_data: Option<Vec<u8>> = None;
         let mut data_source = None;
-        let mut entries_seen = 0usize;
+        let mut entries_seen = 0_u64;
         while let Some(entry) = archive.next_entry() {
             entries_seen += 1;
-            compression::check_archive_entry_limit(entries_seen, "DEB archive")
-                .map_err(|e| Error::InitError(format!("Failed to read DEB archive: {}", e)))?;
+            bounds.admit_archive_entry("DEB archive entries", entries_seen)?;
             let mut entry =
                 entry.map_err(|e| Error::InitError(format!("Failed to read AR entry: {}", e)))?;
             let entry_name = String::from_utf8_lossy(entry.header().identifier()).to_string();
             let trimmed = entry_name.trim_end_matches('/');
             if control_data.is_none() && CONTROL_TAR_NAMES.contains(&trimmed) {
                 let entry_size = entry.header().size();
-                if entry_size > MAX_DEB_CONTROL_MEMBER_SIZE {
-                    return Err(Error::InitError(format!(
-                        "DEB archive member too large: {entry_size} bytes"
-                    )));
-                }
-                let mut buf = Vec::new();
-                entry
-                    .read_to_end(&mut buf)
-                    .map_err(|e| Error::InitError(format!("Failed to read control tar: {}", e)))?;
+                bounds.admit_metadata_bytes("DEB compressed control member", entry_size)?;
+                let mut buf = Vec::with_capacity(usize::try_from(entry_size).map_err(|_| {
+                    Error::ParseError(
+                        "DEB compressed control member exceeds addressable memory".to_string(),
+                    )
+                })?);
+                copy_declared_entry(&mut entry, &mut buf, entry_size, "DEB control member")?;
                 control_data = Some(buf);
             } else if data_source.is_none() && DATA_TAR_NAMES.contains(&trimmed) {
                 let entry_size = entry.header().size();
+                bounds.admit_payload_object("DEB compressed data member", entry_size)?;
                 let spool = PayloadSpool::new(entry_size)?;
                 let path = spool.indexed_path(0);
                 let mut output = File::create(&path)?;
-                let mut remaining = entry_size;
-                let mut buffer = [0_u8; PAYLOAD_IO_BUFFER_SIZE];
-                while remaining > 0 {
-                    let requested = usize::try_from(remaining.min(buffer.len() as u64))
-                        .expect("bounded DEB member chunk");
-                    let read = entry.read(&mut buffer[..requested]).map_err(|error| {
-                        Error::InitError(format!("Failed to read data tar: {error}"))
-                    })?;
-                    if read == 0 {
-                        return Err(Error::InitError(format!(
-                            "DEB data tar ended early with {remaining} bytes remaining"
-                        )));
-                    }
-                    output.write_all(&buffer[..read])?;
-                    remaining -= read as u64;
-                }
+                copy_declared_entry(&mut entry, &mut output, entry_size, "DEB data member")?;
                 output.sync_all()?;
                 data_source = Some(spool.source(path));
             }
@@ -358,20 +386,26 @@ impl DebPackage {
     /// Replaces three separate functions that each decompressed and iterated the
     /// control tarball independently. One decompression, one iteration.
     fn parse_control_tar_all(control_data: &[u8]) -> Result<ControlTarContents> {
-        let reader = Self::create_tar_decoder(control_data)?;
+        let bounds = CCS_BUDGET.archive_decode_bounds()?;
+        let reader = Self::create_tar_decoder(control_data, &bounds)?;
         let mut archive = Archive::new(reader);
         let mut contents = ControlTarContents::default();
-        let mut entries_seen = 0usize;
+        let mut entries_seen = 0_u64;
+        let mut metadata_bytes = 0_u64;
 
         for entry in archive
             .entries()
             .map_err(|e| Error::InitError(format!("Failed to read control.tar: {}", e)))?
         {
             entries_seen += 1;
-            compression::check_archive_entry_limit(entries_seen, "DEB control.tar")
-                .map_err(|e| Error::InitError(format!("Failed to read control.tar: {}", e)))?;
+            bounds.admit_archive_entry("DEB control.tar entries", entries_seen)?;
             let mut entry =
                 entry.map_err(|e| Error::InitError(format!("Failed to read entry: {}", e)))?;
+            metadata_bytes = bounds.add_metadata_bytes(
+                "DEB control.tar metadata",
+                metadata_bytes,
+                entry.size(),
+            )?;
             let entry_path = entry
                 .path()
                 .map_err(|e| Error::InitError(format!("Failed to get entry path: {}", e)))?
@@ -381,35 +415,31 @@ impl DebPackage {
 
             match basename {
                 "control" => {
-                    let mut text = String::new();
-                    entry.read_to_string(&mut text).map_err(|e| {
-                        Error::InitError(format!("Failed to read control file: {}", e))
+                    let declared = entry.size();
+                    let body = read_declared_entry(&mut entry, declared, "DEB control file")?;
+                    let text = String::from_utf8(body).map_err(|error| {
+                        Error::ParseError(format!("DEB control file is not UTF-8: {error}"))
                     })?;
                     contents.control_text = Some(text);
                 }
                 "conffiles" => {
-                    let mut text = String::new();
-                    entry.read_to_string(&mut text).map_err(|error| {
-                        Error::InitError(format!(
-                            "Failed to read DEBIAN/conffiles as UTF-8: {error}"
-                        ))
+                    let declared = entry.size();
+                    let body = read_declared_entry(&mut entry, declared, "DEBIAN/conffiles")?;
+                    let text = String::from_utf8(body).map_err(|error| {
+                        Error::ParseError(format!("DEBIAN/conffiles is not valid UTF-8: {error}"))
                     })?;
                     contents.config_files = Self::parse_conffiles(&text)?;
                 }
                 "config" | "preinst" | "postinst" | "prerm" | "postrm" => {
-                    let mut body = Vec::new();
-                    entry.read_to_end(&mut body).map_err(|e| {
-                        Error::InitError(format!("Failed to read maintainer script: {}", e))
-                    })?;
+                    let declared = entry.size();
+                    let body = read_declared_entry(&mut entry, declared, "DEB maintainer script")?;
                     if let Some(native) = Self::native_abi_from_control_member(basename, &body)? {
                         contents.native_scriptlet_abi.push(native);
                     }
                 }
                 "triggers" => {
-                    let mut body = Vec::new();
-                    entry.read_to_end(&mut body).map_err(|e| {
-                        Error::InitError(format!("Failed to read triggers file: {}", e))
-                    })?;
+                    let declared = entry.size();
+                    let body = read_declared_entry(&mut entry, declared, "DEB triggers file")?;
                     if !body.iter().all(|byte| byte.is_ascii_whitespace()) {
                         contents
                             .native_scriptlet_abi
@@ -429,16 +459,8 @@ impl DebPackage {
                                 .to_string(),
                         ));
                     }
-                    let entry_size = entry.size();
-                    if entry_size > MAX_DEB_CONTROL_MEMBER_SIZE {
-                        return Err(Error::ParseError(format!(
-                            "Invalid DEBIAN/templates: control member is too large: {entry_size} bytes"
-                        )));
-                    }
-                    let mut body = Vec::new();
-                    entry.read_to_end(&mut body).map_err(|error| {
-                        Error::InitError(format!("Failed to read templates file: {error}"))
-                    })?;
+                    let declared = entry.size();
+                    let body = read_declared_entry(&mut entry, declared, "DEBIAN/templates")?;
                     if let Some(templates) = templates::native_abi_entry(body)? {
                         contents.native_scriptlet_abi.push(templates);
                     }

--- a/crates/conary-core/src/packages/deb/payload.rs
+++ b/crates/conary-core/src/packages/deb/payload.rs
@@ -853,7 +853,7 @@ fn display_typeflag(entry_type: u8) -> String {
 }
 
 fn data_tar_error(message: impl Into<String>) -> Error {
-    Error::InitError(format!("Failed to parse DEB data.tar: {}", message.into()))
+    Error::ParseError(format!("Failed to parse DEB data.tar: {}", message.into()))
 }
 
 #[cfg(test)]

--- a/crates/conary-core/src/packages/deb/payload.rs
+++ b/crates/conary-core/src/packages/deb/payload.rs
@@ -7,11 +7,11 @@
 //! GNU sparse, and unknown entry types. Keeping this parser explicit prevents
 //! the generic tar library from silently applying unsupported extensions.
 
+use crate::ccs::{ArchiveDecodeBounds, CCS_BUDGET};
 use crate::compression;
 use crate::error::{Error, Result};
 use crate::hash::{HashAlgorithm, Hasher};
 use crate::packages::archive_utils::normalize_path;
-use crate::packages::common::MAX_EXTRACTION_FILE_SIZE;
 use crate::packages::payload::{
     PAYLOAD_IO_BUFFER_SIZE, PackagePayload, PackagePayloadFile, PayloadSpool, ReopenablePayload,
 };
@@ -87,7 +87,8 @@ struct ParsedEntry {
 
 #[cfg(test)]
 pub(super) fn parse_package_files(data_tar_data: &[u8]) -> Result<Vec<PackageFile>> {
-    parse_reader(open_bytes_decoder(data_tar_data)?, None).map(|entries| {
+    let bounds = CCS_BUDGET.archive_decode_bounds()?;
+    parse_reader(open_bytes_decoder(data_tar_data, &bounds)?, None, &bounds).map(|entries| {
         entries
             .into_iter()
             .map(|entry| PackageFile {
@@ -106,19 +107,15 @@ pub(super) fn extract_files(data_tar_data: &[u8]) -> Result<Vec<ExtractedFile>> 
 }
 
 pub(super) fn parse_package_payload(data_tar: &ReopenablePayload) -> Result<PackagePayload> {
-    let metadata = parse_reader(open_source_decoder(data_tar)?, None)?;
-    let required_bytes = metadata.iter().try_fold(0_u64, |total, entry| {
-        total.checked_add(
-            entry
-                .content_authority
-                .as_ref()
-                .map_or(0, |authority| authority.size),
-        )
-    });
-    let required_bytes =
-        required_bytes.ok_or_else(|| data_tar_error("DEB payload-size arithmetic overflow"))?;
+    let bounds = CCS_BUDGET.archive_decode_bounds()?;
+    let metadata = parse_reader(open_source_decoder(data_tar, &bounds)?, None, &bounds)?;
+    let required_bytes = required_spool_bytes(&metadata, &bounds)?;
     let spool = PayloadSpool::new(required_bytes)?;
-    let parsed = parse_reader(open_source_decoder(data_tar)?, Some(&spool))?;
+    let parsed = parse_reader(
+        open_source_decoder(data_tar, &bounds)?,
+        Some(&spool),
+        &bounds,
+    )?;
     if metadata.len() != parsed.len()
         || metadata.iter().zip(&parsed).any(|(first, second)| {
             first.path != second.path
@@ -144,31 +141,59 @@ pub(super) fn parse_package_payload(data_tar: &ReopenablePayload) -> Result<Pack
         .map(PackagePayload::new)
 }
 
+fn required_spool_bytes(entries: &[ParsedEntry], bounds: &ArchiveDecodeBounds) -> Result<u64> {
+    entries.iter().try_fold(0_u64, |total, entry| {
+        bounds
+            .add_payload_bytes(
+                "DEB data.tar declared payload bytes",
+                total,
+                entry
+                    .content_authority
+                    .as_ref()
+                    .map_or(0, |authority| authority.size),
+            )
+            .map_err(Into::into)
+    })
+}
+
 #[cfg(test)]
-fn open_bytes_decoder(data: &[u8]) -> Result<Box<dyn Read + '_>> {
+fn open_bytes_decoder<'a>(
+    data: &'a [u8],
+    bounds: &ArchiveDecodeBounds,
+) -> Result<Box<dyn Read + 'a>> {
     let format = crate::compression::CompressionFormat::from_magic_bytes(data);
-    compression::create_decoder_limited(data, format, compression::MAX_DECOMPRESS_SIZE)
+    compression::create_decoder_limited(data, format, bounds.max_decompressed_stream_bytes)
         .map_err(|error| data_tar_error(format!("failed to create decoder: {error}")))
 }
 
-fn open_source_decoder(source: &ReopenablePayload) -> Result<Box<dyn Read>> {
+fn open_source_decoder(
+    source: &ReopenablePayload,
+    bounds: &ArchiveDecodeBounds,
+) -> Result<Box<dyn Read>> {
     let mut probe = source.open()?;
     let mut magic = [0_u8; 8];
     let read = probe.read(&mut magic)?;
     let format = crate::compression::CompressionFormat::from_magic_bytes(&magic[..read]);
-    compression::create_decoder_limited(source.open()?, format, compression::MAX_DECOMPRESS_SIZE)
-        .map_err(|error| data_tar_error(format!("failed to create decoder: {error}")))
+    compression::create_decoder_limited(
+        source.open()?,
+        format,
+        bounds.max_decompressed_stream_bytes,
+    )
+    .map_err(|error| data_tar_error(format!("failed to create decoder: {error}")))
 }
 
 fn parse_reader(
     mut reader: Box<dyn Read + '_>,
     spool: Option<&PayloadSpool>,
+    bounds: &ArchiveDecodeBounds,
 ) -> Result<Vec<ParsedEntry>> {
     let mut entries = Vec::<ParsedEntry>::new();
     let mut paths = BTreeSet::<String>::new();
     let mut pending_long_name: Option<Vec<u8>> = None;
     let mut pending_long_link: Option<Vec<u8>> = None;
-    let mut entries_seen = 0usize;
+    let mut entries_seen = 0_u64;
+    let mut declared_payload_bytes = 0_u64;
+    let mut metadata_bytes = 0_u64;
     let mut archive_root_seen = false;
 
     while let Some(block) = read_header_block(&mut reader)? {
@@ -176,13 +201,18 @@ fn parse_reader(
             break;
         }
         entries_seen += 1;
-        compression::check_archive_entry_limit(entries_seen, "DEB data.tar")
-            .map_err(|error| data_tar_error(error.to_string()))?;
+        bounds.admit_archive_entry("DEB data.tar entries", entries_seen)?;
 
         let mut header = decode_header(&block)?;
         match header.entry_type {
             TYPE_GNU_LONG_NAME | TYPE_GNU_LONG_LINK => {
-                let value = read_long_value(&mut reader, header.size, header.entry_type)?;
+                let value = read_long_value(
+                    &mut reader,
+                    header.size,
+                    header.entry_type,
+                    bounds,
+                    &mut metadata_bytes,
+                )?;
                 if header.entry_type == TYPE_GNU_LONG_NAME {
                     pending_long_name = Some(value);
                 } else {
@@ -236,6 +266,11 @@ fn parse_reader(
         let mut source = None;
         let kind = match header.entry_type {
             TYPE_REGULAR_OLD | TYPE_REGULAR if !directory_from_trailing_slash => {
+                declared_payload_bytes = bounds.add_payload_bytes(
+                    "DEB data.tar declared payload bytes",
+                    declared_payload_bytes,
+                    header.size,
+                )?;
                 let (authority, payload_source) =
                     read_regular_content(&mut reader, &path, header.size, spool, entries.len())?;
                 content_authority = Some(authority);
@@ -678,21 +713,23 @@ fn read_header_block(reader: &mut dyn Read) -> Result<Option<[u8; TAR_BLOCK_SIZE
     Ok(Some(block))
 }
 
-fn read_long_value(reader: &mut dyn Read, size: u64, entry_type: u8) -> Result<Vec<u8>> {
-    if size > MAX_EXTRACTION_FILE_SIZE {
-        return Err(data_tar_error(format!(
-            "GNU long {} record exceeds the {} byte extraction limit",
-            if entry_type == TYPE_GNU_LONG_NAME {
-                "name"
-            } else {
-                "link"
-            },
-            MAX_EXTRACTION_FILE_SIZE
-        )));
-    }
+fn read_long_value(
+    reader: &mut dyn Read,
+    size: u64,
+    entry_type: u8,
+    bounds: &ArchiveDecodeBounds,
+    metadata_bytes: &mut u64,
+) -> Result<Vec<u8>> {
+    let label = if entry_type == TYPE_GNU_LONG_NAME {
+        "GNU long-name payload"
+    } else {
+        "GNU long-link payload"
+    };
+    *metadata_bytes =
+        bounds.add_metadata_bytes("DEB data.tar path metadata", *metadata_bytes, size)?;
     let mut value = vec![0u8; size as usize];
-    read_exact(reader, &mut value, "GNU long-name payload")?;
-    discard_padding(reader, size)?;
+    read_exact(reader, &mut value, label)?;
+    discard_padding(reader, size, label)?;
     value.truncate(
         value
             .iter()
@@ -704,7 +741,7 @@ fn read_long_value(reader: &mut dyn Read, size: u64, entry_type: u8) -> Result<V
 
 fn read_regular_content(
     reader: &mut dyn Read,
-    _path: &str,
+    path: &str,
     size: u64,
     spool: Option<&PayloadSpool>,
     index: usize,
@@ -728,7 +765,7 @@ fn read_regular_content(
         }
         remaining -= chunk_size as u64;
     }
-    discard_padding(reader, size)?;
+    discard_padding(reader, size, &format!("regular payload {path:?}"))?;
     if let Some((file, _)) = &mut output {
         file.sync_all()?;
     }
@@ -747,10 +784,16 @@ fn read_regular_content(
     ))
 }
 
-fn discard_padding(reader: &mut dyn Read, size: u64) -> Result<()> {
+fn discard_padding(reader: &mut dyn Read, size: u64, description: &str) -> Result<()> {
     let padding = (TAR_BLOCK_SIZE as u64 - size % TAR_BLOCK_SIZE as u64) % TAR_BLOCK_SIZE as u64;
     let mut bytes = [0u8; TAR_BLOCK_SIZE];
-    read_exact(reader, &mut bytes[..padding as usize], "tar entry padding")
+    read_exact(reader, &mut bytes[..padding as usize], "tar entry padding")?;
+    if bytes[..padding as usize].iter().any(|byte| *byte != 0) {
+        return Err(data_tar_error(format!(
+            "{description} declares {size} bytes but carries nonzero bytes in its padding"
+        )));
+    }
+    Ok(())
 }
 
 fn read_exact(reader: &mut dyn Read, bytes: &mut [u8], description: &str) -> Result<()> {

--- a/crates/conary-core/src/packages/deb/payload/tests.rs
+++ b/crates/conary-core/src/packages/deb/payload/tests.rs
@@ -34,6 +34,185 @@ fn finish(builder: Builder<Vec<u8>>) -> Vec<u8> {
     builder.into_inner().unwrap()
 }
 
+fn bounds_with(
+    max_archive_entries: u64,
+    max_payload_object_bytes: u64,
+    max_total_payload_bytes: u64,
+) -> ArchiveDecodeBounds {
+    ArchiveDecodeBounds {
+        max_archive_entries,
+        max_payload_object_bytes,
+        max_total_payload_bytes,
+        ..CCS_BUDGET.archive_decode_bounds().unwrap()
+    }
+}
+
+#[test]
+fn data_tar_entry_count_over_budget_is_typed() {
+    let mut builder = Builder::new(Vec::new());
+    append(
+        &mut builder,
+        "usr/share/one",
+        EntryType::Regular,
+        0o644,
+        b"one",
+        None,
+    );
+    append(
+        &mut builder,
+        "usr/share/two",
+        EntryType::Regular,
+        0o644,
+        b"two",
+        None,
+    );
+    let archive = finish(builder);
+    let bounds = bounds_with(1, 3, 6);
+
+    let error = parse_reader(Box::new(Cursor::new(archive)), None, &bounds).unwrap_err();
+    let Error::Budget(error) = error else {
+        panic!("expected typed entry-count refusal");
+    };
+    assert_eq!(
+        error.dimension,
+        crate::ccs::BudgetDimension::ArchiveEntryCount
+    );
+    assert_eq!(error.observed, 2);
+    assert_eq!(error.limit, 1);
+}
+
+#[test]
+fn data_tar_cumulative_payload_over_budget_is_typed() {
+    let mut builder = Builder::new(Vec::new());
+    append(
+        &mut builder,
+        "usr/share/one",
+        EntryType::Regular,
+        0o644,
+        b"one",
+        None,
+    );
+    append(
+        &mut builder,
+        "usr/share/two",
+        EntryType::Regular,
+        0o644,
+        b"two",
+        None,
+    );
+    let archive = finish(builder);
+    let bounds = bounds_with(8, 3, 5);
+
+    let error = parse_reader(Box::new(Cursor::new(archive)), None, &bounds).unwrap_err();
+    let Error::Budget(error) = error else {
+        panic!("expected typed cumulative-payload refusal");
+    };
+    assert_eq!(
+        error.dimension,
+        crate::ccs::BudgetDimension::TotalPayloadBytes
+    );
+    assert_eq!(error.observed, 6);
+    assert_eq!(error.limit, 5);
+}
+
+fn vm_hwm_kib() -> Option<u64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    status
+        .lines()
+        .find_map(|line| line.strip_prefix("VmHWM:"))
+        .and_then(|value| value.split_ascii_whitespace().next())
+        .and_then(|value| value.parse().ok())
+}
+
+#[test]
+fn streams_zstd_tar_past_the_retired_two_gib_ceiling() {
+    const DECLARED: u64 = 2 * 1024 * 1024 * 1024 + 64 * 1024;
+    const ZERO_CHUNK_SIZE: usize = 1024 * 1024;
+
+    let before_kib = vm_hwm_kib();
+    let mut header = TarHeader::new_gnu();
+    header
+        .set_path("usr/share/issue-133/large-zero-payload")
+        .unwrap();
+    header.set_entry_type(EntryType::Regular);
+    header.set_mode(0o644);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_size(DECLARED);
+    header.set_cksum();
+    let mut compressed = zstd::stream::encode_all(Cursor::new(header.as_bytes()), 1).unwrap();
+    let zero_chunk = vec![0_u8; ZERO_CHUNK_SIZE];
+    let zero_frame = zstd::stream::encode_all(Cursor::new(&zero_chunk), 1).unwrap();
+    for _ in 0..(DECLARED / ZERO_CHUNK_SIZE as u64) {
+        compressed.extend_from_slice(&zero_frame);
+    }
+    let remainder = usize::try_from(DECLARED % ZERO_CHUNK_SIZE as u64).unwrap();
+    if remainder != 0 {
+        compressed.extend_from_slice(
+            &zstd::stream::encode_all(Cursor::new(&zero_chunk[..remainder]), 1).unwrap(),
+        );
+    }
+    compressed.extend_from_slice(
+        &zstd::stream::encode_all(Cursor::new(&zero_chunk[..TAR_BLOCK_SIZE * 2]), 1).unwrap(),
+    );
+    let after_build_kib = vm_hwm_kib();
+
+    assert!(
+        compressed.len() < 1024 * 1024,
+        "fixture must stay tiny: {} bytes",
+        compressed.len()
+    );
+    let parsed = parse_package_files(&compressed).unwrap();
+    let after_parse_kib = vm_hwm_kib();
+
+    assert_eq!(parsed.len(), 1);
+    assert_eq!(parsed[0].content.as_ref().unwrap().size, DECLARED);
+    eprintln!(
+        "issue133_large_archive compressed_bytes={} VmHWM_before_kib={} \
+         VmHWM_after_build_kib={} VmHWM_after_parse_kib={}",
+        compressed.len(),
+        before_kib.unwrap_or(0),
+        after_build_kib.unwrap_or(0),
+        after_parse_kib.unwrap_or(0),
+    );
+}
+
+fn raw_regular_header(declared: u64) -> Vec<u8> {
+    let mut header = TarHeader::new_gnu();
+    header.set_path("usr/share/declared").unwrap();
+    header.set_entry_type(EntryType::Regular);
+    header.set_mode(0o644);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_size(declared);
+    header.set_cksum();
+    header.as_bytes().to_vec()
+}
+
+#[test]
+fn data_tar_declared_size_mismatch_is_typed_in_both_directions() {
+    let mut shorter = raw_regular_header(3);
+    shorter.extend_from_slice(b"ab");
+    let error = parse_package_files(&shorter).unwrap_err();
+    assert!(matches!(&error, Error::ParseError(_)));
+    assert!(error.to_string().contains("regular payload"), "{error}");
+
+    let mut longer = raw_regular_header(3);
+    longer.extend_from_slice(b"abcd");
+    longer.resize(TAR_BLOCK_SIZE * 2, 0);
+    longer.extend_from_slice(&[0; TAR_BLOCK_SIZE * 2]);
+    let error = parse_package_files(&longer).unwrap_err();
+    assert!(matches!(&error, Error::ParseError(_)));
+    assert!(
+        error
+            .to_string()
+            .contains("carries nonzero bytes in its padding"),
+        "{error}"
+    );
+}
+
 #[test]
 fn accepts_one_exact_archive_root_directory_as_container_metadata() {
     let mut builder = Builder::new(Vec::new());

--- a/crates/conary-core/src/packages/deb/templates.rs
+++ b/crates/conary-core/src/packages/deb/templates.rs
@@ -12,13 +12,6 @@ use crate::packages::native_abi::{
 };
 use std::collections::BTreeSet;
 
-/// Maximum byte length accepted for a debconf templates file.
-///
-/// The runtime `X_LOADTEMPLATEFILE` loader and package control-archive parser
-/// share this bound so a file cannot become valid merely by changing how it
-/// entered the package lifecycle.
-pub const MAX_DEBCONF_TEMPLATES_SIZE: u64 = super::MAX_DEB_CONTROL_MEMBER_SIZE;
-
 pub(crate) fn native_abi_entry(body: Vec<u8>) -> Result<Option<NativeScriptletEntry>> {
     let metadata = parse(&body)?;
     if metadata.records.is_empty() {
@@ -452,7 +445,8 @@ mod tests {
             .set_path("templates")
             .expect("set templates path");
         oversized_header.set_entry_type(tar::EntryType::Regular);
-        oversized_header.set_size(crate::packages::deb::MAX_DEB_CONTROL_MEMBER_SIZE + 1);
+        let max_metadata = crate::ccs::CCS_BUDGET.max_metadata_bytes;
+        oversized_header.set_size(max_metadata + 1);
         oversized_header.set_mode(0o644);
         oversized_header.set_cksum();
         let mut oversized_archive = oversized_header.as_bytes().to_vec();
@@ -461,6 +455,11 @@ mod tests {
             Ok(_) => panic!("oversized templates member must fail"),
             Err(error) => error,
         };
-        assert!(error.to_string().contains("too large"), "{error}");
+        let Error::Budget(error) = error else {
+            panic!("expected typed metadata budget refusal");
+        };
+        assert_eq!(error.dimension, crate::ccs::BudgetDimension::MetadataBytes);
+        assert_eq!(error.observed, max_metadata + 1);
+        assert_eq!(error.limit, max_metadata);
     }
 }

--- a/crates/conary-core/src/packages/deb/tests.rs
+++ b/crates/conary-core/src/packages/deb/tests.rs
@@ -5,6 +5,30 @@ use crate::packages::traits::{
     DebMaintainerMode, DebTriggerAwaitMode, DebTriggerDirective, NativeArgumentValue,
     NativeLifecyclePath, NativeScriptletKind, NativeScriptletMetadata, NativeStdinContract,
 };
+use std::io::Cursor;
+
+#[test]
+fn declared_member_copy_rejects_shorter_and_longer_bodies() {
+    let mut output = Vec::new();
+    let shorter =
+        copy_declared_entry(&mut Cursor::new(b"ab"), &mut output, 3, "test member").unwrap_err();
+    assert!(matches!(&shorter, Error::ParseError(_)));
+    assert!(
+        shorter
+            .to_string()
+            .contains("declares 3 bytes but yields 2")
+    );
+
+    output.clear();
+    let longer =
+        copy_declared_entry(&mut Cursor::new(b"abcd"), &mut output, 3, "test member").unwrap_err();
+    assert!(matches!(&longer, Error::ParseError(_)));
+    assert!(
+        longer
+            .to_string()
+            .contains("declares 3 bytes but yields at least 4")
+    );
+}
 
 #[test]
 fn test_control_parsing() {

--- a/crates/conary-core/src/packages/payload/storage.rs
+++ b/crates/conary-core/src/packages/payload/storage.rs
@@ -42,11 +42,13 @@ pub fn ensure_available_space(path: &Path, required_bytes: u64) -> Result<()> {
 }
 
 fn ensure_capacity(required_bytes: u64, available_bytes: u64) -> Result<()> {
-    if required_bytes > available_bytes {
-        return Err(Error::IoError(format!(
-            "payload spool requires {required_bytes} bytes, but only {available_bytes} bytes are available"
-        )));
-    }
+    crate::ccs::CCS_BUDGET
+        .archive_decode_bounds()?
+        .admit_spool_reservation(
+            "payload spool available bytes",
+            required_bytes,
+            available_bytes,
+        )?;
     Ok(())
 }
 
@@ -93,6 +95,16 @@ mod tests {
 
         assert_eq!(measured, declared);
         ensure_capacity(measured, declared).unwrap();
-        assert!(ensure_capacity(measured, declared - 1).is_err());
+        let error = ensure_capacity(measured, declared - 1).unwrap_err();
+        let Error::Budget(error) = error else {
+            panic!("expected typed budget refusal");
+        };
+        assert_eq!(
+            error.dimension,
+            crate::ccs::BudgetDimension::TotalPayloadBytes
+        );
+        assert_eq!(error.field, "payload spool available bytes");
+        assert_eq!(error.observed, declared);
+        assert_eq!(error.limit, declared - 1);
     }
 }

--- a/crates/conary-core/src/packages/registry.rs
+++ b/crates/conary-core/src/packages/registry.rs
@@ -5,6 +5,7 @@
 //! Provides centralized identification and parsing from package-owned format
 //! markers. File names and extensions are never format authority.
 
+use crate::ccs::CCS_BUDGET;
 use crate::compression::{self, CompressionFormat};
 use crate::error::{Error, Result};
 use crate::packages::traits::PackageFormat;
@@ -69,13 +70,13 @@ pub fn detect_format(path: impl AsRef<Path>) -> Result<PackageFormatType> {
 }
 
 fn has_debian_binary_member(path: &Path) -> Result<bool> {
+    let bounds = CCS_BUDGET.archive_decode_bounds()?;
     let file = File::open(path)?;
     let mut archive = ar::Archive::new(file);
-    let mut entries_seen = 0_usize;
+    let mut entries_seen = 0_u64;
     while let Some(entry) = archive.next_entry() {
         entries_seen += 1;
-        compression::check_archive_entry_limit(entries_seen, "Debian package")
-            .map_err(|error| Error::InitError(error.to_string()))?;
+        bounds.admit_archive_entry("Debian package entries", entries_seen)?;
         let mut entry = entry?;
         let identifier = String::from_utf8_lossy(entry.header().identifier());
         if identifier.trim_end_matches('/') != "debian-binary" {
@@ -92,17 +93,23 @@ fn has_debian_binary_member(path: &Path) -> Result<bool> {
 }
 
 fn has_arch_pkginfo(path: &Path, format: CompressionFormat) -> Result<bool> {
+    let bounds = CCS_BUDGET.archive_decode_bounds()?;
     let file = File::open(path)?;
     let reader =
-        compression::create_decoder_limited(file, format, compression::MAX_DECOMPRESS_SIZE)
+        compression::create_decoder_limited(file, format, bounds.max_decompressed_stream_bytes)
             .map_err(|error| Error::InitError(error.to_string()))?;
     let mut archive = tar::Archive::new(reader);
-    let mut entries_seen = 0_usize;
+    let mut entries_seen = 0_u64;
+    let mut declared_payload_bytes = 0_u64;
     for entry in archive.entries()? {
         entries_seen += 1;
-        compression::check_archive_entry_limit(entries_seen, "ALPM package")
-            .map_err(|error| Error::InitError(error.to_string()))?;
+        bounds.admit_archive_entry("ALPM package entries", entries_seen)?;
         let entry = entry?;
+        declared_payload_bytes = bounds.add_payload_bytes(
+            "ALPM package declared bytes",
+            declared_payload_bytes,
+            entry.size(),
+        )?;
         let path = entry.path()?;
         if path == Path::new(".PKGINFO") || path == Path::new("./.PKGINFO") {
             return Ok(entry.header().entry_type().is_file());

--- a/crates/conary-core/src/packages/rpm/payload/stream.rs
+++ b/crates/conary-core/src/packages/rpm/payload/stream.rs
@@ -4,6 +4,7 @@
 
 use super::header::HeaderRecord;
 use super::{mode_type, parse_error};
+use crate::ccs::{ArchiveDecodeBounds, CCS_BUDGET};
 use crate::compression::{self, CompressionFormat};
 use crate::error::Result;
 use crate::packages::archive_utils::normalize_path;
@@ -18,7 +19,6 @@ const CPIO_NEWC_MAGIC: &[u8; 6] = b"070701";
 const CPIO_CRC_MAGIC: &[u8; 6] = b"070702";
 const CPIO_STRIPPED_MAGIC: &[u8; 6] = b"07070X";
 const CPIO_TRAILER: &str = "TRAILER!!!";
-const MAX_CPIO_NAME_SIZE: u64 = 4096;
 
 #[derive(Debug)]
 pub(super) struct PayloadMember {
@@ -46,13 +46,18 @@ enum RpmPayloadCompressor {
 }
 
 pub(super) fn required_spool_bytes(records: &[HeaderRecord]) -> Result<u64> {
+    let bounds = CCS_BUDGET.archive_decode_bounds()?;
     records
         .iter()
         .filter(|record| !record.ghost && mode_type(record.mode) == libc::S_IFREG)
         .try_fold(0_u64, |total, record| {
-            total
-                .checked_add(record.size)
-                .ok_or_else(|| parse_error("RPM payload spool-size arithmetic overflow"))
+            bounds
+                .add_payload_bytes(
+                    "RPM header declared regular payload bytes",
+                    total,
+                    record.size,
+                )
+                .map_err(Into::into)
         })
 }
 
@@ -62,9 +67,14 @@ pub(super) fn parse_members<'a>(
     records: &'a [HeaderRecord],
     spool: &'a PayloadSpool,
 ) -> Result<Vec<PayloadMember>> {
+    let bounds = CCS_BUDGET.archive_decode_bounds()?;
+    bounds.admit_archive_entry(
+        "RPM payload header entries",
+        records.iter().filter(|record| !record.ghost).count() as u64,
+    )?;
     let compressor = payload_compressor(package)?;
     let reader = payload_decoder(payload, compressor)?;
-    RpmPayloadReader::new(reader, records, spool).read_all()
+    RpmPayloadReader::new(reader, records, spool, bounds).read_all()
 }
 
 fn payload_compressor(package: &Package) -> Result<RpmPayloadCompressor> {
@@ -128,6 +138,7 @@ struct RpmPayloadReader<'a> {
     flavor: Option<ArchiveFlavor>,
     standard_path_indexes: HashMap<&'a str, usize>,
     total_content: u64,
+    bounds: ArchiveDecodeBounds,
 }
 
 impl<'a> RpmPayloadReader<'a> {
@@ -135,6 +146,7 @@ impl<'a> RpmPayloadReader<'a> {
         reader: Box<dyn Read + 'a>,
         records: &'a [HeaderRecord],
         spool: &'a PayloadSpool,
+        bounds: ArchiveDecodeBounds,
     ) -> Self {
         Self {
             reader,
@@ -150,6 +162,7 @@ impl<'a> RpmPayloadReader<'a> {
                 .map(|(index, record)| (record.path.as_str(), index))
                 .collect(),
             total_content: 0,
+            bounds,
         }
     }
 
@@ -243,9 +256,10 @@ impl<'a> RpmPayloadReader<'a> {
         let _rdev_minor = self.read_hex_u32("rdev minor")?;
         let name_size = u64::from(self.read_hex_u32("name size")?);
         let checksum = self.read_hex_u32("checksum")?;
-        if name_size == 0 || name_size > MAX_CPIO_NAME_SIZE {
+        let max_name_size = CCS_BUDGET.max_path_bytes.saturating_add(1);
+        if name_size == 0 || name_size > max_name_size {
             return Err(parse_error(format!(
-                "RPM CPIO name size {name_size} is outside 1..={MAX_CPIO_NAME_SIZE}"
+                "RPM CPIO name size {name_size} is outside 1..={max_name_size}"
             )));
         }
         let mut name = vec![0_u8; name_size as usize];
@@ -295,16 +309,19 @@ impl<'a> RpmPayloadReader<'a> {
         size: u64,
         expected_crc: Option<u32>,
     ) -> Result<()> {
+        self.bounds
+            .admit_archive_entry("RPM CPIO entries", self.members.len() as u64 + 1)?;
         if !self.seen.insert(index) {
             return Err(parse_error(format!(
                 "RPM payload repeats header path {}",
                 self.records[index].path
             )));
         }
-        self.total_content = self
-            .total_content
-            .checked_add(size)
-            .ok_or_else(|| parse_error("RPM payload cumulative content size overflow"))?;
+        self.total_content = self.bounds.add_payload_bytes(
+            "RPM CPIO declared payload bytes",
+            self.total_content,
+            size,
+        )?;
         let record = &self.records[index];
         let (source, sha256, actual_crc) = match mode_type(record.mode) {
             libc::S_IFREG => {
@@ -544,7 +561,12 @@ mod tests {
             Some(std::str::from_utf8(target).unwrap()),
         )];
         let spool = PayloadSpool::new(0).unwrap();
-        let mut reader = RpmPayloadReader::new(Box::new(io::Cursor::new(target)), &symlink, &spool);
+        let mut reader = RpmPayloadReader::new(
+            Box::new(io::Cursor::new(target)),
+            &symlink,
+            &spool,
+            CCS_BUDGET.archive_decode_bounds().unwrap(),
+        );
         let error = reader
             .read_member_content(0, target.len() as u64 - 1, None)
             .unwrap_err();
@@ -556,7 +578,12 @@ mod tests {
         );
 
         let directory = [header_record(libc::S_IFDIR | 0o755, 0, None)];
-        let mut reader = RpmPayloadReader::new(Box::new(io::Cursor::new(b"x")), &directory, &spool);
+        let mut reader = RpmPayloadReader::new(
+            Box::new(io::Cursor::new(b"x")),
+            &directory,
+            &spool,
+            CCS_BUDGET.archive_decode_bounds().unwrap(),
+        );
         let error = reader.read_member_content(0, 1, None).unwrap_err();
         assert!(
             error.to_string().contains(

--- a/crates/conary-core/src/repository/client.rs
+++ b/crates/conary-core/src/repository/client.rs
@@ -5,10 +5,7 @@
 //! Provides a wrapper around reqwest with retry support for
 //! fetching metadata and downloading files.
 
-use crate::compression::{
-    CompressionFormat, MAX_METADATA_DECOMPRESS_SIZE, decompress_auto_with_limit,
-    decompress_with_limit,
-};
+use crate::compression::{CompressionFormat, decompress_metadata, decompress_metadata_auto};
 use crate::error::{Error, Result};
 use crate::repository::error_helpers::ResultExt;
 use crate::repository::error_helpers::http_client_builder_error_message;
@@ -545,8 +542,8 @@ impl RepositoryClient {
         let bytes = self.download_to_bytes(url).await?;
 
         // Auto-detect and decompress
-        let decompressed = decompress_auto_with_limit(&bytes, MAX_METADATA_DECOMPRESS_SIZE)
-            .parse_context(&format!("decompress data from {url}"))?;
+        let decompressed =
+            decompress_metadata_auto(&bytes, &format!("repository metadata from {url}"))?;
 
         debug!(
             "Decompressed {} bytes -> {} bytes",
@@ -580,14 +577,15 @@ impl RepositoryClient {
                     "URL {} has no extension but detected {} compression",
                     url, detected
                 );
-                return decompress_auto_with_limit(&bytes, MAX_METADATA_DECOMPRESS_SIZE)
-                    .map_err(|e| Error::ParseError(format!("Failed to decompress: {}", e)));
+                return decompress_metadata_auto(
+                    &bytes,
+                    &format!("repository metadata from {url}"),
+                );
             }
             return Ok(bytes);
         }
 
-        decompress_with_limit(&bytes, format, MAX_METADATA_DECOMPRESS_SIZE)
-            .map_err(|e| Error::ParseError(format!("Failed to decompress {} data: {}", format, e)))
+        decompress_metadata(&bytes, format, &format!("repository metadata from {url}"))
     }
 
     /// Download a file to the specified path with retry support

--- a/crates/conary-core/src/repository/parsers/arch.rs
+++ b/crates/conary-core/src/repository/parsers/arch.rs
@@ -6,7 +6,7 @@
 //! in a custom text format with %FIELD% markers.
 
 use super::{ChecksumType, PackageMetadata, RepositoryParser};
-use crate::compression::decompress_auto;
+use crate::compression::decompress_metadata_auto;
 use crate::error::{Error, Result};
 use crate::repository::client::RepositoryClient;
 use crate::repository::dependency_model::{
@@ -73,9 +73,7 @@ impl ArchParser {
             }
             Err(error) => return Err(error),
         }
-        decompress_auto(&raw_bytes).map_err(|error| {
-            Error::ParseError(format!("Failed to decompress {}: {}", db_url, error))
-        })
+        decompress_metadata_auto(&raw_bytes, &format!("Arch repository database {db_url}"))
     }
 
     /// Parse a desc file from the tarball

--- a/crates/conary-core/src/repository/parsers/debian.rs
+++ b/crates/conary-core/src/repository/parsers/debian.rs
@@ -7,7 +7,7 @@
 
 use super::common::{self, MAX_PACKAGE_SIZE};
 use super::{ChecksumType, PackageMetadata, RepositoryParser};
-use crate::compression::decompress_auto;
+use crate::compression::decompress_metadata_auto;
 use crate::error::{Error, Result};
 use crate::repository::client::RepositoryClient;
 use crate::repository::dependency_model::{
@@ -90,9 +90,10 @@ impl DebianParser {
                 release_path, authenticated.sha256, actual
             )));
         }
-        let decompressed = decompress_auto(&raw_bytes).map_err(|error| {
-            Error::ParseError(format!("Failed to decompress {}: {}", packages_url, error))
-        })?;
+        let decompressed = decompress_metadata_auto(
+            &raw_bytes,
+            &format!("Debian Packages metadata {packages_url}"),
+        )?;
         let content = String::from_utf8(decompressed).map_err(|error| {
             Error::ParseError(format!("Invalid UTF-8 in Packages.gz: {}", error))
         })?;

--- a/crates/conary-core/src/repository/parsers/fedora.rs
+++ b/crates/conary-core/src/repository/parsers/fedora.rs
@@ -7,7 +7,7 @@
 
 use super::common::{self, MAX_PACKAGE_SIZE};
 use super::{ChecksumType, PackageMetadata, RepositoryParser};
-use crate::compression::decompress_auto;
+use crate::compression::decompress_metadata_auto;
 use crate::error::{Error, Result};
 use crate::repository::client::RepositoryClient;
 use crate::repository::dependency_model::{
@@ -302,9 +302,8 @@ impl FedoraParser {
                 location.sha256, actual
             )));
         }
-        let decompressed = decompress_auto(&raw_bytes).map_err(|error| {
-            Error::ParseError(format!("Failed to decompress {}: {}", primary_url, error))
-        })?;
+        let decompressed =
+            decompress_metadata_auto(&raw_bytes, &format!("RPM primary metadata {primary_url}"))?;
         let content = String::from_utf8(decompressed).map_err(|error| {
             Error::ParseError(format!("Invalid UTF-8 in primary.xml: {}", error))
         })?;

--- a/crates/conary-core/src/repository/trust/openpgp/arch/keyring.rs
+++ b/crates/conary-core/src/repository/trust/openpgp/arch/keyring.rs
@@ -28,11 +28,6 @@ use super::super::super::{ArchKeyringFormat, ArchKeyringTrust};
 const CERTIFICATE_MEMBER: &str = "usr/share/pacman/keyrings/archlinux.gpg";
 const REVOKED_MEMBER: &str = "usr/share/pacman/keyrings/archlinux-revoked";
 
-const MAX_KEYRING_PACKAGE_OUTPUT: u64 = 64 * 1024 * 1024;
-const MAX_KEYRING_BYTES: u64 = 32 * 1024 * 1024;
-const MAX_REVOKED_BYTES: u64 = 1024 * 1024;
-const MAX_KEYRING_PACKAGE_ENTRIES: usize = 4096;
-
 /// Fingerprints pacman disables in the populated keyring.
 ///
 /// `NotCarried` is not "no revocations by default": it records that the
@@ -118,10 +113,11 @@ struct AlpmKeyringMembers {
 }
 
 fn extract_alpm_members(source: &[u8]) -> Result<AlpmKeyringMembers> {
+    let bounds = crate::ccs::CCS_BUDGET.archive_decode_bounds()?;
     let decoder = crate::compression::create_decoder_limited(
         Cursor::new(source),
         crate::compression::CompressionFormat::Zstd,
-        MAX_KEYRING_PACKAGE_OUTPUT,
+        bounds.max_decompressed_stream_bytes,
     )
     .map_err(|error| {
         Error::ParseError(format!(
@@ -130,32 +126,30 @@ fn extract_alpm_members(source: &[u8]) -> Result<AlpmKeyringMembers> {
     })?;
     let mut archive = tar::Archive::new(decoder);
     let mut members = AlpmKeyringMembers::default();
-    for (index, entry) in archive
-        .entries()
-        .map_err(|error| {
-            Error::ParseError(format!("failed to read Arch keyring ALPM package: {error}"))
-        })?
-        .enumerate()
-    {
-        if index >= MAX_KEYRING_PACKAGE_ENTRIES {
-            return Err(Error::ParseError(format!(
-                "Arch keyring ALPM package exceeds {MAX_KEYRING_PACKAGE_ENTRIES} entries"
-            )));
-        }
+    let mut entries_seen = 0_u64;
+    let mut metadata_bytes = 0_u64;
+    for entry in archive.entries().map_err(|error| {
+        Error::ParseError(format!("failed to read Arch keyring ALPM package: {error}"))
+    })? {
+        entries_seen = entries_seen.checked_add(1).ok_or_else(|| {
+            Error::ParseError("Arch keyring ALPM entry count overflows u64".to_string())
+        })?;
+        bounds.admit_archive_entry("Arch keyring ALPM entries", entries_seen)?;
         let entry = entry.map_err(|error| {
             Error::ParseError(format!("failed to read Arch keyring ALPM member: {error}"))
         })?;
+        metadata_bytes = bounds.add_metadata_bytes(
+            "Arch keyring ALPM metadata",
+            metadata_bytes,
+            entry.size(),
+        )?;
         let path = entry.path().map_err(|error| {
             Error::ParseError(format!("invalid Arch keyring ALPM member path: {error}"))
         })?;
-        let (slot, member, limit) = if path.as_ref() == Path::new(CERTIFICATE_MEMBER) {
-            (
-                &mut members.certificates,
-                CERTIFICATE_MEMBER,
-                MAX_KEYRING_BYTES,
-            )
+        let (slot, member) = if path.as_ref() == Path::new(CERTIFICATE_MEMBER) {
+            (&mut members.certificates, CERTIFICATE_MEMBER)
         } else if path.as_ref() == Path::new(REVOKED_MEMBER) {
-            (&mut members.revoked, REVOKED_MEMBER, MAX_REVOKED_BYTES)
+            (&mut members.revoked, REVOKED_MEMBER)
         } else {
             continue;
         };
@@ -164,29 +158,35 @@ fn extract_alpm_members(source: &[u8]) -> Result<AlpmKeyringMembers> {
                 "Arch keyring ALPM package repeats exact member '{member}'"
             )));
         }
-        *slot = Some(read_member(entry, member, limit)?);
+        *slot = Some(read_member(entry, member)?);
     }
     Ok(members)
 }
 
-fn read_member<R: Read>(entry: tar::Entry<'_, R>, member: &str, limit: u64) -> Result<Vec<u8>> {
+fn read_member<R: Read>(entry: tar::Entry<'_, R>, member: &str) -> Result<Vec<u8>> {
     if !entry.header().entry_type().is_file() {
         return Err(Error::ParseError(format!(
             "Arch keyring ALPM member '{member}' is not a regular file"
         )));
     }
-    let mut bytes = Vec::new();
+    let declared = entry.size();
+    let mut bytes = Vec::with_capacity(usize::try_from(declared).map_err(|_| {
+        Error::ParseError(format!(
+            "Arch keyring ALPM member '{member}' exceeds addressable memory"
+        ))
+    })?);
     entry
-        .take(limit + 1)
+        .take(declared.saturating_add(1))
         .read_to_end(&mut bytes)
         .map_err(|error| {
             Error::ParseError(format!(
                 "failed to read Arch keyring ALPM member '{member}': {error}"
             ))
         })?;
-    if bytes.len() as u64 > limit {
+    let actual = bytes.len() as u64;
+    if actual != declared {
         return Err(Error::ParseError(format!(
-            "Arch keyring ALPM member '{member}' exceeds {limit} bytes"
+            "Arch keyring ALPM member '{member}' declares {declared} bytes but yields {actual}"
         )));
     }
     Ok(bytes)

--- a/docs/modules/ccs.md
+++ b/docs/modules/ccs.md
@@ -367,7 +367,17 @@ string and depth bounds, aggregate variable-length pools, payload-object
 bounds, and CBOR nesting depth, and byte ceilings are derived from them. The
 writer admits the authority it is about to sign through the same
 `admit_authority` call verification uses, so a package this repository emits is
-readable by construction. `docs/specs/ccs-format-v2.md` owns the contract.
+readable by construction.
+
+Source-package archive decoding derives its entry-count, cumulative payload,
+metadata, decompressed-stream, and spool bounds from that same owner. One
+payload object may consume the full 64 GiB total-payload allowance because
+native authoring, conversion, FastCDC chunking, CAS ingestion, and package
+writing all use fixed-buffer or reopenable streams rather than whole-object
+buffers. Tar decoders enforce declared size per entry, then independently bound
+cumulative payload, archive entries, metadata, and framing overhead; those
+dimensions replace a guessed global decompression ceiling without weakening
+decompression-bomb resistance. `docs/specs/ccs-format-v2.md` owns the contract.
 
 Configuration authority is exact per path. Each `[[config.files]]` declaration
 and its signed v2 projection carries `noreplace`, `ghost`, and


### PR DESCRIPTION
## Primary Issue

Closes #133

Design / Plan / Roadmap: Refs #99 (slice 99c, the epic's final slice)

## Problem And Outcome

The former archive-resource policy had three independent guesses: a 2 GiB
decompressed-stream cap, a 512 MiB CCS payload-object cap, and archive entry
limits outside the CCS structural owner. That combination rejected an ordinary
ALPM package before conversion and left ALPM payload spooling unaccounted.

The prerequisite whole-package buffering defect recorded in this PR was fixed
by #135/#136 at `1b702f0e`. This branch verifies that current premise and
implements the full hard cut: `CcsStructuralBudget` now derives every
source-archive decode, metadata, entry-count, payload, and spool bound used by
the affected paths. The three legacy compression constants and their helper are
deleted, with no compatibility aliases or configuration knobs.

## Changes

- Added `ArchiveDecodeBounds`, derived only by
  `CcsStructuralBudget::archive_decode_bounds()`.
  - `max_payload_object_bytes` and `max_total_payload_bytes` share the 64 GiB
    total-payload ceiling.
  - metadata uses the owner's 512 MiB `MetadataBytes` dimension.
  - the outer stream ceiling is derived as total payload plus one 1,024-byte
    header/alignment envelope per admissible archive entry.
- Deleted `MAX_DECOMPRESS_SIZE`, `MAX_METADATA_DECOMPRESS_SIZE`,
  `MAX_ARCHIVE_ENTRIES`, `check_archive_entry_limit`, and superseded local
  extraction/control-size constants.
- Routed ALPM, DEB, RPM/CPIO, format detection, repository metadata, debconf
  templates, spool capacity, and the Arch trust-keyring package decoder through
  the shared owner.
- Replaced ALPM's production `PayloadSpool::new(0)` with a first-pass declared
  payload reservation and a second-pass parity check.
- Enforced declared member size in both directions and kept refusals typed:
  resource dimensions return `BudgetError`; malformed archive semantics return
  `ParseError`; spool exhaustion is no longer free-form `io::Error` prose.
- Added the in-repo >2 GiB zstd/tar stream regression, all required one-over
  refusals, exact-limit cases, and a test-only SHA-256 optimization so the real
  integrity path remains practical in CI.
- Documented the payload-object decision and dimensional bomb posture in
  `docs/modules/ccs.md`.

The full-diff audit also found a separate 64 MiB/4,096-entry table in the Arch
trust-keyring ALPM decoder. Because it was another source-archive resource
authority, this slice removed it and now accounts that archive through the
shared entry, metadata, and stream dimensions. The exact keyring member grammar
did not change.

## Design Conformance

### Single owner

[`archive_decode_bounds()`](https://github.com/ConaryLabs/Conary/blob/413a04c80dd820732c59f69143b6908b2d43714a/crates/conary-core/src/ccs/budget.rs#L387-L406)
is the only derivation. Format implementations carry that projection and use
its typed admission methods; they do not copy the numbers into a format table.

The highest touched Rust source file is 927 lines, and `ccs/budget.rs` is 920
lines. Every touched source file remains below the 1,000-line planning gate, so
no ownership decomposition was triggered.

### Payload-object consumer verification

The #136 premise is true on this head:

- Native authoring selects file-backed or disk-spooled
  [`ReopenablePayload`](https://github.com/ConaryLabs/Conary/blob/413a04c80dd820732c59f69143b6908b2d43714a/crates/conary-core/src/ccs/builder.rs#L311-L332);
  hashing uses a fixed 64 KiB buffer and the builder stores descriptors, not
  payload bytes.
- FastCDC production authoring calls
  [`visit_reader_chunks`](https://github.com/ConaryLabs/Conary/blob/413a04c80dd820732c59f69143b6908b2d43714a/crates/conary-core/src/ccs/builder.rs#L399-L423),
  whose streaming implementation holds one bounded chunk at a time
  ([implementation](https://github.com/ConaryLabs/Conary/blob/413a04c80dd820732c59f69143b6908b2d43714a/crates/conary-core/src/ccs/chunking.rs#L150-L190)).
- The foreign conversion result copies `PackagePayloadFile` descriptors and
  content authority, not object bytes
  ([converter](https://github.com/ConaryLabs/Conary/blob/413a04c80dd820732c59f69143b6908b2d43714a/crates/conary-core/src/ccs/convert/converter.rs#L431-L480)).
- Package writing reopens each descriptor and sends it directly to
  `store_reader_expected`
  ([writer](https://github.com/ConaryLabs/Conary/blob/413a04c80dd820732c59f69143b6908b2d43714a/crates/conary-core/src/ccs/builder/package_writer.rs#L204-L225));
  CAS ingestion uses the shared fixed 64 KiB buffer
  ([CAS](https://github.com/ConaryLabs/Conary/blob/413a04c80dd820732c59f69143b6908b2d43714a/crates/conary-core/src/filesystem/cas/stream.rs#L13-L58)).
- Install/conversion parsers expose file-backed reopenable sources. The
  in-memory backing is explicitly bounded test/small-tooling support
  ([payload contract](https://github.com/ConaryLabs/Conary/blob/413a04c80dd820732c59f69143b6908b2d43714a/crates/conary-core/src/packages/payload.rs#L3-L38)).

The aggregate `Chunker::chunk_file`/`chunk_bytes` APIs have no production
caller. The generic `CpioReader` still returns a materialized `Vec` per entry,
but `rg -n 'CpioReader' --glob '*.rs' crates apps` finds no caller outside its
own module/tests; active RPM CPIO conversion uses the streaming spool parser.
The trust-keyring path buffers only exact control-plane metadata and is now
bounded by `MetadataBytes`, not by payload-object size. No active payload
consumer allocates memory proportional to one payload object.

### ALPM and DEB spool decisions

ALPM now performs two archive passes: the first admits entry count and declared
payload cumulatively, reserves the exact spool, and the second repeats the same
accounting while streaming each member under its declared size. A pass-to-pass
declaration change is a typed parse failure.

DEB keeps the per-entry spool for the selected compressed `data.tar.*` AR
member: that spool owns one compressed source envelope and makes it reopenable.
The decoded `data.tar` keeps the existing RPM-style two-pass model: first parse
and sum regular declarations, create one precomputed spool, then parse again
and compare the two projections. Both levels use owner-derived admission and
`ensure_available_space`; there is no DEB-local limit table.

### Decompression-bomb posture

The retired global cap is fully replaced by orthogonal structural checks:

1. each accepted payload/control member is streamed under its declared size
   plus one probe byte, with shorter and longer bodies rejected;
2. cumulative declared payload is admitted against `TotalPayloadBytes`;
3. every traversal is admitted against `ArchiveEntryCount`, bounding repeated
   header/alignment work;
4. in-memory control-plane content is admitted against `MetadataBytes`; and
5. the decompressor's outer reader is bounded by the structurally derived
   payload-plus-entry-envelope ceiling.

That closes payload expansion, repeated-entry expansion, metadata allocation,
and framing overhead independently. A large legitimate member is no longer
confused with a bomb merely because it crosses 2 GiB.

## Verification

All Cargo commands below used `-j 10` or `CARGO_BUILD_JOBS=10` and the ignored,
disk-backed private target `target/issue133`.

```text
$ bash scripts/agent-context.sh --feature ccs --run focused
All 14 focused command(s) passed for CCS Authoring, Conversion, Install, And Native Lifecycle Execution.

$ bash scripts/agent-context.sh --feature ccs --run gate
All 6 gate command(s) passed for CCS Authoring, Conversion, Install, And Native Lifecycle Execution.

$ cargo test -p conary-core packages -j 10
test result: ok. 275 passed; 0 failed; 0 ignored; 0 measured; 2854 filtered out; finished in 7.87s

$ cargo test -p conary-core ccs::budget -j 10
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 3118 filtered out; finished in 4.60s

$ cargo test -p remi conversion -j 10
test result: ok. 70 passed; 0 failed; 0 ignored; 0 measured; 514 filtered out; finished in 0.70s
cli_help: 1 passed; 0 failed

$ cargo clippy --workspace --all-targets -j 10 -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 14s

$ cargo fmt --check
(no output; exit 0)

$ bash scripts/check-doc-truth.sh
Documentation truth checks passed.

$ grep -rn "MAX_DECOMPRESS_SIZE\\|MAX_METADATA_DECOMPRESS_SIZE\\|MAX_ARCHIVE_ENTRIES" crates apps
(no output; exit 1, meaning no matches)

$ git diff --check origin/main
(no output; exit 0)
```

Exact-head GitHub Actions also passed: [`pr-gate` run
30331421843](https://github.com/ConaryLabs/Conary/actions/runs/30331421843)
reported 15 passing checks and no failures on
`413a04c80dd820732c59f69143b6908b2d43714a`; the Ubuntu 26.04 native
cross-source lifecycle job completed in 29m43s.

The committed large-stream test exercises the real decoder and SHA-256 path:

```text
$ cargo test -p conary-core packages::deb::payload::tests::streams_zstd_tar_past_the_retired_two_gib_ceiling -j 10 -- --exact --nocapture --test-threads=1
issue133_large_archive compressed_bytes=102531 VmHWM_before_kib=13096 VmHWM_after_build_kib=20980 VmHWM_after_parse_kib=31988
test result: ok. 1 passed; 0 failed; finished in 7.84s
```

An initial focused-helper invocation failed before running a test because its
nested login shell restored the read-only shared Cargo target. Inspection
confirmed the helper uses `bash -lc`; the successful run injected the private
disk-backed target into those nested shells. No unchanged failing test was
retried.

## Unproven / Pending

- **Pending — reviewer-owned:** bounded scratch-Remi prewarm for pinned
  `0ad-data-0.28.0-1-any.pkg.tar.zst` with `'^0ad-data$'`.
- No production Remi service, `/conary/data`, or `/etc/conary` state was read or
  changed for this slice.

## Review And Merge Notes

- Review focus: single-owner derivation, exact tar/AR member semantics,
  ALPM/DEB spool accounting, and the dimensional decompression-bomb argument.
- Persisted state: none; this is a pre-alpha source-decoder hard cut with no
  compatibility constants or migration chain.
- User impact: legitimate multi-gigabyte source members can convert without
  package-specific behavior; malformed or over-budget archives fail with typed
  diagnostics.
- Required-check bypass: not used.
