### PR TITLE
fix(ci): derive the deploy-site homepage marker from the committed build

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -97,8 +97,10 @@ jobs:
           if [[ "$target" == "site" || "$target" == "both" ]]; then
             home_status="$(curl --retry 5 --retry-delay 2 -sS -o /tmp/conary-home.html -w '%{http_code}' https://conary.io/)"
             [[ "$home_status" == "200" ]] || { echo "conary.io home returned $home_status" >&2; exit 1; }
-            grep -Fq 'Make Linux package state portable, inspectable, and reversible.' /tmp/conary-home.html || {
-              echo "conary.io did not return the committed homepage" >&2
+            marker="$(grep -oE '<h1[^>]*>[^<]+' site/build/index.html | head -1 | sed 's/<[^>]*>//')"
+            [[ -n "$marker" ]] || { echo "could not extract h1 marker from the committed build" >&2; exit 1; }
+            grep -Fq "$marker" /tmp/conary-home.html || {
+              echo "conary.io did not return the committed homepage (missing h1: $marker)" >&2
               exit 1
             }
 


### PR DESCRIPTION
The deploy-site verify step hardcoded a hero sentence; #140's copy rewrite made the stale marker fail a healthy deploy (runs 30333151308 and its rerun — the deploy itself succeeded, /contact/ live, old h1 gone from origin). Deriving the marker from `site/build/index.html`'s h1 makes the proof track the content it proves. Same one-owner principle as check-doc-truth: no second copy of the truth to rot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5GUMVLVmMpvGteUndbfm9