### PR TITLE
fix(ccs): stream native authoring instead of buffering whole packages

### DIFF
--- a/apps/conary/src/commands/ccs/build.rs
+++ b/apps/conary/src/commands/ccs/build.rs
@@ -204,9 +204,9 @@ pub async fn cmd_ccs_build(options: CcsBuildOptions) -> Result<()> {
                         ))
                         .map_err(anyhow::Error::from)?
                     };
-                    builder::write_v2_ccs_package(
+                    builder::write_v2_ccs_package_from_sources(
                         &projected.authority,
-                        &projected.payloads_by_path,
+                        &projected.payloads,
                         &output_path,
                         &signing_key,
                         projected.debug_toml.as_deref(),

--- a/apps/conary/src/commands/ccs/install/command_capability_tests.rs
+++ b/apps/conary/src/commands/ccs/install/command_capability_tests.rs
@@ -75,8 +75,12 @@ async fn ccs_install_persists_capability_declarations() {
                 size: total_size,
             },
         )]),
-        files,
-        blobs: HashMap::from([(file_hash, content), (init_hash, init_content)]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(file_hash, content), (init_hash, init_content)]),
+        )
+        .unwrap(),
         total_size,
         chunked: false,
         chunk_stats: None,
@@ -160,8 +164,12 @@ async fn ccs_install_rejects_scriptlet_capabilities_without_enforcement_before_m
                 size: total_size,
             },
         )]),
-        files,
-        blobs: HashMap::from([(file_hash, content), (init_hash, init_content)]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(file_hash, content), (init_hash, init_content)]),
+        )
+        .unwrap(),
         total_size,
         chunked: false,
         chunk_stats: None,

--- a/apps/conary/src/commands/ccs/install/command_component_tests.rs
+++ b/apps/conary/src/commands/ccs/install/command_component_tests.rs
@@ -76,12 +76,16 @@ async fn ccs_install_respects_manifest_component_selection() {
                 },
             ),
         ]),
-        files,
-        blobs: HashMap::from([
-            (chosen_hash, chosen_content),
-            (skipped_hash, skipped_content),
-            (init_hash, init_content),
-        ]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([
+                (chosen_hash, chosen_content),
+                (skipped_hash, skipped_content),
+                (init_hash, init_content),
+            ]),
+        )
+        .unwrap(),
         total_size: 0,
         chunked: false,
         chunk_stats: None,
@@ -186,6 +190,7 @@ async fn ccs_install_runs_package_hook_for_devel_only_component_selection() {
         reversible: None,
     });
 
+    let files = vec![runtime_file.clone(), devel_file.clone()];
     let result = BuildResult {
         manifest,
         components: HashMap::from([
@@ -208,8 +213,12 @@ async fn ccs_install_runs_package_hook_for_devel_only_component_selection() {
                 },
             ),
         ]),
-        files: vec![runtime_file, devel_file],
-        blobs: HashMap::from([(runtime_hash, runtime_content), (devel_hash, devel_content)]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(runtime_hash, runtime_content), (devel_hash, devel_content)]),
+        )
+        .unwrap(),
         total_size: 0,
         chunked: false,
         chunk_stats: None,

--- a/apps/conary/src/commands/ccs/install/command_hook_tests.rs
+++ b/apps/conary/src/commands/ccs/install/command_hook_tests.rs
@@ -58,8 +58,12 @@ async fn ccs_install_persists_pre_remove_hook() {
                 size: (content.len() + init_content.len()) as u64,
             },
         )]),
-        files,
-        blobs: HashMap::from([(file_hash, content), (init_hash, init_content)]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(file_hash, content), (init_hash, init_content)]),
+        )
+        .unwrap(),
         total_size: 0,
         chunked: false,
         chunk_stats: None,
@@ -138,8 +142,12 @@ async fn ccs_install_rolls_back_after_post_install_error() {
                 size: (content.len() + init_content.len()) as u64,
             },
         )]),
-        files,
-        blobs: HashMap::from([(hash, content), (init_hash, init_content)]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(hash, content), (init_hash, init_content)]),
+        )
+        .unwrap(),
         total_size: 5 + init_file
             .content
             .as_ref()
@@ -233,8 +241,12 @@ async fn ccs_install_discards_pre_hook_directories_when_post_hook_fails() {
                 size: file_content.len() as u64,
             },
         )]),
-        files,
-        blobs: HashMap::from([(file_hash, file_content)]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(file_hash, file_content)]),
+        )
+        .unwrap(),
         total_size: 7,
         chunked: false,
         chunk_stats: None,

--- a/apps/conary/src/commands/ccs/install/command_metadata_tests.rs
+++ b/apps/conary/src/commands/ccs/install/command_metadata_tests.rs
@@ -55,11 +55,15 @@ async fn ccs_install_records_payload_without_direct_live_root_write() {
                 size: total_size,
             },
         )]),
-        files,
-        blobs: HashMap::from([
-            (file_hash.clone(), content.clone()),
-            (init_hash, init_content),
-        ]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([
+                (file_hash.clone(), content.clone()),
+                (init_hash, init_content),
+            ]),
+        )
+        .unwrap(),
         total_size,
         chunked: false,
         chunk_stats: None,
@@ -153,8 +157,12 @@ async fn ccs_install_strips_special_permission_bits_from_db_metadata() {
                 size: total_size,
             },
         )]),
-        files,
-        blobs: HashMap::from([(file_hash, content), (init_hash, init_content)]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(file_hash, content), (init_hash, init_content)]),
+        )
+        .unwrap(),
         total_size,
         chunked: false,
         chunk_stats: None,
@@ -226,8 +234,12 @@ async fn ccs_install_persists_manifest_provides() {
                 size: init_content.len() as u64,
             },
         )]),
-        files,
-        blobs: HashMap::from([(init_hash.clone(), init_content.clone())]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(init_hash.clone(), init_content.clone())]),
+        )
+        .unwrap(),
         total_size: 0,
         chunked: false,
         chunk_stats: None,
@@ -317,8 +329,12 @@ async fn ccs_install_persists_typed_provide_when_name_collides() {
                 size: init_content.len() as u64,
             },
         )]),
-        files,
-        blobs: HashMap::from([(init_hash.clone(), init_content.clone())]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(init_hash.clone(), init_content.clone())]),
+        )
+        .unwrap(),
         total_size: 0,
         chunked: false,
         chunk_stats: None,
@@ -372,7 +388,7 @@ async fn ccs_install_registers_metadata_only_package_without_files() {
         manifest: CcsManifest::new_minimal("metadata-only", "1.0.0"),
         components: HashMap::new(),
         files: Vec::new(),
-        blobs: HashMap::new(),
+        payloads: Vec::new(),
         total_size: 0,
         chunked: false,
         chunk_stats: None,
@@ -465,8 +481,12 @@ async fn ccs_install_does_not_infer_ldconfig_trigger_from_library_path() {
                 },
             ),
         ]),
-        files,
-        blobs: HashMap::from([(file_hash, content), (init_hash, init_content)]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(file_hash, content), (init_hash, init_content)]),
+        )
+        .unwrap(),
         total_size: 0,
         chunked: false,
         chunk_stats: None,

--- a/apps/conary/src/commands/ccs/install/command_payload_tests.rs
+++ b/apps/conary/src/commands/ccs/install/command_payload_tests.rs
@@ -55,8 +55,12 @@ async fn ccs_install_rejects_child_write_beneath_package_symlink() {
                 size: child_content.len() as u64,
             },
         )]),
-        files,
-        blobs: HashMap::from([(child_hash, child_content.clone())]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(child_hash, child_content.clone())]),
+        )
+        .unwrap(),
         total_size: child_content.len() as u64,
         chunked: false,
         chunk_stats: None,
@@ -143,11 +147,15 @@ async fn ccs_install_rejects_child_before_package_symlink() {
                 size: (child_content.len() + init_content.len()) as u64,
             },
         )]),
-        files,
-        blobs: HashMap::from([
-            (child_hash, child_content.clone()),
-            (init_hash, init_content.clone()),
-        ]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([
+                (child_hash, child_content.clone()),
+                (init_hash, init_content.clone()),
+            ]),
+        )
+        .unwrap(),
         total_size: (child_content.len() + init_content.len()) as u64,
         chunked: false,
         chunk_stats: None,
@@ -239,8 +247,12 @@ async fn ccs_install_persists_usrmerge_payload_under_usr_path() {
                 size: total_size,
             },
         )]),
-        files,
-        blobs: HashMap::from([(file_hash, content.clone()), (init_hash, init_content)]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(file_hash, content.clone()), (init_hash, init_content)]),
+        )
+        .unwrap(),
         total_size,
         chunked: false,
         chunk_stats: None,
@@ -346,8 +358,12 @@ async fn ccs_install_resolves_safe_existing_lib64_ancestor_inside_root() {
                 size: total_size,
             },
         )]),
-        files,
-        blobs: HashMap::from([(library_hash, library_content), (init_hash, init_content)]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(library_hash, library_content), (init_hash, init_content)]),
+        )
+        .unwrap(),
         total_size,
         chunked: false,
         chunk_stats: None,
@@ -434,8 +450,12 @@ async fn ccs_install_allows_identical_existing_symlink_destination() {
                 size: init_content.len() as u64,
             },
         )]),
-        files,
-        blobs: HashMap::from([(init_hash, init_content.clone())]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(init_hash, init_content.clone())]),
+        )
+        .unwrap(),
         total_size: init_content.len() as u64,
         chunked: false,
         chunk_stats: None,
@@ -521,8 +541,12 @@ async fn generation_install_records_replacement_without_mutating_current_leaf_sy
                 size: init_content.len() as u64,
             },
         )]),
-        files,
-        blobs: HashMap::from([(init_hash, init_content.clone())]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(init_hash, init_content.clone())]),
+        )
+        .unwrap(),
         total_size: init_content.len() as u64,
         chunked: false,
         chunk_stats: None,
@@ -622,8 +646,12 @@ async fn ccs_install_coalesces_identical_usrmerge_duplicate_files() {
                 size: content.len() as u64 * 2 + init_content.len() as u64,
             },
         )]),
-        files,
-        blobs: HashMap::from([(file_hash, content.clone()), (init_hash, init_content)]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(file_hash, content.clone()), (init_hash, init_content)]),
+        )
+        .unwrap(),
         total_size: content.len() as u64 * 2,
         chunked: false,
         chunk_stats: None,
@@ -727,12 +755,16 @@ async fn ccs_install_rejects_conflicting_usrmerge_duplicate_files() {
                 size: (bin_content.len() + usr_content.len() + init_content.len()) as u64,
             },
         )]),
-        files,
-        blobs: HashMap::from([
-            (bin_hash, bin_content),
-            (usr_hash, usr_content),
-            (init_hash, init_content),
-        ]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([
+                (bin_hash, bin_content),
+                (usr_hash, usr_content),
+                (init_hash, init_content),
+            ]),
+        )
+        .unwrap(),
         total_size: 0,
         chunked: false,
         chunk_stats: None,

--- a/apps/conary/src/commands/ccs/install/command_reinstall_tests.rs
+++ b/apps/conary/src/commands/ccs/install/command_reinstall_tests.rs
@@ -31,7 +31,7 @@ async fn ccs_install_reinstall_dry_run_does_not_mutate_db() {
         manifest: CcsManifest::new_minimal("reinstall-dry-run", "1.0.0"),
         components: HashMap::new(),
         files: Vec::new(),
-        blobs: HashMap::new(),
+        payloads: Vec::new(),
         total_size: 0,
         chunked: false,
         chunk_stats: None,

--- a/apps/conary/src/commands/install/ccs_transaction/converted_directory_tests.rs
+++ b/apps/conary/src/commands/install/ccs_transaction/converted_directory_tests.rs
@@ -129,8 +129,12 @@ fn write_converted_directory_package(
                 size: init_content.len() as u64,
             },
         )]),
-        files,
-        blobs: HashMap::from([(init_hash, init_content)]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(init_hash, init_content)]),
+        )
+        .unwrap(),
         total_size: 0,
         chunked: false,
         chunk_stats: None,

--- a/apps/conary/src/commands/install/conversion/tests.rs
+++ b/apps/conary/src/commands/install/conversion/tests.rs
@@ -240,8 +240,12 @@ fn write_runtime_ccs_package(
                 size: init_content.len() as u64,
             },
         )]),
-        files,
-        blobs: HashMap::from([(init_hash, init_content)]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(init_hash, init_content)]),
+        )
+        .unwrap(),
         total_size: 0,
         chunked: false,
         chunk_stats: None,
@@ -278,8 +282,12 @@ fn write_runtime_signed_ccs_package(
                 size: init_content.len() as u64,
             },
         )]),
-        files,
-        blobs: HashMap::from([(init_hash, init_content)]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(init_hash, init_content)]),
+        )
+        .unwrap(),
         total_size: 0,
         chunked: false,
         chunk_stats: None,
@@ -772,8 +780,12 @@ async fn converted_ccs_install_rejects_symlink_child_payload() {
                 size: (child_content.len() + init_content.len()) as u64,
             },
         )]),
-        files,
-        blobs: HashMap::from([(child_hash, child_content), (init_hash, init_content)]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(child_hash, child_content), (init_hash, init_content)]),
+        )
+        .unwrap(),
         total_size: 0,
         chunked: false,
         chunk_stats: None,
@@ -859,8 +871,12 @@ async fn converted_ccs_install_rejects_child_before_package_symlink() {
                 size: (child_content.len() + init_content.len()) as u64,
             },
         )]),
-        files,
-        blobs: HashMap::from([(child_hash, child_content), (init_hash, init_content)]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(child_hash, child_content), (init_hash, init_content)]),
+        )
+        .unwrap(),
         total_size: 0,
         chunked: false,
         chunk_stats: None,

--- a/apps/conary/src/commands/model/test_support.rs
+++ b/apps/conary/src/commands/model/test_support.rs
@@ -72,8 +72,12 @@ pub(super) fn build_test_ccs_package(
                 size: component_size,
             },
         )]),
-        files,
-        blobs: HashMap::from([(binary_hash, binary_content), (init_hash, init_content)]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(binary_hash, binary_content), (init_hash, init_content)]),
+        )
+        .unwrap(),
         total_size: 0,
         chunked: false,
         chunk_stats: None,

--- a/apps/conary/src/commands/remi_publish.rs
+++ b/apps/conary/src/commands/remi_publish.rs
@@ -83,7 +83,7 @@ mod tests {
         let payload = b"hello world\n".to_vec();
         let authority = minimal_v2_authority_for_preflight("hello", &payload);
         let payloads = std::collections::BTreeMap::from([("/usr/bin/hello".to_string(), payload)]);
-        conary_core::ccs::builder::write_v2_ccs_package(
+        conary_core::ccs::builder::write_v2_ccs_package_from_bounded_memory_for_tests(
             &authority,
             &payloads,
             &package_path,

--- a/apps/conary/src/commands/state/tests.rs
+++ b/apps/conary/src/commands/state/tests.rs
@@ -66,8 +66,12 @@ fn build_test_ccs_package_with_manifest(
                 size: binary_content.len() as u64,
             },
         )]),
-        files,
-        blobs: HashMap::from([(binary_hash, binary_content)]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(binary_hash, binary_content)]),
+        )
+        .unwrap(),
         total_size: 0,
         chunked: false,
         chunk_stats: None,

--- a/apps/conary/src/commands/try_session/mod.rs
+++ b/apps/conary/src/commands/try_session/mod.rs
@@ -304,8 +304,12 @@ pub(super) mod test_support {
                     size: total_size,
                 },
             )]),
-            files,
-            blobs: HashMap::from([(tool_hash, tool_content), (init_hash, init_content)]),
+            files: files.clone(),
+            payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+                &files,
+                HashMap::from([(tool_hash, tool_content), (init_hash, init_content)]),
+            )
+            .unwrap(),
             total_size,
             chunked: false,
             chunk_stats: None,

--- a/apps/conary/src/commands/try_session/validation.rs
+++ b/apps/conary/src/commands/try_session/validation.rs
@@ -203,8 +203,12 @@ mod tests {
                     size: content.len() as u64,
                 },
             )]),
-            files,
-            blobs: HashMap::from([(hash, content)]),
+            files: files.clone(),
+            payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+                &files,
+                HashMap::from([(hash, content)]),
+            )
+            .unwrap(),
             total_size: 11,
             chunked: false,
             chunk_stats: None,

--- a/apps/conary/tests/component.rs
+++ b/apps/conary/tests/component.rs
@@ -88,6 +88,11 @@ fn ccs_archive_preserves_exact_author_component_membership() {
         remove_on_upgrade: false,
     }];
 
+    let files = vec![
+        runtime_file.clone(),
+        config_file.clone(),
+        devel_file.clone(),
+    ];
     let result = BuildResult {
         manifest,
         components: HashMap::from([
@@ -119,12 +124,16 @@ fn ccs_archive_preserves_exact_author_component_membership() {
                 },
             ),
         ]),
-        files: vec![runtime_file, config_file, devel_file],
-        blobs: HashMap::from([
-            (conary_core::hash::sha256(&runtime_content), runtime_content),
-            (conary_core::hash::sha256(&config_content), config_content),
-            (conary_core::hash::sha256(&devel_content), devel_content),
-        ]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([
+                (conary_core::hash::sha256(&runtime_content), runtime_content),
+                (conary_core::hash::sha256(&config_content), config_content),
+                (conary_core::hash::sha256(&devel_content), devel_content),
+            ]),
+        )
+        .unwrap(),
         total_size: 0,
         chunked: false,
         chunk_stats: None,

--- a/apps/conary/tests/packaging_m1b.rs
+++ b/apps/conary/tests/packaging_m1b.rs
@@ -269,6 +269,7 @@ fn write_single_binary_ccs(package_path: &Path, content: Vec<u8>) {
         component: "runtime".to_string(),
         chunks: None,
     };
+    let files = vec![file.clone()];
     let result = BuildResult {
         manifest: CcsManifest::new_minimal(PACKAGE_NAME, PACKAGE_VERSION),
         components: HashMap::from([(
@@ -280,8 +281,12 @@ fn write_single_binary_ccs(package_path: &Path, content: Vec<u8>) {
                 size: total_size,
             },
         )]),
-        files: vec![file],
-        blobs: HashMap::from([(hash, content)]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(hash, content)]),
+        )
+        .unwrap(),
         total_size,
         chunked: false,
         chunk_stats: None,

--- a/apps/conary/tests/packaging_m4a.rs
+++ b/apps/conary/tests/packaging_m4a.rs
@@ -2,7 +2,7 @@
 
 mod common;
 
