### PR TITLE
chore(site): bump dev deps typescript 6, svelte-check, @types/node

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -11,10 +11,10 @@
 				"@sveltejs/adapter-static": "^3.0.8",
 				"@sveltejs/kit": "^2.70.1",
 				"@sveltejs/vite-plugin-svelte": "^7.2.0",
-				"@types/node": "^20.19.41",
+				"@types/node": "^26.1.2",
 				"svelte": "^5.56.8",
-				"svelte-check": "^4.0.0",
-				"typescript": "^5.7.0",
+				"svelte-check": "^4.7.4",
+				"typescript": "^6.0.3",
 				"vite": "^8.0.16"
 			}
 		},
@@ -490,9 +490,9 @@
 			}
 		},
 		"node_modules/@sveltejs/load-config": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.1.1.tgz",
-			"integrity": "sha512-BXXm+VOH/9X4N7Dd1iZ2MqA1h7M+9i2noI8QYuLDY8QcN2WHYn7D/VK/+IJNfcAmRw7ACNJ538UT9GXIhnBTiA==",
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.1.tgz",
+			"integrity": "sha512-5m3B2cbqQ4TbwW6Xkh66Ntw6dD7gNc77cCxABTTesWcq9jxIzMgTk97pZx5vEtvQx8iokgi7GIphqZe+PGwcZA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -545,13 +545,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "20.19.43",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
-			"integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+			"version": "26.1.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+			"integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~6.21.0"
+				"undici-types": "~8.3.0"
 			}
 		},
 		"node_modules/@types/trusted-types": {
@@ -1249,14 +1249,14 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.6.0.tgz",
-			"integrity": "sha512-KhVnDFDSid57mmZtHz8gfW8AAGylOZ0vPnOIzVmAL+urzwK8sBYXRss953gD8T0OdgAQ11mdWhE6uadmtOz8TQ==",
+			"version": "4.7.4",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.4.tgz",
+			"integrity": "sha512-IW9ot9YqAoyv8FvyN+eb4ZTe8zgcKZrJLNYU6dzSKkGwEBsSPc4K7lmQ8bKn8W2YMXM6WDfZSSVOaGtekyUfOQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.25",
-				"@sveltejs/load-config": "0.1.1",
+				"@sveltejs/load-config": "^0.2.1",
 				"chokidar": "^4.0.1",
 				"fdir": "^6.2.0",
 				"picocolors": "^1.0.0",
@@ -1270,7 +1270,7 @@
 			},
 			"peerDependencies": {
 				"svelte": "^4.0.0 || ^5.0.0-next.0",
-				"typescript": ">=5.0.0"
+				"typescript": "^5.0.0 || ^6.0.0"
 			}
 		},
 		"node_modules/tinyglobby": {
@@ -1309,9 +1309,9 @@
 			"optional": true
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -1323,9 +1323,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/site/package.json
+++ b/site/package.json
@@ -14,10 +14,10 @@
 		"@sveltejs/adapter-static": "^3.0.8",
 		"@sveltejs/kit": "^2.70.1",
 		"@sveltejs/vite-plugin-svelte": "^7.2.0",
-		"@types/node": "^20.19.41",
+		"@types/node": "^26.1.2",
 		"svelte": "^5.56.8",
-		"svelte-check": "^4.0.0",
-		"typescript": "^5.7.0",
+		"svelte-check": "^4.7.4",
+		"typescript": "^6.0.3",
 		"vite": "^8.0.16"
 	},
 	"overrides": {


### PR DESCRIPTION
Supersedes #82, #84, #85 in one locally verified bump. Dependabot's typescript 7.0.2 conflicts with svelte-check@4.7.4's peer range (`^5 || ^6`) — that was #85's frontends failure — so typescript lands on latest 6.x instead.

Verification (local): `npm run check` → 0 errors / 0 warnings (305 files); `npm run build` → 6 prerendered pages verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5GUMVLVmMpvGteUndbfm9