### PR TITLE
docs(readme): surface scale and the verification layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,34 @@ Conary is a virtual Rust workspace:
 For the maintained architecture map, see
 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
+## Scale And Verification
+
+Conary is a single-maintainer project, so the verification layer carries the
+weight that a team's review would otherwise carry.
+
+| | |
+| --- | --- |
+| First-party Rust | 447,093 lines across 1,225 files, 8-crate workspace, edition 2024, Rust 1.96+ |
+| Unit tests | 5,499 `#[test]` and `#[tokio::test]` functions |
+| Integration tests | 324 tests in 29 suites across 4 phases |
+| Test targets | Real Fedora 44, Ubuntu 26.04 LTS, and Arch VMs driven by `apps/conary-test` |
+| CI | 7 GitHub Actions workflows: merge validation, PR gate, release build, release-artifact proof, deploy-and-verify, site deploy, scheduled ops |
+| Lint gate | `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check` |
+
+Two of those deserve specific mention:
+
+- **Cross-distro proof runs on real hosts, not mocks.** The integration harness
+  boots Fedora, Ubuntu, and Arch VMs and exercises the same RPM, DEB, Arch, and
+  CCS pipeline on each, because the claim being tested is that a package keeps
+  its source semantics on a host whose native format differs. A mocked target
+  cannot prove that.
+- **Documentation claims are gated by CI.** `scripts/check-doc-truth.sh` fails
+  the build when this README, the roadmap, the module docs, or the public
+  websites claim something the code does not do. Release tags, install-command
+  forms, and preview boundaries are all checked against the source tree. The
+  cost of that is real: changing a public claim means changing the code or the
+  check, not the prose.
+
 ## Build From Source
 
 Conary requires Rust 1.96+ on Linux.


### PR DESCRIPTION
Refs #139.

## Problem

The README documents every limitation and none of the evidence. Three of the
first four sections are caveats, which is correct for testers and is the
project's actual asset. But nothing tells a reader that the cross-distro claim
is proven against real Fedora, Ubuntu, and Arch VMs rather than mocks, or that
public claims are gated by CI. `Architecture At A Glance` is a list of crate
names.

## Change

Adds one `Scale And Verification` section after the architecture map. Additive
only — no warning, boundary, or `What Will Break` entry is softened or moved.

Every number is counted from the tree at this commit:

| Claim | How it was counted |
| --- | --- |
| 447,093 lines / 1,225 files | `find apps crates -name '*.rs' -not -path '*/target/*' -not -path '*/vendor/*'`, concatenated, `wc -l` |
| 5,499 unit tests | same file set, `grep -h '#\[test\]\|#\[tokio::test\]'` |
| 324 integration tests | `grep -h '^\[\[test\]\]$'` over `apps/conary/tests/integration/remi/manifests/*.toml` |
| 29 suites | `grep -h '^\[suite\]$'` over the same manifests |
| 4 phases | `phase1`–`phase4` manifest prefixes |
| 7 workflows | `.github/workflows/*.yml` |

Two counting errors were caught before publishing and are worth recording:
`grep '\[\[test'` also matches `[[test.step]]` and gave 950; `grep '\[\[suite'`
matches `[[suite.setup]]` and `[[suite.mock_server.routes]]` and gave 32. The
anchored patterns above are the correct ones. Largest single source file is
1,300 lines and only 2 files are marked generated, so the line count is
hand-written code rather than generated bulk.

## Verification

```
$ bash scripts/check-doc-truth.sh
Documentation truth checks passed.
```

## Not included

A terminal demo. For a CLI that is the single strongest artifact this README
could have, but producing it means running a real cross-distro install on a
real host and capturing the real output. Fabricating plausible output would
violate the repo's own rule against presenting expected results as observed, so
it is left for a recorded session on a test host.