-use conary_core::ccs::builder::write_v2_ccs_package;
+use conary_core::ccs::builder::write_v2_ccs_package_from_bounded_memory_for_tests;
 use conary_core::ccs::signing::SigningKeyPair;
 use conary_core::ccs::v2::schema::{
     AuthorityDocumentV2, ComponentAuthorityV2, ConflictPolicyV2, DependencyKindV2,
@@ -117,7 +117,7 @@ fn write_unsigned_v2_package(package_path: &Path) {
 fn write_signed_v2_package(package_path: &Path, signer: &SigningKeyPair) {
     let authority = signed_v2_authority();
     let payloads = BTreeMap::from([("/usr/bin/hello".to_string(), b"hello world\n".to_vec())]);
-    write_v2_ccs_package(
+    write_v2_ccs_package_from_bounded_memory_for_tests(
         &authority,
         &payloads,
         package_path,

--- a/apps/conary/tests/packaging_m4c.rs
+++ b/apps/conary/tests/packaging_m4c.rs
@@ -8,7 +8,7 @@ use conary_core::ccs::attestation::{
     BUILD_ATTESTATION_SCHEMA_V1, BuildAttestationPayload, BuildOutputIdentity, canonical_json_hash,
     compute_v2_content_identity, compute_v2_file_merkle_root, sign_build_attestation,
 };
-use conary_core::ccs::builder::write_v2_ccs_package;
+use conary_core::ccs::builder::write_v2_ccs_package_from_bounded_memory_for_tests;
 use conary_core::ccs::signing::SigningKeyPair;
 use conary_core::ccs::v2::schema::{
     AuthorityDocumentV2, ComponentAuthorityV2, ConflictPolicyV2, DependencyKindV2,
@@ -413,7 +413,7 @@ fn release_artifact_with_attestation(
     };
     let envelope = sign_build_attestation(attestation, signer).unwrap();
     let package_path = temp.path().join("release.ccs");
-    write_v2_ccs_package(
+    write_v2_ccs_package_from_bounded_memory_for_tests(
         &authority,
         &payloads,
         &package_path,

--- a/apps/conary/tests/static_repo_m1a.rs
+++ b/apps/conary/tests/static_repo_m1a.rs
@@ -406,6 +406,7 @@ fn write_single_payload_ccs(package_path: &Path, signing_key: &SigningKeyPair) {
         libc: "gnu".to_string(),
         abi: None,
     });
+    let files = vec![file.clone()];
     let result = BuildResult {
         manifest,
         components: HashMap::from([(
@@ -417,8 +418,12 @@ fn write_single_payload_ccs(package_path: &Path, signing_key: &SigningKeyPair) {
                 size: content_size,
             },
         )]),
-        files: vec![file],
-        blobs: HashMap::from([(hash, content)]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(hash, content)]),
+        )
+        .unwrap(),
         total_size: content_size,
         chunked: false,
         chunk_stats: None,

--- a/apps/conary/tests/workflow.rs
+++ b/apps/conary/tests/workflow.rs
@@ -329,8 +329,12 @@ fn test_parent_upgrade_marks_built_derived_package_stale_via_install_cli() {
                 size: (binary_content.len() + config_content.len()) as u64,
             },
         )]),
-        files,
-        blobs: HashMap::from([(binary_hash, binary_content), (config_hash, config_content)]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(binary_hash, binary_content), (config_hash, config_content)]),
+        )
+        .unwrap(),
         total_size: 0,
         chunked: false,
         chunk_stats: None,

--- a/apps/remi/src/server/conversion/test_support.rs
+++ b/apps/remi/src/server/conversion/test_support.rs
@@ -167,7 +167,7 @@ pub(super) fn make_conversion_result(package_path: Option<std::path::PathBuf>) -
         manifest,
         components: std::collections::HashMap::new(),
         files: Vec::<FileEntry>::new(),
-        blobs: std::collections::HashMap::new(),
+        payloads: Vec::new(),
         total_size: 0,
         chunked: false,
         chunk_stats: None,

--- a/apps/remi/src/server/release_publish.rs
+++ b/apps/remi/src/server/release_publish.rs
@@ -254,7 +254,7 @@ mod tests {
         canonical_json_hash, compute_v2_content_identity, compute_v2_file_merkle_root,
         sign_build_attestation,
     };
-    use conary_core::ccs::builder::write_v2_ccs_package;
+    use conary_core::ccs::builder::write_v2_ccs_package_from_bounded_memory_for_tests;
     use conary_core::ccs::signing::SigningKeyPair;
     use conary_core::ccs::v2::schema::{
         AuthorityDocumentV2, ComponentAuthorityV2, ConflictPolicyV2, DependencyKindV2,
@@ -841,7 +841,7 @@ mod tests {
         };
         let envelope = sign_build_attestation(payload, signer).unwrap();
         let package_path = temp.path().join("release.ccs");
-        write_v2_ccs_package(
+        write_v2_ccs_package_from_bounded_memory_for_tests(
             &authority,
             &payloads,
             &package_path,
@@ -922,7 +922,7 @@ mod tests {
             debug_toml_sha256: None,
         };
         let package_path = temp.path().join("local-dev.ccs");
-        write_v2_ccs_package(
+        write_v2_ccs_package_from_bounded_memory_for_tests(
             &authority,
             &payloads,
             &package_path,

--- a/crates/conary-core/src/ccs/archive_reader/tests.rs
+++ b/crates/conary-core/src/ccs/archive_reader/tests.rs
@@ -1,7 +1,7 @@
 // conary-core/src/ccs/archive_reader/tests.rs
 
 use super::*;
-use crate::ccs::builder::write_v2_ccs_package;
+use crate::ccs::builder::write_v2_ccs_package_from_bounded_memory_for_tests;
 use crate::ccs::signing::SigningKeyPair;
 use flate2::Compression;
 use flate2::write::GzEncoder;
@@ -13,7 +13,7 @@ fn current_package() -> (tempfile::TempDir, std::path::PathBuf) {
     let path = temp.path().join("current.ccs");
     let authority = crate::ccs::v2::test_support::package_authority_with_one_file("current");
     let payloads = crate::ccs::v2::test_support::one_file_payloads_for_tests();
-    write_v2_ccs_package(
+    write_v2_ccs_package_from_bounded_memory_for_tests(
         &authority,
         &payloads,
         &path,

--- a/crates/conary-core/src/ccs/builder.rs
+++ b/crates/conary-core/src/ccs/builder.rs
@@ -1,27 +1,25 @@
 // conary-core/src/ccs/builder.rs
-//! CCS package builder
+//! CCS package builder.
 //!
-//! Builds .ccs packages from a manifest and source directory.
-//! Handles file scanning, explicit component assignment, and package creation.
-//! Supports Content-Defined Chunking (CDC) for efficient delta updates.
+//! The builder owns typed package assembly. Native source discovery lives in
+//! `builder/source.rs`, policy owns disk-backed transforms, and
+//! `builder/package_writer.rs` owns final streamed archive emission.
 
 use crate::ccs::chunking::{Chunker, MIN_CHUNK_SIZE};
 use crate::ccs::manifest::CcsManifest;
 use crate::ccs::policy::{PolicyAction, PolicyChain, PolicyError};
-use crate::hash;
-use crate::packages::traits::ExtractedFile;
-use crate::payload::{
-    PayloadContentAuthority, PayloadIdentity, PayloadNode, PayloadNodeKind, PayloadTimestamp,
-};
-use anyhow::Result;
+use crate::packages::payload::{PackagePayloadFile, ReopenablePayload};
+use crate::payload::PayloadContentAuthority;
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::os::unix::fs::{FileTypeExt, MetadataExt};
+use std::io::Read;
 use std::path::{Path, PathBuf};
-use walkdir::WalkDir;
+use std::sync::Arc;
 
 mod package_writer;
+mod source;
 
 pub use package_writer::{
     print_build_summary, write_signed_current_ccs_package, write_v2_ccs_package,
@@ -31,127 +29,202 @@ pub use package_writer::{
 #[cfg(test)]
 pub(crate) mod test_support;
 
-/// Typed errors for the CCS builder pipeline
+/// Typed errors for the CCS builder pipeline.
 #[derive(Debug, thiserror::Error)]
 pub enum BuilderError {
-    /// The manifest contains an invalid build-policy configuration.
     #[error(transparent)]
     PolicyConfiguration(#[from] PolicyError),
 
-    /// File is not under the expected source directory
     #[error("file not under source directory: {0}")]
     FileNotUnderSource(PathBuf),
 
-    /// A build policy rejected a file
     #[error("policy rejected file {path}: {reason}")]
     PolicyRejected { path: String, reason: String },
 
-    /// Chunker was expected but not initialized
     #[error("chunker not initialized even though chunking is enabled")]
     ChunkerNotInitialized,
 
-    /// I/O error during build (file read/write, directory creation)
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 }
 
-/// A file entry in a CCS package
+/// One signed file entry in a CCS package.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct FileEntry {
-    /// Installation path (absolute)
     pub path: String,
-    /// Exact POSIX node authority.
-    pub node: PayloadNode,
-    /// Content authority, present only for regular files.
+    pub node: crate::payload::PayloadNode,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content: Option<PayloadContentAuthority>,
-    /// Component assignment
     pub component: String,
-    /// Chunk hashes for CDC (if file is chunked)
-    /// When present, the file content is stored as chunks instead of a single blob.
-    /// Chunks are stored by their hash in objects/ and must be concatenated in order.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub chunks: Option<Vec<String>>,
 }
 
-/// Component data in a built package
+/// Component data in a built package.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ComponentData {
     pub name: String,
     pub files: Vec<FileEntry>,
-    /// Combined hash of all files in component (merkle-ish)
     pub hash: String,
-    /// Total size of component
     pub size: u64,
 }
 
-/// Result of building a CCS package
+/// Result of building a CCS package.
 #[derive(Debug)]
 pub struct BuildResult {
-    /// Package manifest with exact author and source-package metadata.
     pub manifest: CcsManifest,
-    /// Components with their files
     pub components: HashMap<String, ComponentData>,
-    /// All file entries
     pub files: Vec<FileEntry>,
-    /// Content blobs (hash -> content)
-    /// With CDC enabled, this contains chunks; without CDC, it contains whole files.
-    pub blobs: HashMap<String, Vec<u8>>,
-    /// Total package size
+    /// Reopenable content descriptors. No payload object is aggregated here.
+    pub payloads: Vec<PackagePayloadFile>,
     pub total_size: u64,
-    /// Whether CDC chunking was used
     pub chunked: bool,
-    /// CDC statistics (if chunking was used)
     pub chunk_stats: Option<ChunkStats>,
 }
 
-/// Statistics about CDC chunking in a build
+impl BuildResult {
+    /// Resolve the sole content descriptor for a signed regular-file path.
+    pub fn payload(&self, path: &str) -> Result<&PackagePayloadFile> {
+        let mut matches = self.payloads.iter().filter(|payload| payload.path == path);
+        let payload = matches
+            .next()
+            .with_context(|| format!("missing payload source for {path}"))?;
+        if matches.next().is_some() {
+            anyhow::bail!("payload source path {path} appears more than once");
+        }
+        Ok(payload)
+    }
+
+    /// Open a regular file and verify descriptor authority matches build state.
+    pub fn open_file(&self, file: &FileEntry) -> Result<Box<dyn Read + Send>> {
+        let payload = self.payload(&file.path)?;
+        if payload.node != file.node || payload.content_authority != file.content {
+            anyhow::bail!(
+                "payload descriptor authority disagrees with build entry {}",
+                file.path
+            );
+        }
+        payload.open_content().map_err(anyhow::Error::from)
+    }
+}
+
+/// Convert already-bounded test fixture blobs into the same reopenable source
+/// descriptors used by production authoring.
+///
+/// This is public only because workspace integration tests are separate
+/// crates. It rejects aggregate fixture input above the package-writer's fixed
+/// small-memory ceiling.
+#[doc(hidden)]
+pub fn payloads_from_bounded_memory_for_tests(
+    files: &[FileEntry],
+    blobs: HashMap<String, Vec<u8>>,
+) -> Result<Vec<PackagePayloadFile>> {
+    let total = blobs.values().try_fold(0_u64, |total, bytes| {
+        total
+            .checked_add(bytes.len() as u64)
+            .context("bounded in-memory CCS fixture size overflow")
+    })?;
+    if total > package_writer::BOUNDED_MEMORY_FIXTURE_BYTES {
+        anyhow::bail!(
+            "bounded in-memory CCS fixture input is {} bytes; limit is {} bytes",
+            total,
+            package_writer::BOUNDED_MEMORY_FIXTURE_BYTES
+        );
+    }
+    let blobs = blobs
+        .into_iter()
+        .map(|(hash, bytes)| (hash, Arc::<[u8]>::from(bytes)))
+        .collect::<HashMap<_, _>>();
+    let mut used = HashSet::new();
+    let mut payloads = Vec::with_capacity(files.len());
+    for file in files {
+        let source = if file.node.kind.is_regular() {
+            let authority = file.content.as_ref().with_context(|| {
+                format!(
+                    "regular fixture payload node {} has no content authority",
+                    file.path
+                )
+            })?;
+            let bytes = if let Some(chunks) = &file.chunks {
+                let capacity = usize::try_from(authority.size)
+                    .context("bounded fixture payload size exceeds usize")?;
+                let mut assembled = Vec::with_capacity(capacity);
+                for chunk in chunks {
+                    let bytes = blobs.get(chunk).with_context(|| {
+                        format!("missing bounded fixture chunk {chunk} for {}", file.path)
+                    })?;
+                    used.insert(chunk.as_str());
+                    assembled.extend_from_slice(bytes);
+                }
+                Arc::<[u8]>::from(assembled)
+            } else {
+                used.insert(authority.sha256.as_str());
+                Arc::clone(blobs.get(&authority.sha256).with_context(|| {
+                    format!("missing bounded fixture payload for {}", file.path)
+                })?)
+            };
+            if bytes.len() as u64 != authority.size
+                || crate::hash::sha256(&bytes) != authority.sha256
+            {
+                anyhow::bail!(
+                    "bounded fixture payload does not match authority for {}",
+                    file.path
+                );
+            }
+            Some(ReopenablePayload::from_in_memory_bytes(bytes))
+        } else {
+            None
+        };
+        payloads.push(
+            PackagePayloadFile::new(
+                file.path.clone(),
+                file.node.clone(),
+                file.content.clone(),
+                source,
+            )
+            .map_err(anyhow::Error::from)?,
+        );
+    }
+    if let Some(extra) = blobs.keys().find(|hash| !used.contains(hash.as_str())) {
+        anyhow::bail!("bounded fixture carries unreferenced payload object {extra}");
+    }
+    Ok(payloads)
+}
+
+/// Statistics from bounded FastCDC visits.
 #[derive(Debug, Clone, Default)]
 pub struct ChunkStats {
-    /// Number of files that were chunked
     pub chunked_files: usize,
-    /// Number of files stored as whole blobs (too small to chunk)
     pub whole_files: usize,
-    /// Total number of chunks created
     pub total_chunks: usize,
-    /// Number of unique chunks (after dedup within package)
     pub unique_chunks: usize,
-    /// Bytes saved by intra-package deduplication
     pub dedup_savings: u64,
 }
 
-/// CCS package builder
+/// Native CCS authoring builder.
 pub struct CcsBuilder {
     manifest: CcsManifest,
     source_dir: PathBuf,
     install_prefix: PathBuf,
     policy_chain: PolicyChain,
-    /// Enable CDC chunking for delta-efficient packages
     use_chunking: bool,
-    /// Chunker instance (created lazily if chunking is enabled)
     chunker: Option<Chunker>,
-    /// Exact source-package payload entries. When present, this is the
-    /// authority for explicit directories and entry kinds; the temporary
-    /// materialization tree is not rescanned for inferred parent directories.
-    package_entries: Option<Vec<ExtractedFile>>,
 }
 
-fn is_suspicious_component_executable(component: &str, node: &PayloadNode) -> bool {
+fn is_suspicious_component_executable(component: &str, node: &crate::payload::PayloadNode) -> bool {
     node.kind.is_regular()
         && node.mode & 0o111 != 0
         && matches!(component, "doc" | "config" | "data")
 }
 
 impl CcsBuilder {
-    /// Create a builder after compiling the complete manifest policy chain.
     pub fn new(
         manifest: CcsManifest,
         source_dir: &Path,
     ) -> std::result::Result<Self, BuilderError> {
         let policy_chain = PolicyChain::from_config(&manifest.policy)?;
-
         Ok(Self {
             manifest,
             source_dir: source_dir.to_path_buf(),
@@ -159,432 +232,201 @@ impl CcsBuilder {
             policy_chain,
             use_chunking: false,
             chunker: None,
-            package_entries: None,
         })
     }
 
-    /// Set the install prefix (default: /)
+    #[must_use]
     pub fn with_install_prefix(mut self, prefix: &Path) -> Self {
         self.install_prefix = prefix.to_path_buf();
         self
     }
 
-    /// Enable CDC chunking for delta-efficient packages
-    ///
-    /// When enabled, large files are split into content-defined chunks.
-    /// This enables efficient delta updates - clients only download
-    /// changed chunks instead of entire files.
+    #[must_use]
     pub fn with_chunking(mut self) -> Self {
         self.use_chunking = true;
         self.chunker = Some(Chunker::new());
         self
     }
 
-    /// Build from exact source-package payload entries instead of inferring
-    /// package structure from the materialized source tree.
-    pub fn with_package_entries(mut self, entries: &[ExtractedFile]) -> Self {
-        self.package_entries = Some(entries.to_vec());
-        self
-    }
-
-    /// Build the package
+    /// Build source-backed package authority without retaining payload bytes.
     pub fn build(&self) -> Result<BuildResult> {
         self.validate_component_contract()?;
-        // Phase 1: Collect files with content (before policies)
-        let mut raw_files: Vec<(PathBuf, FileEntry, Vec<u8>)> = Vec::new();
-        if let Some(package_entries) = &self.package_entries {
-            for package_entry in package_entries {
-                let source_path =
-                    crate::filesystem::safe_join(&self.source_dir, &package_entry.path)?;
-                let (entry, content) = self.collect_package_entry(package_entry)?;
-                raw_files.push((source_path, entry, content));
-            }
-        } else {
-            let mut hardlink_anchors = HashMap::new();
-            for source_path in self.scan_source_files()? {
-                let (entry, content) = self.collect_file(&source_path, &mut hardlink_anchors)?;
-                raw_files.push((source_path, entry, content));
-            }
-        }
+        let source_paths = self.scan_source_files()?;
+        let workspace_parent = self
+            .source_dir
+            .parent()
+            .unwrap_or(self.source_dir.as_path());
+        let policy_workspace = Arc::new(
+            tempfile::Builder::new()
+                .prefix(".conary-ccs-authoring-")
+                .tempdir_in(workspace_parent)
+                .with_context(|| {
+                    format!(
+                        "create CCS authoring workspace beside {}",
+                        self.source_dir.display()
+                    )
+                })?,
+        );
 
-        // Phase 2: Apply policies and optionally chunk files
-        let mut files = Vec::new();
-        let mut blobs = HashMap::new();
+        let mut hardlink_anchors = HashMap::new();
+        let mut files = Vec::with_capacity(source_paths.len());
+        let mut payloads = Vec::with_capacity(source_paths.len());
         let mut components: HashMap<String, Vec<FileEntry>> = HashMap::new();
         let mut chunk_stats = ChunkStats::default();
+        let mut unique_chunks = HashSet::new();
 
-        for (source_path, mut entry, content) in raw_files {
-            let (action, new_content) = self.policy_chain.apply(
-                &mut entry,
-                content,
+        for (index, source_path) in source_paths.into_iter().enumerate() {
+            let mut collected = self.collect_source(&source_path, &mut hardlink_anchors)?;
+            let entry_workspace = policy_workspace.path().join(format!("{index:08}"));
+            fs::create_dir(&entry_workspace)?;
+            let policy_action = self.policy_chain.apply(
+                &mut collected.entry,
                 &source_path,
+                &entry_workspace,
                 &self.manifest.policy,
             )?;
-            let final_content = match action {
-                PolicyAction::Skip => {
-                    continue;
+            if matches!(policy_action, PolicyAction::Skip) {
+                continue;
+            }
+            if let PolicyAction::Reject(reason) = policy_action {
+                return Err(BuilderError::PolicyRejected {
+                    path: collected.entry.path,
+                    reason,
                 }
-                PolicyAction::Reject(msg) => {
-                    return Err(BuilderError::PolicyRejected {
-                        path: entry.path.clone(),
-                        reason: msg,
+                .into());
+            }
+
+            let source = if collected.entry.node.kind.is_regular() {
+                let payload_source = match policy_action {
+                    PolicyAction::Replace(path) => {
+                        ReopenablePayload::from_spooled_path(path, Arc::clone(&policy_workspace))
                     }
-                    .into());
+                    PolicyAction::Keep => ReopenablePayload::from_path(source_path),
+                    PolicyAction::Skip | PolicyAction::Reject(_) => unreachable!(),
+                };
+                let authority = stream_content_authority(&payload_source)?;
+                collected.entry.content = Some(authority.clone());
+                if self.use_chunking && authority.size >= u64::from(MIN_CHUNK_SIZE) {
+                    self.visit_chunks(
+                        &mut collected.entry,
+                        &payload_source,
+                        authority.size,
+                        &mut chunk_stats,
+                        &mut unique_chunks,
+                    )?;
+                } else {
+                    chunk_stats.whole_files += 1;
                 }
-                PolicyAction::Keep => new_content,
-                PolicyAction::Replace(_) => {
-                    let content_authority = entry.content.as_mut().ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "policy attempted to replace non-regular payload node {}",
-                            entry.path
-                        )
-                    })?;
-                    content_authority.sha256 = hash::sha256(&new_content);
-                    content_authority.size = new_content.len() as u64;
-                    new_content
-                }
+                Some(payload_source)
+            } else {
+                None
             };
 
-            if is_suspicious_component_executable(&entry.component, &entry.node) {
+            collected.entry.node.validate()?;
+            collected
+                .entry
+                .node
+                .validate_content(collected.entry.content.as_ref())?;
+            if is_suspicious_component_executable(&collected.entry.component, &collected.entry.node)
+            {
                 tracing::warn!(
                     "Suspicious executable file {} assigned to '{}' component",
-                    entry.path,
-                    entry.component
+                    collected.entry.path,
+                    collected.entry.component
                 );
             }
-
-            // Phase 3: Store content (chunked or whole)
-            if !entry.node.kind.is_regular() {
-                if !final_content.is_empty() {
-                    anyhow::bail!(
-                        "non-regular payload node {} carries payload bytes",
-                        entry.path
-                    );
-                }
-            } else if self.use_chunking && self.should_chunk(&entry, &final_content) {
-                // Chunk the file
-                let chunker = self
-                    .chunker
-                    .as_ref()
-                    .ok_or(BuilderError::ChunkerNotInitialized)?;
-                let chunks = chunker.chunk_bytes(&final_content);
-
-                let mut chunk_hashes = Vec::with_capacity(chunks.len());
-                for chunk in &chunks {
-                    let chunk_hash = hex::encode(chunk.hash);
-                    chunk_hashes.push(chunk_hash.clone());
-                    chunk_stats.total_chunks += 1;
-
-                    // Store chunk (may deduplicate)
-                    use std::collections::hash_map::Entry;
-                    match blobs.entry(chunk_hash) {
-                        Entry::Vacant(e) => {
-                            e.insert(chunk.data.clone());
-                            chunk_stats.unique_chunks += 1;
-                        }
-                        Entry::Occupied(_) => {
-                            chunk_stats.dedup_savings += chunk.length as u64;
-                        }
-                    }
-                }
-
-                entry.chunks = Some(chunk_hashes);
-                chunk_stats.chunked_files += 1;
-            } else {
-                // Store as whole blob
-                let content_authority = entry.content.as_ref().ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "regular payload node {} has no content authority",
-                        entry.path
-                    )
-                })?;
-                blobs.insert(content_authority.sha256.clone(), final_content);
-                chunk_stats.whole_files += 1;
-            }
-
+            let payload = PackagePayloadFile::new(
+                collected.entry.path.clone(),
+                collected.entry.node.clone(),
+                collected.entry.content.clone(),
+                source,
+            )
+            .map_err(anyhow::Error::from)?;
             components
-                .entry(entry.component.clone())
+                .entry(collected.entry.component.clone())
                 .or_default()
-                .push(entry.clone());
-
-            files.push(entry);
+                .push(collected.entry.clone());
+            files.push(collected.entry);
+            payloads.push(payload);
         }
 
-        // Build component data
         let mut component_data = HashMap::new();
-        for (name, comp_files) in components {
-            let size: u64 = comp_files
+        for (name, component_files) in components {
+            let size = component_files
                 .iter()
                 .filter_map(|file| file.content.as_ref().map(|content| content.size))
                 .sum();
-            let hash = self.compute_component_hash(&comp_files);
-
+            let hash = self.compute_component_hash(&component_files);
             component_data.insert(
                 name.clone(),
                 ComponentData {
                     name,
-                    files: comp_files,
+                    files: component_files,
                     hash,
                     size,
                 },
             );
         }
-
         let total_size = files
             .iter()
             .filter_map(|file| file.content.as_ref().map(|content| content.size))
             .sum();
+        chunk_stats.unique_chunks = unique_chunks.len();
 
         Ok(BuildResult {
             manifest: self.manifest.clone(),
             components: component_data,
             files,
-            blobs,
+            payloads,
             total_size,
             chunked: self.use_chunking,
-            chunk_stats: if self.use_chunking {
-                Some(chunk_stats)
-            } else {
-                None
-            },
+            chunk_stats: self.use_chunking.then_some(chunk_stats),
         })
     }
 
-    /// Determine if a file should be chunked
-    ///
-    /// Files are chunked if:
-    /// - They are regular files (not symlinks/directories)
-    /// - They are larger than the minimum chunk size (16KB)
-    fn should_chunk(&self, entry: &FileEntry, content: &[u8]) -> bool {
-        if !entry.node.kind.is_regular() {
-            return false;
-        }
-
-        // Only chunk files larger than minimum chunk size
-        // (smaller files wouldn't benefit from CDC)
-        content.len() >= MIN_CHUNK_SIZE as usize
-    }
-
-    /// Collect a file's metadata and content without hashing
-    fn collect_file(
+    fn visit_chunks(
         &self,
-        source_path: &Path,
-        hardlink_anchors: &mut HashMap<(u64, u64), (String, String)>,
-    ) -> Result<(FileEntry, Vec<u8>)> {
-        // Calculate install path
-        let relative = source_path
-            .strip_prefix(&self.source_dir)
-            .map_err(|_| BuilderError::FileNotUnderSource(source_path.to_path_buf()))?;
-        let install_path = self.install_prefix.join(relative);
-        let install_path_str = install_path
-            .to_str()
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "CCS payload install path derived from {} is not valid UTF-8",
-                    source_path.display()
-                )
-            })?
-            .to_string();
-
-        // Get metadata
-        let metadata = fs::symlink_metadata(source_path)?;
-        let source_kind = metadata.file_type();
-        let xattrs = read_payload_xattrs(source_path)?;
-
-        // Determine file type and content from the filesystem's typed entry
-        // metadata, never from mode bits or target presence.
-        let (kind, content) = if source_kind.is_symlink() {
-            let target = fs::read_link(source_path)?;
-            let target = target.into_os_string().into_string().map_err(|_| {
-                anyhow::anyhow!(
-                    "payload symlink {} has a non-UTF-8 target",
-                    source_path.display()
-                )
-            })?;
-            (PayloadNodeKind::Symlink { target }, Vec::new())
-        } else if source_kind.is_dir() {
-            (PayloadNodeKind::Directory, Vec::new())
-        } else if source_kind.is_file() {
-            let hardlink_key = (metadata.dev(), metadata.ino());
-            if metadata.nlink() > 1
-                && let Some((target, identity)) = hardlink_anchors.get(&hardlink_key)
-            {
-                (
-                    PayloadNodeKind::Hardlink {
-                        target: target.clone(),
-                        identity: identity.clone(),
-                    },
-                    Vec::new(),
-                )
-            } else {
-                let hardlink_identity = (metadata.nlink() > 1).then(|| {
-                    let identity = format!("path:{install_path_str}");
-                    hardlink_anchors
-                        .insert(hardlink_key, (install_path_str.clone(), identity.clone()));
-                    identity
-                });
-                (
-                    PayloadNodeKind::Regular { hardlink_identity },
-                    fs::read(source_path)?,
-                )
+        entry: &mut FileEntry,
+        source: &ReopenablePayload,
+        expected_size: u64,
+        stats: &mut ChunkStats,
+        unique_chunks: &mut HashSet<String>,
+    ) -> Result<()> {
+        let chunker = self
+            .chunker
+            .as_ref()
+            .ok_or(BuilderError::ChunkerNotInitialized)?;
+        let mut chunk_hashes = Vec::new();
+        let processed = chunker.visit_reader_chunks(source.open()?, |chunk| {
+            let hash = chunk.hash_hex();
+            chunk_hashes.push(hash.clone());
+            stats.total_chunks += 1;
+            if !unique_chunks.insert(hash) {
+                stats.dedup_savings = stats
+                    .dedup_savings
+                    .checked_add(u64::from(chunk.length))
+                    .context("chunk deduplication savings overflow")?;
             }
-        } else if source_kind.is_block_device() {
-            let (major, minor) = payload_device_numbers(metadata.rdev());
-            (PayloadNodeKind::BlockDevice { major, minor }, Vec::new())
-        } else if source_kind.is_char_device() {
-            let (major, minor) = payload_device_numbers(metadata.rdev());
-            (
-                PayloadNodeKind::CharacterDevice { major, minor },
-                Vec::new(),
-            )
-        } else if source_kind.is_fifo() {
-            (PayloadNodeKind::Fifo, Vec::new())
-        } else if source_kind.is_socket() {
-            (PayloadNodeKind::Socket, Vec::new())
-        } else {
+            Ok(())
+        })?;
+        if processed != expected_size {
             anyhow::bail!(
-                "unsupported source payload entry kind at {}",
-                source_path.display()
+                "payload source size changed while chunking {}: expected {}, got {}",
+                entry.path,
+                expected_size,
+                processed
             );
-        };
-
-        let content_authority = kind.is_regular().then(|| PayloadContentAuthority {
-            sha256: hash::sha256(&content),
-            size: content.len() as u64,
-        });
-        let node = PayloadNode {
-            kind,
-            mode: metadata.mode(),
-            user: PayloadIdentity::Numeric {
-                id: u64::from(metadata.uid()),
-            },
-            group: PayloadIdentity::Numeric {
-                id: u64::from(metadata.gid()),
-            },
-            mtime: PayloadTimestamp {
-                seconds: metadata.mtime(),
-                nanoseconds: u32::try_from(metadata.mtime_nsec()).map_err(|_| {
-                    anyhow::anyhow!(
-                        "payload entry {} has invalid negative mtime nanoseconds",
-                        source_path.display()
-                    )
-                })?,
-            },
-            xattrs,
-        };
-        node.validate()?;
-        node.validate_content(content_authority.as_ref())?;
-
-        // Apply exact component assignment.
-        let component = self.component_for_path(&install_path_str)?;
-
-        let entry = FileEntry {
-            path: install_path_str,
-            node,
-            content: content_authority,
-            component,
-            chunks: None, // Set during build if chunking is enabled
-        };
-
-        Ok((entry, content))
-    }
-
-    fn collect_package_entry(&self, file: &ExtractedFile) -> Result<(FileEntry, Vec<u8>)> {
-        let relative = Path::new(&file.path)
-            .strip_prefix("/")
-            .unwrap_or_else(|_| Path::new(&file.path));
-        let install_path = self.install_prefix.join(relative);
-        let install_path_str = install_path
-            .to_str()
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "CCS payload install path derived from {} is not valid UTF-8",
-                    file.path
-                )
-            })?
-            .to_string();
-        file.node.validate()?;
-        file.node
-            .validate_content(file.content_authority.as_ref())?;
-        let content = if file.node.kind.is_regular() {
-            let authority = file.content_authority.as_ref().ok_or_else(|| {
-                anyhow::anyhow!(
-                    "regular payload entry {} has no content authority",
-                    file.path
-                )
-            })?;
-            if authority.size != file.content.len() as u64
-                || authority.sha256 != hash::sha256(&file.content)
-            {
-                anyhow::bail!(
-                    "regular payload entry {} content does not match its exact authority",
-                    file.path
-                );
-            }
-            file.content.clone()
-        } else {
-            if !file.content.is_empty() {
-                anyhow::bail!("non-regular payload entry {} carries content", file.path);
-            }
-            Vec::new()
-        };
-
-        let component = self.component_for_path(&install_path_str)?;
-        Ok((
-            FileEntry {
-                path: install_path_str,
-                node: file.node.clone(),
-                content: file.content_authority.clone(),
-                component,
-                chunks: None,
-            },
-            content,
-        ))
-    }
-
-    /// Scan source directory for all explicit entries.
-    fn scan_source_files(&self) -> Result<Vec<PathBuf>> {
-        let mut files = Vec::new();
-
-        for entry in WalkDir::new(&self.source_dir) {
-            let entry = entry.map_err(|error| {
-                anyhow::anyhow!(
-                    "failed to scan complete CCS source authority at {}: {error}",
-                    self.source_dir.display()
-                )
-            })?;
-            let path = entry.path();
-
-            // Skip the source directory itself
-            if path == self.source_dir {
-                continue;
-            }
-
-            // Skip manifest files - these are metadata, not package content
-            if let Some(file_name) = path.file_name().and_then(|n| n.to_str())
-                && (file_name == "ccs.toml" || file_name == "MANIFEST.toml")
-            {
-                continue;
-            }
-
-            files.push(path.to_path_buf());
         }
-
-        files.sort();
-        Ok(files)
+        entry.chunks = Some(chunk_hashes);
+        stats.chunked_files += 1;
+        Ok(())
     }
 
-    /// Resolve a file's explicit author-owned component assignment.
-    ///
-    /// Exact path declarations take precedence over author-declared glob
-    /// grammar. A path without either declaration belongs to the single
-    /// lossless runtime component; Conary never guesses from its filename.
     fn component_for_path(&self, path: &str) -> Result<String> {
-        if let Some(comp) = self.manifest.components.files.get(path) {
-            return Ok(comp.clone());
+        if let Some(component) = self.manifest.components.files.get(path) {
+            return Ok(component.clone());
         }
-
-        let mut matched_component: Option<&str> = None;
+        let mut matched_component = None;
         for rule in &self.manifest.components.rules {
             let pattern = glob::Pattern::new(&rule.path).map_err(|error| {
                 anyhow::anyhow!("invalid components.rules pattern '{}': {error}", rule.path)
@@ -600,9 +442,8 @@ impl CcsBuilder {
                     rule.component
                 );
             }
-            matched_component = Some(&rule.component);
+            matched_component = Some(rule.component.as_str());
         }
-
         Ok(matched_component.unwrap_or("runtime").to_string())
     }
 
@@ -626,7 +467,6 @@ impl CcsBuilder {
         Ok(())
     }
 
-    /// Compute a combined hash for a component
     fn compute_component_hash(&self, files: &[FileEntry]) -> String {
         let mut hasher = crate::hash::Hasher::new(crate::hash::HashAlgorithm::Sha256);
         for file in files {
@@ -639,319 +479,27 @@ impl CcsBuilder {
     }
 }
 
-fn read_payload_xattrs(path: &Path) -> Result<BTreeMap<String, Vec<u8>>> {
-    let mut attributes = BTreeMap::new();
-    for name in xattr::list(path)? {
-        let name = name.into_string().map_err(|_| {
-            anyhow::anyhow!(
-                "payload entry {} has a non-UTF-8 xattr name",
-                path.display()
-            )
-        })?;
-        let value = xattr::get(path, &name)?.ok_or_else(|| {
-            anyhow::anyhow!(
-                "payload xattr {} disappeared while reading {}",
-                name,
-                path.display()
-            )
-        })?;
-        attributes.insert(name, value);
+fn stream_content_authority(source: &ReopenablePayload) -> Result<PayloadContentAuthority> {
+    let mut reader = source.open()?;
+    let mut hasher = crate::hash::Hasher::new(crate::hash::HashAlgorithm::Sha256);
+    let mut size = 0_u64;
+    let mut buffer = [0_u8; crate::packages::payload::PAYLOAD_IO_BUFFER_SIZE];
+    loop {
+        let count = reader.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+        size = size
+            .checked_add(count as u64)
+            .context("payload source size overflow")?;
     }
-    Ok(attributes)
-}
-
-fn payload_device_numbers(device: u64) -> (u64, u64) {
-    (nix::sys::stat::major(device), nix::sys::stat::minor(device))
+    Ok(PayloadContentAuthority {
+        sha256: hasher.finalize().value,
+        size,
+    })
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::TempDir;
-
-    fn create_test_manifest() -> CcsManifest {
-        CcsManifest::new_minimal("test-package", "1.0.0")
-    }
-
-    #[test]
-    fn test_builder_empty_dir() {
-        let temp_dir = TempDir::new().unwrap();
-        let manifest = create_test_manifest();
-
-        let builder = CcsBuilder::new(manifest, temp_dir.path()).unwrap();
-        let result = builder.build().unwrap();
-
-        assert!(result.files.is_empty());
-        assert!(result.components.is_empty());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn builder_rejects_an_incomplete_source_walk() {
-        use std::os::unix::fs::PermissionsExt;
-
-        // A privileged process can traverse mode-000 directories, so this
-        // permission-boundary proof applies only when the kernel enforces the
-        // unreadable directory for the current test process.
-        if unsafe { libc::geteuid() } == 0 {
-            return;
-        }
-
-        let temp_dir = TempDir::new().unwrap();
-        fs::write(
-            temp_dir.path().join("visible"),
-            b"must not become a partial package",
-        )
-        .unwrap();
-        let unreadable = temp_dir.path().join("unreadable");
-        fs::create_dir(&unreadable).unwrap();
-        fs::write(unreadable.join("hidden"), b"exact authority").unwrap();
-        fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o0)).unwrap();
-
-        let result = CcsBuilder::new(create_test_manifest(), temp_dir.path())
-            .unwrap()
-            .build();
-
-        // Restore access before TempDir cleanup.
-        fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o700)).unwrap();
-        let error = result.expect_err("an unreadable subtree must abort the CCS build");
-        assert!(
-            error
-                .to_string()
-                .contains("failed to scan complete CCS source authority"),
-            "{error:#}"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn builder_rejects_non_utf8_payload_paths_without_renaming_them() {
-        use std::ffi::OsString;
-        use std::os::unix::ffi::OsStringExt;
-
-        let temp_dir = TempDir::new().unwrap();
-        let invalid_name = OsString::from_vec(vec![b'p', b'a', b'y', b'l', b'o', b'a', b'd', 0xff]);
-        fs::write(temp_dir.path().join(invalid_name), b"exact bytes").unwrap();
-
-        let error = CcsBuilder::new(create_test_manifest(), temp_dir.path())
-            .unwrap()
-            .build()
-            .expect_err("a non-UTF-8 payload path must not be signed under a lossy name");
-        assert!(
-            error.to_string().contains("is not valid UTF-8"),
-            "{error:#}"
-        );
-    }
-
-    #[test]
-    fn invalid_policy_configuration_fails_builder_construction() {
-        let temp_dir = TempDir::new().unwrap();
-        let mut manifest = create_test_manifest();
-        manifest.policy.reject_paths = vec!["[".to_string()];
-
-        let error = match CcsBuilder::new(manifest, temp_dir.path()) {
-            Ok(_) => panic!("invalid policy configuration must not create a builder"),
-            Err(error) => error,
-        };
-        assert!(matches!(
-            error,
-            BuilderError::PolicyConfiguration(PolicyError::Config(_))
-        ));
-    }
-
-    #[test]
-    fn builder_always_applies_mandatory_setuid_policy() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let temp_dir = TempDir::new().unwrap();
-        let bin_dir = temp_dir.path().join("usr/bin");
-        fs::create_dir_all(&bin_dir).unwrap();
-        let helper = bin_dir.join("helper");
-        fs::write(&helper, b"#!/bin/sh\n").unwrap();
-        fs::set_permissions(&helper, fs::Permissions::from_mode(0o6755)).unwrap();
-
-        let result = CcsBuilder::new(create_test_manifest(), temp_dir.path())
-            .unwrap()
-            .build()
-            .unwrap();
-        let helper = result
-            .files
-            .iter()
-            .find(|entry| entry.path == "/usr/bin/helper")
-            .unwrap();
-        assert_eq!(helper.node.mode & 0o6000, 0);
-    }
-
-    #[test]
-    fn payload_authority_types_reject_unknown_fields() {
-        let file = FileEntry {
-            path: "/usr/bin/example".to_string(),
-            node: PayloadNode::regular(0o755),
-            content: None,
-            component: "runtime".to_string(),
-            chunks: None,
-        };
-        let mut file_value = serde_json::to_value(&file).unwrap();
-        file_value
-            .as_object_mut()
-            .unwrap()
-            .insert("invented_authority".to_string(), serde_json::json!(true));
-        assert!(serde_json::from_value::<FileEntry>(file_value).is_err());
-
-        let component = ComponentData {
-            name: "runtime".to_string(),
-            files: vec![file],
-            hash: "sha256:test".to_string(),
-            size: 0,
-        };
-        let mut component_value = serde_json::to_value(&component).unwrap();
-        component_value
-            .as_object_mut()
-            .unwrap()
-            .insert("invented_authority".to_string(), serde_json::json!(true));
-        assert!(serde_json::from_value::<ComponentData>(component_value).is_err());
-    }
-
-    #[test]
-    fn test_builder_single_file() {
-        let temp_dir = TempDir::new().unwrap();
-
-        // Create a test file
-        let bin_dir = temp_dir.path().join("usr/bin");
-        fs::create_dir_all(&bin_dir).unwrap();
-        fs::write(bin_dir.join("myapp"), b"#!/bin/bash\necho hello").unwrap();
-
-        let manifest = create_test_manifest();
-        let builder = CcsBuilder::new(manifest, temp_dir.path()).unwrap();
-        let result = builder.build().unwrap();
-
-        let files = result
-            .files
-            .iter()
-            .filter(|entry| entry.node.kind.is_regular())
-            .collect::<Vec<_>>();
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].path, "/usr/bin/myapp");
-        assert_eq!(files[0].component, "runtime");
-    }
-
-    #[test]
-    fn builder_does_not_infer_components_from_payload_paths() {
-        let temp_dir = TempDir::new().unwrap();
-
-        // Create files in different categories
-        let dirs = [
-            ("usr/bin", "myapp"),
-            ("usr/lib", "libfoo.so.1"),
-            ("usr/include", "foo.h"),
-            ("etc/myapp", "config.conf"),
-            ("usr/share/doc/myapp", "README"),
-        ];
-
-        for (dir, file) in &dirs {
-            let path = temp_dir.path().join(dir);
-            fs::create_dir_all(&path).unwrap();
-            fs::write(path.join(file), b"test content").unwrap();
-        }
-
-        let manifest = create_test_manifest();
-        let builder = CcsBuilder::new(manifest, temp_dir.path()).unwrap();
-        let result = builder.build().unwrap();
-
-        let payload_files = result
-            .files
-            .iter()
-            .filter(|entry| entry.node.kind.is_regular())
-            .collect::<Vec<_>>();
-        assert_eq!(payload_files.len(), 5);
-        assert!(
-            payload_files
-                .iter()
-                .all(|entry| entry.component == "runtime")
-        );
-        assert_eq!(result.components.len(), 1);
-        assert!(result.components.contains_key("runtime"));
-    }
-
-    #[test]
-    fn test_builder_file_override() {
-        let temp_dir = TempDir::new().unwrap();
-
-        // Create a test file
-        let bin_dir = temp_dir.path().join("usr/bin");
-        fs::create_dir_all(&bin_dir).unwrap();
-        fs::write(bin_dir.join("helper"), b"helper script").unwrap();
-
-        // Create manifest with override
-        let mut manifest = create_test_manifest();
-        manifest
-            .components
-            .files
-            .insert("/usr/bin/helper".to_string(), "lib".to_string());
-
-        let builder = CcsBuilder::new(manifest, temp_dir.path()).unwrap();
-        let result = builder.build().unwrap();
-
-        let helper = result
-            .files
-            .iter()
-            .find(|entry| entry.path == "/usr/bin/helper")
-            .unwrap();
-        assert_eq!(helper.component, "lib");
-    }
-
-    #[test]
-    fn test_builder_symlink() {
-        let temp_dir = TempDir::new().unwrap();
-
-        // Create a file and symlink
-        let lib_dir = temp_dir.path().join("usr/lib");
-        fs::create_dir_all(&lib_dir).unwrap();
-        fs::write(lib_dir.join("libfoo.so.1.0.0"), b"library content").unwrap();
-
-        #[cfg(unix)]
-        std::os::unix::fs::symlink("libfoo.so.1.0.0", lib_dir.join("libfoo.so.1")).unwrap();
-
-        let manifest = create_test_manifest();
-        let builder = CcsBuilder::new(manifest, temp_dir.path()).unwrap();
-        let result = builder.build().unwrap();
-
-        #[cfg(unix)]
-        {
-            let symlink = result
-                .files
-                .iter()
-                .find(|f| f.path == "/usr/lib/libfoo.so.1")
-                .unwrap();
-            assert_eq!(
-                symlink.node.kind,
-                PayloadNodeKind::Symlink {
-                    target: "libfoo.so.1.0.0".to_string()
-                }
-            );
-        }
-    }
-
-    #[test]
-    fn test_suspicious_executable_component_audit_targets_doc_config_and_data() {
-        let executable = PayloadNode::regular(0o755);
-        for component in ["doc", "config", "data"] {
-            assert!(
-                is_suspicious_component_executable(component, &executable),
-                "{component} executables should be flagged as suspicious"
-            );
-        }
-
-        assert!(!is_suspicious_component_executable("runtime", &executable));
-        assert!(!is_suspicious_component_executable(
-            "doc",
-            &PayloadNode::regular(0o644)
-        ));
-        let mut symlink = PayloadNode::regular(0o755);
-        symlink.kind = PayloadNodeKind::Symlink {
-            target: "target".to_string(),
-        };
-        symlink.mode = libc::S_IFLNK | 0o755;
-        assert!(!is_suspicious_component_executable("doc", &symlink));
-    }
-}
+#[path = "builder/tests.rs"]
+mod tests;

--- a/crates/conary-core/src/ccs/builder.rs
+++ b/crates/conary-core/src/ccs/builder.rs
@@ -121,15 +121,27 @@ pub fn payloads_from_bounded_memory_for_tests(
     files: &[FileEntry],
     blobs: HashMap<String, Vec<u8>>,
 ) -> Result<Vec<PackagePayloadFile>> {
-    let total = blobs.values().try_fold(0_u64, |total, bytes| {
+    let input_total = blobs.values().try_fold(0_u64, |total, bytes| {
         total
             .checked_add(bytes.len() as u64)
             .context("bounded in-memory CCS fixture size overflow")
     })?;
-    if total > package_writer::BOUNDED_MEMORY_FIXTURE_BYTES {
+    if input_total > package_writer::BOUNDED_MEMORY_FIXTURE_BYTES {
         anyhow::bail!(
             "bounded in-memory CCS fixture input is {} bytes; limit is {} bytes",
-            total,
+            input_total,
+            package_writer::BOUNDED_MEMORY_FIXTURE_BYTES
+        );
+    }
+    let retained_total = files.iter().try_fold(0_u64, |total, file| {
+        total
+            .checked_add(file.content.as_ref().map_or(0, |authority| authority.size))
+            .context("bounded in-memory CCS fixture retained size overflow")
+    })?;
+    if retained_total > package_writer::BOUNDED_MEMORY_FIXTURE_BYTES {
+        anyhow::bail!(
+            "bounded in-memory CCS fixture would retain {} payload bytes; limit is {} bytes",
+            retained_total,
             package_writer::BOUNDED_MEMORY_FIXTURE_BYTES
         );
     }

--- a/crates/conary-core/src/ccs/builder.rs
+++ b/crates/conary-core/src/ccs/builder.rs
@@ -22,8 +22,8 @@ mod package_writer;
 mod source;
 
 pub use package_writer::{
-    print_build_summary, write_signed_current_ccs_package, write_v2_ccs_package,
-    write_v2_ccs_package_from_sources,
+    print_build_summary, write_signed_current_ccs_package,
+    write_v2_ccs_package_from_bounded_memory_for_tests, write_v2_ccs_package_from_sources,
 };
 
 #[cfg(test)]

--- a/crates/conary-core/src/ccs/builder/package_writer.rs
+++ b/crates/conary-core/src/ccs/builder/package_writer.rs
@@ -12,16 +12,16 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::sync::Arc;
 
-/// Explicit ceiling for legacy test and small-tool in-memory fixture input.
+/// Explicit ceiling for test-only in-memory fixture input.
 ///
 /// Native authoring and foreign conversion do not use this adapter. It exists
-/// only for callers that already constructed small byte fixtures, immediately
+/// only for tests that already constructed small byte fixtures, immediately
 /// spools those bytes to reopenable files, and delegates to the sole streamed
 /// package writer.
-pub const BOUNDED_MEMORY_FIXTURE_BYTES: u64 = 16 * 1024 * 1024;
+pub(super) const BOUNDED_MEMORY_FIXTURE_BYTES: u64 = 16 * 1024 * 1024;
 
 #[doc(hidden)]
-pub fn write_v2_ccs_package(
+pub fn write_v2_ccs_package_from_bounded_memory_for_tests(
     authority: &crate::ccs::v2::AuthorityDocumentV2,
     payloads_by_path: &std::collections::BTreeMap<String, Vec<u8>>,
     output_path: &Path,
@@ -421,7 +421,7 @@ mod tests {
         let payloads = crate::ccs::v2::test_support::one_file_payloads_for_tests();
         let key = crate::ccs::signing::SigningKeyPair::generate();
 
-        write_v2_ccs_package(
+        write_v2_ccs_package_from_bounded_memory_for_tests(
             &authority,
             &payloads,
             &path,
@@ -451,7 +451,10 @@ mod tests {
         let authority = crate::ccs::v2::test_support::package_authority_with_one_file("nodup");
         let payloads = crate::ccs::v2::test_support::one_file_payloads_for_tests();
         let key = crate::ccs::signing::SigningKeyPair::generate();
-        write_v2_ccs_package(&authority, &payloads, &path, &key, None, None, None).unwrap();
+        write_v2_ccs_package_from_bounded_memory_for_tests(
+            &authority, &payloads, &path, &key, None, None, None,
+        )
+        .unwrap();
 
         let mut archive =
             tar::Archive::new(flate2::read::GzDecoder::new(fs::File::open(&path).unwrap()));

--- a/crates/conary-core/src/ccs/builder/package_writer.rs
+++ b/crates/conary-core/src/ccs/builder/package_writer.rs
@@ -10,7 +10,17 @@ use anyhow::{Context, Result};
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
+use std::sync::Arc;
 
+/// Explicit ceiling for legacy test and small-tool in-memory fixture input.
+///
+/// Native authoring and foreign conversion do not use this adapter. It exists
+/// only for callers that already constructed small byte fixtures, immediately
+/// spools those bytes to reopenable files, and delegates to the sole streamed
+/// package writer.
+pub const BOUNDED_MEMORY_FIXTURE_BYTES: u64 = 16 * 1024 * 1024;
+
+#[doc(hidden)]
 pub fn write_v2_ccs_package(
     authority: &crate::ccs::v2::AuthorityDocumentV2,
     payloads_by_path: &std::collections::BTreeMap<String, Vec<u8>>,
@@ -20,19 +30,74 @@ pub fn write_v2_ccs_package(
     build_attestation: Option<&crate::ccs::attestation::BuildAttestationEnvelope>,
     foreign_conversion_boundary: Option<&crate::ccs::attestation::ForeignConversionBoundary>,
 ) -> Result<()> {
-    write_v2_ccs_package_with_open(
+    use crate::ccs::v2::schema::PackageKindV2;
+    use crate::packages::payload::{PackagePayloadFile, ReopenablePayload};
+
+    let total = payloads_by_path.values().try_fold(0_u64, |total, bytes| {
+        total
+            .checked_add(bytes.len() as u64)
+            .context("bounded in-memory CCS fixture size overflow")
+    })?;
+    if total > BOUNDED_MEMORY_FIXTURE_BYTES {
+        anyhow::bail!(
+            "bounded in-memory CCS fixture input is {} bytes; limit is {} bytes",
+            total,
+            BOUNDED_MEMORY_FIXTURE_BYTES
+        );
+    }
+    let output_parent = output_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let spool = Arc::new(
+        tempfile::Builder::new()
+            .prefix(".conary-ccs-memory-fixture-")
+            .tempdir_in(output_parent)?,
+    );
+    let PackageKindV2::Package(package) = &authority.kind else {
+        anyhow::bail!("v2 package writer only writes package payloads");
+    };
+    let mut payloads = Vec::with_capacity(package.files.len());
+    let mut expected_paths = std::collections::HashSet::new();
+    for (index, file) in package.files.iter().enumerate() {
+        let source = if file.node.kind.is_regular() {
+            let bytes = payloads_by_path
+                .get(&file.path)
+                .with_context(|| format!("missing payload for {}", file.path))?;
+            let path = spool.path().join(format!("{index:08}"));
+            fs::write(&path, bytes)?;
+            expected_paths.insert(file.path.as_str());
+            Some(ReopenablePayload::from_spooled_path(
+                path,
+                Arc::clone(&spool),
+            ))
+        } else {
+            None
+        };
+        payloads.push(
+            PackagePayloadFile::new(
+                file.path.clone(),
+                file.node.clone(),
+                file.content.clone(),
+                source,
+            )
+            .map_err(anyhow::Error::from)?,
+        );
+    }
+    if let Some(extra) = payloads_by_path
+        .keys()
+        .find(|path| !expected_paths.contains(path.as_str()))
+    {
+        anyhow::bail!("in-memory fixture carries unsigned payload path {extra}");
+    }
+    write_v2_ccs_package_from_sources(
         authority,
+        &payloads,
         output_path,
         signing_key,
         debug_toml,
         build_attestation,
         foreign_conversion_boundary,
-        |path| {
-            let payload = payloads_by_path
-                .get(path)
-                .with_context(|| format!("missing payload for {path}"))?;
-            Ok(Box::new(std::io::Cursor::new(payload.as_slice())) as Box<dyn std::io::Read>)
-        },
     )
 }
 
@@ -90,7 +155,13 @@ fn write_v2_ccs_package_with_open<'a>(
     // construction rather than by coincidence.
     let census =
         crate::ccs::v2::authority_census(authority).map_err(|error| anyhow::anyhow!("{error}"))?;
-    let temp_dir = tempfile::tempdir()?;
+    let output_parent = output_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let temp_dir = tempfile::Builder::new()
+        .prefix(".conary-ccs-package-")
+        .tempdir_in(output_parent)?;
     let manifest_cbor = authority.to_cbor()?;
     CCS_BUDGET.admit_encoded_authority(&census, manifest_cbor.len() as u64)?;
     fs::write(temp_dir.path().join("MANIFEST"), &manifest_cbor)?;
@@ -199,9 +270,9 @@ pub fn write_signed_current_ccs_package(
     })
     .context("project current CCS v2 authority")?;
     let provenance = result.manifest.provenance.as_ref();
-    write_v2_ccs_package(
+    write_v2_ccs_package_from_sources(
         &projected.authority,
-        &projected.payloads_by_path,
+        &projected.payloads,
         output_path,
         signing_key,
         projected.debug_toml.as_deref(),
@@ -222,7 +293,14 @@ pub fn print_build_summary(result: &BuildResult) {
     );
     println!("Total files: {}", result.files.len());
     println!("Total size: {} bytes", result.total_size);
-    println!("Blobs: {} objects", result.blobs.len());
+    println!(
+        "Payload sources: {} regular files",
+        result
+            .payloads
+            .iter()
+            .filter(|payload| payload.node.kind.is_regular())
+            .count()
+    );
 
     if let Some(ref stats) = result.chunk_stats {
         println!();

--- a/crates/conary-core/src/ccs/builder/source.rs
+++ b/crates/conary-core/src/ccs/builder/source.rs
@@ -1,0 +1,168 @@
+// conary-core/src/ccs/builder/source.rs
+//! Native filesystem discovery and exact node-authority collection.
+
+use super::{BuilderError, CcsBuilder, FileEntry};
+use crate::payload::{PayloadIdentity, PayloadNode, PayloadNodeKind, PayloadTimestamp};
+use anyhow::Result;
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+pub(super) struct CollectedSource {
+    pub(super) entry: FileEntry,
+}
+
+impl CcsBuilder {
+    pub(super) fn collect_source(
+        &self,
+        source_path: &Path,
+        hardlink_anchors: &mut HashMap<(u64, u64), (String, String)>,
+    ) -> Result<CollectedSource> {
+        let relative = source_path
+            .strip_prefix(&self.source_dir)
+            .map_err(|_| BuilderError::FileNotUnderSource(source_path.to_path_buf()))?;
+        let install_path = self.install_prefix.join(relative);
+        let install_path_text = install_path
+            .to_str()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "CCS payload install path derived from {} is not valid UTF-8",
+                    source_path.display()
+                )
+            })?
+            .to_string();
+        let metadata = fs::symlink_metadata(source_path)?;
+        let source_kind = metadata.file_type();
+        let xattrs = read_payload_xattrs(source_path)?;
+
+        let kind = if source_kind.is_symlink() {
+            let target = fs::read_link(source_path)?;
+            let target = target.into_os_string().into_string().map_err(|_| {
+                anyhow::anyhow!(
+                    "payload symlink {} has a non-UTF-8 target",
+                    source_path.display()
+                )
+            })?;
+            PayloadNodeKind::Symlink { target }
+        } else if source_kind.is_dir() {
+            PayloadNodeKind::Directory
+        } else if source_kind.is_file() {
+            let hardlink_key = (metadata.dev(), metadata.ino());
+            if metadata.nlink() > 1
+                && let Some((target, identity)) = hardlink_anchors.get(&hardlink_key)
+            {
+                PayloadNodeKind::Hardlink {
+                    target: target.clone(),
+                    identity: identity.clone(),
+                }
+            } else {
+                let hardlink_identity = (metadata.nlink() > 1).then(|| {
+                    let identity = format!("path:{install_path_text}");
+                    hardlink_anchors
+                        .insert(hardlink_key, (install_path_text.clone(), identity.clone()));
+                    identity
+                });
+                PayloadNodeKind::Regular { hardlink_identity }
+            }
+        } else if source_kind.is_block_device() {
+            let (major, minor) = payload_device_numbers(metadata.rdev());
+            PayloadNodeKind::BlockDevice { major, minor }
+        } else if source_kind.is_char_device() {
+            let (major, minor) = payload_device_numbers(metadata.rdev());
+            PayloadNodeKind::CharacterDevice { major, minor }
+        } else if source_kind.is_fifo() {
+            PayloadNodeKind::Fifo
+        } else if source_kind.is_socket() {
+            PayloadNodeKind::Socket
+        } else {
+            anyhow::bail!(
+                "unsupported source payload entry kind at {}",
+                source_path.display()
+            );
+        };
+        let node = PayloadNode {
+            kind,
+            mode: metadata.mode(),
+            user: PayloadIdentity::Numeric {
+                id: u64::from(metadata.uid()),
+            },
+            group: PayloadIdentity::Numeric {
+                id: u64::from(metadata.gid()),
+            },
+            mtime: PayloadTimestamp {
+                seconds: metadata.mtime(),
+                nanoseconds: u32::try_from(metadata.mtime_nsec()).map_err(|_| {
+                    anyhow::anyhow!(
+                        "payload entry {} has invalid negative mtime nanoseconds",
+                        source_path.display()
+                    )
+                })?,
+            },
+            xattrs,
+        };
+        node.validate()?;
+        let component = self.component_for_path(&install_path_text)?;
+        Ok(CollectedSource {
+            entry: FileEntry {
+                path: install_path_text,
+                node,
+                content: None,
+                component,
+                chunks: None,
+            },
+        })
+    }
+
+    pub(super) fn scan_source_files(&self) -> Result<Vec<PathBuf>> {
+        let mut files = Vec::new();
+        for entry in WalkDir::new(&self.source_dir) {
+            let entry = entry.map_err(|error| {
+                anyhow::anyhow!(
+                    "failed to scan complete CCS source authority at {}: {error}",
+                    self.source_dir.display()
+                )
+            })?;
+            let path = entry.path();
+            if path == self.source_dir {
+                continue;
+            }
+            if path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| matches!(name, "ccs.toml" | "MANIFEST.toml"))
+            {
+                continue;
+            }
+            files.push(path.to_path_buf());
+        }
+        files.sort();
+        Ok(files)
+    }
+}
+
+fn read_payload_xattrs(path: &Path) -> Result<BTreeMap<String, Vec<u8>>> {
+    let mut attributes = BTreeMap::new();
+    for name in xattr::list(path)? {
+        let name = name.into_string().map_err(|_| {
+            anyhow::anyhow!(
+                "payload entry {} has a non-UTF-8 xattr name",
+                path.display()
+            )
+        })?;
+        let value = xattr::get(path, &name)?.ok_or_else(|| {
+            anyhow::anyhow!(
+                "payload xattr {} disappeared while reading {}",
+                name,
+                path.display()
+            )
+        })?;
+        attributes.insert(name, value);
+    }
+    Ok(attributes)
+}
+
+fn payload_device_numbers(device: u64) -> (u64, u64) {
+    (nix::sys::stat::major(device), nix::sys::stat::minor(device))
+}

--- a/crates/conary-core/src/ccs/builder/test_support.rs
+++ b/crates/conary-core/src/ccs/builder/test_support.rs
@@ -28,6 +28,17 @@ pub(crate) fn single_file_build_result_at(
         component: "runtime".to_string(),
         chunks: None,
     };
+    let payload = crate::packages::payload::PackagePayloadFile::new(
+        path.to_string(),
+        entry.node.clone(),
+        entry.content.clone(),
+        Some(
+            crate::packages::payload::ReopenablePayload::from_in_memory_bytes(
+                std::sync::Arc::<[u8]>::from(bytes),
+            ),
+        ),
+    )
+    .unwrap();
     BuildResult {
         manifest,
         components: HashMap::from([(
@@ -40,7 +51,7 @@ pub(crate) fn single_file_build_result_at(
             },
         )]),
         files: vec![entry],
-        blobs: HashMap::from([(hash, bytes.to_vec())]),
+        payloads: vec![payload],
         total_size: bytes.len() as u64,
         chunked: false,
         chunk_stats: None,

--- a/crates/conary-core/src/ccs/builder/tests.rs
+++ b/crates/conary-core/src/ccs/builder/tests.rs
@@ -1,0 +1,284 @@
+// conary-core/src/ccs/builder/tests.rs
+
+use super::*;
+use crate::payload::PayloadNodeKind;
+use std::io::Write;
+use tempfile::TempDir;
+
+fn create_test_manifest() -> CcsManifest {
+    CcsManifest::new_minimal("test-package", "1.0.0")
+}
+
+#[test]
+fn builder_empty_dir() {
+    let source = TempDir::new().unwrap();
+    let result = CcsBuilder::new(create_test_manifest(), source.path())
+        .unwrap()
+        .build()
+        .unwrap();
+    assert!(result.files.is_empty());
+    assert!(result.payloads.is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn builder_rejects_an_incomplete_source_walk() {
+    use std::os::unix::fs::PermissionsExt;
+    if unsafe { libc::geteuid() } == 0 {
+        return;
+    }
+    let source = TempDir::new().unwrap();
+    let unreadable = source.path().join("unreadable");
+    fs::create_dir(&unreadable).unwrap();
+    fs::write(unreadable.join("hidden"), b"exact authority").unwrap();
+    fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o0)).unwrap();
+    let result = CcsBuilder::new(create_test_manifest(), source.path())
+        .unwrap()
+        .build();
+    fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o700)).unwrap();
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("failed to scan complete CCS source authority")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn builder_rejects_non_utf8_payload_paths_without_renaming_them() {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+    let source = TempDir::new().unwrap();
+    fs::write(
+        source
+            .path()
+            .join(OsString::from_vec(vec![b'p', b'a', b'y', 0xff])),
+        b"exact bytes",
+    )
+    .unwrap();
+    let error = CcsBuilder::new(create_test_manifest(), source.path())
+        .unwrap()
+        .build()
+        .unwrap_err();
+    assert!(error.to_string().contains("is not valid UTF-8"));
+}
+
+#[test]
+fn invalid_policy_configuration_fails_builder_construction() {
+    let source = TempDir::new().unwrap();
+    let mut manifest = create_test_manifest();
+    manifest.policy.reject_paths = vec!["[".to_string()];
+    let error = match CcsBuilder::new(manifest, source.path()) {
+        Ok(_) => panic!("invalid policy configuration must fail"),
+        Err(error) => error,
+    };
+    assert!(matches!(
+        error,
+        BuilderError::PolicyConfiguration(PolicyError::Config(_))
+    ));
+}
+
+#[test]
+fn builder_streams_regular_source_authority() {
+    let source = TempDir::new().unwrap();
+    fs::create_dir_all(source.path().join("usr/bin")).unwrap();
+    fs::write(source.path().join("usr/bin/myapp"), b"#!/bin/sh\necho hi\n").unwrap();
+    let result = CcsBuilder::new(create_test_manifest(), source.path())
+        .unwrap()
+        .build()
+        .unwrap();
+    let entry = result
+        .files
+        .iter()
+        .find(|entry| entry.path == "/usr/bin/myapp")
+        .unwrap();
+    assert_eq!(
+        entry.content.as_ref().unwrap().sha256,
+        crate::hash::sha256(b"#!/bin/sh\necho hi\n")
+    );
+    assert!(
+        result
+            .payload(&entry.path)
+            .unwrap()
+            .source()
+            .unwrap()
+            .path()
+            .is_some()
+    );
+}
+
+#[test]
+fn builder_streams_policy_replacement_and_rehashes_it() {
+    let source = TempDir::new().unwrap();
+    fs::create_dir_all(source.path().join("usr/bin")).unwrap();
+    fs::write(
+        source.path().join("usr/bin/tool"),
+        b"#!/usr/bin/env python\nprint('hello')\n",
+    )
+    .unwrap();
+    let mut manifest = create_test_manifest();
+    manifest.policy.fix_shebangs.insert(
+        "/usr/bin/env python".to_string(),
+        "/usr/bin/python3".to_string(),
+    );
+    let result = CcsBuilder::new(manifest, source.path())
+        .unwrap()
+        .build()
+        .unwrap();
+    let entry = result
+        .files
+        .iter()
+        .find(|entry| entry.path == "/usr/bin/tool")
+        .unwrap();
+    assert_eq!(
+        entry.content.as_ref().unwrap().sha256,
+        crate::hash::sha256(b"#!/usr/bin/python3\nprint('hello')\n")
+    );
+    let mut actual = Vec::new();
+    result
+        .open_file(entry)
+        .unwrap()
+        .read_to_end(&mut actual)
+        .unwrap();
+    assert_eq!(actual, b"#!/usr/bin/python3\nprint('hello')\n");
+}
+
+#[test]
+fn chunking_visits_reader_without_retaining_chunk_bytes() {
+    let source = TempDir::new().unwrap();
+    let bytes = vec![0x5a; MIN_CHUNK_SIZE as usize * 8];
+    fs::write(source.path().join("large"), &bytes).unwrap();
+    let result = CcsBuilder::new(create_test_manifest(), source.path())
+        .unwrap()
+        .with_chunking()
+        .build()
+        .unwrap();
+    let entry = result
+        .files
+        .iter()
+        .find(|entry| entry.path == "/large")
+        .unwrap();
+    assert!(!entry.chunks.as_ref().unwrap().is_empty());
+    assert_eq!(result.payloads.len(), 1);
+    assert_eq!(result.chunk_stats.as_ref().unwrap().chunked_files, 1);
+}
+
+#[test]
+fn builder_preserves_explicit_component_assignment() {
+    let source = TempDir::new().unwrap();
+    fs::write(source.path().join("helper"), b"helper").unwrap();
+    let mut manifest = create_test_manifest();
+    manifest
+        .components
+        .files
+        .insert("/helper".to_string(), "lib".to_string());
+    let result = CcsBuilder::new(manifest, source.path())
+        .unwrap()
+        .build()
+        .unwrap();
+    assert_eq!(result.files[0].component, "lib");
+}
+
+#[cfg(unix)]
+#[test]
+fn builder_preserves_symlink_authority_without_content_source() {
+    let source = TempDir::new().unwrap();
+    fs::write(source.path().join("target"), b"payload").unwrap();
+    std::os::unix::fs::symlink("target", source.path().join("link")).unwrap();
+    let result = CcsBuilder::new(create_test_manifest(), source.path())
+        .unwrap()
+        .build()
+        .unwrap();
+    let link = result
+        .files
+        .iter()
+        .find(|entry| entry.path == "/link")
+        .unwrap();
+    assert_eq!(
+        link.node.kind,
+        PayloadNodeKind::Symlink {
+            target: "target".to_string()
+        }
+    );
+    assert!(result.payload("/link").unwrap().source().is_none());
+}
+
+#[test]
+fn large_sparse_file_authoring_peak_rss_is_bounded() {
+    const CHILD_ENV: &str = "CONARY_ISSUE_135_RSS_CHILD";
+    if std::env::var_os(CHILD_ENV).is_none() {
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "ccs::builder::tests::large_sparse_file_authoring_peak_rss_is_bounded",
+                "--nocapture",
+            ])
+            .env(CHILD_ENV, "1")
+            .output()
+            .unwrap();
+        print!("{}", String::from_utf8_lossy(&output.stdout));
+        std::io::stderr().write_all(&output.stderr).unwrap();
+        assert!(output.status.success(), "large-file RSS child failed");
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains("ISSUE135_VM_HWM_KIB="),
+            "large-file RSS child did not report VmHWM"
+        );
+        return;
+    }
+
+    const DECLARED_SIZE: u64 = 2 * 1024 * 1024 * 1024 + 1;
+    const RSS_LIMIT_KIB: u64 = 256 * 1024;
+    let target_root = std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| std::env::current_dir().unwrap().join("target"));
+    fs::create_dir_all(&target_root).unwrap();
+    let workspace = tempfile::Builder::new()
+        .prefix("issue-135-rss-")
+        .tempdir_in(&target_root)
+        .unwrap();
+    let source = workspace.path().join("source");
+    fs::create_dir(&source).unwrap();
+    let large = fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(source.join("large-zero-file"))
+        .unwrap();
+    large.set_len(DECLARED_SIZE).unwrap();
+
+    let result = CcsBuilder::new(create_test_manifest(), &source)
+        .unwrap()
+        .build()
+        .unwrap();
+    assert_eq!(result.total_size, DECLARED_SIZE);
+    assert_eq!(
+        result.files[0].content.as_ref().unwrap().size,
+        DECLARED_SIZE
+    );
+    assert!(
+        result.payloads[0]
+            .source()
+            .and_then(ReopenablePayload::path)
+            .is_some()
+    );
+
+    let high_water_kib = vm_hwm_kib().unwrap();
+    println!("ISSUE135_VM_HWM_KIB={high_water_kib}");
+    assert!(
+        high_water_kib < RSS_LIMIT_KIB,
+        "VmHWM {high_water_kib} KiB exceeded fixed {RSS_LIMIT_KIB} KiB bound"
+    );
+}
+
+fn vm_hwm_kib() -> Option<u64> {
+    let mut status = String::new();
+    fs::File::open("/proc/self/status")
+        .ok()?
+        .read_to_string(&mut status)
+        .ok()?;
+    status.lines().find_map(|line| {
+        line.strip_prefix("VmHWM:")
+            .and_then(|value| value.split_whitespace().next())
+            .and_then(|value| value.parse().ok())
+    })
+}

--- a/crates/conary-core/src/ccs/builder/tests.rs
+++ b/crates/conary-core/src/ccs/builder/tests.rs
@@ -165,6 +165,33 @@ fn chunking_visits_reader_without_retaining_chunk_bytes() {
 }
 
 #[test]
+fn bounded_memory_fixture_rejects_repeated_assembly_over_aggregate_limit() {
+    const FIXTURE_BYTES: usize = 9 * 1024 * 1024;
+    let bytes = vec![0x5a; FIXTURE_BYTES];
+    let hash = crate::hash::sha256(&bytes);
+    let files = ["/first", "/second"]
+        .into_iter()
+        .map(|path| FileEntry {
+            path: path.to_string(),
+            node: crate::payload::PayloadNode::regular(0o644),
+            content: Some(PayloadContentAuthority {
+                sha256: hash.clone(),
+                size: FIXTURE_BYTES as u64,
+            }),
+            component: "runtime".to_string(),
+            chunks: Some(vec![hash.clone()]),
+        })
+        .collect::<Vec<_>>();
+    let error =
+        payloads_from_bounded_memory_for_tests(&files, HashMap::from([(hash, bytes)])).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("would retain 18874368 payload bytes")
+    );
+}
+
+#[test]
 fn builder_preserves_explicit_component_assignment() {
     let source = TempDir::new().unwrap();
     fs::write(source.path().join("helper"), b"helper").unwrap();

--- a/crates/conary-core/src/ccs/chunking.rs
+++ b/crates/conary-core/src/ccs/chunking.rs
@@ -301,8 +301,20 @@ impl ChunkStore {
     /// Retrieve a chunk by hash
     pub fn get_chunk(&self, hash: &[u8; 32]) -> Result<Vec<u8>> {
         let path = self.chunk_path(hash);
-        let data = std::fs::read(&path)
+        let mut file = File::open(&path)
             .with_context(|| format!("Failed to read chunk: {}", path.display()))?;
+        let mut data = Vec::with_capacity(MAX_CHUNK_SIZE as usize);
+        Read::by_ref(&mut file)
+            .take(u64::from(MAX_CHUNK_SIZE) + 1)
+            .read_to_end(&mut data)
+            .with_context(|| format!("Failed to read chunk: {}", path.display()))?;
+        if data.len() > MAX_CHUNK_SIZE as usize {
+            bail!(
+                "stored chunk exceeds the {} byte maximum: {}",
+                MAX_CHUNK_SIZE,
+                path.display()
+            );
+        }
         let expected_hash = hex::encode(hash);
         crate::hash::verify_sha256(&data, &expected_hash).map_err(|error| {
             anyhow::anyhow!("chunk hash mismatch for {}: {}", path.display(), error)
@@ -783,7 +795,11 @@ mod tests {
             return;
         }
 
-        let data = std::fs::read(binary_path).unwrap();
+        let mut data = Vec::new();
+        File::open(binary_path)
+            .unwrap()
+            .read_to_end(&mut data)
+            .unwrap();
         println!("\nTesting CDC on real binary:");
         println!("  Binary: {:?}", binary_path);
         println!(

--- a/crates/conary-core/src/ccs/convert/converter.rs
+++ b/crates/conary-core/src/ccs/convert/converter.rs
@@ -473,7 +473,7 @@ fn build_streaming_result(
         manifest,
         components,
         files,
-        blobs: HashMap::new(),
+        payloads: payloads.to_vec(),
         total_size,
         chunked: false,
         chunk_stats: None,

--- a/crates/conary-core/src/ccs/hooks/capabilities/interface_contract.rs
+++ b/crates/conary-core/src/ccs/hooks/capabilities/interface_contract.rs
@@ -3,6 +3,7 @@
 //! Exact executable identities for target-owned hook interfaces.
 
 use serde::{Deserialize, Serialize};
+use std::fs::File;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::os::unix::process::CommandExt as _;
 use std::path::{Path, PathBuf};
@@ -133,8 +134,11 @@ impl ExecutableInterface {
         if !functional_handshake(&actual_executable, contract) {
             return None;
         }
-        let executable_sha256 =
-            crate::hash::sha256_prefixed(&std::fs::read(&actual_executable).ok()?);
+        let mut executable = File::open(&actual_executable).ok()?;
+        let executable_sha256 = format!(
+            "sha256:{}",
+            crate::hash::sha256_reader_hex(&mut executable).ok()?
+        );
         Some(Self {
             executable: persisted_executable,
             contract,

--- a/crates/conary-core/src/ccs/native_export/arch.rs
+++ b/crates/conary-core/src/ccs/native_export/arch.rs
@@ -13,7 +13,7 @@ use crate::ccs::manifest::Hooks;
 use crate::payload::PayloadNodeKind;
 use anyhow::{Context, Result};
 use std::fs::{self, File};
-use std::io::Write;
+use std::io::{self, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use tar::Builder as TarBuilder;
@@ -225,8 +225,7 @@ pub fn generate(result: &BuildResult, output_path: &Path) -> Result<GenerationRe
 
         match &file.node.kind {
             PayloadNodeKind::Regular { .. } => {
-                let content = super::get_file_content(file, &result.blobs)?;
-                fs::write(&dest_path, &content)?;
+                super::copy_file_content(result, file, &dest_path)?;
 
                 // Set permissions
                 let mut perms = fs::metadata(&dest_path)?.permissions();
@@ -380,11 +379,12 @@ fn create_arch_package(pkg_root: &Path, output_path: &Path) -> Result<()> {
         archive.finish()?;
     }
 
-    // Compress with zstd
-    let tar_data = fs::read(&tar_path)?;
-    let compressed = zstd::encode_all(&tar_data[..], 19)?; // Level 19 for high compression
-
-    fs::write(output_path, compressed)?;
+    // Compress from disk so native export does not re-buffer the full tarball.
+    let mut tar_file = File::open(&tar_path)?;
+    let output_file = File::create(output_path)?;
+    let mut encoder = zstd::Encoder::new(output_file, 19)?; // Level 19 for high compression
+    io::copy(&mut tar_file, &mut encoder)?;
+    encoder.finish()?;
     fs::remove_file(&tar_path)?;
 
     Ok(())
@@ -433,7 +433,7 @@ mod tests {
             manifest,
             components: HashMap::new(),
             files: vec![],
-            blobs: HashMap::new(),
+            payloads: Vec::new(),
             total_size: 0,
             chunked: false,
             chunk_stats: None,

--- a/crates/conary-core/src/ccs/native_export/deb.rs
+++ b/crates/conary-core/src/ccs/native_export/deb.rs
@@ -233,8 +233,7 @@ pub fn generate(result: &BuildResult, output_path: &Path) -> Result<GenerationRe
 
         match &file.node.kind {
             PayloadNodeKind::Regular { .. } => {
-                let content = super::get_file_content(file, &result.blobs)?;
-                fs::write(&dest_path, &content)?;
+                let content_md5 = super::copy_file_content(result, file, &dest_path)?;
 
                 // Set permissions
                 let mut perms = fs::metadata(&dest_path)?.permissions();
@@ -242,7 +241,7 @@ pub fn generate(result: &BuildResult, output_path: &Path) -> Result<GenerationRe
                 fs::set_permissions(&dest_path, perms)?;
 
                 // Add to md5sums using the already-computed relative path.
-                md5sums.push(format!("{}  {}", compute_md5(&content), rel_path));
+                md5sums.push(format!("{}  {}", content_md5, rel_path));
             }
             PayloadNodeKind::Symlink { target } => {
                 #[cfg(unix)]
@@ -362,12 +361,6 @@ fn set_executable(path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Compute MD5 hash of content (for md5sums file)
-fn compute_md5(content: &[u8]) -> String {
-    use md5::{Digest, Md5};
-    hex::encode(Md5::digest(content))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -385,7 +378,7 @@ mod tests {
             manifest,
             components: HashMap::new(),
             files: vec![],
-            blobs: HashMap::new(),
+            payloads: Vec::new(),
             total_size: 0,
             chunked: false,
             chunk_stats: None,
@@ -449,17 +442,5 @@ mod tests {
 
         assert!(post.contains("echo installed > /var/lib/myapp/installed"));
         assert!(pre_remove.contains("echo removed > /var/lib/myapp/removed"));
-    }
-
-    #[test]
-    fn test_compute_md5() {
-        // Known MD5 hash of "hello world\n"
-        let content = b"hello world\n";
-        let hash = compute_md5(content);
-        assert_eq!(hash, "6f5902ac237024bdd0c176cb93063dc4");
-
-        // Empty content
-        let empty_hash = compute_md5(b"");
-        assert_eq!(empty_hash, "d41d8cd98f00b204e9800998ecf8427e");
     }
 }

--- a/crates/conary-core/src/ccs/native_export/mod.rs
+++ b/crates/conary-core/src/ccs/native_export/mod.rs
@@ -260,6 +260,43 @@ mod tests {
     use super::*;
 
     #[test]
+    fn source_backed_copy_preserves_bytes_and_computes_debian_md5() {
+        let result = crate::ccs::builder::test_support::minimal_file_build_result(
+            "hello",
+            "1.0.0",
+            b"hello world",
+        );
+        let output = tempfile::NamedTempFile::new().unwrap();
+        let digest = copy_file_content(&result, &result.files[0], output.path()).unwrap();
+
+        assert_eq!(std::fs::read(output.path()).unwrap(), b"hello world");
+        assert_eq!(digest, "5eb63bbbe01eeed093cb22bb8f5acdc3");
+    }
+
+    #[test]
+    fn source_backed_copy_rejects_content_changed_after_authoring() {
+        let source = tempfile::tempdir().unwrap();
+        let source_file = source.path().join("payload");
+        std::fs::write(&source_file, b"signed bytes").unwrap();
+        let result = crate::ccs::builder::CcsBuilder::new(
+            crate::ccs::manifest::CcsManifest::new_minimal("changed", "1.0.0"),
+            source.path(),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+        std::fs::write(source_file, b"changed bytes").unwrap();
+        let output = tempfile::NamedTempFile::new().unwrap();
+
+        let error = copy_file_content(&result, &result.files[0], output.path()).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("payload source does not match authority")
+        );
+    }
+
+    #[test]
     fn shell_escape_handles_quotes() {
         assert_eq!(shell_escape("it's"), "'it'\\''s'");
     }
@@ -267,7 +304,22 @@ mod tests {
     #[test]
     fn architecture_mapping_remains_format_specific() {
         assert_eq!(arch_for_format(Some("x86_64"), "deb").unwrap(), "amd64");
+        assert_eq!(arch_for_format(Some("aarch64"), "deb").unwrap(), "arm64");
         assert_eq!(arch_for_format(Some("amd64"), "rpm").unwrap(), "x86_64");
         assert!(arch_for_format(Some("all"), "rpm").is_err());
+        assert!(arch_for_format(Some("any"), "rpm").is_err());
+        assert!(arch_for_format(Some("noarch"), "deb").is_err());
+        assert!(arch_for_format(None, "arch").is_err());
+        assert!(arch_for_format(Some("riscv64"), "arch").is_err());
+    }
+
+    #[test]
+    fn loss_report_tracks_unsupported_features() {
+        let mut report = LossReport::default();
+        assert!(report.is_empty());
+
+        report.add_unsupported("merkle tree verification");
+        assert!(!report.is_empty());
+        assert_eq!(report.unsupported_features.len(), 1);
     }
 }

--- a/crates/conary-core/src/ccs/native_export/mod.rs
+++ b/crates/conary-core/src/ccs/native_export/mod.rs
@@ -1,73 +1,62 @@
 // conary-core/src/ccs/native_export/mod.rs
-//! Native package format exporters
-//!
-//! This module exports CCS packages as DEB, RPM, and Arch packages for native
-//! package-manager consumption.
+//! Native package format exporters.
 
 pub mod arch;
 pub mod deb;
 pub mod rpm;
 
-use crate::ccs::builder::FileEntry;
+use crate::ccs::builder::{BuildResult, FileEntry};
 use crate::ccs::manifest::Hooks;
-use anyhow::anyhow;
-use std::collections::HashMap;
+use anyhow::Context;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::Path;
 
-/// Retrieve file content from the blob map, handling both whole-file and
-/// CDC-chunked storage.
+/// Copy one source-backed regular file while verifying its signed authority.
 ///
-/// When a file has `chunks: Some(chunk_hashes)`, the content is assembled by
-/// concatenating the blobs keyed by each chunk hash in order. When `chunks`
-/// is `None`, the content is looked up by the whole-file hash directly.
-pub fn get_file_content(
+/// The returned value is the MD5 digest required by Debian package metadata.
+pub fn copy_file_content(
+    result: &BuildResult,
     file: &FileEntry,
-    blobs: &HashMap<String, Vec<u8>>,
-) -> anyhow::Result<Vec<u8>> {
-    let authority = file.content.as_ref().ok_or_else(|| {
-        anyhow!(
-            "Non-regular payload node {} has no content authority",
+    destination: &Path,
+) -> anyhow::Result<String> {
+    let authority = file.content.as_ref().with_context(|| {
+        format!(
+            "regular payload node {} has no content authority",
             file.path
         )
     })?;
-    if let Some(chunk_hashes) = &file.chunks {
-        let mut assembled = Vec::with_capacity(authority.size as usize);
-        for chunk_hash in chunk_hashes {
-            let chunk = blobs
-                .get(chunk_hash)
-                .ok_or_else(|| anyhow!("Chunk {} not found for file {}", chunk_hash, file.path))?;
-            assembled.extend_from_slice(chunk);
+    let mut reader = result.open_file(file)?;
+    let mut writer = File::create(destination)?;
+    let mut sha256 = crate::hash::Hasher::new(crate::hash::HashAlgorithm::Sha256);
+    let mut md5 = crate::hash::Hasher::new(crate::hash::HashAlgorithm::Md5);
+    let mut size = 0_u64;
+    let mut buffer = [0_u8; crate::packages::payload::PAYLOAD_IO_BUFFER_SIZE];
+    loop {
+        let count = reader.read(&mut buffer)?;
+        if count == 0 {
+            break;
         }
-        if assembled.len() as u64 != authority.size
-            || crate::hash::sha256(&assembled) != authority.sha256
-        {
-            anyhow::bail!(
-                "Assembled content does not match authority for {}",
-                file.path
-            );
-        }
-        Ok(assembled)
-    } else {
-        let content = blobs
-            .get(&authority.sha256)
-            .cloned()
-            .ok_or_else(|| anyhow!("Blob not found for file {}", file.path))?;
-        if content.len() as u64 != authority.size
-            || crate::hash::sha256(&content) != authority.sha256
-        {
-            anyhow::bail!("Blob does not match authority for {}", file.path);
-        }
-        Ok(content)
+        writer.write_all(&buffer[..count])?;
+        sha256.update(&buffer[..count]);
+        md5.update(&buffer[..count]);
+        size = size
+            .checked_add(count as u64)
+            .context("native export payload size overflow")?;
     }
+    writer.flush()?;
+    let actual_sha256 = sha256.finalize().value;
+    if size != authority.size || actual_sha256 != authority.sha256 {
+        anyhow::bail!("payload source does not match authority for {}", file.path);
+    }
+    Ok(md5.finalize().value)
 }
 
 /// Information that may be lost when exporting to a native package format.
 #[derive(Debug, Default)]
 pub struct LossReport {
-    /// Features that couldn't be represented in the target format
     pub unsupported_features: Vec<String>,
-    /// Hooks that were approximated or skipped
     pub hook_notes: Vec<String>,
-    /// Dependency mappings that may be inaccurate
     pub dependency_notes: Vec<String>,
 }
 
@@ -90,60 +79,41 @@ impl LossReport {
         self.dependency_notes.push(note.to_string());
     }
 
-    /// Print a summary of what was lost in conversion
     pub fn print_summary(&self, format_name: &str) {
         if self.is_empty() {
             return;
         }
-
-        println!("  Conversion notes for {}:", format_name);
-
+        println!("  Conversion notes for {format_name}:");
         for note in &self.unsupported_features {
-            println!("    [UNSUPPORTED] {}", note);
+            println!("    [UNSUPPORTED] {note}");
         }
-
         for note in &self.hook_notes {
-            println!("    [HOOK] {}", note);
+            println!("    [HOOK] {note}");
         }
-
         for note in &self.dependency_notes {
-            println!("    [DEPENDENCY] {}", note);
+            println!("    [DEPENDENCY] {note}");
         }
     }
 }
 
-/// Result of native package generation.
 #[derive(Debug)]
 pub struct GenerationResult {
-    /// Size of the generated package in bytes
     pub size: u64,
-    /// Any lossy conversion notes
     pub loss_report: LossReport,
 }
 
-/// Convert CCS hooks to format-specific install scripts
 pub trait HookConverter {
-    /// Generate pre-install script content
     fn pre_install(&self, hooks: &Hooks) -> Option<String>;
-
-    /// Generate post-install script content
     fn post_install(&self, hooks: &Hooks) -> Option<String>;
-
-    /// Generate pre-remove script content
     fn pre_remove(&self, hooks: &Hooks) -> Option<String>;
-
-    /// Generate post-remove script content
     fn post_remove(&self, hooks: &Hooks) -> Option<String>;
 }
 
-/// Common functionality for generating install scripts from CCS hooks
 pub struct CommonHookGenerator;
 
 impl CommonHookGenerator {
-    /// Generate user creation commands
     pub fn user_creation_commands(hooks: &Hooks) -> Vec<String> {
         let mut commands = Vec::new();
-
         for group in &hooks.groups {
             let flags = if group.system { "--system " } else { "" };
             let name = shell_escape(&group.name);
@@ -151,7 +121,6 @@ impl CommonHookGenerator {
                 "getent group {name} >/dev/null || groupadd {flags}{name}"
             ));
         }
-
         for user in &hooks.users {
             let mut flags = Vec::new();
             if user.system {
@@ -168,125 +137,96 @@ impl CommonHookGenerator {
             if let Some(group) = &user.group {
                 flags.push(format!("--gid {}", shell_escape(group)));
             }
-
-            let flags_str = if flags.is_empty() {
+            let flags = if flags.is_empty() {
                 String::new()
             } else {
                 format!("{} ", flags.join(" "))
             };
-
             let name = shell_escape(&user.name);
             commands.push(format!(
-                "getent passwd {name} >/dev/null || useradd {flags_str}{name}"
+                "getent passwd {name} >/dev/null || useradd {flags}{name}"
             ));
         }
-
         commands
     }
 
-    /// Generate directory creation commands
     pub fn directory_commands(hooks: &Hooks) -> Vec<String> {
-        let mut commands = Vec::new();
-
-        for dir in &hooks.directories {
-            commands.push(format!(
-                "install -d -m {} -o {} -g {} {}",
-                shell_escape(&dir.mode),
-                shell_escape(&dir.owner),
-                shell_escape(&dir.group),
-                shell_escape(&dir.path),
-            ));
-        }
-
-        commands
+        hooks
+            .directories
+            .iter()
+            .map(|directory| {
+                format!(
+                    "install -d -m {} -o {} -g {} {}",
+                    shell_escape(&directory.mode),
+                    shell_escape(&directory.owner),
+                    shell_escape(&directory.group),
+                    shell_escape(&directory.path),
+                )
+            })
+            .collect()
     }
 
-    /// Generate systemd enable/disable commands
     pub fn systemd_commands(hooks: &Hooks, enable: bool) -> Vec<String> {
         let mut commands = Vec::new();
-
         for unit in &hooks.systemd {
             if unit.enable && enable {
-                // Only enable if requested
                 let unit_name = shell_escape(&unit.unit);
                 commands.push(format!(
                     "if command -v systemctl >/dev/null 2>&1; then systemctl daemon-reload; systemctl enable {unit_name}; fi"
                 ));
             } else if !enable {
-                // Stop on removal
                 let unit_name = shell_escape(&unit.unit);
                 commands.push(format!(
                     "if command -v systemctl >/dev/null 2>&1; then systemctl stop {unit_name} 2>/dev/null || true; fi"
                 ));
             }
         }
-
         commands
     }
 
-    /// Generate tmpfiles.d commands
     pub fn tmpfiles_commands(hooks: &Hooks) -> Vec<String> {
-        let mut commands = Vec::new();
-
-        if !hooks.tmpfiles.is_empty() {
-            // systemd-tmpfiles --create will read from /usr/lib/tmpfiles.d/
-            commands.push(
+        if hooks.tmpfiles.is_empty() {
+            Vec::new()
+        } else {
+            vec![
                 "if command -v systemd-tmpfiles >/dev/null 2>&1; then systemd-tmpfiles --create; fi"
                     .to_string(),
-            );
+            ]
         }
-
-        commands
     }
 
-    /// Generate sysctl commands
-    ///
-    /// Sysctl keys and values are validated to contain only safe characters
-    /// (alphanumeric, dots, underscores, hyphens, digits) and emitted unquoted.
-    /// This avoids breaking arithmetic comparisons and sysctl -w assignments
-    /// that would fail with shell-escaped (single-quoted) values.
     pub fn sysctl_commands(hooks: &Hooks) -> Vec<String> {
-        let mut commands = Vec::new();
-
-        for sysctl in &hooks.sysctl {
-            let key = &sysctl.key;
-            let value = &sysctl.value;
-
-            // Validate that key and value contain only safe characters
-            let is_safe = |s: &str| {
-                !s.is_empty()
-                    && s.bytes()
-                        .all(|b| b.is_ascii_alphanumeric() || b == b'.' || b == b'_' || b == b'-')
-            };
-
-            if !is_safe(key) || !is_safe(value) {
-                // Fall back to shell-escaped form for safety, but only for
-                // non-arithmetic (unconditional) sysctl writes
-                let escaped_key = shell_escape(key);
-                let escaped_value = shell_escape(value);
-                commands.push(format!("sysctl -w {escaped_key}={escaped_value}"));
-                continue;
-            }
-
-            commands.push(format!("sysctl -w {key}={value}"));
-        }
-
-        commands
+        hooks
+            .sysctl
+            .iter()
+            .map(|sysctl| {
+                let safe = |value: &str| {
+                    !value.is_empty()
+                        && value.bytes().all(|byte| {
+                            byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-')
+                        })
+                };
+                if safe(&sysctl.key) && safe(&sysctl.value) {
+                    format!("sysctl -w {}={}", sysctl.key, sysctl.value)
+                } else {
+                    format!(
+                        "sysctl -w {}={}",
+                        shell_escape(&sysctl.key),
+                        shell_escape(&sysctl.value)
+                    )
+                }
+            })
+            .collect()
     }
 }
 
-/// Escape a string for safe use in shell commands.
-///
-/// Wraps the value in single quotes and escapes any embedded single quotes
-/// using the `'\''` idiom, which is safe against shell injection.
-pub fn shell_escape(s: &str) -> String {
-    format!("'{}'", s.replace('\'', r"'\''"))
+pub fn shell_escape(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 /// Resolve a CCS architecture through the exact target-format contract.
 pub fn arch_for_format(arch: Option<&str>, format: &str) -> anyhow::Result<String> {
-    let arch = arch.ok_or_else(|| anyhow!("CCS package has no target architecture"))?;
-
+    let arch = arch.ok_or_else(|| anyhow::anyhow!("CCS package has no target architecture"))?;
     let target = match format {
         "deb" => match arch {
             "x86_64" | "amd64" => "amd64",
@@ -318,82 +258,16 @@ pub fn arch_for_format(arch: Option<&str>, format: &str) -> anyhow::Result<Strin
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::payload::{PayloadContentAuthority, PayloadNode};
 
-    fn regular_entry(path: &str, bytes: &[u8], chunks: Option<Vec<String>>) -> FileEntry {
-        FileEntry {
-            path: path.to_string(),
-            node: PayloadNode::regular(0o755),
-            content: Some(PayloadContentAuthority {
-                sha256: crate::hash::sha256(bytes),
-                size: bytes.len() as u64,
-            }),
-            component: "runtime".to_string(),
-            chunks,
-        }
+    #[test]
+    fn shell_escape_handles_quotes() {
+        assert_eq!(shell_escape("it's"), "'it'\\''s'");
     }
 
     #[test]
-    fn test_arch_mapping() {
+    fn architecture_mapping_remains_format_specific() {
         assert_eq!(arch_for_format(Some("x86_64"), "deb").unwrap(), "amd64");
-        assert_eq!(arch_for_format(Some("aarch64"), "deb").unwrap(), "arm64");
         assert_eq!(arch_for_format(Some("amd64"), "rpm").unwrap(), "x86_64");
         assert!(arch_for_format(Some("all"), "rpm").is_err());
-        assert!(arch_for_format(Some("any"), "rpm").is_err());
-        assert!(arch_for_format(Some("noarch"), "deb").is_err());
-        assert!(arch_for_format(None, "arch").is_err());
-        assert!(arch_for_format(Some("riscv64"), "arch").is_err());
-    }
-
-    #[test]
-    fn test_loss_report() {
-        let mut report = LossReport::default();
-        assert!(report.is_empty());
-
-        report.add_unsupported("merkle tree verification");
-        assert!(!report.is_empty());
-        assert_eq!(report.unsupported_features.len(), 1);
-    }
-
-    #[test]
-    fn test_get_file_content_whole_blob() {
-        let bytes = b"hello world";
-        let digest = crate::hash::sha256(bytes);
-        let mut blobs = HashMap::new();
-        blobs.insert(digest, bytes.to_vec());
-        let file = regular_entry("/usr/bin/foo", bytes, None);
-
-        let content = get_file_content(&file, &blobs).unwrap();
-        assert_eq!(content, bytes);
-    }
-
-    #[test]
-    fn test_get_file_content_chunked() {
-        let first = b"hello ";
-        let second = b"world";
-        let first_digest = crate::hash::sha256(first);
-        let second_digest = crate::hash::sha256(second);
-        let mut blobs = HashMap::new();
-        blobs.insert(first_digest.clone(), first.to_vec());
-        blobs.insert(second_digest.clone(), second.to_vec());
-        let file = regular_entry(
-            "/usr/bin/bar",
-            b"hello world",
-            Some(vec![first_digest, second_digest]),
-        );
-
-        let content = get_file_content(&file, &blobs).unwrap();
-        assert_eq!(content, b"hello world");
-    }
-
-    #[test]
-    fn test_get_file_content_missing_chunk_errors() {
-        let blobs = HashMap::new();
-        let missing_digest = crate::hash::sha256(b"missing");
-        let file = regular_entry("/usr/bin/baz", b"hello", Some(vec![missing_digest.clone()]));
-
-        let result = get_file_content(&file, &blobs);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains(&missing_digest));
     }
 }

--- a/crates/conary-core/src/ccs/native_export/rpm.rs
+++ b/crates/conary-core/src/ccs/native_export/rpm.rs
@@ -148,7 +148,6 @@ pub fn generate(result: &BuildResult, output_path: &Path) -> Result<GenerationRe
 
         match &file.node.kind {
             PayloadNodeKind::Regular { .. } => {
-                let content = super::get_file_content(file, &result.blobs)?;
                 // Write to temp location
                 let content_hash = &file
                     .content
@@ -156,7 +155,7 @@ pub fn generate(result: &BuildResult, output_path: &Path) -> Result<GenerationRe
                     .expect("regular node content validated by CCS builder")
                     .sha256;
                 let temp_path = temp_dir.path().join(content_hash);
-                fs::write(&temp_path, &content)?;
+                super::copy_file_content(result, file, &temp_path)?;
 
                 // Determine file options
                 let options =
@@ -326,7 +325,7 @@ mod tests {
             manifest,
             components: HashMap::new(),
             files: vec![],
-            blobs: HashMap::new(),
+            payloads: Vec::new(),
             total_size: 0,
             chunked: false,
             chunk_stats: None,

--- a/crates/conary-core/src/ccs/package.rs
+++ b/crates/conary-core/src/ccs/package.rs
@@ -458,7 +458,7 @@ license = "MIT"
         let payloads = crate::ccs::v2::test_support::one_file_payloads_for_tests();
         let signing_key = SigningKeyPair::generate();
 
-        let error = crate::ccs::builder::write_v2_ccs_package(
+        let error = crate::ccs::builder::write_v2_ccs_package_from_bounded_memory_for_tests(
             &authority,
             &payloads,
             &package_path,
@@ -581,7 +581,7 @@ license = "MIT"
         let authority = crate::ccs::v2::test_support::package_authority_with_one_file("adapter-v2");
         let payloads = crate::ccs::v2::test_support::one_file_payloads_for_tests();
         let key = crate::ccs::signing::SigningKeyPair::generate();
-        crate::ccs::builder::write_v2_ccs_package(
+        crate::ccs::builder::write_v2_ccs_package_from_bounded_memory_for_tests(
             &authority, &payloads, &path, &key, None, None, None,
         )
         .unwrap();

--- a/crates/conary-core/src/ccs/policy.rs
+++ b/crates/conary-core/src/ccs/policy.rs
@@ -1,19 +1,23 @@
 // conary-core/src/ccs/policy.rs
-//! Build policy system for CCS packages
+//! Build-policy orchestration for CCS authoring.
 //!
-//! Provides automated quality enforcement during package builds through a
-//! trait-based policy engine. Policies can validate, transform, or reject
-//! files during the build process.
+//! Metadata policies mutate typed file authority in place. Content policies
+//! write replacements into an authoring workspace and return a new path, so
+//! the builder never needs a whole-file byte vector.
 
 use crate::ccs::builder::FileEntry;
 use anyhow::Result;
 use glob::Pattern;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use thiserror::Error;
 
-/// Policy errors
+mod content;
+
+pub use content::{CompressManpagesPolicy, FixShebangsPolicy, StripBinariesPolicy};
+
+/// Policy errors.
 #[derive(Error, Debug)]
 pub enum PolicyError {
     #[error("Policy violation: {policy} - {message}")]
@@ -26,156 +30,130 @@ pub enum PolicyError {
     Execution(String),
 }
 
-/// Result of applying a policy to a file
-#[derive(Debug, Clone)]
+/// Result of applying a policy to one source-backed entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PolicyAction {
-    /// Keep file unchanged
+    /// Keep the current source unchanged.
     Keep,
-    /// Replace file content with new bytes
-    Replace(Vec<u8>),
-    /// Skip this file (remove from package)
+    /// Replace the current source with this disk-backed path.
+    Replace(PathBuf),
+    /// Skip this file.
     Skip,
-    /// Reject the build entirely with error message
+    /// Reject the build.
     Reject(String),
 }
 
-/// Context provided to policies during application
+/// Context provided to policies during application.
 pub struct PolicyContext<'a> {
-    /// Source path of the file on disk
+    /// Current source path. This may be an earlier policy's replacement.
     pub source_path: &'a Path,
-    /// File entry metadata
+    /// Unique destination reserved for this policy invocation.
+    pub replacement_path: &'a Path,
+    /// File-entry metadata.
     pub entry: &'a mut FileEntry,
-    /// File content bytes
-    pub content: &'a [u8],
-    /// All policies configuration
+    /// All policy configuration.
     pub config: &'a BuildPolicyConfig,
 }
 
-/// A build policy that can validate or transform files
+/// A build policy that can validate, transform, or reject one entry.
 pub trait BuildPolicy: Send + Sync {
-    /// Policy name for logging and error messages
     fn name(&self) -> &str;
 
-    /// Apply this policy to a file
-    ///
-    /// Returns a `PolicyAction` indicating what to do with the file:
-    /// - `Keep`: Leave unchanged
-    /// - `Replace(bytes)`: Replace content with new bytes
-    /// - `Skip`: Remove from package
-    /// - `Reject(msg)`: Fail the entire build
-    fn apply(&self, ctx: &mut PolicyContext) -> Result<PolicyAction>;
+    /// Apply the policy without materializing the complete content in memory.
+    fn apply(&self, ctx: &mut PolicyContext<'_>) -> Result<PolicyAction>;
 }
 
-/// Policy chain - applies policies in sequence
+/// Ordered policy chain.
 pub struct PolicyChain {
     policies: Vec<Box<dyn BuildPolicy>>,
 }
 
 impl PolicyChain {
-    /// Create an empty policy chain
+    #[must_use]
     pub fn new() -> Self {
         Self {
             policies: Vec::new(),
         }
     }
 
-    /// Create a policy chain from configuration
     pub fn from_config(config: &BuildPolicyConfig) -> std::result::Result<Self, PolicyError> {
         let mut chain = Self::new();
-
-        // Add DenyPaths if configured
         if !config.reject_paths.is_empty() {
             chain.add(Box::new(DenyPathsPolicy::new(&config.reject_paths)?));
         }
-
-        // Always strip setuid/setgid bits from packaged files.
         chain.add(Box::new(StripSetuidPolicy::new()));
-
-        // Add NormalizeTimestamps if configured
         if config.normalize_timestamps {
             chain.add(Box::new(NormalizeTimestampsPolicy::new()));
         }
-
-        // Add StripBinaries if configured
         if config.strip_binaries {
             chain.add(Box::new(StripBinariesPolicy::new()));
         }
-
-        // Add FixShebangs if configured
         if !config.fix_shebangs.is_empty() {
+            if config.fix_shebangs.keys().any(String::is_empty) {
+                return Err(PolicyError::Config(
+                    "fix_shebangs patterns must not be empty".to_string(),
+                ));
+            }
             chain.add(Box::new(FixShebangsPolicy::new(
                 config.fix_shebangs.clone(),
             )));
         }
-
-        // Add CompressManpages if configured
         if config.compress_manpages {
             chain.add(Box::new(CompressManpagesPolicy::new()));
         }
-
         Ok(chain)
     }
 
-    /// Add a policy to the chain
     pub fn add(&mut self, policy: Box<dyn BuildPolicy>) {
         self.policies.push(policy);
     }
 
-    /// Check if the chain is empty
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.policies.is_empty()
     }
 
-    /// Apply all policies to a file entry and content
-    ///
-    /// Returns the final action and potentially modified content
+    /// Apply all policies and return the final source path when replaced.
     pub fn apply(
         &self,
         entry: &mut FileEntry,
-        content: Vec<u8>,
         source_path: &Path,
+        workspace: &Path,
         config: &BuildPolicyConfig,
-    ) -> Result<(PolicyAction, Vec<u8>)> {
-        let mut current_content = content;
-        let mut was_replaced = false;
+    ) -> Result<PolicyAction> {
+        let mut current_source = source_path.to_path_buf();
+        let mut replaced = false;
 
-        for policy in &self.policies {
+        for (index, policy) in self.policies.iter().enumerate() {
+            let replacement_path = workspace.join(format!("{index:04}"));
             let mut ctx = PolicyContext {
-                source_path,
+                source_path: &current_source,
+                replacement_path: &replacement_path,
                 entry,
-                content: &current_content,
                 config,
             };
-
             match policy.apply(&mut ctx)? {
-                PolicyAction::Keep => {
-                    // Continue to next policy
+                PolicyAction::Keep => {}
+                PolicyAction::Replace(path) => {
+                    current_source = path;
+                    replaced = true;
                 }
-                PolicyAction::Replace(new_content) => {
-                    current_content = new_content;
-                    was_replaced = true;
-                    // Continue to next policy with new content
-                }
-                PolicyAction::Skip => {
-                    return Ok((PolicyAction::Skip, current_content));
-                }
-                PolicyAction::Reject(msg) => {
+                PolicyAction::Skip => return Ok(PolicyAction::Skip),
+                PolicyAction::Reject(message) => {
                     return Err(PolicyError::Violation {
                         policy: policy.name().to_string(),
-                        message: msg,
+                        message,
                     }
                     .into());
                 }
             }
         }
 
-        // Signal Replace so the builder knows to rehash the modified content
-        let action = if was_replaced {
-            PolicyAction::Replace(Vec::new())
+        Ok(if replaced {
+            PolicyAction::Replace(current_source)
         } else {
             PolicyAction::Keep
-        };
-        Ok((action, current_content))
+        })
     }
 }
 
@@ -185,39 +163,29 @@ impl Default for PolicyChain {
     }
 }
 
-/// Build policy configuration from ccs.toml
+/// Build-policy configuration from `ccs.toml`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct BuildPolicyConfig {
-    /// Paths to reject (glob patterns)
     #[serde(default)]
     pub reject_paths: Vec<String>,
 
-    /// Exact paths where setuid mode bits may be preserved.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub allow_setuid_paths: Vec<String>,
 
-    /// Whether to strip ELF binaries
     #[serde(default)]
     pub strip_binaries: bool,
 
-    /// Shebang replacements (old -> new)
     #[serde(default)]
     pub fix_shebangs: HashMap<String, String>,
 
-    /// Whether to normalize file timestamps
     #[serde(default)]
     pub normalize_timestamps: bool,
 
-    /// Whether to compress man pages
     #[serde(default)]
     pub compress_manpages: bool,
 }
 
-// =============================================================================
-// Policy Implementations
-// =============================================================================
-
-/// Policy to reject files matching forbidden path patterns
+/// Reject paths selected by exact author configuration.
 pub struct DenyPathsPolicy {
     patterns: Vec<Pattern>,
     pattern_strings: Vec<String>,
@@ -225,15 +193,16 @@ pub struct DenyPathsPolicy {
 
 impl DenyPathsPolicy {
     pub fn new(patterns: &[String]) -> std::result::Result<Self, PolicyError> {
-        let mut compiled = Vec::new();
-        for pat in patterns {
-            let pattern = Pattern::new(pat).map_err(|e| {
-                PolicyError::Config(format!("Invalid glob pattern '{}': {}", pat, e))
-            })?;
-            compiled.push(pattern);
-        }
+        let patterns_compiled = patterns
+            .iter()
+            .map(|pattern| {
+                Pattern::new(pattern).map_err(|error| {
+                    PolicyError::Config(format!("Invalid glob pattern '{pattern}': {error}"))
+                })
+            })
+            .collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(Self {
-            patterns: compiled,
+            patterns: patterns_compiled,
             pattern_strings: patterns.to_vec(),
         })
     }
@@ -244,12 +213,12 @@ impl BuildPolicy for DenyPathsPolicy {
         "DenyPaths"
     }
 
-    fn apply(&self, ctx: &mut PolicyContext) -> Result<PolicyAction> {
-        for (pattern, pattern_str) in self.patterns.iter().zip(self.pattern_strings.iter()) {
+    fn apply(&self, ctx: &mut PolicyContext<'_>) -> Result<PolicyAction> {
+        for (pattern, pattern_text) in self.patterns.iter().zip(&self.pattern_strings) {
             if pattern.matches(&ctx.entry.path) {
                 return Ok(PolicyAction::Reject(format!(
-                    "path '{}' matches reject pattern '{}'",
-                    ctx.entry.path, pattern_str
+                    "path '{}' matches reject pattern '{pattern_text}'",
+                    ctx.entry.path
                 )));
             }
         }
@@ -257,23 +226,22 @@ impl BuildPolicy for DenyPathsPolicy {
     }
 }
 
-/// Policy to normalize file timestamps for reproducible builds
+/// Reproducible timestamp policy marker.
 pub struct NormalizeTimestampsPolicy {
-    /// The timestamp to use (Unix epoch seconds)
     timestamp: u64,
 }
 
 impl NormalizeTimestampsPolicy {
+    #[must_use]
     pub fn new() -> Self {
-        // Check SOURCE_DATE_EPOCH environment variable (standard for reproducible builds)
         let timestamp = std::env::var("SOURCE_DATE_EPOCH")
             .ok()
-            .and_then(|s| s.parse::<u64>().ok())
-            .unwrap_or(1704067200); // 2024-01-01 00:00:00 UTC
-
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(1_704_067_200);
         Self { timestamp }
     }
 
+    #[must_use]
     pub fn timestamp(&self) -> u64 {
         self.timestamp
     }
@@ -290,19 +258,17 @@ impl BuildPolicy for NormalizeTimestampsPolicy {
         "NormalizeTimestamps"
     }
 
-    fn apply(&self, _ctx: &mut PolicyContext) -> Result<PolicyAction> {
-        // Timestamp normalization doesn't modify file content
-        // It's applied at the tar archive level when writing the package
-        // We just return Keep here and the builder handles mtime normalization
+    fn apply(&self, _ctx: &mut PolicyContext<'_>) -> Result<PolicyAction> {
         Ok(PolicyAction::Keep)
     }
 }
 
-/// Policy to strip setuid/setgid bits from packaged files
+/// Always remove setgid and remove setuid unless explicitly allowed.
 #[derive(Default)]
 pub struct StripSetuidPolicy;
 
 impl StripSetuidPolicy {
+    #[must_use]
     pub fn new() -> Self {
         Self
     }
@@ -313,7 +279,7 @@ impl BuildPolicy for StripSetuidPolicy {
         "StripSetuid"
     }
 
-    fn apply(&self, ctx: &mut PolicyContext) -> Result<PolicyAction> {
+    fn apply(&self, ctx: &mut PolicyContext<'_>) -> Result<PolicyAction> {
         let allow_setuid = ctx
             .config
             .allow_setuid_paths
@@ -328,666 +294,6 @@ impl BuildPolicy for StripSetuidPolicy {
     }
 }
 
-/// Policy to strip debug symbols from ELF binaries
-#[derive(Default)]
-pub struct StripBinariesPolicy;
-
-impl StripBinariesPolicy {
-    pub fn new() -> Self {
-        Self
-    }
-
-    /// Check if content is an ELF binary
-    fn is_elf(content: &[u8]) -> bool {
-        content.len() >= 4 && &content[0..4] == b"\x7fELF"
-    }
-
-    /// Check if file is executable
-    fn is_executable(entry: &FileEntry) -> bool {
-        entry.node.kind.is_regular() && entry.node.mode & 0o111 != 0
-    }
-}
-
-impl BuildPolicy for StripBinariesPolicy {
-    fn name(&self) -> &str {
-        "StripBinaries"
-    }
-
-    fn apply(&self, ctx: &mut PolicyContext) -> Result<PolicyAction> {
-        // Only process ELF files that are executable or shared libraries
-        if !Self::is_elf(ctx.content) {
-            return Ok(PolicyAction::Keep);
-        }
-
-        // Skip if not executable and not a .so file
-        if !Self::is_executable(ctx.entry) && !ctx.entry.path.contains(".so") {
-            return Ok(PolicyAction::Keep);
-        }
-
-        // Prefer system strip binary (preserves .note.gnu.build-id and .gnu.hash),
-        // fall back to native Rust implementation if unavailable
-        match strip_elf_with_system_tool(ctx.source_path) {
-            Ok(stripped) => {
-                if stripped.len() < ctx.content.len() {
-                    log::debug!(
-                        "Stripped {} with system strip: {} -> {} bytes",
-                        ctx.entry.path,
-                        ctx.content.len(),
-                        stripped.len()
-                    );
-                    return Ok(PolicyAction::Replace(stripped));
-                }
-                return Ok(PolicyAction::Keep);
-            }
-            Err(_) => {
-                // System strip not available, fall back to native implementation
-            }
-        }
-
-        match strip_elf_binary(ctx.content) {
-            Ok(stripped) => {
-                // Only replace if we actually reduced size
-                if stripped.len() < ctx.content.len() {
-                    log::debug!(
-                        "Stripped {}: {} -> {} bytes (native)",
-                        ctx.entry.path,
-                        ctx.content.len(),
-                        stripped.len()
-                    );
-                    Ok(PolicyAction::Replace(stripped))
-                } else {
-                    Ok(PolicyAction::Keep)
-                }
-            }
-            Err(e) => {
-                // Strip failed, but don't reject - just keep original
-                log::debug!("strip failed for {}: {}", ctx.entry.path, e);
-                Ok(PolicyAction::Keep)
-            }
-        }
-    }
-}
-
-/// Attempt to strip an ELF binary using the system `strip` or `llvm-strip` tool.
-///
-/// This preserves `.note.gnu.build-id` sections (needed for debuginfod) and
-/// `.gnu.hash` sections that the native Rust stripper would remove.
-fn strip_elf_with_system_tool(source_path: &Path) -> std::result::Result<Vec<u8>, String> {
-    // Copy to a temp file so we don't modify the original
-    let temp_file =
-        tempfile::NamedTempFile::new().map_err(|e| format!("Failed to create temp file: {}", e))?;
-    std::fs::copy(source_path, temp_file.path())
-        .map_err(|e| format!("Failed to copy for stripping: {}", e))?;
-
-    // Try strip, then llvm-strip
-    let strip_result = std::process::Command::new("strip")
-        .arg("--strip-unneeded")
-        .arg(temp_file.path())
-        .output();
-
-    let success = match strip_result {
-        Ok(output) if output.status.success() => true,
-        _ => {
-            // Try llvm-strip as fallback
-            let llvm_result = std::process::Command::new("llvm-strip")
-                .arg("--strip-unneeded")
-                .arg(temp_file.path())
-                .output();
-            matches!(llvm_result, Ok(output) if output.status.success())
-        }
-    };
-
-    if !success {
-        return Err("No system strip tool available".to_string());
-    }
-
-    std::fs::read(temp_file.path()).map_err(|e| format!("Failed to read stripped binary: {}", e))
-}
-
-/// Strip debug symbols from an ELF binary using native Rust
-///
-/// This implementation removes section headers and debug sections by:
-/// 1. Parsing the ELF structure with goblin
-/// 2. Finding the end of the last loadable segment (PT_LOAD)
-/// 3. Truncating the file to that point
-/// 4. Updating the ELF header to indicate no section headers
-///
-/// This is equivalent to a basic `strip --strip-unneeded` for executables
-/// and shared libraries. It preserves program headers needed for execution.
-fn strip_elf_binary(content: &[u8]) -> std::result::Result<Vec<u8>, String> {
-    use goblin::elf::{Elf, header::*, program_header::PT_LOAD};
-
-    // Parse the ELF file
-    let elf = Elf::parse(content).map_err(|e| format!("Failed to parse ELF: {}", e))?;
-
-    // Only strip executables (ET_EXEC) and shared objects (ET_DYN)
-    // Don't strip relocatable files (ET_REL) as they need section headers
-    if elf.header.e_type != ET_EXEC && elf.header.e_type != ET_DYN {
-        return Err("Not an executable or shared library".to_string());
-    }
-
-    // Find the end of the last loadable segment
-    let mut last_segment_end: u64 = 0;
-    for phdr in &elf.program_headers {
-        if phdr.p_type == PT_LOAD {
-            let segment_end = phdr.p_offset + phdr.p_filesz;
-            if segment_end > last_segment_end {
-                last_segment_end = segment_end;
-            }
-        }
-    }
-
-    // Also need to keep program headers
-    let phdr_end = elf.header.e_phoff + (elf.header.e_phnum as u64 * elf.header.e_phentsize as u64);
-    if phdr_end > last_segment_end {
-        last_segment_end = phdr_end;
-    }
-
-    // Ensure we keep at least the ELF header
-    let elf_header_size = elf.header.e_ehsize as u64;
-    if last_segment_end < elf_header_size {
-        last_segment_end = elf_header_size;
-    }
-
-    // Truncate the binary
-    let truncate_at = last_segment_end as usize;
-    if truncate_at >= content.len() {
-        // Nothing to strip
-        return Err("No sections to strip".to_string());
-    }
-
-    let mut stripped = content[..truncate_at].to_vec();
-
-    // Zero out section header references in the ELF header
-    // This tells the loader there are no section headers
-    // Use the correct byte order based on ELF header endianness
-    if elf.is_64 {
-        // 64-bit ELF: e_shoff at offset 40 (8 bytes), e_shnum at 60 (2 bytes), e_shstrndx at 62 (2 bytes)
-        if stripped.len() >= 64 {
-            if elf.little_endian {
-                stripped[40..48].copy_from_slice(&0u64.to_le_bytes());
-                stripped[60..62].copy_from_slice(&0u16.to_le_bytes());
-                stripped[62..64].copy_from_slice(&0u16.to_le_bytes());
-            } else {
-                stripped[40..48].copy_from_slice(&0u64.to_be_bytes());
-                stripped[60..62].copy_from_slice(&0u16.to_be_bytes());
-                stripped[62..64].copy_from_slice(&0u16.to_be_bytes());
-            }
-        }
-    } else {
-        // 32-bit ELF: e_shoff at offset 32 (4 bytes), e_shnum at 48 (2 bytes), e_shstrndx at 50 (2 bytes)
-        if stripped.len() >= 52 {
-            if elf.little_endian {
-                stripped[32..36].copy_from_slice(&0u32.to_le_bytes());
-                stripped[48..50].copy_from_slice(&0u16.to_le_bytes());
-                stripped[50..52].copy_from_slice(&0u16.to_le_bytes());
-            } else {
-                stripped[32..36].copy_from_slice(&0u32.to_be_bytes());
-                stripped[48..50].copy_from_slice(&0u16.to_be_bytes());
-                stripped[50..52].copy_from_slice(&0u16.to_be_bytes());
-            }
-        }
-    }
-
-    Ok(stripped)
-}
-
-/// Policy to normalize shebangs in scripts
-pub struct FixShebangsPolicy {
-    replacements: HashMap<String, String>,
-}
-
-impl FixShebangsPolicy {
-    pub fn new(replacements: HashMap<String, String>) -> Self {
-        Self { replacements }
-    }
-
-    /// Check if content looks like a script (starts with #!)
-    fn is_script(content: &[u8]) -> bool {
-        content.len() >= 2 && &content[0..2] == b"#!"
-    }
-
-    /// Extract shebang line from content
-    fn extract_shebang(content: &[u8]) -> Option<&[u8]> {
-        if !Self::is_script(content) {
-            return None;
-        }
-        let end = content
-            .iter()
-            .position(|&b| b == b'\n')
-            .unwrap_or(content.len());
-        Some(&content[0..end])
-    }
-}
-
-impl BuildPolicy for FixShebangsPolicy {
-    fn name(&self) -> &str {
-        "FixShebangs"
-    }
-
-    fn apply(&self, ctx: &mut PolicyContext) -> Result<PolicyAction> {
-        let Some(shebang_bytes) = Self::extract_shebang(ctx.content) else {
-            return Ok(PolicyAction::Keep);
-        };
-
-        let Ok(shebang) = std::str::from_utf8(shebang_bytes) else {
-            return Ok(PolicyAction::Keep);
-        };
-
-        // Check each replacement pattern
-        for (old, new) in &self.replacements {
-            // Check if shebang contains the old pattern
-            if shebang.contains(old) {
-                let new_shebang = shebang.replace(old, new);
-                let mut new_content = new_shebang.into_bytes();
-                new_content.extend_from_slice(&ctx.content[shebang_bytes.len()..]);
-                return Ok(PolicyAction::Replace(new_content));
-            }
-        }
-
-        Ok(PolicyAction::Keep)
-    }
-}
-
-/// Policy to compress man pages
-#[derive(Default)]
-pub struct CompressManpagesPolicy;
-
-impl CompressManpagesPolicy {
-    pub fn new() -> Self {
-        Self
-    }
-
-    /// Check if path looks like a man page
-    fn is_manpage(path: &str) -> bool {
-        const MAN_DIRS: &[&str] = &[
-            "/man/", "/man1/", "/man2/", "/man3/", "/man4/", "/man5/", "/man6/", "/man7/", "/man8/",
-        ];
-        const MAN_EXTS: &[&str] = &[".1", ".2", ".3", ".4", ".5", ".6", ".7", ".8", ".n", ".l"];
-
-        if !MAN_DIRS.iter().any(|d| path.contains(d)) {
-            return false;
-        }
-
-        let filename = path.rsplit('/').next().unwrap_or("");
-        MAN_EXTS.iter().any(|ext| filename.ends_with(ext))
-    }
-
-    /// Check if content is already gzipped
-    fn is_gzipped(content: &[u8]) -> bool {
-        content.len() >= 2 && content[0] == 0x1f && content[1] == 0x8b
-    }
-}
-
-impl BuildPolicy for CompressManpagesPolicy {
-    fn name(&self) -> &str {
-        "CompressManpages"
-    }
-
-    fn apply(&self, ctx: &mut PolicyContext) -> Result<PolicyAction> {
-        // Only process man pages
-        if !Self::is_manpage(&ctx.entry.path) {
-            return Ok(PolicyAction::Keep);
-        }
-
-        // Skip if already compressed
-        if Self::is_gzipped(ctx.content) {
-            return Ok(PolicyAction::Keep);
-        }
-
-        // Compress with gzip
-        use flate2::Compression;
-        use flate2::write::GzEncoder;
-        use std::io::Write;
-
-        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-        encoder
-            .write_all(ctx.content)
-            .map_err(|e| PolicyError::Execution(format!("Failed to compress: {}", e)))?;
-        let compressed = encoder
-            .finish()
-            .map_err(|e| PolicyError::Execution(format!("Failed to finish compression: {}", e)))?;
-
-        Ok(PolicyAction::Replace(compressed))
-    }
-}
-
 #[cfg(test)]
-mod tests {
-    use super::*;
-    fn make_entry(path: &str, mode: u32) -> FileEntry {
-        FileEntry {
-            path: path.to_string(),
-            node: crate::payload::PayloadNode::regular(mode),
-            content: Some(crate::payload::PayloadContentAuthority {
-                sha256: crate::hash::sha256(&[]),
-                size: 0,
-            }),
-            component: "runtime".to_string(),
-            chunks: None,
-        }
-    }
-
-    #[test]
-    fn test_deny_paths_policy() {
-        let policy =
-            DenyPathsPolicy::new(&["/home/*".to_string(), "/tmp/build*".to_string()]).unwrap();
-
-        // Should reject /home/user/file
-        let mut entry = make_entry("/home/user/file", 0o644);
-        let mut ctx = PolicyContext {
-            source_path: Path::new("/src/home/user/file"),
-            entry: &mut entry,
-            content: b"test",
-            config: &BuildPolicyConfig::default(),
-        };
-        let result = policy.apply(&mut ctx).unwrap();
-        assert!(matches!(result, PolicyAction::Reject(_)));
-
-        // Should reject /tmp/build123
-        let mut entry = make_entry("/tmp/build123", 0o644);
-        let mut ctx = PolicyContext {
-            source_path: Path::new("/src/tmp/build123"),
-            entry: &mut entry,
-            content: b"test",
-            config: &BuildPolicyConfig::default(),
-        };
-        let result = policy.apply(&mut ctx).unwrap();
-        assert!(matches!(result, PolicyAction::Reject(_)));
-
-        // Should allow /usr/bin/myapp
-        let mut entry = make_entry("/usr/bin/myapp", 0o755);
-        let mut ctx = PolicyContext {
-            source_path: Path::new("/src/usr/bin/myapp"),
-            entry: &mut entry,
-            content: b"test",
-            config: &BuildPolicyConfig::default(),
-        };
-        let result = policy.apply(&mut ctx).unwrap();
-        assert!(matches!(result, PolicyAction::Keep));
-    }
-
-    #[test]
-    fn test_fix_shebangs_policy() {
-        let mut replacements = HashMap::new();
-        replacements.insert(
-            "/usr/bin/env python".to_string(),
-            "/usr/bin/python3".to_string(),
-        );
-        let policy = FixShebangsPolicy::new(replacements);
-
-        // Should fix python shebang
-        let mut entry = make_entry("/usr/bin/script.py", 0o755);
-        let content = b"#!/usr/bin/env python\nprint('hello')";
-        let mut ctx = PolicyContext {
-            source_path: Path::new("/src/usr/bin/script.py"),
-            entry: &mut entry,
-            content,
-            config: &BuildPolicyConfig::default(),
-        };
-        let result = policy.apply(&mut ctx).unwrap();
-        if let PolicyAction::Replace(new_content) = result {
-            assert!(new_content.starts_with(b"#!/usr/bin/python3"));
-        } else {
-            panic!("Expected Replace action");
-        }
-
-        // Should keep bash shebang unchanged
-        let content = b"#!/bin/bash\necho hello";
-        let mut ctx = PolicyContext {
-            source_path: Path::new("/src/usr/bin/script.sh"),
-            entry: &mut entry,
-            content,
-            config: &BuildPolicyConfig::default(),
-        };
-        let result = policy.apply(&mut ctx).unwrap();
-        assert!(matches!(result, PolicyAction::Keep));
-    }
-
-    #[test]
-    fn test_compress_manpages_policy() {
-        let policy = CompressManpagesPolicy::new();
-
-        // Should compress man page
-        let mut entry = make_entry("/usr/share/man/man1/myapp.1", 0o644);
-        let content = b".TH MYAPP 1\n.SH NAME\nmyapp - test application";
-        let mut ctx = PolicyContext {
-            source_path: Path::new("/src/usr/share/man/man1/myapp.1"),
-            entry: &mut entry,
-            content,
-            config: &BuildPolicyConfig::default(),
-        };
-        let result = policy.apply(&mut ctx).unwrap();
-        if let PolicyAction::Replace(new_content) = result {
-            // Should be gzipped (magic bytes)
-            assert_eq!(new_content[0], 0x1f);
-            assert_eq!(new_content[1], 0x8b);
-        } else {
-            panic!("Expected Replace action");
-        }
-
-        // Should skip non-man files
-        let mut entry = make_entry("/usr/bin/myapp", 0o755);
-        let mut ctx = PolicyContext {
-            source_path: Path::new("/src/usr/bin/myapp"),
-            entry: &mut entry,
-            content: b"test",
-            config: &BuildPolicyConfig::default(),
-        };
-        let result = policy.apply(&mut ctx).unwrap();
-        assert!(matches!(result, PolicyAction::Keep));
-    }
-
-    #[test]
-    fn test_normalize_timestamps_policy() {
-        // Test with SOURCE_DATE_EPOCH
-        // SAFETY: We're in a single-threaded test context
-        unsafe { std::env::set_var("SOURCE_DATE_EPOCH", "1700000000") };
-        let policy = NormalizeTimestampsPolicy::new();
-        assert_eq!(policy.timestamp(), 1700000000);
-        // SAFETY: We're in a single-threaded test context
-        unsafe { std::env::remove_var("SOURCE_DATE_EPOCH") };
-
-        // Test without SOURCE_DATE_EPOCH (should use default)
-        let policy = NormalizeTimestampsPolicy::new();
-        assert_eq!(policy.timestamp(), 1704067200); // 2024-01-01
-    }
-
-    #[test]
-    fn test_policy_chain() {
-        let config = BuildPolicyConfig {
-            reject_paths: vec!["/home/*".to_string()],
-            strip_binaries: false,
-            fix_shebangs: HashMap::new(),
-            normalize_timestamps: false,
-            compress_manpages: false,
-            allow_setuid_paths: Vec::new(),
-        };
-
-        let chain = PolicyChain::from_config(&config).unwrap();
-        assert!(!chain.is_empty());
-    }
-
-    #[test]
-    fn test_default_policy_chain_includes_setuid_stripping() {
-        let config = BuildPolicyConfig::default();
-        let chain = PolicyChain::from_config(&config).unwrap();
-        assert!(!chain.is_empty());
-    }
-
-    #[test]
-    fn test_strip_elf_binary_not_elf() {
-        // Non-ELF content should fail
-        let content = b"not an elf file";
-        let result = strip_elf_binary(content);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_strip_elf_binary_real() {
-        // Test with a real system binary (if available)
-        // This test is skipped if the binary doesn't exist
-        let binary_paths = ["/bin/true", "/usr/bin/true", "/bin/ls", "/usr/bin/ls"];
-
-        let content = binary_paths
-            .iter()
-            .find_map(|path| std::fs::read(path).ok());
-
-        let Some(content) = content else {
-            // Skip test if no binary found
-            return;
-        };
-
-        // Verify it's an ELF
-        assert!(content.len() >= 4 && &content[0..4] == b"\x7fELF");
-
-        let result = strip_elf_binary(&content);
-
-        // Strip should either succeed (reducing size) or fail gracefully
-        // Modern binaries are often already stripped, so we accept both outcomes
-        match result {
-            Ok(stripped) => {
-                // If successful, verify the output is valid
-                assert!(
-                    stripped.len() >= 64,
-                    "stripped binary should have ELF header"
-                );
-                assert_eq!(&stripped[0..4], b"\x7fELF", "should still be ELF");
-
-                // Section header offset should be zeroed
-                let shoff = u64::from_le_bytes(stripped[40..48].try_into().unwrap());
-                assert_eq!(shoff, 0, "shoff should be zeroed");
-            }
-            Err(e) => {
-                // Acceptable errors: already stripped, nothing to strip
-                assert!(
-                    e.contains("No sections") || e.contains("Not an executable"),
-                    "unexpected error: {}",
-                    e
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn test_policy_chain_returns_replace_when_content_modified() {
-        // A policy chain should return Replace (not Keep) when a policy modifies content.
-        // This is critical because the builder uses the action to decide whether to rehash.
-        let mut chain = PolicyChain::new();
-
-        // Add a shebang-fixing policy that will modify the content
-        let mut replacements = HashMap::new();
-        replacements.insert(
-            "/usr/bin/env python".to_string(),
-            "/usr/bin/python3".to_string(),
-        );
-        chain.add(Box::new(FixShebangsPolicy::new(replacements)));
-
-        let mut entry = make_entry("/usr/bin/script.py", 0o755);
-        let content = b"#!/usr/bin/env python\nprint('hello')".to_vec();
-        let config = BuildPolicyConfig::default();
-
-        let (action, new_content) = chain
-            .apply(
-                &mut entry,
-                content,
-                Path::new("/src/usr/bin/script.py"),
-                &config,
-            )
-            .unwrap();
-
-        // Content should have been modified
-        assert!(new_content.starts_with(b"#!/usr/bin/python3"));
-
-        // Action MUST be Replace so the builder knows to rehash
-        assert!(
-            matches!(action, PolicyAction::Replace(_)),
-            "Expected Replace action when content was modified, got Keep"
-        );
-    }
-
-    #[test]
-    fn test_policy_chain_returns_keep_when_content_unmodified() {
-        // When no policy modifies content, the chain should return Keep
-        let mut chain = PolicyChain::new();
-
-        // Add a shebang-fixing policy, but content won't match
-        let mut replacements = HashMap::new();
-        replacements.insert(
-            "/usr/bin/env python".to_string(),
-            "/usr/bin/python3".to_string(),
-        );
-        chain.add(Box::new(FixShebangsPolicy::new(replacements)));
-
-        let mut entry = make_entry("/usr/bin/script.sh", 0o755);
-        let content = b"#!/bin/bash\necho hello".to_vec();
-        let config = BuildPolicyConfig::default();
-
-        let (action, _) = chain
-            .apply(
-                &mut entry,
-                content,
-                Path::new("/src/usr/bin/script.sh"),
-                &config,
-            )
-            .unwrap();
-
-        assert!(
-            matches!(action, PolicyAction::Keep),
-            "Expected Keep action when content was not modified"
-        );
-    }
-
-    #[test]
-    fn test_strip_binaries_policy_non_elf() {
-        let policy = StripBinariesPolicy::new();
-
-        // Non-ELF file should be kept unchanged
-        let mut entry = make_entry("/usr/bin/script", 0o755);
-        let content = b"#!/bin/bash\necho hello";
-        let mut ctx = PolicyContext {
-            source_path: Path::new("/src/usr/bin/script"),
-            entry: &mut entry,
-            content,
-            config: &BuildPolicyConfig::default(),
-        };
-        let result = policy.apply(&mut ctx).unwrap();
-        assert!(matches!(result, PolicyAction::Keep));
-    }
-
-    #[test]
-    fn test_strip_setuid_policy_masks_setuid_and_setgid_bits() {
-        let policy = StripSetuidPolicy::new();
-        let mut entry = make_entry("/usr/bin/helper", 0o6755);
-        let mut ctx = PolicyContext {
-            source_path: Path::new("/src/usr/bin/helper"),
-            entry: &mut entry,
-            content: b"#!/bin/sh\necho hi",
-            config: &BuildPolicyConfig::default(),
-        };
-
-        let result = policy.apply(&mut ctx).unwrap();
-        assert!(matches!(result, PolicyAction::Keep));
-        assert_eq!(ctx.entry.node.mode, libc::S_IFREG | 0o755);
-    }
-
-    #[test]
-    fn test_strip_setuid_policy_preserves_explicitly_allowed_setuid_path() {
-        let policy = StripSetuidPolicy::new();
-        let mut entry = make_entry("/usr/bin/helper", 0o4755);
-        let config = BuildPolicyConfig {
-            allow_setuid_paths: vec!["/usr/bin/helper".to_string()],
-            ..BuildPolicyConfig::default()
-        };
-        let mut ctx = PolicyContext {
-            source_path: Path::new("/src/usr/bin/helper"),
-            entry: &mut entry,
-            content: b"#!/bin/sh\necho hi",
-            config: &config,
-        };
-
-        let result = policy.apply(&mut ctx).unwrap();
-        assert!(matches!(result, PolicyAction::Keep));
-        assert_eq!(ctx.entry.node.mode, libc::S_IFREG | 0o4755);
-    }
-}
+#[path = "policy/tests.rs"]
+mod tests;

--- a/crates/conary-core/src/ccs/policy/content.rs
+++ b/crates/conary-core/src/ccs/policy/content.rs
@@ -1,0 +1,427 @@
+// conary-core/src/ccs/policy/content.rs
+//! Disk-backed content transforms for CCS build policy.
+
+use super::{BuildPolicy, PolicyAction, PolicyContext, PolicyError};
+use anyhow::Result;
+use std::collections::HashMap;
+use std::fs::{self, File};
+use std::io::{self, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
+use std::path::Path;
+
+const STREAM_BUFFER_SIZE: usize = crate::packages::payload::PAYLOAD_IO_BUFFER_SIZE;
+
+#[derive(Default)]
+pub struct StripBinariesPolicy;
+
+impl StripBinariesPolicy {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl BuildPolicy for StripBinariesPolicy {
+    fn name(&self) -> &str {
+        "StripBinaries"
+    }
+
+    fn apply(&self, ctx: &mut PolicyContext<'_>) -> Result<PolicyAction> {
+        if !ctx.entry.node.kind.is_regular()
+            || (!is_elf(ctx.source_path)?
+                || (ctx.entry.node.mode & 0o111 == 0 && !ctx.entry.path.contains(".so")))
+        {
+            return Ok(PolicyAction::Keep);
+        }
+
+        let original_size = fs::metadata(ctx.source_path)?.len();
+        if strip_elf_with_system_tool(ctx.source_path, ctx.replacement_path).is_ok() {
+            let stripped_size = fs::metadata(ctx.replacement_path)?.len();
+            if stripped_size < original_size {
+                log::debug!(
+                    "Stripped {} with system strip: {} -> {} bytes",
+                    ctx.entry.path,
+                    original_size,
+                    stripped_size
+                );
+                return Ok(PolicyAction::Replace(ctx.replacement_path.to_path_buf()));
+            }
+            return Ok(PolicyAction::Keep);
+        }
+
+        match strip_elf_streaming(ctx.source_path, ctx.replacement_path) {
+            Ok(stripped_size) if stripped_size < original_size => {
+                log::debug!(
+                    "Stripped {}: {} -> {} bytes (native)",
+                    ctx.entry.path,
+                    original_size,
+                    stripped_size
+                );
+                Ok(PolicyAction::Replace(ctx.replacement_path.to_path_buf()))
+            }
+            Ok(_) => Ok(PolicyAction::Keep),
+            Err(error) => {
+                log::debug!("strip failed for {}: {}", ctx.entry.path, error);
+                Ok(PolicyAction::Keep)
+            }
+        }
+    }
+}
+
+fn is_elf(path: &Path) -> io::Result<bool> {
+    let mut file = File::open(path)?;
+    let mut magic = [0_u8; 4];
+    Ok(file.read(&mut magic)? == magic.len() && magic == *b"\x7fELF")
+}
+
+fn strip_elf_with_system_tool(source: &Path, output: &Path) -> std::result::Result<(), String> {
+    fs::copy(source, output).map_err(|error| format!("Failed to copy for stripping: {error}"))?;
+    for tool in ["strip", "llvm-strip"] {
+        if std::process::Command::new(tool)
+            .arg("--strip-unneeded")
+            .arg(output)
+            .output()
+            .is_ok_and(|result| result.status.success())
+        {
+            return Ok(());
+        }
+    }
+    Err("No system strip tool available".to_string())
+}
+
+fn strip_elf_streaming(source: &Path, output: &Path) -> std::result::Result<u64, String> {
+    let mut input = File::open(source).map_err(|error| error.to_string())?;
+    let source_size = input.metadata().map_err(|error| error.to_string())?.len();
+    let mut header = [0_u8; 64];
+    input
+        .read_exact(&mut header)
+        .map_err(|error| format!("Failed to read ELF header: {error}"))?;
+    if header[..4] != *b"\x7fELF" {
+        return Err("Not an ELF file".to_string());
+    }
+    let class = header[4];
+    let little_endian = match header[5] {
+        1 => true,
+        2 => false,
+        _ => return Err("Unsupported ELF byte order".to_string()),
+    };
+    let read_u16 = |bytes: &[u8]| {
+        if little_endian {
+            u16::from_le_bytes(bytes.try_into().expect("two-byte ELF field"))
+        } else {
+            u16::from_be_bytes(bytes.try_into().expect("two-byte ELF field"))
+        }
+    };
+    let read_u32 = |bytes: &[u8]| {
+        if little_endian {
+            u32::from_le_bytes(bytes.try_into().expect("four-byte ELF field"))
+        } else {
+            u32::from_be_bytes(bytes.try_into().expect("four-byte ELF field"))
+        }
+    };
+    let read_u64 = |bytes: &[u8]| {
+        if little_endian {
+            u64::from_le_bytes(bytes.try_into().expect("eight-byte ELF field"))
+        } else {
+            u64::from_be_bytes(bytes.try_into().expect("eight-byte ELF field"))
+        }
+    };
+
+    let e_type = read_u16(&header[16..18]);
+    if !matches!(e_type, 2 | 3) {
+        return Err("Not an executable or shared library".to_string());
+    }
+    let (header_size, phoff, phentsize, phnum, expected_phentsize) = match class {
+        1 => (
+            u64::from(read_u16(&header[40..42])),
+            u64::from(read_u32(&header[28..32])),
+            u64::from(read_u16(&header[42..44])),
+            u64::from(read_u16(&header[44..46])),
+            32_usize,
+        ),
+        2 => (
+            u64::from(read_u16(&header[52..54])),
+            read_u64(&header[32..40]),
+            u64::from(read_u16(&header[54..56])),
+            u64::from(read_u16(&header[56..58])),
+            56_usize,
+        ),
+        _ => return Err("Unsupported ELF class".to_string()),
+    };
+    if phentsize < expected_phentsize as u64 {
+        return Err("ELF program-header entry is too short".to_string());
+    }
+
+    let mut last_segment_end = 0_u64;
+    let mut program_header = [0_u8; 56];
+    for index in 0..phnum {
+        let offset = phoff
+            .checked_add(
+                index
+                    .checked_mul(phentsize)
+                    .ok_or("ELF program-header offset overflow")?,
+            )
+            .ok_or("ELF program-header offset overflow")?;
+        input
+            .seek(SeekFrom::Start(offset))
+            .and_then(|_| input.read_exact(&mut program_header[..expected_phentsize]))
+            .map_err(|error| format!("Failed to read ELF program header: {error}"))?;
+        if read_u32(&program_header[..4]) != 1 {
+            continue;
+        }
+        let (segment_offset, segment_size) = if class == 1 {
+            (
+                u64::from(read_u32(&program_header[4..8])),
+                u64::from(read_u32(&program_header[16..20])),
+            )
+        } else {
+            (
+                read_u64(&program_header[8..16]),
+                read_u64(&program_header[32..40]),
+            )
+        };
+        last_segment_end = last_segment_end.max(
+            segment_offset
+                .checked_add(segment_size)
+                .ok_or("ELF segment extent overflow")?,
+        );
+    }
+
+    let phdr_end = phoff
+        .checked_add(
+            phnum
+                .checked_mul(phentsize)
+                .ok_or("ELF program-header table overflow")?,
+        )
+        .ok_or("ELF program-header table overflow")?;
+    let truncate_at = last_segment_end.max(phdr_end).max(header_size);
+    if truncate_at >= source_size {
+        return Err("No sections to strip".to_string());
+    }
+
+    input
+        .seek(SeekFrom::Start(0))
+        .map_err(|error| error.to_string())?;
+    let mut output_file = File::create(output).map_err(|error| error.to_string())?;
+    let copied = io::copy(
+        &mut Read::by_ref(&mut input).take(truncate_at),
+        &mut output_file,
+    )
+    .map_err(|error| error.to_string())?;
+    if copied != truncate_at {
+        return Err(format!(
+            "ELF source ended early while stripping: expected {truncate_at}, got {copied}"
+        ));
+    }
+    match class {
+        1 => {
+            write_zeros(&mut output_file, 32, 4)?;
+            write_zeros(&mut output_file, 48, 4)?;
+        }
+        2 => {
+            write_zeros(&mut output_file, 40, 8)?;
+            write_zeros(&mut output_file, 60, 4)?;
+        }
+        _ => unreachable!(),
+    }
+    Ok(truncate_at)
+}
+
+fn write_zeros(file: &mut File, offset: u64, count: usize) -> std::result::Result<(), String> {
+    file.seek(SeekFrom::Start(offset))
+        .and_then(|_| file.write_all(&[0_u8; 8][..count]))
+        .map_err(|error| error.to_string())
+}
+
+pub struct FixShebangsPolicy {
+    replacements: HashMap<String, String>,
+}
+
+impl FixShebangsPolicy {
+    #[must_use]
+    pub fn new(replacements: HashMap<String, String>) -> Self {
+        Self { replacements }
+    }
+}
+
+impl BuildPolicy for FixShebangsPolicy {
+    fn name(&self) -> &str {
+        "FixShebangs"
+    }
+
+    fn apply(&self, ctx: &mut PolicyContext<'_>) -> Result<PolicyAction> {
+        if !ctx.entry.node.kind.is_regular() || !has_prefix(ctx.source_path, b"#!")? {
+            return Ok(PolicyAction::Keep);
+        }
+        if !first_line_is_utf8(ctx.source_path)? {
+            return Ok(PolicyAction::Keep);
+        }
+        for (old, new) in &self.replacements {
+            if !old.is_empty() && first_line_contains(ctx.source_path, old.as_bytes())? {
+                rewrite_first_line(
+                    ctx.source_path,
+                    ctx.replacement_path,
+                    old.as_bytes(),
+                    new.as_bytes(),
+                )?;
+                return Ok(PolicyAction::Replace(ctx.replacement_path.to_path_buf()));
+            }
+        }
+        Ok(PolicyAction::Keep)
+    }
+}
+
+fn has_prefix(path: &Path, expected: &[u8]) -> io::Result<bool> {
+    let mut file = File::open(path)?;
+    let mut prefix = vec![0_u8; expected.len()];
+    Ok(file.read(&mut prefix)? == expected.len() && prefix == expected)
+}
+
+fn first_line_is_utf8(path: &Path) -> io::Result<bool> {
+    let mut reader = File::open(path)?;
+    let mut buffer = [0_u8; STREAM_BUFFER_SIZE];
+    let mut carry = Vec::with_capacity(3);
+    loop {
+        let count = reader.read(&mut buffer)?;
+        if count == 0 {
+            return Ok(carry.is_empty());
+        }
+        let line_count = buffer[..count]
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .unwrap_or(count);
+        let mut candidate = Vec::with_capacity(carry.len() + line_count);
+        candidate.extend_from_slice(&carry);
+        candidate.extend_from_slice(&buffer[..line_count]);
+        match std::str::from_utf8(&candidate) {
+            Ok(_) => carry.clear(),
+            Err(error) if error.error_len().is_some() => return Ok(false),
+            Err(error) => {
+                carry.clear();
+                carry.extend_from_slice(&candidate[error.valid_up_to()..]);
+                if carry.len() > 3 {
+                    return Ok(false);
+                }
+            }
+        }
+        if line_count < count {
+            return Ok(carry.is_empty());
+        }
+    }
+}
+
+fn first_line_contains(path: &Path, needle: &[u8]) -> io::Result<bool> {
+    let mut reader = File::open(path)?;
+    let mut buffer = [0_u8; STREAM_BUFFER_SIZE];
+    let mut overlap = Vec::with_capacity(needle.len().saturating_sub(1));
+    loop {
+        let count = reader.read(&mut buffer)?;
+        if count == 0 {
+            return Ok(overlap.windows(needle.len()).any(|window| window == needle));
+        }
+        let line_count = buffer[..count]
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .unwrap_or(count);
+        let mut candidate = Vec::with_capacity(overlap.len() + line_count);
+        candidate.extend_from_slice(&overlap);
+        candidate.extend_from_slice(&buffer[..line_count]);
+        if candidate
+            .windows(needle.len())
+            .any(|window| window == needle)
+        {
+            return Ok(true);
+        }
+        let retain = needle.len().saturating_sub(1).min(candidate.len());
+        overlap.clear();
+        overlap.extend_from_slice(&candidate[candidate.len() - retain..]);
+        if line_count < count {
+            return Ok(false);
+        }
+    }
+}
+
+fn rewrite_first_line(source: &Path, output: &Path, old: &[u8], new: &[u8]) -> io::Result<()> {
+    let input = File::open(source)?;
+    let mut reader = BufReader::with_capacity(STREAM_BUFFER_SIZE, input);
+    let mut writer = BufWriter::with_capacity(STREAM_BUFFER_SIZE, File::create(output)?);
+    let mut pending = Vec::with_capacity(old.len());
+    let mut byte = [0_u8; 1];
+    loop {
+        let count = reader.read(&mut byte)?;
+        if count == 0 {
+            writer.write_all(&pending)?;
+            break;
+        }
+        if byte[0] == b'\n' {
+            writer.write_all(&pending)?;
+            writer.write_all(&byte)?;
+            io::copy(&mut reader, &mut writer)?;
+            break;
+        }
+        pending.push(byte[0]);
+        loop {
+            if pending == old {
+                writer.write_all(new)?;
+                pending.clear();
+                break;
+            }
+            if old.starts_with(&pending) {
+                break;
+            }
+            writer.write_all(&pending[..1])?;
+            pending.remove(0);
+        }
+    }
+    writer.flush()
+}
+
+#[derive(Default)]
+pub struct CompressManpagesPolicy;
+
+impl CompressManpagesPolicy {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn is_manpage(path: &str) -> bool {
+        const MAN_DIRS: &[&str] = &[
+            "/man/", "/man1/", "/man2/", "/man3/", "/man4/", "/man5/", "/man6/", "/man7/", "/man8/",
+        ];
+        const MAN_EXTS: &[&str] = &[".1", ".2", ".3", ".4", ".5", ".6", ".7", ".8", ".n", ".l"];
+        MAN_DIRS.iter().any(|directory| path.contains(directory))
+            && path
+                .rsplit('/')
+                .next()
+                .is_some_and(|name| MAN_EXTS.iter().any(|extension| name.ends_with(extension)))
+    }
+}
+
+impl BuildPolicy for CompressManpagesPolicy {
+    fn name(&self) -> &str {
+        "CompressManpages"
+    }
+
+    fn apply(&self, ctx: &mut PolicyContext<'_>) -> Result<PolicyAction> {
+        if !ctx.entry.node.kind.is_regular()
+            || !Self::is_manpage(&ctx.entry.path)
+            || has_prefix(ctx.source_path, &[0x1f, 0x8b])?
+        {
+            return Ok(PolicyAction::Keep);
+        }
+        let mut input = File::open(ctx.source_path)?;
+        let output = File::create(ctx.replacement_path)?;
+        let mut encoder = flate2::write::GzEncoder::new(output, flate2::Compression::default());
+        io::copy(&mut input, &mut encoder)
+            .map_err(|error| PolicyError::Execution(format!("Failed to compress: {error}")))?;
+        encoder.finish().map_err(|error| {
+            PolicyError::Execution(format!("Failed to finish compression: {error}"))
+        })?;
+        Ok(PolicyAction::Replace(ctx.replacement_path.to_path_buf()))
+    }
+}
+
+#[cfg(test)]
+pub(super) fn strip_elf_for_test(source: &Path, output: &Path) -> Result<u64, String> {
+    strip_elf_streaming(source, output)
+}

--- a/crates/conary-core/src/ccs/policy/tests.rs
+++ b/crates/conary-core/src/ccs/policy/tests.rs
@@ -1,0 +1,162 @@
+// conary-core/src/ccs/policy/tests.rs
+
+use super::*;
+use std::fs::File;
+use std::io::Read;
+use tempfile::TempDir;
+
+fn make_entry(path: &str, mode: u32) -> FileEntry {
+    FileEntry {
+        path: path.to_string(),
+        node: crate::payload::PayloadNode::regular(mode),
+        content: None,
+        component: "runtime".to_string(),
+        chunks: None,
+    }
+}
+
+fn context_paths(temp: &TempDir, bytes: &[u8]) -> (PathBuf, PathBuf) {
+    let source = temp.path().join("source");
+    let replacement = temp.path().join("replacement");
+    std::fs::write(&source, bytes).unwrap();
+    (source, replacement)
+}
+
+fn read_all(path: &Path) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    File::open(path).unwrap().read_to_end(&mut bytes).unwrap();
+    bytes
+}
+
+#[test]
+fn deny_paths_policy_rejects_configured_paths() {
+    let policy = DenyPathsPolicy::new(&["/home/*".to_string()]).unwrap();
+    let temp = TempDir::new().unwrap();
+    let (source, replacement) = context_paths(&temp, b"content");
+    let mut entry = make_entry("/home/user/file", 0o644);
+    let mut context = PolicyContext {
+        source_path: &source,
+        replacement_path: &replacement,
+        entry: &mut entry,
+        config: &BuildPolicyConfig::default(),
+    };
+    assert!(matches!(
+        policy.apply(&mut context).unwrap(),
+        PolicyAction::Reject(_)
+    ));
+}
+
+#[test]
+fn fix_shebangs_streams_replacement_to_disk() {
+    let policy = FixShebangsPolicy::new(HashMap::from([(
+        "/usr/bin/env python".to_string(),
+        "/usr/bin/python3".to_string(),
+    )]));
+    let temp = TempDir::new().unwrap();
+    let (source, replacement) = context_paths(&temp, b"#!/usr/bin/env python\nprint('hello')\n");
+    let mut entry = make_entry("/usr/bin/script.py", 0o755);
+    let mut context = PolicyContext {
+        source_path: &source,
+        replacement_path: &replacement,
+        entry: &mut entry,
+        config: &BuildPolicyConfig::default(),
+    };
+    assert!(matches!(
+        policy.apply(&mut context).unwrap(),
+        PolicyAction::Replace(_)
+    ));
+    assert_eq!(
+        read_all(&replacement),
+        b"#!/usr/bin/python3\nprint('hello')\n"
+    );
+}
+
+#[test]
+fn compress_manpages_streams_deterministic_gzip() {
+    let policy = CompressManpagesPolicy::new();
+    let temp = TempDir::new().unwrap();
+    let (source, replacement) = context_paths(&temp, b".TH APP 1\n.SH NAME\napp\n");
+    let mut entry = make_entry("/usr/share/man/man1/app.1", 0o644);
+    let mut context = PolicyContext {
+        source_path: &source,
+        replacement_path: &replacement,
+        entry: &mut entry,
+        config: &BuildPolicyConfig::default(),
+    };
+    assert!(matches!(
+        policy.apply(&mut context).unwrap(),
+        PolicyAction::Replace(_)
+    ));
+    assert_eq!(&read_all(&replacement)[..2], &[0x1f, 0x8b]);
+}
+
+#[test]
+fn policy_chain_returns_disk_replacement() {
+    let mut chain = PolicyChain::new();
+    chain.add(Box::new(FixShebangsPolicy::new(HashMap::from([(
+        "/usr/bin/env python".to_string(),
+        "/usr/bin/python3".to_string(),
+    )]))));
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source");
+    let workspace = temp.path().join("workspace");
+    std::fs::write(&source, b"#!/usr/bin/env python\n").unwrap();
+    std::fs::create_dir(&workspace).unwrap();
+    let mut entry = make_entry("/usr/bin/script.py", 0o755);
+    let action = chain
+        .apply(
+            &mut entry,
+            &source,
+            &workspace,
+            &BuildPolicyConfig::default(),
+        )
+        .unwrap();
+    let PolicyAction::Replace(path) = action else {
+        panic!("expected disk-backed replacement");
+    };
+    assert_eq!(read_all(&path), b"#!/usr/bin/python3\n");
+}
+
+#[test]
+fn strip_setuid_policy_preserves_only_explicit_setuid() {
+    let temp = TempDir::new().unwrap();
+    let (source, replacement) = context_paths(&temp, b"payload");
+    let mut entry = make_entry("/usr/bin/helper", 0o6755);
+    let config = BuildPolicyConfig {
+        allow_setuid_paths: vec!["/usr/bin/helper".to_string()],
+        ..BuildPolicyConfig::default()
+    };
+    let mut context = PolicyContext {
+        source_path: &source,
+        replacement_path: &replacement,
+        entry: &mut entry,
+        config: &config,
+    };
+    assert_eq!(
+        StripSetuidPolicy::new().apply(&mut context).unwrap(),
+        PolicyAction::Keep
+    );
+    assert_eq!(context.entry.node.mode, libc::S_IFREG | 0o4755);
+}
+
+#[test]
+fn native_elf_strip_is_disk_backed() {
+    let Some(binary) = ["/bin/true", "/usr/bin/true", "/bin/ls", "/usr/bin/ls"]
+        .into_iter()
+        .find(|path| Path::new(path).exists())
+    else {
+        return;
+    };
+    let temp = TempDir::new().unwrap();
+    let output = temp.path().join("stripped");
+    match super::content::strip_elf_for_test(Path::new(binary), &output) {
+        Ok(size) => {
+            assert!(size >= 52);
+            assert_eq!(&read_all(&output)[..4], b"\x7fELF");
+        }
+        Err(error) => assert!(
+            error.contains("No sections") || error.contains("Not an executable"),
+            "{error}"
+        ),
+    }
+}

--- a/crates/conary-core/src/ccs/signing.rs
+++ b/crates/conary-core/src/ccs/signing.rs
@@ -11,8 +11,7 @@ use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
 use rand_core_06::OsRng;
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::io::ErrorKind;
-use std::io::Write;
+use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -329,6 +328,7 @@ pub fn load_public_key(path: &Path) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Read;
     use tempfile::TempDir;
 
     #[test]
@@ -408,10 +408,10 @@ mod tests {
         let loaded = SigningKeyPair::load_from_file(&private_path).unwrap();
         assert_eq!(loaded.public_key_base64(), replacement_public);
         assert_eq!(loaded.key_id(), Some("replacement-key"));
-        assert_eq!(
-            fs::read(&stale_temp_path).unwrap(),
-            b"stale temp from earlier implementation"
-        );
+        let mut stale_temp = fs::File::open(&stale_temp_path).unwrap();
+        let mut stale_contents = Vec::new();
+        stale_temp.read_to_end(&mut stale_contents).unwrap();
+        assert_eq!(stale_contents, b"stale temp from earlier implementation");
     }
 
     #[test]

--- a/crates/conary-core/src/ccs/v2/authoring.rs
+++ b/crates/conary-core/src/ccs/v2/authoring.rs
@@ -5,7 +5,7 @@ use crate::ccs::builder::BuildResult;
 use crate::ccs::v2::PackageKindTagV2;
 use crate::repository::dependency_model::RepositoryRequirementGroup;
 use crate::repository::versioning::VersionScheme;
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
@@ -93,17 +93,18 @@ impl std::fmt::Debug for V2AuthoringInput<'_> {
 #[derive(Debug)]
 pub struct ProjectedV2Package {
     pub authority: AuthorityDocumentV2,
-    pub payloads_by_path: BTreeMap<String, Vec<u8>>,
+    pub payloads: Vec<crate::packages::payload::PackagePayloadFile>,
     pub debug_toml: Option<String>,
 }
 
 pub fn project_build_result_to_v2(input: V2AuthoringInput<'_>) -> Result<ProjectedV2Package> {
-    let payloads_by_path = payloads_by_path(input.build)?;
+    validate_payload_sources(input.build)?;
+    let payloads = input.build.payloads.clone();
     let debug_toml = input.debug_toml.clone();
     let authority = project_build_result_authority_to_v2(input)?;
     Ok(ProjectedV2Package {
         authority,
-        payloads_by_path,
+        payloads,
         debug_toml,
     })
 }
@@ -407,40 +408,32 @@ fn select_default_component(build: &BuildResult) -> Result<String> {
     Ok(default_component)
 }
 
-fn payloads_by_path(build: &BuildResult) -> Result<BTreeMap<String, Vec<u8>>> {
-    let mut payloads = BTreeMap::new();
-    for file in &build.files {
-        if !file.node.kind.is_regular() {
-            continue;
+fn validate_payload_sources(build: &BuildResult) -> Result<()> {
+    let mut seen = BTreeSet::new();
+    for payload in &build.payloads {
+        if !seen.insert(payload.path.as_str()) {
+            bail!(
+                "payload source path {} appears more than once",
+                payload.path
+            );
         }
-        let content = file.content.as_ref().with_context(|| {
-            format!(
-                "regular payload node {} has no content authority",
-                file.path
-            )
-        })?;
-        let bytes =
-            if let Some(chunks) = &file.chunks {
-                let mut bytes = Vec::new();
-                for chunk_hash in chunks {
-                    bytes.extend(build.blobs.get(chunk_hash).with_context(|| {
-                        format!("missing chunk {chunk_hash} for {}", file.path)
-                    })?);
-                }
-                bytes
-            } else {
-                build
-                    .blobs
-                    .get(&content.sha256)
-                    .with_context(|| format!("missing payload blob for {}", file.path))?
-                    .clone()
-            };
-        if crate::hash::sha256(&bytes) != content.sha256 || bytes.len() as u64 != content.size {
-            bail!("payload bytes for {} do not match builder hash", file.path);
-        }
-        payloads.insert(file.path.clone(), bytes);
     }
-    Ok(payloads)
+    for file in &build.files {
+        let payload = build.payload(&file.path)?;
+        if payload.node != file.node || payload.content_authority != file.content {
+            bail!(
+                "payload descriptor authority disagrees with build entry {}",
+                file.path
+            );
+        }
+        if file.node.kind.is_regular() != payload.source().is_some() {
+            bail!(
+                "payload source presence disagrees with build entry {}",
+                file.path
+            );
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/conary-core/src/ccs/v2/authoring/tests.rs
+++ b/crates/conary-core/src/ccs/v2/authoring/tests.rs
@@ -6,6 +6,7 @@ use crate::repository::dependency_model::{
     RepositoryCapabilityKind, RepositoryRequirementClause, RepositoryRequirementGroup,
     RepositoryRequirementKind,
 };
+use std::io::Read;
 
 fn config_file(path: &str, noreplace: bool) -> crate::packages::traits::ConfigFileInfo {
     crate::packages::traits::ConfigFileInfo {
@@ -54,7 +55,12 @@ fn projection_builds_complete_local_dev_package_authority() {
         Some("host")
     );
     assert!(projected.authority.components["runtime"].default);
-    assert!(projected.payloads_by_path.contains_key("/hello"));
+    assert!(
+        projected
+            .payloads
+            .iter()
+            .any(|payload| payload.path == "/hello")
+    );
 }
 
 #[test]
@@ -85,7 +91,7 @@ fn projection_gives_payloadless_packages_an_explicit_empty_default_component() {
     let mut build = test_support::minimal_file_build_result("empty", "0.1.0", b"discarded");
     build.files.clear();
     build.components.clear();
-    build.blobs.clear();
+    build.payloads.clear();
     build.total_size = 0;
 
     let projected = project_build_result_to_v2(V2AuthoringInput {
@@ -99,7 +105,7 @@ fn projection_gives_payloadless_packages_an_explicit_empty_default_component() {
     assert!(runtime.default);
     assert_eq!(runtime.file_count, 0);
     assert_eq!(runtime.total_size, 0);
-    assert!(projected.payloads_by_path.is_empty());
+    assert!(projected.payloads.is_empty());
 }
 
 #[test]
@@ -125,7 +131,7 @@ fn projection_rejects_ambiguous_or_missing_default_component_authority() {
 }
 
 #[test]
-fn projection_reconstructs_payload_from_chunk_blobs() {
+fn projection_preserves_reopenable_payload_when_chunk_metadata_is_present() {
     let mut build = test_support::minimal_file_build_result("hello", "0.1.0", b"hello\n");
     build.manifest.package.release = "1".to_string();
     build.manifest.package.kind = crate::ccs::v2::PackageKindTagV2::Package;
@@ -135,10 +141,6 @@ fn projection_reconstructs_payload_from_chunk_blobs() {
         .iter()
         .map(|chunk| crate::hash::sha256(chunk))
         .collect::<Vec<_>>();
-    build.blobs.clear();
-    for (hash, bytes) in chunk_hashes.iter().zip(chunks) {
-        build.blobs.insert(hash.clone(), bytes);
-    }
     build.files[0].chunks = Some(chunk_hashes.clone());
     build.components.get_mut("runtime").unwrap().files[0].chunks = Some(chunk_hashes);
     build.chunked = true;
@@ -150,7 +152,13 @@ fn projection_reconstructs_payload_from_chunk_blobs() {
     })
     .unwrap();
 
-    assert_eq!(projected.payloads_by_path["/hello"], b"hello\n");
+    let mut bytes = Vec::new();
+    projected.payloads[0]
+        .open_content()
+        .unwrap()
+        .read_to_end(&mut bytes)
+        .unwrap();
+    assert_eq!(bytes, b"hello\n");
 }
 
 #[test]

--- a/crates/conary-core/src/ccs/verify.rs
+++ b/crates/conary-core/src/ccs/verify.rs
@@ -315,7 +315,7 @@ pub fn print_result(result: &VerifiedCcsArchive) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ccs::builder::write_v2_ccs_package;
+    use crate::ccs::builder::write_v2_ccs_package_from_bounded_memory_for_tests;
     use crate::ccs::signing::SigningKeyPair;
 
     fn package(signer: &SigningKeyPair) -> (tempfile::TempDir, std::path::PathBuf, TrustPolicy) {
@@ -323,7 +323,10 @@ mod tests {
         let path = temp.path().join("verified.ccs");
         let authority = crate::ccs::v2::test_support::package_authority_with_one_file("verified");
         let payloads = crate::ccs::v2::test_support::one_file_payloads_for_tests();
-        write_v2_ccs_package(&authority, &payloads, &path, signer, None, None, None).unwrap();
+        write_v2_ccs_package_from_bounded_memory_for_tests(
+            &authority, &payloads, &path, signer, None, None, None,
+        )
+        .unwrap();
         let policy = TrustPolicy::strict(vec![signer.public_key_base64()]);
         (temp, path, policy)
     }

--- a/crates/conary-core/src/ccs/verify/stream.rs
+++ b/crates/conary-core/src/ccs/verify/stream.rs
@@ -599,7 +599,7 @@ fn require_known_directory(path: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ccs::builder::write_v2_ccs_package;
+    use crate::ccs::builder::write_v2_ccs_package_from_bounded_memory_for_tests;
     use crate::ccs::signing::SigningKeyPair;
     use flate2::Compression;
     use flate2::read::GzDecoder as ReadGzDecoder;
@@ -625,7 +625,10 @@ mod tests {
         let authority = crate::ccs::v2::test_support::package_authority_with_one_file("stream");
         let payloads = crate::ccs::v2::test_support::one_file_payloads_for_tests();
         let signer = SigningKeyPair::generate();
-        write_v2_ccs_package(&authority, &payloads, &path, &signer, None, None, None).unwrap();
+        write_v2_ccs_package_from_bounded_memory_for_tests(
+            &authority, &payloads, &path, &signer, None, None, None,
+        )
+        .unwrap();
         let policy = TrustPolicy::strict(vec![signer.public_key_base64()]);
 
         let mut archive = Archive::new(ReadGzDecoder::new(File::open(&path).unwrap()));

--- a/crates/conary-core/src/ccs/verify/stream.rs
+++ b/crates/conary-core/src/ccs/verify/stream.rs
@@ -808,7 +808,8 @@ mod tests {
     #[test]
     fn rejects_truncated_archive_and_aggregate_metadata_without_allocation() {
         let (temp, _, policy, base) = fixture();
-        let bytes = std::fs::read(base).unwrap();
+        let mut bytes = Vec::new();
+        File::open(base).unwrap().read_to_end(&mut bytes).unwrap();
         let truncated = temp.path().join("truncated.ccs");
         let mut output = File::create(&truncated).unwrap();
         output.write_all(&bytes[..bytes.len() / 2]).unwrap();
@@ -864,7 +865,8 @@ mod tests {
         assert!(error_text(&appended_tar, &policy).contains("non-zero data"));
 
         let appended_gzip = temp.path().join("appended-gzip.ccs");
-        let mut bytes = std::fs::read(&base).unwrap();
+        let mut bytes = Vec::new();
+        File::open(&base).unwrap().read_to_end(&mut bytes).unwrap();
         let mut member = GzEncoder::new(Vec::new(), Compression::default());
         member.write_all(b"second member").unwrap();
         bytes.extend(member.finish().unwrap());

--- a/crates/conary-core/src/recipe/kitchen/package_output.rs
+++ b/crates/conary-core/src/recipe/kitchen/package_output.rs
@@ -110,10 +110,14 @@ impl Cook<'_> {
         })?;
 
         self.log_line(&format!(
-            "Created CCS package: {} ({} files, {} blobs)",
+            "Created CCS package: {} ({} files, {} payload sources)",
             package_path.display(),
             build_result.files.len(),
-            build_result.blobs.len()
+            build_result
+                .payloads
+                .iter()
+                .filter(|payload| payload.node.kind.is_regular())
+                .count()
         ));
         info!(
             "Cooked: {} ({} files, DNA: {})",

--- a/crates/conary-core/src/repository/static_repo/publish_context/tests.rs
+++ b/crates/conary-core/src/repository/static_repo/publish_context/tests.rs
@@ -63,7 +63,7 @@ fn project_form_attestation_reemits_v2_package_as_v2() {
     let package_path = temp.path().join("project-v2.ccs");
     let mut authority = crate::ccs::v2::test_support::package_authority_with_one_file("project-v2");
     authority.provenance.hermetic_evidence_hash = Some(evidence_hash);
-    crate::ccs::builder::write_v2_ccs_package(
+    crate::ccs::builder::write_v2_ccs_package_from_bounded_memory_for_tests(
         &authority,
         &crate::ccs::v2::test_support::one_file_payloads_for_tests(),
         &package_path,

--- a/crates/conary-core/src/repository/static_repo/publish_gate/tests.rs
+++ b/crates/conary-core/src/repository/static_repo/publish_gate/tests.rs
@@ -115,7 +115,7 @@ fn artifact_gate_accepts_attested_v2_package() {
         &signer,
         STATIC_PUBLISH_POLICY_DIGEST_V1,
     );
-    crate::ccs::builder::write_v2_ccs_package(
+    crate::ccs::builder::write_v2_ccs_package_from_bounded_memory_for_tests(
         &authority,
         &payloads,
         &package_path,
@@ -152,7 +152,7 @@ fn artifact_gate_does_not_require_command_risk_diagnostics() {
     envelope.payload.build_command_risk_report_hash.clear();
     envelope.payload.command_risk_classifier_version.clear();
     let envelope = sign_build_attestation(envelope.payload, &signer).unwrap();
-    crate::ccs::builder::write_v2_ccs_package(
+    crate::ccs::builder::write_v2_ccs_package_from_bounded_memory_for_tests(
         &authority,
         &payloads,
         &package_path,
@@ -189,7 +189,7 @@ fn artifact_gate_candidate_returns_verified_v2_package_for_native_intake() {
         &signer,
         STATIC_PUBLISH_POLICY_DIGEST_V1,
     );
-    crate::ccs::builder::write_v2_ccs_package(
+    crate::ccs::builder::write_v2_ccs_package_from_bounded_memory_for_tests(
         &authority,
         &payloads,
         &package_path,
@@ -225,7 +225,7 @@ fn artifact_gate_rejects_local_dev_v2_package() {
     let mut authority = crate::ccs::v2::test_support::package_authority_with_one_file("local-dev");
     authority.provenance.hardening_level = Some("host".to_string());
     let payloads = crate::ccs::v2::test_support::one_file_payloads_for_tests();
-    crate::ccs::builder::write_v2_ccs_package(
+    crate::ccs::builder::write_v2_ccs_package_from_bounded_memory_for_tests(
         &authority,
         &payloads,
         &package_path,

--- a/crates/conary-core/src/self_update.rs
+++ b/crates/conary-core/src/self_update.rs
@@ -461,10 +461,6 @@ mod tests {
             .iter()
             .map(|chunk| crate::hash::sha256(chunk))
             .collect::<Vec<_>>();
-        build.blobs.clear();
-        for (hash, chunk) in chunk_hashes.iter().zip(chunks) {
-            build.blobs.insert(hash.clone(), chunk.to_vec());
-        }
         build.files[0].chunks = Some(chunk_hashes.clone());
         build.components.get_mut("runtime").unwrap().files[0].chunks = Some(chunk_hashes);
         build.chunked = true;

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -124,7 +124,10 @@ commands.
 - CCS authoring, conversion, native package contracts, and repository feed
   profiles:
   `docs/modules/feature-ownership.md` slugs `ccs`, `packaging`, and `profiles`,
-  plus `docs/modules/ccs.md` and `docs/modules/recipe.md`. Debian lifecycle
+  plus `docs/modules/ccs.md` and `docs/modules/recipe.md`. Native authoring
+  content flow starts in `crates/conary-core/src/ccs/builder.rs`,
+  `builder/source.rs`, `policy/content.rs`, and `builder/package_writer.rs`.
+  Debian lifecycle
   service-helper argv grammar starts in
   `crates/conary-core/src/packages/deb/lifecycle_helpers.rs` and its focused
   child modules. The selected-root namespace, capability, and seccomp contract

--- a/docs/modules/ccs.md
+++ b/docs/modules/ccs.md
@@ -27,7 +27,7 @@ CcsBuilder::new(manifest, source_dir)
      |
   Group files by component -> ComponentData
      |
-  BuildResult { manifest, components, files, blobs, chunk_stats }
+  BuildResult { manifest, components, files, payloads, chunk_stats }
      |
   Sign manifest (Ed25519) -> embed PackageSignature
      |

--- a/docs/modules/ccs.md
+++ b/docs/modules/ccs.md
@@ -41,8 +41,8 @@ CcsBuilder::new(manifest, source_dir)
 | `CcsManifest` | manifest.rs | Root ccs.toml structure (package, provides, requires, hooks, policy, etc.) |
 | `ManifestProvenance` | manifest_provenance.rs | Provenance DTOs embedded by the root manifest, including hermetic evidence, build attestations, and foreign conversion boundaries |
 | `BuildAttestationEnvelope` | attestation.rs | Signed M2 release-publish attestation payload and verification helpers |
-| `CcsBuilder` | builder.rs | Builds a CCS package from manifest + source directory |
-| `BuildResult` | builder.rs | Output: manifest, components, files, blobs, total_size |
+| `CcsBuilder` | builder.rs + builder/source.rs | Describes a CCS package from filesystem metadata and reopenable payload sources |
+| `BuildResult` | builder.rs | Output: manifest, components, files, reopenable payload sources, total_size |
 | `CcsPackage` | package.rs | Parsed .ccs file ready for installation via PackageFormat trait |
 | CCS package projection | package/v2_projection.rs | Project verified signed v2 authority into install-time package data |
 | `AuthorityDocumentV2` | v2/schema.rs | Signed CCS v2 native package authority |
@@ -128,6 +128,13 @@ files, documentation, or configuration ownership from path spelling.
 Overlapping rules that select different component names are invalid. Foreign
 packages without an explicit Conary component contract likewise remain one
 lossless `runtime` component.
+
+Native payload content is source-backed throughout authoring.
+`builder/source.rs` owns filesystem enumeration and reopenable source
+descriptors, `policy/content.rs` owns disk-backed streaming transforms, and
+`builder/package_writer.rs` reopens those sources for signed CCS emission.
+Authoring hashes and chunks fixed-buffer streams; it does not retain complete
+files, chunks, or package payloads in memory.
 
 ### Exact payload authority
 
@@ -272,7 +279,9 @@ surfaces.
 
 Native v2 authoring from `ccs.toml` starts in
 `apps/conary/src/commands/ccs/{templates.rs,lint.rs,build.rs,test.rs,local_dev.rs}`
-for command ergonomics and local-dev state, and
+for command ergonomics and local-dev state,
+`crates/conary-core/src/ccs/{builder.rs,builder/source.rs,policy/content.rs,builder/package_writer.rs}`
+for source-backed collection, policy transforms, and archive emission, and
 `crates/conary-core/src/ccs/v2/authoring.rs` for projection from `BuildResult`
 into signed v2 authority. `crates/conary-core/src/ccs/v2/lifecycle.rs` owns the
 exact bidirectional projection between manifest lifecycle declarations, signed


### PR DESCRIPTION
## Primary Issue

Closes #135

Refs #99

Unblocks #133 / PR #134.

## Problem And Outcome

Native CCS authoring retained every regular file as `Vec<u8>`, cloned chunk
content into a package-wide blob map, and cloned complete objects again at the
package boundary. Peak memory therefore scaled with payload size.

This hard cut makes reopenable payload descriptors the only production content
path. Native discovery, policy transforms, digesting, FastCDC visitation,
package-object storage, and native export now consume readers or disk-backed
sources. The signed authority shape, hashes, chunk boundaries, and emitted CCS
format are unchanged.

## Design And Buffered-Path Disposition

- `raw_files: Vec<(PathBuf, FileEntry, Vec<u8>)>` is deleted. The builder
  discovers typed nodes and processes one reopenable source at a time.
- `collect_file` and its payload `fs::read` are deleted. Regular-file SHA-256
  is computed through a fixed 64 KiB buffer.
- `chunk_bytes(&final_content)` and `BuildResult.blobs` are deleted.
  `visit_reader_chunks` streams FastCDC boundaries and retains only chunk
  hashes and statistics; package emission reopens the original or transformed
  source.
- `collect_package_entry` is deleted. Foreign conversion and native authoring
  now converge on `PackagePayloadFile` descriptors rather than cloning complete
  objects.
- `v2::authoring::payloads_by_path` is deleted from production emission. The
  writer validates the descriptor set, reopens each regular file, and streams
  it through `store_reader_expected`.
- Native RPM/DEB export no longer reconstructs complete objects from the old
  blob map. It copies source-backed readers while verifying the signed digest.
- Content-changing policy owns disk-backed replacements in
  `ccs/policy/content.rs`; unchanged content remains path-backed. Temporary
  workspaces are created beside the source/output on disk, not in tmpfs.
- The only `Vec<u8>` package adapter is explicitly test-only:
  `write_v2_ccs_package_from_bounded_memory_for_tests`. It rejects more than
  16 MiB of unique fixture input or retained signed payload aggregate, spools
  accepted bytes immediately, and delegates to the sole streamed writer. It is
  not reachable from native authoring or foreign conversion.

## Ownership Decomposition

- `builder.rs` owns manifest orchestration and streamed metadata assembly
  (517 lines, down from 957 on the reported base).
- `builder/source.rs` owns native filesystem discovery and node authority.
- `builder/package_writer.rs` owns descriptor validation and streamed archive
  emission.
- `policy/content.rs` owns disk-backed payload transforms.
- The subsystem map and CCS module documentation point contributors at the new
  ownership boundaries.

## Fidelity And Regression Coverage

- No golden fixture was regenerated or changed.
- Golden conversion, CCS round trips, package verification, native export
  byte/MD5 checks, source-mutation rejection, architecture mapping, and loss
  reporting all pass.
- The RSS regression creates a sparse zero-filled regular file with declared
  size `2,147,483,649` bytes, builds its native authoring result in a child
  process, and asserts `VmHWM < 262,144 KiB`.
- Observed on this branch: `ISSUE135_VM_HWM_KIB=29676` (29,676 KiB).
- The large-file proof exercises the native builder path where #135's
  whole-file/package retention occurred. It intentionally does not emit a
  >2 GiB archive because the current CCS object budget rejects that size;
  changing that budget or decoder/spool enforcement belongs to #133. Streamed
  writer behavior is proved separately by the round-trip, golden, package
  writer, and Remi conversion tests.

## Scope

- In scope: native CCS authoring content flow, source-backed package emission,
  native export consumers, ownership-based decomposition, fidelity proof, and
  bounded-memory proof.
- Out of scope and unchanged: #133 budget constants, decoder enforcement,
  archive spool accounting, CCS schema/signing format, production Remi, and
  host data.

## Verification

The feature harness starts each command with `bash -lc`; on this host that
restored a read-only shared `CARGO_TARGET_DIR`. I exported a `cargo` shell
function that pins nested commands to this worktree's disk-backed `target/`
with `CARGO_BUILD_JOBS=10`. The feature-card commands themselves were unchanged.

```text
$ bash scripts/agent-context.sh --feature ccs --run focused
All 14 focused command(s) passed for CCS Authoring, Conversion, Install, And Native Lifecycle Execution.

$ bash scripts/agent-context.sh --feature ccs --run gate
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.22s
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.16s
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.17s
test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 3104 filtered out; finished in 0.07s
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 577 filtered out; finished in 0.29s
test result: ok. 70 passed; 0 failed; 0 ignored; 0 measured; 514 filtered out; finished in 0.73s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.01s
All 6 gate command(s) passed for CCS Authoring, Conversion, Install, And Native Lifecycle Execution.

$ cargo test -p conary-core ccs -j 10 -- --nocapture
ISSUE135_VM_HWM_KIB=29676
test result: ok. 414 passed; 0 failed; 1 ignored; 0 measured; 2706 filtered out; finished in 85.59s

$ cargo test -p conary --test conversion_integration golden_conversion
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.22s

$ cargo test -p remi conversion
test result: ok. 70 passed; 0 failed; 0 ignored; 0 measured; 514 filtered out; finished in 0.73s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.01s

$ cargo clippy --workspace --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 34.00s

$ cargo fmt --check
(no output; exit 0)

$ bash scripts/check-doc-truth.sh
Documentation truth checks passed.

$ git diff --check origin/main
(no output; exit 0)

$ rg 'fs::read\b' crates/conary-core/src/ccs/
crates/conary-core/src/ccs/native_export/mod.rs:        assert_eq!(std::fs::read(output.path()).unwrap(), b"hello world");
```

The sole `fs::read` hit is a unit-test assertion that reads an 11-byte exported
fixture for exact-byte verification. It is not an authoring, conversion,
package-writing, or payload-ingestion path.

## Unproven

None for #135's acceptance criteria. The excluded #133 budget/decoder/spool
work remains deliberately unmodified.

## Review And Merge Notes

- Review focus: the single descriptor-backed production path, disk-backed
  policy ownership, byte identity, and the RSS test boundary.
- Required-check bypass: not used.
- No production data, `/conary/data`, `/etc/conary`, or production Remi service
  was touched.
