### PR TITLE
fix(repo): sync Remi through bounded sparse pages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rust-s3 = { path = "third_party/rust-s3-0.37.2-patched" }
 
 [workspace.dependencies]
 # Database
-rusqlite = { version = "0.40", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled", "limits"] }
 
 # Error handling
 thiserror = "2.0"

--- a/apps/conary/src/commands/repo_static.rs
+++ b/apps/conary/src/commands/repo_static.rs
@@ -21,6 +21,17 @@ const MAX_STATIC_ROOT_SIZE: u64 = 10 * 1024 * 1024;
 const KEY_ID_HEX_LEN: usize = 64;
 
 pub(crate) async fn try_cmd_repo_add_static(opts: &RepoAddOptions) -> Result<bool> {
+    // `--package-format` is required for non-static repositories and meaningless
+    // for static ones, which declare their own signed metadata contract. When the
+    // caller states the format, the repository kind is settled before any network
+    // access; the identity probe is discovery evidence and must not override it.
+    // Without this, a host that answers every path with a 200 body — an SPA
+    // fallback, a captive portal, an error page — turns `repo add` into a hard
+    // failure on a repository the caller never described as static.
+    if opts.package_format.is_some() {
+        return Ok(false);
+    }
+
     let Some(normalized_base) = normalize_static_repo_base(&opts.url)? else {
         return Ok(false);
     };

--- a/apps/conary/src/commands/repo_static/tests.rs
+++ b/apps/conary/src/commands/repo_static/tests.rs
@@ -239,6 +239,45 @@ async fn add_static_repo_with(
     .await
 }
 
+/// Add a repository whose format the caller declares, the shape every Remi
+/// consumer uses (`--package-format json --source-profile <profile>`).
+async fn add_repo_with_declared_format(
+    db: &TestDb,
+    url: &str,
+    source_profile: &str,
+) -> anyhow::Result<()> {
+    cmd_repo_add(RepoAddOptions {
+        name: "acme".to_string(),
+        url: url.to_string(),
+        package_format: Some(conary_core::repository::RepositoryFormat::Json),
+        distribution: None,
+        component: None,
+        architecture: None,
+        database: None,
+        db_path: db.db_path.clone(),
+        content_url: None,
+        priority: 50,
+        disabled: false,
+        debian_release_keys: Vec::new(),
+        rpm_metadata_keys: Vec::new(),
+        rpm_metalink: None,
+        rpm_package_keys: Vec::new(),
+        arch_keyring: None,
+        arch_keyring_format: None,
+        arch_master_keys: Vec::new(),
+        arch_packager_key_threshold: None,
+        arch_database_signature: None,
+        default_strategy: Some("remi".to_string()),
+        remi_endpoint: Some(url.to_string()),
+        source_profile: Some(source_profile.to_string()),
+        security_advisory_support: SecurityAdvisorySupport::Unknown,
+        fingerprints: Vec::new(),
+        yes: true,
+        replace: false,
+    })
+    .await
+}
+
 fn assert_no_repo(conn: &Connection, name: &str) {
     assert!(
         Repository::find_by_name(conn, name).unwrap().is_none(),
@@ -457,6 +496,46 @@ async fn static_repo_add_rejects_native_trust_flags_after_probe_without_fingerpr
 
     assert!(err.to_string().contains("native repository trust flags"));
     assert_no_repo(&db.conn(), "acme");
+}
+
+/// A host that answers every path with a 200 body — an SPA fallback, a captive
+/// portal, an error page — makes the identity probe see a `conary-repo.toml`
+/// that is not one. Declaring the package format settles the repository kind
+/// before any of that is fetched, so the probe's answer cannot decide the add.
+#[tokio::test]
+async fn declared_package_format_adds_a_native_repo_whatever_the_identity_probe_would_find() {
+    let db = TestDb::new();
+    let served = tempfile::tempdir().unwrap();
+    std::fs::write(
+        served.path().join("conary-repo.toml"),
+        b"<!doctype html>\n<html lang=\"en\"><head><title>index</title></head></html>\n",
+    )
+    .unwrap();
+    let base_url = format!("file://{}", served.path().display());
+
+    add_repo_with_declared_format(&db, &base_url, "fedora-44")
+        .await
+        .unwrap();
+
+    let repo = repo(&db.conn());
+    assert_eq!(repo.url, base_url);
+    assert_eq!(repo.source_profile.as_deref(), Some("fedora-44"));
+    assert_ne!(repo.default_strategy.as_deref(), Some("static"));
+    assert_eq!(repo.tuf_root_url, None);
+}
+
+/// The probe still owns the undeclared case, so the test above cannot pass by
+/// the probe having been removed.
+#[tokio::test]
+async fn undeclared_package_format_still_reaches_the_identity_probe() {
+    let db = TestDb::new();
+    let fixture = StaticRepoFixture::single_key("acme-static");
+
+    add_static_repo(&db, &fixture, fixture.root_key_ids.clone())
+        .await
+        .unwrap();
+
+    assert_eq!(repo(&db.conn()).default_strategy.as_deref(), Some("static"));
 }
 
 #[test]

--- a/apps/remi/src/server/handlers/mod.rs
+++ b/apps/remi/src/server/handlers/mod.rs
@@ -168,20 +168,8 @@ pub fn supported_route_slugs() -> Vec<String> {
 /// Validate a package or distro name: no path traversal, no null bytes, reasonable length
 #[allow(clippy::result_large_err)]
 pub fn validate_name(name: &str) -> Result<(), Response> {
-    if name.is_empty() {
-        return Err((StatusCode::BAD_REQUEST, "Name must not be empty").into_response());
-    }
-    if name.len() > conary_core::repository::remi_metadata::REMI_SPARSE_NAME_MAX_BYTES {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "Name exceeds the public repository wire limit",
-        )
-            .into_response());
-    }
-    if name.contains('/') || name.contains("..") || name.contains('\0') {
-        return Err((StatusCode::BAD_REQUEST, "Name contains invalid characters").into_response());
-    }
-    Ok(())
+    conary_core::repository::remi_metadata::validate_remi_public_name(name)
+        .map_err(|reason| (StatusCode::BAD_REQUEST, reason).into_response())
 }
 
 #[allow(clippy::result_large_err)]

--- a/apps/remi/src/server/handlers/mod.rs
+++ b/apps/remi/src/server/handlers/mod.rs
@@ -171,8 +171,12 @@ pub fn validate_name(name: &str) -> Result<(), Response> {
     if name.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "Name must not be empty").into_response());
     }
-    if name.len() > 256 {
-        return Err((StatusCode::BAD_REQUEST, "Name too long (max 256 chars)").into_response());
+    if name.len() > conary_core::repository::remi_metadata::REMI_SPARSE_NAME_MAX_BYTES {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Name exceeds the public repository wire limit",
+        )
+            .into_response());
     }
     if name.contains('/') || name.contains("..") || name.contains('\0') {
         return Err((StatusCode::BAD_REQUEST, "Name contains invalid characters").into_response());

--- a/apps/remi/src/server/handlers/sparse.rs
+++ b/apps/remi/src/server/handlers/sparse.rs
@@ -12,50 +12,37 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use conary_core::db::models::{ConvertedPackage, NativePackagePublication, RepositoryPackage};
-use conary_core::repository::remi_metadata::{RemiProvide, RemiRequirementGroup};
+use conary_core::repository::remi_metadata::{
+    REMI_SPARSE_MAX_PAGE_SIZE, REMI_SPARSE_MIN_PACKAGE_SIZE, RemiSparseListInclude,
+    RemiSparsePackageList as PackageListResponse, RemiSparsePackagePage,
+};
+pub use conary_core::repository::remi_metadata::{
+    RemiSparseIndexEntry as SparseIndexEntry, RemiSparseVersionEntry as SparseVersionEntry,
+};
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-/// A sparse index entry for a single package across all versions
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SparseIndexEntry {
-    pub name: String,
-    pub distro: String,
-    pub versions: Vec<SparseVersionEntry>,
-}
+mod page;
 
-/// Version-level metadata within a sparse index entry
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SparseVersionEntry {
-    pub version: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub release: Option<String>,
-    pub provides: Vec<RemiProvide>,
-    pub requirement_groups: Vec<RemiRequirementGroup>,
-    pub architecture: Option<String>,
-    pub size: i64,
-    pub converted: bool,
-    pub content_hash: Option<String>,
-}
+use page::{build_package_list, build_package_page};
 
 /// Query parameters for the package list endpoint
 #[derive(Debug, Deserialize)]
 pub struct ListQuery {
     pub page: Option<usize>,
     pub per_page: Option<usize>,
+    #[serde(default)]
+    pub include: RemiSparseListInclude,
 }
 
-/// Paginated package list response
 #[derive(Debug, Serialize)]
-pub struct PackageListResponse {
-    pub distro: String,
-    pub packages: Vec<String>,
-    pub total: usize,
-    pub page: usize,
-    pub per_page: usize,
+#[serde(untagged)]
+enum PackageListProjection {
+    Names(PackageListResponse),
+    Versions(RemiSparsePackagePage),
 }
 
 /// GET /v1/index/{distro}/{name}
@@ -131,9 +118,10 @@ pub async fn get_sparse_entry(
     }
 }
 
-/// GET /v1/index/{distro}?page=1&per_page=100
+/// GET /v1/index/{distro}?page=1&per_page=100&include=versions
 ///
-/// Returns a paginated list of package names for a distribution.
+/// Returns package names by default, or complete resolution entries when the
+/// typed `include=versions` expansion is selected.
 pub async fn list_packages(
     State(state): State<Arc<RwLock<ServerState>>>,
     Path(distro): Path<String>,
@@ -144,15 +132,24 @@ pub async fn list_packages(
     }
 
     let page = query.page.unwrap_or(1).max(1);
-    let per_page = query.per_page.unwrap_or(100).clamp(1, 1000);
+    let per_page = query
+        .per_page
+        .unwrap_or(100)
+        .clamp(1, REMI_SPARSE_MAX_PAGE_SIZE);
+    let include = query.include;
 
     let state_guard = state.read().await;
     let db_path = state_guard.config.db_path.clone();
     drop(state_guard);
 
-    let result =
-        tokio::task::spawn_blocking(move || build_package_list(&db_path, &distro, page, per_page))
-            .await;
+    let result = tokio::task::spawn_blocking(move || match include {
+        RemiSparseListInclude::Names => {
+            build_package_list(&db_path, &distro, page, per_page).map(PackageListProjection::Names)
+        }
+        RemiSparseListInclude::Versions => build_package_page(&db_path, &distro, page, per_page)
+            .map(PackageListProjection::Versions),
+    })
+    .await;
 
     match result {
         Ok(Ok(list)) => {
@@ -195,34 +192,7 @@ fn build_sparse_entry(
         return Ok(None);
     }
 
-    // Get all versions of this package across all matching repositories
-    let placeholders: String = (1..=repo_ids.len())
-        .map(|i| format!("?{i}"))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let name_idx = repo_ids.len() + 1;
-    let sql = format!(
-        "SELECT {}
-         FROM repository_packages
-         WHERE repository_id IN ({placeholders}) AND name = ?{name_idx}
-         AND size > 0
-         ORDER BY version",
-        RepositoryPackage::COLUMNS
-    );
-
-    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = repo_ids
-        .iter()
-        .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
-        .collect();
-    params.push(Box::new(name.to_string()));
-
-    let mut stmt = conn.prepare(&sql)?;
-    let packages: Vec<RepositoryPackage> = stmt
-        .query_map(
-            rusqlite::params_from_iter(&params),
-            RepositoryPackage::from_row,
-        )?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let packages = load_visible_repository_packages(&conn, &repo_ids, &[name.to_string()])?;
 
     if packages.is_empty() {
         return Ok(None);
@@ -312,80 +282,54 @@ fn build_sparse_entry(
     }))
 }
 
-/// Build a paginated list of unique package names for a distro, aggregating
-/// across all matching repos (e.g. arch-core + arch-extra).
-fn build_package_list(
-    db_path: &std::path::Path,
-    distro: &str,
-    page: usize,
-    per_page: usize,
-) -> Result<PackageListResponse, anyhow::Error> {
-    let conn = Connection::open(db_path)?;
-    let source_profile =
-        conary_core::repository::supported_profiles::profile_for_remi_route(distro)
-            .ok_or_else(|| anyhow::anyhow!("unsupported public route '{distro}'"))?;
-
-    // Find all repositories for this distro
-    let repositories = find_repositories_for_profile(&conn, source_profile.id())?;
-    let repo_ids = repositories
-        .iter()
-        .map(super::require_persisted_repository_id)
-        .collect::<anyhow::Result<Vec<_>>>()?;
-    if repo_ids.is_empty() {
-        return Ok(PackageListResponse {
-            distro: distro.to_string(),
-            packages: vec![],
-            total: 0,
-            page,
-            per_page,
-        });
+fn load_visible_repository_packages(
+    conn: &Connection,
+    repo_ids: &[i64],
+    names: &[String],
+) -> Result<Vec<RepositoryPackage>, anyhow::Error> {
+    if repo_ids.is_empty() || names.is_empty() {
+        return Ok(Vec::new());
     }
 
-    let placeholders: String = (1..=repo_ids.len())
-        .map(|i| format!("?{i}"))
+    let repository_placeholders = (1..=repo_ids.len())
+        .map(|index| format!("?{index}"))
         .collect::<Vec<_>>()
         .join(", ");
-
-    // Count distinct package names across all repos
-    let count_sql = format!(
-        "SELECT COUNT(DISTINCT name) FROM repository_packages WHERE repository_id IN ({placeholders})"
-    );
-    let count_params: Vec<Box<dyn rusqlite::types::ToSql>> =
-        repo_ids.iter().map(|id| Box::new(*id) as _).collect();
-    let total: usize = conn.query_row(
-        &count_sql,
-        rusqlite::params_from_iter(&count_params),
-        |row| row.get::<_, i64>(0).map(|v| v as usize),
-    )?;
-
-    // Get paginated distinct names
-    let offset = (page - 1) * per_page;
-    let limit_idx = repo_ids.len() + 1;
-    let offset_idx = repo_ids.len() + 2;
-    let list_sql = format!(
-        "SELECT DISTINCT name FROM repository_packages
-         WHERE repository_id IN ({placeholders})
-         ORDER BY name
-         LIMIT ?{limit_idx} OFFSET ?{offset_idx}"
+    let first_name_index = repo_ids.len() + 1;
+    let name_placeholders = (first_name_index..first_name_index + names.len())
+        .map(|index| format!("?{index}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let minimum_size_index = first_name_index + names.len();
+    let sql = format!(
+        "SELECT {}
+         FROM repository_packages
+         WHERE repository_id IN ({repository_placeholders})
+           AND name IN ({name_placeholders})
+           AND size >= ?{minimum_size_index}
+         ORDER BY name, version, package_release, architecture",
+        RepositoryPackage::COLUMNS
     );
 
-    let mut list_params: Vec<Box<dyn rusqlite::types::ToSql>> =
-        repo_ids.iter().map(|id| Box::new(*id) as _).collect();
-    list_params.push(Box::new(per_page as i64));
-    list_params.push(Box::new(offset as i64));
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = repo_ids
+        .iter()
+        .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
+        .collect();
+    params.extend(
+        names
+            .iter()
+            .cloned()
+            .map(|name| Box::new(name) as Box<dyn rusqlite::types::ToSql>),
+    );
+    params.push(Box::new(REMI_SPARSE_MIN_PACKAGE_SIZE));
 
-    let mut stmt = conn.prepare(&list_sql)?;
-    let packages: Vec<String> = stmt
-        .query_map(rusqlite::params_from_iter(&list_params), |row| row.get(0))?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
-
-    Ok(PackageListResponse {
-        distro: distro.to_string(),
-        packages,
-        total,
-        page,
-        per_page,
-    })
+    let mut stmt = conn.prepare(&sql)?;
+    stmt.query_map(
+        rusqlite::params_from_iter(&params),
+        RepositoryPackage::from_row,
+    )?
+    .collect::<rusqlite::Result<Vec<_>>>()
+    .map_err(Into::into)
 }
 
 /// Alias to shared implementations in handlers/mod.rs
@@ -451,6 +395,7 @@ mod tests {
             Query(ListQuery {
                 page: None,
                 per_page: None,
+                include: RemiSparseListInclude::Names,
             }),
         )
         .await;
@@ -478,7 +423,13 @@ mod tests {
         repo.insert(conn).unwrap()
     }
 
-    fn insert_package(conn: &Connection, repo_id: i64, name: &str, version: &str, size: i64) {
+    fn insert_package(
+        conn: &Connection,
+        repo_id: i64,
+        name: &str,
+        version: &str,
+        size: i64,
+    ) -> i64 {
         let mut pkg = RepositoryPackage::new(
             repo_id,
             name.to_string(),
@@ -513,6 +464,7 @@ mod tests {
             );
             atom.insert(conn).unwrap();
         }
+        package_id
     }
 
     fn insert_stale_conversion(
@@ -626,6 +578,63 @@ mod tests {
 
         let result = build_sparse_entry(temp_file.path(), "fedora", "nginx").unwrap();
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn sparse_list_bulk_page_and_lookup_share_one_visibility_contract() {
+        let (temp_file, conn) = create_test_db();
+        let repo_id = insert_repo(&conn, "fedora-base", "fedora");
+        let fetchable_id = insert_package(&conn, repo_id, "fetchable", "1.0-1.fc44", 1024);
+        conn.execute(
+            "UPDATE repository_packages SET metadata = ?1 WHERE id = ?2",
+            rusqlite::params![
+                serde_json::json!({
+                    "security_advisory": {
+                        "id": "FEDORA-2026-0001",
+                        "source": "remi",
+                        "source_trust": "trusted",
+                        "fixed_version": "1.0-1.fc44"
+                    }
+                })
+                .to_string(),
+                fetchable_id,
+            ],
+        )
+        .unwrap();
+        insert_package(&conn, repo_id, "mixed", "0.9-1.fc44", 0);
+        insert_package(&conn, repo_id, "mixed", "1.0-1.fc44", 2048);
+        insert_package(&conn, repo_id, "placeholder-only", "1.0-1.fc44", 0);
+
+        let all_names = ["fetchable", "mixed", "placeholder-only"];
+        let fetchable = all_names
+            .into_iter()
+            .filter(|name| {
+                build_sparse_entry(temp_file.path(), "fedora", name)
+                    .unwrap()
+                    .is_some()
+            })
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        let list = build_package_list(temp_file.path(), "fedora", 1, 100).unwrap();
+        let page = build_package_page(temp_file.path(), "fedora", 1, 100).unwrap();
+        let page_names = page
+            .packages
+            .iter()
+            .map(|entry| entry.name.clone())
+            .collect::<Vec<_>>();
+
+        assert_eq!(fetchable, vec!["fetchable", "mixed"]);
+        assert_eq!(list.packages, fetchable);
+        assert_eq!(page_names, fetchable);
+        assert_eq!(list.total, fetchable.len());
+        assert_eq!(page.total, fetchable.len());
+        assert_eq!(
+            page.packages[0].versions[0].metadata.as_ref().unwrap()["security_advisory"]["id"],
+            "FEDORA-2026-0001"
+        );
+        assert_eq!(page.packages[1].versions.len(), 1);
+        assert_eq!(page.packages[1].versions[0].version, "1.0-1.fc44");
+        assert_eq!(page.packages[1].versions[0].requirement_groups.len(), 2);
     }
 
     #[test]

--- a/apps/remi/src/server/handlers/sparse/page.rs
+++ b/apps/remi/src/server/handlers/sparse/page.rs
@@ -6,7 +6,7 @@ use anyhow::Context;
 use conary_core::db::models::RepositoryPackage;
 use conary_core::repository::remi_metadata::{
     REMI_SPARSE_MIN_PACKAGE_SIZE, RemiSparsePackageList, RemiSparsePackagePage,
-    RemiSparseResolutionEntry, RemiSparseResolutionVersionEntry,
+    RemiSparseResolutionEntry, RemiSparseResolutionVersionEntry, validate_remi_public_name,
 };
 use rusqlite::Connection;
 use std::collections::BTreeMap;
@@ -161,16 +161,20 @@ fn select_sparse_name_page(
     let mut count_params: Vec<Box<dyn rusqlite::types::ToSql>> =
         repo_ids.iter().map(|id| Box::new(*id) as _).collect();
     count_params.push(Box::new(REMI_SPARSE_MIN_PACKAGE_SIZE));
-    let total: usize = conn.query_row(
+    let total = conn.query_row(
         &count_sql,
         rusqlite::params_from_iter(&count_params),
-        |row| row.get::<_, i64>(0).map(|v| v as usize),
+        |row| row.get::<_, i64>(0),
     )?;
+    let total = usize::try_from(total)
+        .context("sparse package-name count does not fit the response platform")?;
 
     let offset = page
         .checked_sub(1)
         .and_then(|zero_based| zero_based.checked_mul(per_page))
         .ok_or_else(|| anyhow::anyhow!("sparse page offset overflow"))?;
+    let limit = sqlite_page_value(per_page, "limit")?;
+    let offset = sqlite_page_value(offset, "offset")?;
     let minimum_size_idx = repo_ids.len() + 1;
     let limit_idx = repo_ids.len() + 2;
     let offset_idx = repo_ids.len() + 3;
@@ -185,17 +189,43 @@ fn select_sparse_name_page(
     let mut list_params: Vec<Box<dyn rusqlite::types::ToSql>> =
         repo_ids.iter().map(|id| Box::new(*id) as _).collect();
     list_params.push(Box::new(REMI_SPARSE_MIN_PACKAGE_SIZE));
-    list_params.push(Box::new(per_page as i64));
-    list_params.push(Box::new(offset as i64));
+    list_params.push(Box::new(limit));
+    list_params.push(Box::new(offset));
 
     let mut stmt = conn.prepare(&list_sql)?;
     let packages: Vec<String> = stmt
         .query_map(rusqlite::params_from_iter(&list_params), |row| row.get(0))?
         .collect::<rusqlite::Result<Vec<_>>>()?;
+    for package in &packages {
+        validate_remi_public_name(package).map_err(|reason| {
+            anyhow::anyhow!("repository contains invalid sparse package name {package:?}: {reason}")
+        })?;
+    }
 
     Ok(SparseNamePageSelection {
         repo_ids,
         names: packages,
         total,
     })
+}
+
+fn sqlite_page_value(value: usize, field: &str) -> Result<i64, anyhow::Error> {
+    i64::try_from(value).with_context(|| format!("sparse page {field} exceeds SQLite's range"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sqlite_page_values_fail_closed_instead_of_wrapping_negative() {
+        assert_eq!(sqlite_page_value(128, "limit").unwrap(), 128);
+        if let Some(overflow) = usize::try_from(i64::MAX)
+            .ok()
+            .and_then(|maximum| maximum.checked_add(1))
+        {
+            let error = sqlite_page_value(overflow, "offset").unwrap_err();
+            assert!(error.to_string().contains("exceeds SQLite's range"));
+        }
+    }
 }

--- a/apps/remi/src/server/handlers/sparse/page.rs
+++ b/apps/remi/src/server/handlers/sparse/page.rs
@@ -1,0 +1,201 @@
+// apps/remi/src/server/handlers/sparse/page.rs
+
+//! Stable sparse-index page selection and resolution projection.
+
+use anyhow::Context;
+use conary_core::db::models::RepositoryPackage;
+use conary_core::repository::remi_metadata::{
+    REMI_SPARSE_MIN_PACKAGE_SIZE, RemiSparsePackageList, RemiSparsePackagePage,
+    RemiSparseResolutionEntry, RemiSparseResolutionVersionEntry,
+};
+use rusqlite::Connection;
+use std::collections::BTreeMap;
+
+/// Build a paginated list of unique package names for a distro, aggregating
+/// across all matching repos (e.g. arch-core + arch-extra).
+pub(super) fn build_package_list(
+    db_path: &std::path::Path,
+    distro: &str,
+    page: usize,
+    per_page: usize,
+) -> Result<RemiSparsePackageList, anyhow::Error> {
+    let conn = Connection::open(db_path)?;
+    let selection = select_sparse_name_page(&conn, distro, page, per_page)?;
+
+    Ok(RemiSparsePackageList {
+        distro: distro.to_string(),
+        packages: selection.names,
+        total: selection.total,
+        page,
+        per_page,
+    })
+}
+
+pub(super) fn build_package_page(
+    db_path: &std::path::Path,
+    distro: &str,
+    page: usize,
+    per_page: usize,
+) -> Result<RemiSparsePackagePage, anyhow::Error> {
+    let conn = Connection::open(db_path)?;
+    let selection = select_sparse_name_page(&conn, distro, page, per_page)?;
+    let packages =
+        super::load_visible_repository_packages(&conn, &selection.repo_ids, &selection.names)?;
+    let package_ids = packages
+        .iter()
+        .map(|package| {
+            package
+                .id
+                .ok_or_else(|| anyhow::anyhow!("repository package has no persisted ID"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut exact_metadata =
+        crate::server::package_metadata::load_exact_package_metadata_batch(&conn, &package_ids)?;
+    let mut packages_by_name = BTreeMap::<String, Vec<RepositoryPackage>>::new();
+    for package in packages {
+        packages_by_name
+            .entry(package.name.clone())
+            .or_default()
+            .push(package);
+    }
+
+    let mut entries = Vec::with_capacity(selection.names.len());
+    for name in selection.names {
+        let packages = packages_by_name.remove(&name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "sparse visibility query listed package '{name}' without a fetchable version"
+            )
+        })?;
+        let mut versions = Vec::with_capacity(packages.len());
+        for package in packages {
+            let package_id = package
+                .id
+                .ok_or_else(|| anyhow::anyhow!("repository package has no persisted ID"))?;
+            let exact = exact_metadata.remove(&package_id).ok_or_else(|| {
+                anyhow::anyhow!("exact metadata missing for repository package {package_id}")
+            })?;
+            versions.push(build_resolution_version(package, exact)?);
+        }
+        entries.push(RemiSparseResolutionEntry {
+            name,
+            distro: distro.to_string(),
+            versions,
+        });
+    }
+    if !exact_metadata.is_empty() {
+        anyhow::bail!("bulk sparse metadata included packages outside the selected name page");
+    }
+
+    Ok(RemiSparsePackagePage {
+        distro: distro.to_string(),
+        packages: entries,
+        total: selection.total,
+        page,
+        per_page,
+    })
+}
+
+fn build_resolution_version(
+    package: RepositoryPackage,
+    exact: crate::server::package_metadata::ExactPackageMetadata,
+) -> Result<RemiSparseResolutionVersionEntry, anyhow::Error> {
+    let metadata = package
+        .metadata
+        .as_deref()
+        .map(serde_json::from_str)
+        .transpose()
+        .with_context(|| {
+            format!(
+                "repository package '{}' version '{}' has malformed persisted metadata",
+                package.name, package.version
+            )
+        })?;
+    Ok(RemiSparseResolutionVersionEntry {
+        version: package.version,
+        release: (!package.package_release.is_empty()).then_some(package.package_release),
+        provides: exact.provides,
+        requirement_groups: exact.requirement_groups,
+        architecture: package.architecture,
+        size: package.size,
+        metadata,
+    })
+}
+
+struct SparseNamePageSelection {
+    repo_ids: Vec<i64>,
+    names: Vec<String>,
+    total: usize,
+}
+
+fn select_sparse_name_page(
+    conn: &Connection,
+    distro: &str,
+    page: usize,
+    per_page: usize,
+) -> Result<SparseNamePageSelection, anyhow::Error> {
+    let source_profile =
+        conary_core::repository::supported_profiles::profile_for_remi_route(distro)
+            .ok_or_else(|| anyhow::anyhow!("unsupported public route '{distro}'"))?;
+    let repositories = super::find_repositories_for_profile(conn, source_profile.id())?;
+    let repo_ids = repositories
+        .iter()
+        .map(super::super::require_persisted_repository_id)
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    if repo_ids.is_empty() {
+        return Ok(SparseNamePageSelection {
+            repo_ids,
+            names: Vec::new(),
+            total: 0,
+        });
+    }
+
+    let placeholders = (1..=repo_ids.len())
+        .map(|index| format!("?{index}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let minimum_size_idx = repo_ids.len() + 1;
+    let count_sql = format!(
+        "SELECT COUNT(DISTINCT name) FROM repository_packages
+         WHERE repository_id IN ({placeholders}) AND size >= ?{minimum_size_idx}"
+    );
+    let mut count_params: Vec<Box<dyn rusqlite::types::ToSql>> =
+        repo_ids.iter().map(|id| Box::new(*id) as _).collect();
+    count_params.push(Box::new(REMI_SPARSE_MIN_PACKAGE_SIZE));
+    let total: usize = conn.query_row(
+        &count_sql,
+        rusqlite::params_from_iter(&count_params),
+        |row| row.get::<_, i64>(0).map(|v| v as usize),
+    )?;
+
+    let offset = page
+        .checked_sub(1)
+        .and_then(|zero_based| zero_based.checked_mul(per_page))
+        .ok_or_else(|| anyhow::anyhow!("sparse page offset overflow"))?;
+    let minimum_size_idx = repo_ids.len() + 1;
+    let limit_idx = repo_ids.len() + 2;
+    let offset_idx = repo_ids.len() + 3;
+    let list_sql = format!(
+        "SELECT DISTINCT name FROM repository_packages
+         WHERE repository_id IN ({placeholders})
+         AND size >= ?{minimum_size_idx}
+         ORDER BY name
+         LIMIT ?{limit_idx} OFFSET ?{offset_idx}"
+    );
+
+    let mut list_params: Vec<Box<dyn rusqlite::types::ToSql>> =
+        repo_ids.iter().map(|id| Box::new(*id) as _).collect();
+    list_params.push(Box::new(REMI_SPARSE_MIN_PACKAGE_SIZE));
+    list_params.push(Box::new(per_page as i64));
+    list_params.push(Box::new(offset as i64));
+
+    let mut stmt = conn.prepare(&list_sql)?;
+    let packages: Vec<String> = stmt
+        .query_map(rusqlite::params_from_iter(&list_params), |row| row.get(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    Ok(SparseNamePageSelection {
+        repo_ids,
+        names: packages,
+        total,
+    })
+}

--- a/apps/remi/src/server/package_metadata.rs
+++ b/apps/remi/src/server/package_metadata.rs
@@ -8,6 +8,7 @@ use conary_core::db::models::{
 };
 use conary_core::repository::remi_metadata::{RemiProvide, RemiRequirement, RemiRequirementGroup};
 use rusqlite::Connection;
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ExactPackageMetadata {
@@ -19,9 +20,26 @@ pub(crate) fn load_exact_package_metadata(
     conn: &Connection,
     repository_package_id: i64,
 ) -> Result<ExactPackageMetadata> {
-    let provides = RepositoryProvide::find_by_repository_package(conn, repository_package_id)?
-        .into_iter()
-        .map(|provide| RemiProvide {
+    load_exact_package_metadata_batch(conn, &[repository_package_id])?
+        .remove(&repository_package_id)
+        .context("requested repository package metadata was not loaded")
+}
+
+pub(crate) fn load_exact_package_metadata_batch(
+    conn: &Connection,
+    repository_package_ids: &[i64],
+) -> Result<HashMap<i64, ExactPackageMetadata>> {
+    let mut metadata = repository_package_ids
+        .iter()
+        .copied()
+        .map(|package_id| (package_id, ExactPackageMetadata::default()))
+        .collect::<HashMap<_, _>>();
+
+    for provide in RepositoryProvide::find_by_repository_packages(conn, repository_package_ids)? {
+        let package_metadata = metadata
+            .get_mut(&provide.repository_package_id)
+            .context("repository provide belongs to an unrequested package")?;
+        package_metadata.provides.push(RemiProvide {
             capability: provide.capability,
             version: provide.version,
             version_relation: provide.version_relation,
@@ -29,55 +47,68 @@ pub(crate) fn load_exact_package_metadata(
             raw: provide.raw,
             version_scheme: provide.version_scheme,
             architecture_qualifier: provide.architecture_qualifier,
-        })
-        .collect();
-
-    let atoms = RepositoryRequirement::find_by_repository_package(conn, repository_package_id)?;
-    let groups =
-        RepositoryRequirementGroup::find_by_repository_package(conn, repository_package_id)?;
-    let mut requirement_groups = Vec::with_capacity(groups.len());
-    let mut group_ids = Vec::with_capacity(groups.len());
-    for group in groups {
-        let group_id = group
-            .id
-            .context("repository requirement group has no persisted ID")?;
-        group_ids.push(group_id);
-        let clauses = atoms
-            .iter()
-            .filter(|requirement| requirement.group_id == group_id)
-            .map(|requirement| RemiRequirement {
-                capability: requirement.capability.clone(),
-                version_constraint: requirement.version_constraint.clone(),
-                kind: requirement.kind.clone(),
-                dependency_type: requirement.dependency_type.clone(),
-                raw: requirement.raw.clone(),
-            })
-            .collect::<Vec<_>>();
-        if clauses.is_empty() {
-            bail!(
-                "repository requirement group {group_id} for package \
-                 {repository_package_id} has no searchable atoms"
-            );
-        }
-        requirement_groups.push(RemiRequirementGroup {
-            kind: group.kind,
-            behavior: group.behavior,
-            description: group.description,
-            native_text: group.native_text,
-            expression_json: group.expression_json,
-            clauses,
         });
     }
 
-    if atoms.iter().any(|atom| !group_ids.contains(&atom.group_id)) {
+    let atoms = RepositoryRequirement::find_by_repository_packages(conn, repository_package_ids)?;
+    let mut atoms_by_group = HashMap::<i64, Vec<RepositoryRequirement>>::new();
+    for atom in atoms {
+        atoms_by_group.entry(atom.group_id).or_default().push(atom);
+    }
+
+    for group in
+        RepositoryRequirementGroup::find_by_repository_packages(conn, repository_package_ids)?
+    {
+        let group_id = group
+            .id
+            .context("repository requirement group has no persisted ID")?;
+        let atoms = atoms_by_group.remove(&group_id).unwrap_or_default();
+        if atoms.is_empty() {
+            bail!(
+                "repository requirement group {group_id} for package {} has no searchable atoms",
+                group.repository_package_id
+            );
+        }
+        if atoms
+            .iter()
+            .any(|atom| atom.repository_package_id != group.repository_package_id)
+        {
+            bail!("repository requirement group {group_id} crosses package ownership boundaries");
+        }
+        let clauses = atoms
+            .into_iter()
+            .map(|requirement| RemiRequirement {
+                capability: requirement.capability,
+                version_constraint: requirement.version_constraint,
+                kind: requirement.kind,
+                dependency_type: requirement.dependency_type,
+                raw: requirement.raw,
+            })
+            .collect();
+        metadata
+            .get_mut(&group.repository_package_id)
+            .context("repository requirement group belongs to an unrequested package")?
+            .requirement_groups
+            .push(RemiRequirementGroup {
+                kind: group.kind,
+                behavior: group.behavior,
+                description: group.description,
+                native_text: group.native_text,
+                expression_json: group.expression_json,
+                clauses,
+            });
+    }
+
+    if let Some((group_id, atoms)) = atoms_by_group.into_iter().next() {
+        let package_id = atoms
+            .first()
+            .map(|atom| atom.repository_package_id)
+            .unwrap_or_default();
         bail!(
-            "repository package {repository_package_id} has requirement atoms \
-             outside its authoritative exact groups"
+            "repository package {package_id} has requirement atoms outside authoritative group \
+             {group_id}"
         );
     }
 
-    Ok(ExactPackageMetadata {
-        provides,
-        requirement_groups,
-    })
+    Ok(metadata)
 }

--- a/crates/conary-core/src/db/models/mod.rs
+++ b/crates/conary-core/src/db/models/mod.rs
@@ -129,6 +129,25 @@ pub use trigger_engine::TriggerEngine;
 pub use trove::{InstallReason, InstallSource, Trove, TroveType};
 pub use try_session::{CreateTrySession, TrySession, TrySessionMode, TrySessionStatus};
 
+/// Return the connection's authoritative SQLite bind-variable limit as a
+/// non-zero Rust batch size.
+///
+/// Multi-package model queries chunk against the runtime connection limit
+/// instead of assuming the compile-time default used by one SQLite build.
+pub(super) fn sqlite_variable_batch_size(
+    conn: &rusqlite::Connection,
+) -> crate::error::Result<usize> {
+    let limit = conn.limit(rusqlite::limits::Limit::SQLITE_LIMIT_VARIABLE_NUMBER)?;
+    usize::try_from(limit)
+        .ok()
+        .filter(|limit| *limit > 0)
+        .ok_or_else(|| {
+            crate::error::Error::InitError(
+                "SQLite reported a non-positive bind-variable limit".to_string(),
+            )
+        })
+}
+
 /// Format a byte count as a human-readable size string.
 ///
 /// Delegates to [`crate::util::format_size`].

--- a/crates/conary-core/src/db/models/repository_capability.rs
+++ b/crates/conary-core/src/db/models/repository_capability.rs
@@ -138,6 +138,38 @@ impl RepositoryProvide {
         Ok(rows)
     }
 
+    /// Load exact provides for a bounded set of repository packages in one
+    /// query.
+    pub fn find_by_repository_packages(
+        conn: &Connection,
+        repository_package_ids: &[i64],
+    ) -> Result<Vec<Self>> {
+        if repository_package_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders = repository_package_ids
+            .iter()
+            .enumerate()
+            .map(|(index, _)| format!("?{}", index + 1))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT id, repository_package_id, capability, version, version_relation, kind, raw,
+                    version_scheme, architecture_qualifier_kind, architecture
+             FROM repository_provides
+             WHERE repository_package_id IN ({placeholders})
+             ORDER BY repository_package_id, capability, version"
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map(
+                rusqlite::params_from_iter(repository_package_ids.iter()),
+                Self::from_row,
+            )?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
     pub fn find_by_capability(conn: &Connection, capability: &str) -> Result<Vec<Self>> {
         let mut stmt = conn.prepare(
             "SELECT rp.id, rp.repository_package_id, rp.capability, rp.version,

--- a/crates/conary-core/src/db/models/repository_capability.rs
+++ b/crates/conary-core/src/db/models/repository_capability.rs
@@ -7,6 +7,7 @@ use crate::repository::dependency_model::{ProvideArchitectureQualifier, ProvideV
 use crate::repository::distro::version_scheme_from_db;
 use crate::repository::versioning::VersionScheme;
 use rusqlite::{Connection, Row, params};
+use std::collections::BTreeSet;
 use std::io;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -147,26 +148,41 @@ impl RepositoryProvide {
         if repository_package_ids.is_empty() {
             return Ok(Vec::new());
         }
-        let placeholders = repository_package_ids
+        let package_ids = repository_package_ids
             .iter()
-            .enumerate()
-            .map(|(index, _)| format!("?{}", index + 1))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let sql = format!(
-            "SELECT id, repository_package_id, capability, version, version_relation, kind, raw,
-                    version_scheme, architecture_qualifier_kind, architecture
-             FROM repository_provides
-             WHERE repository_package_id IN ({placeholders})
-             ORDER BY repository_package_id, capability, version"
-        );
-        let mut stmt = conn.prepare(&sql)?;
-        let rows = stmt
-            .query_map(
-                rusqlite::params_from_iter(repository_package_ids.iter()),
-                Self::from_row,
-            )?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
+            .copied()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let batch_size = super::sqlite_variable_batch_size(conn)?;
+        let mut rows = Vec::new();
+        for package_ids in package_ids.chunks(batch_size) {
+            let placeholders = (1..=package_ids.len())
+                .map(|index| format!("?{index}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let sql = format!(
+                "SELECT id, repository_package_id, capability, version, version_relation, kind, raw,
+                        version_scheme, architecture_qualifier_kind, architecture
+                 FROM repository_provides
+                 WHERE repository_package_id IN ({placeholders})"
+            );
+            let mut stmt = conn.prepare(&sql)?;
+            rows.extend(
+                stmt.query_map(
+                    rusqlite::params_from_iter(package_ids.iter()),
+                    Self::from_row,
+                )?
+                .collect::<std::result::Result<Vec<_>, _>>()?,
+            );
+        }
+        rows.sort_by(|left, right| {
+            (left.repository_package_id, &left.capability, &left.version).cmp(&(
+                right.repository_package_id,
+                &right.capability,
+                &right.version,
+            ))
+        });
         Ok(rows)
     }
 
@@ -462,6 +478,50 @@ mod tests {
         let found = RepositoryProvide::find_by_repository_package(&conn, 1).unwrap();
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].version_scheme, VersionScheme::Rpm);
+    }
+
+    #[test]
+    fn multi_package_lookup_chunks_at_the_runtime_sqlite_variable_limit() {
+        let conn = test_db();
+        seed_repo_and_package(&conn);
+        for package_id in 2..=5 {
+            conn.execute(
+                "INSERT INTO repository_packages
+                 (id, repository_id, name, version, checksum, size, download_url, version_scheme)
+                 VALUES (?1, 1, ?2, '1.0', 'sha256:test', 1, ?3, 'rpm')",
+                params![
+                    package_id,
+                    format!("pkg-{package_id}"),
+                    format!("https://example.test/pkg-{package_id}")
+                ],
+            )
+            .unwrap();
+        }
+        for package_id in 1..=5 {
+            let mut provide = RepositoryProvide::new(
+                package_id,
+                format!("cap-{package_id}"),
+                None,
+                "package".to_string(),
+                None,
+                VersionScheme::Rpm,
+            );
+            provide.insert(&conn).unwrap();
+        }
+        conn.set_limit(rusqlite::limits::Limit::SQLITE_LIMIT_VARIABLE_NUMBER, 2)
+            .unwrap();
+
+        let found =
+            RepositoryProvide::find_by_repository_packages(&conn, &[5, 4, 3, 2, 1, 1]).unwrap();
+
+        assert_eq!(found.len(), 5);
+        assert_eq!(
+            found
+                .iter()
+                .map(|provide| provide.repository_package_id)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 3, 4, 5]
+        );
     }
 
     #[test]

--- a/crates/conary-core/src/db/models/repository_requirement.rs
+++ b/crates/conary-core/src/db/models/repository_requirement.rs
@@ -145,6 +145,38 @@ impl RepositoryRequirement {
         Ok(rows)
     }
 
+    /// Load exact requirement clauses for a bounded set of repository
+    /// packages in one query.
+    pub fn find_by_repository_packages(
+        conn: &Connection,
+        repository_package_ids: &[i64],
+    ) -> Result<Vec<Self>> {
+        if repository_package_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders = repository_package_ids
+            .iter()
+            .enumerate()
+            .map(|(index, _)| format!("?{}", index + 1))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT id, repository_package_id, group_id, capability, version_constraint, kind,
+                    dependency_type, raw
+             FROM repository_requirements
+             WHERE repository_package_id IN ({placeholders})
+             ORDER BY repository_package_id, group_id, capability, version_constraint"
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map(
+                rusqlite::params_from_iter(repository_package_ids.iter()),
+                Self::from_row,
+            )?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
     /// List all requirement clauses belonging to a specific group.
     pub fn find_by_group(conn: &Connection, group_id: i64) -> Result<Vec<Self>> {
         let mut stmt = conn.prepare(
@@ -300,6 +332,38 @@ impl RepositoryRequirementGroup {
         )?;
         let rows = stmt
             .query_map([repository_package_id], Self::from_row)?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// Load exact requirement groups for a bounded set of repository packages
+    /// in one query.
+    pub fn find_by_repository_packages(
+        conn: &Connection,
+        repository_package_ids: &[i64],
+    ) -> Result<Vec<Self>> {
+        if repository_package_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders = repository_package_ids
+            .iter()
+            .enumerate()
+            .map(|(index, _)| format!("?{}", index + 1))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT id, repository_package_id, kind, behavior, description, native_text,
+                    expression_json
+             FROM repository_requirement_groups
+             WHERE repository_package_id IN ({placeholders})
+             ORDER BY repository_package_id, id"
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map(
+                rusqlite::params_from_iter(repository_package_ids.iter()),
+                Self::from_row,
+            )?
             .collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(rows)
     }

--- a/crates/conary-core/src/db/models/repository_requirement.rs
+++ b/crates/conary-core/src/db/models/repository_requirement.rs
@@ -4,6 +4,7 @@
 
 use crate::error::Result;
 use rusqlite::{Connection, Row, params};
+use std::collections::BTreeSet;
 
 /// A searchable clause index belonging to an authoritative requirement group.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -154,26 +155,48 @@ impl RepositoryRequirement {
         if repository_package_ids.is_empty() {
             return Ok(Vec::new());
         }
-        let placeholders = repository_package_ids
+        let package_ids = repository_package_ids
             .iter()
-            .enumerate()
-            .map(|(index, _)| format!("?{}", index + 1))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let sql = format!(
-            "SELECT id, repository_package_id, group_id, capability, version_constraint, kind,
-                    dependency_type, raw
-             FROM repository_requirements
-             WHERE repository_package_id IN ({placeholders})
-             ORDER BY repository_package_id, group_id, capability, version_constraint"
-        );
-        let mut stmt = conn.prepare(&sql)?;
-        let rows = stmt
-            .query_map(
-                rusqlite::params_from_iter(repository_package_ids.iter()),
-                Self::from_row,
-            )?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
+            .copied()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let batch_size = super::sqlite_variable_batch_size(conn)?;
+        let mut rows = Vec::new();
+        for package_ids in package_ids.chunks(batch_size) {
+            let placeholders = (1..=package_ids.len())
+                .map(|index| format!("?{index}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let sql = format!(
+                "SELECT id, repository_package_id, group_id, capability, version_constraint, kind,
+                        dependency_type, raw
+                 FROM repository_requirements
+                 WHERE repository_package_id IN ({placeholders})"
+            );
+            let mut stmt = conn.prepare(&sql)?;
+            rows.extend(
+                stmt.query_map(
+                    rusqlite::params_from_iter(package_ids.iter()),
+                    Self::from_row,
+                )?
+                .collect::<std::result::Result<Vec<_>, _>>()?,
+            );
+        }
+        rows.sort_by(|left, right| {
+            (
+                left.repository_package_id,
+                left.group_id,
+                &left.capability,
+                &left.version_constraint,
+            )
+                .cmp(&(
+                    right.repository_package_id,
+                    right.group_id,
+                    &right.capability,
+                    &right.version_constraint,
+                ))
+        });
         Ok(rows)
     }
 
@@ -345,26 +368,35 @@ impl RepositoryRequirementGroup {
         if repository_package_ids.is_empty() {
             return Ok(Vec::new());
         }
-        let placeholders = repository_package_ids
+        let package_ids = repository_package_ids
             .iter()
-            .enumerate()
-            .map(|(index, _)| format!("?{}", index + 1))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let sql = format!(
-            "SELECT id, repository_package_id, kind, behavior, description, native_text,
-                    expression_json
-             FROM repository_requirement_groups
-             WHERE repository_package_id IN ({placeholders})
-             ORDER BY repository_package_id, id"
-        );
-        let mut stmt = conn.prepare(&sql)?;
-        let rows = stmt
-            .query_map(
-                rusqlite::params_from_iter(repository_package_ids.iter()),
-                Self::from_row,
-            )?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
+            .copied()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let batch_size = super::sqlite_variable_batch_size(conn)?;
+        let mut rows = Vec::new();
+        for package_ids in package_ids.chunks(batch_size) {
+            let placeholders = (1..=package_ids.len())
+                .map(|index| format!("?{index}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let sql = format!(
+                "SELECT id, repository_package_id, kind, behavior, description, native_text,
+                        expression_json
+                 FROM repository_requirement_groups
+                 WHERE repository_package_id IN ({placeholders})"
+            );
+            let mut stmt = conn.prepare(&sql)?;
+            rows.extend(
+                stmt.query_map(
+                    rusqlite::params_from_iter(package_ids.iter()),
+                    Self::from_row,
+                )?
+                .collect::<std::result::Result<Vec<_>, _>>()?,
+            );
+        }
+        rows.sort_by_key(|group| (group.repository_package_id, group.id));
         Ok(rows)
     }
 
@@ -471,6 +503,67 @@ mod tests {
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].capability, "libmagic");
         assert_eq!(found[0].version_constraint.as_deref(), Some(">= 1.0"));
+    }
+
+    #[test]
+    fn multi_package_requirement_lookup_chunks_at_the_runtime_variable_limit() {
+        let conn = test_db();
+        seed_repo_and_package(&conn);
+        for package_id in 2..=5 {
+            conn.execute(
+                "INSERT INTO repository_packages
+                 (id, repository_id, name, version, checksum, size, download_url, version_scheme)
+                 VALUES (?1, 1, ?2, '1.0', 'sha256:test', 1, ?3, 'rpm')",
+                params![
+                    package_id,
+                    format!("pkg-{package_id}"),
+                    format!("https://example.test/pkg-{package_id}")
+                ],
+            )
+            .unwrap();
+        }
+        for package_id in 1..=5 {
+            let mut group = RepositoryRequirementGroup::new(
+                package_id,
+                "depends".to_string(),
+                "hard".to_string(),
+                expression_json(&format!("dep-{package_id}")),
+            );
+            let group_id = group.insert(&conn).unwrap();
+            let mut requirement = RepositoryRequirement::new(
+                package_id,
+                group_id,
+                format!("dep-{package_id}"),
+                None,
+                "package".to_string(),
+                "runtime".to_string(),
+                None,
+            );
+            requirement.insert(&conn).unwrap();
+        }
+        conn.set_limit(rusqlite::limits::Limit::SQLITE_LIMIT_VARIABLE_NUMBER, 2)
+            .unwrap();
+
+        let ids = [5, 4, 3, 2, 1, 1];
+        let groups = RepositoryRequirementGroup::find_by_repository_packages(&conn, &ids).unwrap();
+        let requirements = RepositoryRequirement::find_by_repository_packages(&conn, &ids).unwrap();
+
+        assert_eq!(groups.len(), 5);
+        assert_eq!(requirements.len(), 5);
+        assert_eq!(
+            groups
+                .iter()
+                .map(|group| group.repository_package_id)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 3, 4, 5]
+        );
+        assert_eq!(
+            requirements
+                .iter()
+                .map(|requirement| requirement.repository_package_id)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 3, 4, 5]
+        );
     }
 
     #[test]

--- a/crates/conary-core/src/repository/remi_metadata.rs
+++ b/crates/conary-core/src/repository/remi_metadata.rs
@@ -31,6 +31,24 @@ pub const REMI_SPARSE_MIN_PACKAGE_SIZE: i64 = 1;
 pub const REMI_SPARSE_SYNC_PAGE_SIZE: usize = 128;
 const _: () = assert!(REMI_SPARSE_SYNC_PAGE_SIZE <= REMI_SPARSE_MAX_PAGE_SIZE);
 
+/// Validate one public Remi route component or sparse package name.
+///
+/// The server applies this before exposing database-owned names and the client
+/// applies the same contract before persisting a page. Keeping the rule here
+/// prevents the two sides from admitting different sparse-index names.
+pub fn validate_remi_public_name(name: &str) -> Result<(), &'static str> {
+    if name.is_empty() {
+        return Err("name must not be empty");
+    }
+    if name.len() > REMI_SPARSE_NAME_MAX_BYTES {
+        return Err("name exceeds the public repository wire limit");
+    }
+    if name.contains('/') || name.contains("..") || name.contains('\0') {
+        return Err("name contains invalid characters");
+    }
+    Ok(())
+}
+
 /// One sparse-index document for a package name across all versions.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -147,4 +165,19 @@ pub struct RemiRequirementGroup {
     pub native_text: Option<String>,
     pub expression_json: String,
     pub clauses: Vec<RemiRequirement>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn public_name_validation_is_the_shared_sparse_wire_contract() {
+        assert!(validate_remi_public_name("kernel-core").is_ok());
+        assert!(validate_remi_public_name("").is_err());
+        assert!(validate_remi_public_name("../escape").is_err());
+        assert!(validate_remi_public_name("bad/name").is_err());
+        assert!(validate_remi_public_name("bad\0name").is_err());
+        assert!(validate_remi_public_name(&"x".repeat(REMI_SPARSE_NAME_MAX_BYTES + 1)).is_err());
+    }
 }

--- a/crates/conary-core/src/repository/remi_metadata.rs
+++ b/crates/conary-core/src/repository/remi_metadata.rs
@@ -16,6 +16,13 @@ pub const REMI_SPARSE_NAME_MAX_BYTES: usize = 256;
 /// Maximum page size admitted by Remi's sparse package-name listing.
 pub const REMI_SPARSE_MAX_PAGE_SIZE: usize = 1000;
 
+/// Smallest repository-package artifact admitted by Remi's public index.
+///
+/// Historical zero-sized rows are discovery placeholders, not downloadable
+/// package records. Every sparse list and lookup uses this shared threshold so
+/// the list cannot advertise a name that the lookup route hides.
+pub const REMI_SPARSE_MIN_PACKAGE_SIZE: i64 = 1;
+
 /// Number of package names Conary requests and persists per sparse sync page.
 ///
 /// This fixed page is the structural owner of the sync working set. Increasing
@@ -24,26 +31,6 @@ pub const REMI_SPARSE_MAX_PAGE_SIZE: usize = 1000;
 pub const REMI_SPARSE_SYNC_PAGE_SIZE: usize = 128;
 const _: () = assert!(REMI_SPARSE_SYNC_PAGE_SIZE <= REMI_SPARSE_MAX_PAGE_SIZE);
 
-/// Maximum compact JSON bytes for a requested sparse package-name page.
-///
-/// A page contains at most `per_page` names, each at most 256 input bytes.
-/// JSON escaping can expand one input byte to at most six ASCII bytes
-/// (`\u00XX`). The remaining fixed envelope contains the distro, pagination
-/// counters, field names, punctuation, and integer text.
-pub const fn sparse_package_list_max_bytes(per_page: usize) -> u64 {
-    const JSON_ESCAPE_EXPANSION: usize = 6;
-    const STRING_DELIMITERS_AND_COMMA: usize = 3;
-    const FIXED_ENVELOPE_BYTES: usize = 2048;
-
-    (per_page
-        .saturating_mul(
-            REMI_SPARSE_NAME_MAX_BYTES
-                .saturating_mul(JSON_ESCAPE_EXPANSION)
-                .saturating_add(STRING_DELIMITERS_AND_COMMA),
-        )
-        .saturating_add(FIXED_ENVELOPE_BYTES)) as u64
-}
-
 /// One sparse-index document for a package name across all versions.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -51,6 +38,19 @@ pub struct RemiSparseIndexEntry {
     pub name: String,
     pub distro: String,
     pub versions: Vec<RemiSparseVersionEntry>,
+}
+
+/// Resolution-only sparse entry emitted by bulk sync pages.
+///
+/// Conversion state and content hashes belong to on-demand package lookup and
+/// are deliberately absent here: repository sync persists native resolution
+/// authority and does not consume serving-cache state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RemiSparseResolutionEntry {
+    pub name: String,
+    pub distro: String,
+    pub versions: Vec<RemiSparseResolutionVersionEntry>,
 }
 
 /// One version emitted by a sparse package document.
@@ -68,12 +68,49 @@ pub struct RemiSparseVersionEntry {
     pub content_hash: Option<String>,
 }
 
+/// One native resolution version emitted by a bulk sparse page.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RemiSparseResolutionVersionEntry {
+    pub version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub release: Option<String>,
+    pub provides: Vec<RemiProvide>,
+    pub requirement_groups: Vec<RemiRequirementGroup>,
+    pub architecture: Option<String>,
+    pub size: i64,
+    /// Persisted package metadata consumed by repository sync, including
+    /// explicitly trusted security-advisory authority when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
 /// One page from Remi's sparse package-name listing.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RemiSparsePackageList {
     pub distro: String,
     pub packages: Vec<String>,
+    pub total: usize,
+    pub page: usize,
+    pub per_page: usize,
+}
+
+/// Optional sparse-list expansion selected by the `include` query field.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RemiSparseListInclude {
+    #[default]
+    Names,
+    Versions,
+}
+
+/// One sparse sync page containing complete resolution entries.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RemiSparsePackagePage {
+    pub distro: String,
+    pub packages: Vec<RemiSparseResolutionEntry>,
     pub total: usize,
     pub page: usize,
     pub per_page: usize,

--- a/crates/conary-core/src/repository/remi_metadata.rs
+++ b/crates/conary-core/src/repository/remi_metadata.rs
@@ -6,6 +6,79 @@ use crate::repository::dependency_model::{ProvideArchitectureQualifier, ProvideV
 use crate::repository::versioning::VersionScheme;
 use serde::{Deserialize, Serialize};
 
+/// Maximum package-name bytes admitted by Remi's public sparse-index routes.
+///
+/// This is a wire-contract bound, not an observed corpus size. Remi validates
+/// every distro and package path component against the same limit before
+/// querying its index.
+pub const REMI_SPARSE_NAME_MAX_BYTES: usize = 256;
+
+/// Maximum page size admitted by Remi's sparse package-name listing.
+pub const REMI_SPARSE_MAX_PAGE_SIZE: usize = 1000;
+
+/// Number of package names Conary requests and persists per sparse sync page.
+///
+/// This fixed page is the structural owner of the sync working set. Increasing
+/// a distro from thousands to millions of package names increases page count,
+/// not retained package metadata.
+pub const REMI_SPARSE_SYNC_PAGE_SIZE: usize = 128;
+const _: () = assert!(REMI_SPARSE_SYNC_PAGE_SIZE <= REMI_SPARSE_MAX_PAGE_SIZE);
+
+/// Maximum compact JSON bytes for a requested sparse package-name page.
+///
+/// A page contains at most `per_page` names, each at most 256 input bytes.
+/// JSON escaping can expand one input byte to at most six ASCII bytes
+/// (`\u00XX`). The remaining fixed envelope contains the distro, pagination
+/// counters, field names, punctuation, and integer text.
+pub const fn sparse_package_list_max_bytes(per_page: usize) -> u64 {
+    const JSON_ESCAPE_EXPANSION: usize = 6;
+    const STRING_DELIMITERS_AND_COMMA: usize = 3;
+    const FIXED_ENVELOPE_BYTES: usize = 2048;
+
+    (per_page
+        .saturating_mul(
+            REMI_SPARSE_NAME_MAX_BYTES
+                .saturating_mul(JSON_ESCAPE_EXPANSION)
+                .saturating_add(STRING_DELIMITERS_AND_COMMA),
+        )
+        .saturating_add(FIXED_ENVELOPE_BYTES)) as u64
+}
+
+/// One sparse-index document for a package name across all versions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RemiSparseIndexEntry {
+    pub name: String,
+    pub distro: String,
+    pub versions: Vec<RemiSparseVersionEntry>,
+}
+
+/// One version emitted by a sparse package document.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RemiSparseVersionEntry {
+    pub version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub release: Option<String>,
+    pub provides: Vec<RemiProvide>,
+    pub requirement_groups: Vec<RemiRequirementGroup>,
+    pub architecture: Option<String>,
+    pub size: i64,
+    pub converted: bool,
+    pub content_hash: Option<String>,
+}
+
+/// One page from Remi's sparse package-name listing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RemiSparsePackageList {
+    pub distro: String,
+    pub packages: Vec<String>,
+    pub total: usize,
+    pub page: usize,
+    pub per_page: usize,
+}
+
 /// A normalized capability provided by one repository package.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RemiProvide {

--- a/crates/conary-core/src/repository/sync.rs
+++ b/crates/conary-core/src/repository/sync.rs
@@ -30,11 +30,9 @@ use native::{
 #[cfg(test)]
 use remi::remi_sync_row;
 use remi::{
-    fetch_and_persist_canonical_map, fetch_canonical_map_snapshot, fetch_remi_sync_rows,
-    persist_canonical_map, sync_repository_remi,
+    fetch_and_persist_canonical_map, fetch_canonical_map_snapshot, persist_canonical_map,
+    sync_repository_remi, sync_repository_remi_from_db_path,
 };
-#[cfg(test)]
-use types::RemiPackageEntry;
 use types::{
     JsonPackageDelta, JsonRepositorySyncSnapshot, RepositorySyncSnapshot, SyncedPackageRow,
 };
@@ -162,12 +160,6 @@ async fn fetch_repository_sync_snapshot(
     repo: &Repository,
     keyring_dir: &Path,
 ) -> Result<RepositorySyncSnapshot> {
-    if repo.default_strategy.as_deref() == Some("remi") {
-        return fetch_remi_sync_rows(repo)
-            .await
-            .map(RepositorySyncSnapshot::NativeRows);
-    }
-
     match repo.require_parser_config()?.format() {
         RepositoryFormat::Json => fetch_repository_json_snapshot(repo).await,
         RepositoryFormat::Arch | RepositoryFormat::Debian | RepositoryFormat::Fedora => {
@@ -231,23 +223,27 @@ pub async fn sync_repository_from_db_path(db_path: PathBuf, repo: Repository) ->
         );
     }
 
-    let keyring_dir = crate::db::paths::keyring_dir(&db_path.display().to_string());
-    let snapshot = fetch_repository_sync_snapshot(&repo, &keyring_dir).await?;
+    let count = if repo.default_strategy.as_deref() == Some("remi") {
+        sync_repository_remi_from_db_path(db_path.clone(), repo.clone()).await?
+    } else {
+        let keyring_dir = crate::db::paths::keyring_dir(&db_path.display().to_string());
+        let snapshot = fetch_repository_sync_snapshot(&repo, &keyring_dir).await?;
 
-    let persist_repo_id = repo
-        .id
-        .ok_or_else(|| Error::InitError("Repository has no ID".to_string()))?;
-    let persist_db_path = db_path.clone();
-    let count = run_blocking_sync(move || {
-        let conn = crate::db::open_fast(&persist_db_path)?;
-        let mut repo = Repository::find_by_id(&conn, persist_repo_id)?.ok_or_else(|| {
-            Error::NotFound(format!(
-                "Repository {persist_repo_id} not found during sync"
-            ))
-        })?;
-        persist_repository_sync_snapshot(&conn, &mut repo, snapshot)
-    })
-    .await?;
+        let persist_repo_id = repo
+            .id
+            .ok_or_else(|| Error::InitError("Repository has no ID".to_string()))?;
+        let persist_db_path = db_path.clone();
+        run_blocking_sync(move || {
+            let conn = crate::db::open_fast(&persist_db_path)?;
+            let mut repo = Repository::find_by_id(&conn, persist_repo_id)?.ok_or_else(|| {
+                Error::NotFound(format!(
+                    "Repository {persist_repo_id} not found during sync"
+                ))
+            })?;
+            persist_repository_sync_snapshot(&conn, &mut repo, snapshot)
+        })
+        .await?
+    };
 
     if let Some(ref remi_endpoint) = repo.default_strategy_endpoint {
         match fetch_canonical_map_snapshot(remi_endpoint).await {

--- a/crates/conary-core/src/repository/sync.rs
+++ b/crates/conary-core/src/repository/sync.rs
@@ -701,11 +701,7 @@ fn persist_repository_sync_snapshot(
 ) -> Result<usize> {
     match snapshot {
         RepositorySyncSnapshot::NativeRows(synced_packages) => {
-            let mut repo_packages: Vec<RepositoryPackage> = synced_packages
-                .iter()
-                .map(|row| row.package.clone())
-                .collect();
-            persist_native_sync_rows(conn, repo, &mut repo_packages, synced_packages)
+            persist_native_sync_rows(conn, repo, synced_packages)
         }
         RepositorySyncSnapshot::StaticRows {
             packages,
@@ -719,12 +715,7 @@ fn persist_repository_sync_snapshot(
 
             let tx = conn.unchecked_transaction()?;
 
-            let mut repo_packages = snapshot
-                .packages
-                .iter()
-                .map(|row| row.package.clone())
-                .collect::<Vec<_>>();
-            persist_synced_package_rows(&tx, repo_id, &mut repo_packages, snapshot.packages)?;
+            persist_synced_package_rows(&tx, repo_id, snapshot.packages)?;
 
             let mut delta_count = 0;
             for delta in snapshot.deltas {
@@ -769,14 +760,9 @@ fn persist_static_sync_rows(
         .id
         .ok_or_else(|| Error::InitError("Repository has no ID".to_string()))?;
     let count = synced_packages.len();
-    let mut repo_packages: Vec<RepositoryPackage> = synced_packages
-        .iter()
-        .map(|row| row.package.clone())
-        .collect();
-
     let tx = conn.unchecked_transaction()?;
 
-    persist_synced_package_rows(&tx, repo_id, &mut repo_packages, synced_packages)?;
+    persist_synced_package_rows(&tx, repo_id, synced_packages)?;
     replace_package_keys_for_repository(&tx, repo_id, &package_keys)?;
     link_canonical_ids(&tx, repo_id)?;
 

--- a/crates/conary-core/src/repository/sync/native.rs
+++ b/crates/conary-core/src/repository/sync/native.rs
@@ -18,7 +18,6 @@ use super::{current_timestamp, link_canonical_ids};
 pub(super) fn persist_native_sync_rows(
     conn: &Connection,
     repo: &mut Repository,
-    repo_packages: &mut [RepositoryPackage],
     synced_packages: Vec<SyncedPackageRow>,
 ) -> Result<usize> {
     let repo_id = repo
@@ -28,7 +27,7 @@ pub(super) fn persist_native_sync_rows(
 
     let tx = conn.unchecked_transaction()?;
 
-    persist_synced_package_rows(&tx, repo_id, repo_packages, synced_packages)?;
+    persist_synced_package_rows(&tx, repo_id, synced_packages)?;
     link_canonical_ids(&tx, repo_id)?;
 
     repo.last_sync = Some(current_timestamp());
@@ -42,11 +41,10 @@ pub(super) fn persist_native_sync_rows(
 pub(super) fn persist_synced_package_rows(
     conn: &Connection,
     repo_id: i64,
-    repo_packages: &mut [RepositoryPackage],
     synced_packages: Vec<SyncedPackageRow>,
 ) -> Result<usize> {
     RepositoryPackage::delete_by_repository(conn, repo_id)?;
-    append_synced_package_rows(conn, repo_packages, synced_packages)
+    append_synced_package_rows(conn, synced_packages)
 }
 
 /// Append one bounded batch of normalized package rows.
@@ -56,12 +54,24 @@ pub(super) fn persist_synced_package_rows(
 /// projections accumulate in process memory for the full distribution.
 pub(super) fn append_synced_package_rows(
     conn: &Connection,
-    repo_packages: &mut [RepositoryPackage],
     synced_packages: Vec<SyncedPackageRow>,
 ) -> Result<usize> {
     let count = synced_packages.len();
+    for (index, row) in synced_packages.iter().enumerate() {
+        if row.requirement_groups.len() != row.requirement_group_clauses.len() {
+            return Err(Error::InitError(format!(
+                "normalized repository row {index} has {} requirement groups but {} clause batches",
+                row.requirement_groups.len(),
+                row.requirement_group_clauses.len()
+            )));
+        }
+    }
 
-    RepositoryPackage::batch_insert_with_ids(conn, repo_packages)?;
+    let mut repo_packages = synced_packages
+        .iter()
+        .map(|row| row.package.clone())
+        .collect::<Vec<_>>();
+    RepositoryPackage::batch_insert_with_ids(conn, &mut repo_packages)?;
 
     let mut repo_provides = Vec::new();
     let mut all_groups: Vec<DbRequirementGroup> = Vec::new();
@@ -222,4 +232,59 @@ pub(in crate::repository) fn convert_requirement_groups(
     }
 
     (db_groups, clause_batches)
+}
+
+#[cfg(test)]
+mod append_tests {
+    use super::*;
+    use crate::db::testing::create_test_db;
+    use crate::repository::versioning::VersionScheme;
+
+    fn package(name: &str) -> RepositoryPackage {
+        RepositoryPackage::new(
+            1,
+            name.to_string(),
+            "1".to_string(),
+            VersionScheme::Rpm,
+            "checksum".to_string(),
+            1,
+            format!("https://repo.test/{name}"),
+        )
+    }
+
+    fn synced(package: RepositoryPackage) -> SyncedPackageRow {
+        SyncedPackageRow {
+            package,
+            provides: Vec::new(),
+            requirement_groups: Vec::new(),
+            requirement_group_clauses: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn append_rejects_group_and_clause_batch_mismatch_before_writing() {
+        let (_temp, conn) = create_test_db();
+        let package = package("alpha");
+        let mut row = synced(package);
+        row.requirement_groups.push(DbRequirementGroup::new(
+            0,
+            "depends".to_string(),
+            "hard".to_string(),
+            r#"{"kind":"all","items":[]}"#.to_string(),
+        ));
+
+        let error = append_synced_package_rows(&conn, vec![row]).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("1 requirement groups but 0 clause batches")
+        );
+        let stored: i64 = conn
+            .query_row("SELECT COUNT(*) FROM repository_packages", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(stored, 0);
+    }
 }

--- a/crates/conary-core/src/repository/sync/native.rs
+++ b/crates/conary-core/src/repository/sync/native.rs
@@ -45,9 +45,22 @@ pub(super) fn persist_synced_package_rows(
     repo_packages: &mut [RepositoryPackage],
     synced_packages: Vec<SyncedPackageRow>,
 ) -> Result<usize> {
+    RepositoryPackage::delete_by_repository(conn, repo_id)?;
+    append_synced_package_rows(conn, repo_packages, synced_packages)
+}
+
+/// Append one bounded batch of normalized package rows.
+///
+/// Callers own replacement/transaction semantics. Sparse Remi sync uses this
+/// with a fixed-size staging page so neither package rows nor their capability
+/// projections accumulate in process memory for the full distribution.
+pub(super) fn append_synced_package_rows(
+    conn: &Connection,
+    repo_packages: &mut [RepositoryPackage],
+    synced_packages: Vec<SyncedPackageRow>,
+) -> Result<usize> {
     let count = synced_packages.len();
 
-    RepositoryPackage::delete_by_repository(conn, repo_id)?;
     RepositoryPackage::batch_insert_with_ids(conn, repo_packages)?;
 
     let mut repo_provides = Vec::new();

--- a/crates/conary-core/src/repository/sync/remi.rs
+++ b/crates/conary-core/src/repository/sync/remi.rs
@@ -13,47 +13,45 @@ use crate::repository::dependency_model::{
     ConditionalRequirementBehavior, RepositoryRequirementExpression,
     RepositoryRequirementGroup as TypedRequirementGroup, RepositoryRequirementKind,
 };
-use crate::repository::metadata::PackageSecurityAdvisoryMetadata;
 use crate::repository::package_relation::validate_native_relation;
-use crate::repository::retry::RetryConfig;
+use crate::repository::remi_metadata::{
+    REMI_SPARSE_NAME_MAX_BYTES, REMI_SPARSE_SYNC_PAGE_SIZE, RemiSparseIndexEntry,
+    RemiSparsePackageList, RemiSparseVersionEntry, sparse_package_list_max_bytes,
+};
+use crate::repository::retry::{RetryConfig, with_retry_async};
 use crate::repository::versioning::VersionScheme;
+use futures::stream::{self, StreamExt};
 use rusqlite::Connection;
 use std::collections::HashSet;
-use tracing::{debug, info, warn};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tracing::{debug, info};
 
-use super::apply_trusted_package_security_advisory;
-use super::native::persist_native_sync_rows;
-use super::types::{RemiMetadataResponse, RemiPackageEntry, SyncedPackageRow};
+use super::native::append_synced_package_rows;
+use super::support::run_blocking_sync;
+use super::types::SyncedPackageRow;
 
 pub(super) fn remi_sync_row(
     repo_id: i64,
     endpoint: String,
     distro: String,
-    entry: RemiPackageEntry,
+    name: String,
+    entry: RemiSparseVersionEntry,
 ) -> Result<SyncedPackageRow> {
-    let RemiPackageEntry {
-        name,
+    let RemiSparseVersionEntry {
         version,
         release,
         converted: _,
         architecture,
         provides: wire_provides,
         requirement_groups: wire_requirement_groups,
-        metadata,
+        size,
+        content_hash: _,
     } = entry;
     let profile = crate::repository::supported_profiles::profile_for_remi_target(&distro)
         .ok_or_else(|| Error::ConfigError(format!("unsupported Remi target: {distro}")))?;
     let route_slug = profile.remi_route_slug();
     let public_profile_id = profile.id();
-    let package_release = release
-        .or_else(|| {
-            metadata
-                .as_ref()
-                .and_then(|metadata| metadata.pointer("/identity/release"))
-                .and_then(|value| value.as_str())
-                .map(str::to_string)
-        })
-        .unwrap_or_default();
+    let package_release = release.unwrap_or_default();
     let mut query = vec![format!("version={}", urlencoding::encode(&version))];
     if !package_release.is_empty() {
         query.push(format!("release={}", urlencoding::encode(&package_release)));
@@ -74,47 +72,11 @@ pub(super) fn remi_sync_row(
         version.clone(),
         scheme,
         "remi:server-verified".to_string(),
-        0,
+        size,
         download_url,
     );
     package.package_release = package_release;
     package.architecture = architecture;
-
-    let mut metadata = metadata.unwrap_or(serde_json::Value::Null);
-    if let Some(advisory_value) = metadata.get("security_advisory").cloned() {
-        match serde_json::from_value::<PackageSecurityAdvisoryMetadata>(advisory_value) {
-            Ok(advisory) => {
-                match apply_trusted_package_security_advisory(
-                    &mut package,
-                    &advisory,
-                    "remi",
-                    "unknown",
-                ) {
-                    Ok(normalized) => {
-                        if let Some(object) = metadata.as_object_mut() {
-                            object.insert("security_advisory".to_string(), normalized);
-                        }
-                    }
-                    Err(error) => {
-                        warn!(
-                            "Ignoring untrusted Remi security advisory metadata for {} {}: {}",
-                            name, version, error
-                        );
-                    }
-                }
-            }
-            Err(error) => {
-                warn!(
-                    "Ignoring malformed Remi security advisory metadata for {} {}: {}",
-                    name, version, error
-                );
-            }
-        }
-    }
-    package.metadata = match metadata {
-        serde_json::Value::Null => None,
-        ref value => Some(value.to_string()),
-    };
 
     package.source_profile = Some(public_profile_id.to_string());
 
@@ -123,7 +85,7 @@ pub(super) fn remi_sync_row(
         .any(|provide| provide.kind == "package" && provide.capability == name)
     {
         return Err(Error::ConfigError(format!(
-            "Remi metadata for '{name}' has no normalized package self-provide"
+            "Remi sparse entry for '{name}' has no normalized package self-provide"
         )));
     }
     let provides = wire_provides
@@ -260,78 +222,429 @@ fn validate_remi_relation_group(
     validate_native_relation(&relation, scheme).map_err(Error::ConfigError)
 }
 
-/// Synchronize repository directly from a Remi metadata API
-///
-/// For repos with `default_strategy = "remi"`, fetches the package index from
-/// the Remi server's `/v1/{distro}/metadata` endpoint instead of parsing
-/// traditional repo formats (repomd.xml, Packages, etc.).
-pub(super) async fn fetch_remi_sync_rows(repo: &Repository) -> Result<Vec<SyncedPackageRow>> {
-    let configured_target = repo.source_profile.as_deref().ok_or_else(|| {
-        Error::ConfigError(format!(
-            "Repository '{}' has strategy 'remi' but no source profile configured (use --source-profile)",
-            repo.name
-        ))
-    })?;
-    let profile = crate::repository::supported_profiles::profile_for_remi_target(configured_target)
-        .ok_or_else(|| {
-            Error::ConfigError(format!("unsupported Remi target: {configured_target}"))
-        })?;
-    let route_slug = profile.remi_route_slug();
+const REMI_SPARSE_ENTRY_CONCURRENCY: usize = 16;
 
-    let endpoint = repo
-        .default_strategy_endpoint
-        .as_deref()
-        .unwrap_or(&repo.url)
-        .trim_end_matches('/');
-
-    let metadata_url = format!("{endpoint}/v1/{route_slug}/metadata");
-    info!(
-        "Syncing repository {} from Remi metadata: {}",
-        repo.name, metadata_url
-    );
-
-    let client = RepositoryClient::new()?;
-    let response =
-        fetch_remi_metadata_with_retry(&client, &metadata_url, &RetryConfig::quick()).await?;
-
-    let repo_id = repo
-        .id
-        .ok_or_else(|| Error::InitError("Repository has no ID".to_string()))?;
-
-    let mut seen = HashSet::new();
-    let mut synced_packages = Vec::new();
-    for entry in response.packages {
-        let key = (
-            entry.name.clone(),
-            entry.version.clone(),
-            entry.release.clone(),
-            entry.architecture.clone(),
-        );
-        if !seen.insert(key) {
-            continue;
-        }
-        synced_packages.push(remi_sync_row(
-            repo_id,
-            endpoint.to_string(),
-            configured_target.to_string(),
-            entry,
-        )?);
-    }
-
-    Ok(synced_packages)
+struct RemiSparseSync {
+    client: RepositoryClient,
+    retry_policy: RetryConfig,
+    endpoint: String,
+    configured_target: String,
+    route_slug: String,
+    repo_id: i64,
+    next_page: usize,
+    expected_total_names: Option<usize>,
+    names_seen: usize,
+    last_name: Option<String>,
 }
 
-pub(super) fn persist_remi_sync_rows(
+impl RemiSparseSync {
+    fn new(repo: &Repository) -> Result<Self> {
+        let configured_target = repo.source_profile.as_deref().ok_or_else(|| {
+            Error::ConfigError(format!(
+                "Repository '{}' has strategy 'remi' but no source profile configured (use --source-profile)",
+                repo.name
+            ))
+        })?;
+        let profile =
+            crate::repository::supported_profiles::profile_for_remi_target(configured_target)
+                .ok_or_else(|| {
+                    Error::ConfigError(format!("unsupported Remi target: {configured_target}"))
+                })?;
+        let endpoint = repo
+            .default_strategy_endpoint
+            .as_deref()
+            .unwrap_or(&repo.url)
+            .trim_end_matches('/')
+            .to_string();
+        let repo_id = repo
+            .id
+            .ok_or_else(|| Error::InitError("Repository has no ID".to_string()))?;
+
+        Ok(Self {
+            client: RepositoryClient::new()?,
+            retry_policy: RetryConfig::quick(),
+            endpoint,
+            configured_target: configured_target.to_string(),
+            route_slug: profile.remi_route_slug().to_string(),
+            repo_id,
+            next_page: 1,
+            expected_total_names: None,
+            names_seen: 0,
+            last_name: None,
+        })
+    }
+
+    async fn next_rows(&mut self) -> Result<Option<Vec<SyncedPackageRow>>> {
+        if self
+            .expected_total_names
+            .is_some_and(|total| self.names_seen == total)
+        {
+            return Ok(None);
+        }
+
+        let list_url = format!(
+            "{}/v1/index/{}?page={}&per_page={}",
+            self.endpoint, self.route_slug, self.next_page, REMI_SPARSE_SYNC_PAGE_SIZE
+        );
+        let list = fetch_sparse_list_with_retry(
+            &self.client,
+            &list_url,
+            &self.retry_policy,
+            REMI_SPARSE_SYNC_PAGE_SIZE,
+        )
+        .await?;
+
+        let endpoint = self.endpoint.as_str();
+        let route_slug = self.route_slug.as_str();
+        let retry_policy = &self.retry_policy;
+        let client = &self.client;
+        let fetches = stream::iter(list.packages.iter().cloned())
+            .map(|name| async move {
+                let url = format!(
+                    "{endpoint}/v1/index/{route_slug}/{}",
+                    urlencoding::encode(&name)
+                );
+                let entry = fetch_sparse_entry_with_retry(client, &url, retry_policy).await?;
+                Ok::<_, Error>((name, entry))
+            })
+            .buffer_unordered(REMI_SPARSE_ENTRY_CONCURRENCY);
+        let entries = fetches
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>>>()?;
+        self.consume_page(list, entries).map(Some)
+    }
+
+    fn consume_page(
+        &mut self,
+        list: RemiSparsePackageList,
+        entries: Vec<(String, RemiSparseIndexEntry)>,
+    ) -> Result<Vec<SyncedPackageRow>> {
+        self.validate_list_page(&list)?;
+        if entries.len() != list.packages.len() {
+            return Err(Error::ParseError(format!(
+                "Remi sparse page returned {} entries for {} package names",
+                entries.len(),
+                list.packages.len()
+            )));
+        }
+        let mut expected_names = list.packages.iter().cloned().collect::<HashSet<_>>();
+        let mut rows = Vec::new();
+        for (requested_name, entry) in entries {
+            if !expected_names.remove(&requested_name) {
+                return Err(Error::ParseError(format!(
+                    "Remi sparse page returned an unexpected or duplicate entry for '{requested_name}'"
+                )));
+            }
+            self.validate_sparse_entry(&requested_name, &entry)?;
+            let mut seen_versions = HashSet::new();
+            for version in entry.versions {
+                let key = (
+                    version.version.clone(),
+                    version.release.clone(),
+                    version.architecture.clone(),
+                );
+                if !seen_versions.insert(key) {
+                    return Err(Error::ParseError(format!(
+                        "Remi sparse entry '{}' repeats an exact version/release/architecture identity",
+                        requested_name
+                    )));
+                }
+                rows.push(remi_sync_row(
+                    self.repo_id,
+                    self.endpoint.clone(),
+                    self.configured_target.clone(),
+                    requested_name.clone(),
+                    version,
+                )?);
+            }
+        }
+        if !expected_names.is_empty() {
+            return Err(Error::ParseError(
+                "Remi sparse page omitted one or more requested package entries".to_string(),
+            ));
+        }
+
+        self.names_seen = self
+            .names_seen
+            .checked_add(list.packages.len())
+            .ok_or_else(|| Error::ParseError("Remi sparse package count overflow".to_string()))?;
+        self.last_name = list.packages.last().cloned();
+        self.next_page += 1;
+        Ok(rows)
+    }
+
+    fn validate_list_page(&mut self, list: &RemiSparsePackageList) -> Result<()> {
+        if list.distro != self.route_slug {
+            return Err(Error::ParseError(format!(
+                "Remi sparse list distro '{}' disagrees with requested route '{}'",
+                list.distro, self.route_slug
+            )));
+        }
+        if list.page != self.next_page || list.per_page != REMI_SPARSE_SYNC_PAGE_SIZE {
+            return Err(Error::ParseError(format!(
+                "Remi sparse list pagination disagrees with request: page={}, per_page={}",
+                list.page, list.per_page
+            )));
+        }
+        if list.packages.len() > REMI_SPARSE_SYNC_PAGE_SIZE {
+            return Err(Error::ParseError(format!(
+                "Remi sparse list returned {} names for a {}-name page",
+                list.packages.len(),
+                REMI_SPARSE_SYNC_PAGE_SIZE
+            )));
+        }
+        match self.expected_total_names {
+            Some(total) if total != list.total => {
+                return Err(Error::ParseError(format!(
+                    "Remi sparse list changed total package-name count during sync: {total} -> {}",
+                    list.total
+                )));
+            }
+            None => self.expected_total_names = Some(list.total),
+            _ => {}
+        }
+        if list.packages.is_empty() && self.names_seen < list.total {
+            return Err(Error::ParseError(format!(
+                "Remi sparse list ended after {} of {} package names",
+                self.names_seen, list.total
+            )));
+        }
+        if self
+            .names_seen
+            .checked_add(list.packages.len())
+            .is_none_or(|count| count > list.total)
+        {
+            return Err(Error::ParseError(
+                "Remi sparse list returned more package names than its declared total".to_string(),
+            ));
+        }
+
+        let mut previous = self.last_name.as_deref();
+        for name in &list.packages {
+            validate_sparse_name(name)?;
+            if previous.is_some_and(|prior| prior >= name.as_str()) {
+                return Err(Error::ParseError(format!(
+                    "Remi sparse package names are not globally unique and ordered at '{name}'"
+                )));
+            }
+            previous = Some(name);
+        }
+        Ok(())
+    }
+
+    fn validate_sparse_entry(
+        &self,
+        requested_name: &str,
+        entry: &RemiSparseIndexEntry,
+    ) -> Result<()> {
+        if entry.name != requested_name {
+            return Err(Error::ParseError(format!(
+                "Remi sparse entry name '{}' disagrees with requested package '{requested_name}'",
+                entry.name
+            )));
+        }
+        if entry.distro != self.route_slug {
+            return Err(Error::ParseError(format!(
+                "Remi sparse entry distro '{}' disagrees with requested route '{}'",
+                entry.distro, self.route_slug
+            )));
+        }
+        if entry.versions.is_empty() {
+            return Err(Error::ParseError(format!(
+                "Remi sparse entry '{requested_name}' has no versions"
+            )));
+        }
+        Ok(())
+    }
+}
+
+fn validate_sparse_name(name: &str) -> Result<()> {
+    if name.is_empty()
+        || name.len() > REMI_SPARSE_NAME_MAX_BYTES
+        || name.contains('/')
+        || name.contains("..")
+        || name.contains('\0')
+    {
+        return Err(Error::ParseError(format!(
+            "Remi sparse list contains invalid package name {name:?}"
+        )));
+    }
+    Ok(())
+}
+
+async fn fetch_sparse_list_with_retry(
+    client: &RepositoryClient,
+    url: &str,
+    retry_policy: &RetryConfig,
+    requested_page_size: usize,
+) -> Result<RemiSparsePackageList> {
+    with_retry_async(retry_policy, || async {
+        let response = fetch_sparse_response(client, url).await?;
+        let bytes = crate::repository::client::read_response_bytes_with_limit(
+            response,
+            sparse_package_list_max_bytes(requested_page_size),
+            url,
+        )
+        .await?;
+        serde_json::from_slice(&bytes).map_err(|error| {
+            Error::ParseError(format!(
+                "Failed to parse Remi sparse package list from {url}: {error}"
+            ))
+        })
+    })
+    .await
+}
+
+async fn fetch_sparse_entry_with_retry(
+    client: &RepositoryClient,
+    url: &str,
+    retry_policy: &RetryConfig,
+) -> Result<RemiSparseIndexEntry> {
+    with_retry_async(retry_policy, || async {
+        let response = fetch_sparse_response(client, url).await?;
+        response.json().await.map_err(|error| {
+            Error::ParseError(format!(
+                "Failed to parse Remi sparse package entry from {url}: {error}"
+            ))
+        })
+    })
+    .await
+}
+
+async fn fetch_sparse_response(client: &RepositoryClient, url: &str) -> Result<reqwest::Response> {
+    crate::repository::client::validate_url_scheme(url)?;
+    let response = client
+        .inner()
+        .get(url)
+        .timeout(crate::repository::client::TimeoutConfig::default().download)
+        .send()
+        .await
+        .map_err(|error| Error::DownloadError(format!("{error}: {url}")))?;
+    if !response.status().is_success() {
+        return Err(Error::HttpStatus {
+            status: response.status().as_u16(),
+            url: url.to_string(),
+        });
+    }
+    Ok(response)
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RemiSyncStage {
+    repository_id: i64,
+    staging_repository_id: i64,
+}
+
+fn begin_remi_sync_stage(conn: &Connection, repo: &Repository) -> Result<RemiSyncStage> {
+    let repository_id = repo
+        .id
+        .ok_or_else(|| Error::InitError("Repository has no ID".to_string()))?;
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let mut staging = repo.clone();
+    staging.id = None;
+    staging.name = format!("__conary_sparse_sync_{repository_id}_{nonce}");
+    staging.enabled = false;
+    staging.last_sync = None;
+    staging.created_at = None;
+    staging.tuf_enabled = false;
+    staging.tuf_root_version = None;
+    staging.tuf_root_url = None;
+    let staging_repository_id = staging.insert(conn)?;
+    Ok(RemiSyncStage {
+        repository_id,
+        staging_repository_id,
+    })
+}
+
+fn append_remi_sync_page(
     conn: &Connection,
-    repo: &mut Repository,
-    synced_packages: Vec<SyncedPackageRow>,
+    stage: RemiSyncStage,
+    mut rows: Vec<SyncedPackageRow>,
 ) -> Result<usize> {
-    let mut repo_packages: Vec<RepositoryPackage> = synced_packages
+    for row in &mut rows {
+        row.package.repository_id = stage.staging_repository_id;
+    }
+    let mut packages = rows
         .iter()
         .map(|row| row.package.clone())
-        .collect();
-    let count = persist_native_sync_rows(conn, repo, &mut repo_packages, synced_packages)?;
+        .collect::<Vec<_>>();
+    let tx = conn.unchecked_transaction()?;
+    let count = append_synced_package_rows(&tx, &mut packages, rows)?;
+    tx.commit()?;
+    Ok(count)
+}
 
+fn finish_remi_sync_stage(
+    conn: &Connection,
+    repo: &mut Repository,
+    stage: RemiSyncStage,
+) -> Result<usize> {
+    let tx = conn.unchecked_transaction()?;
+    let count = tx.query_row(
+        "SELECT COUNT(*) FROM repository_packages WHERE repository_id = ?1",
+        [stage.staging_repository_id],
+        |row| row.get::<_, i64>(0),
+    )?;
+    let count = usize::try_from(count)
+        .map_err(|_| Error::InitError("sparse sync package count exceeds usize".to_string()))?;
+    RepositoryPackage::delete_by_repository(&tx, stage.repository_id)?;
+    tx.execute(
+        "UPDATE repository_packages SET repository_id = ?1 WHERE repository_id = ?2",
+        [stage.repository_id, stage.staging_repository_id],
+    )?;
+    Repository::delete(&tx, stage.staging_repository_id)?;
+    super::link_canonical_ids(&tx, stage.repository_id)?;
+    repo.last_sync = Some(super::current_timestamp());
+    repo.update(&tx)?;
+    tx.commit()?;
+    Ok(count)
+}
+
+fn abort_remi_sync_stage(conn: &Connection, stage: RemiSyncStage) {
+    if let Err(error) = Repository::delete(conn, stage.staging_repository_id) {
+        debug!(
+            "Failed to remove sparse-sync staging repository {}: {}",
+            stage.staging_repository_id, error
+        );
+    }
+}
+
+pub(super) async fn sync_repository_remi(
+    conn: &Connection,
+    repo: &mut Repository,
+) -> Result<usize> {
+    info!(
+        "Syncing repository {} from the paginated Remi sparse index",
+        repo.name
+    );
+    let mut fetcher = RemiSparseSync::new(repo)?;
+    let stage = begin_remi_sync_stage(conn, repo)?;
+    loop {
+        let rows = match fetcher.next_rows().await {
+            Ok(Some(rows)) => rows,
+            Ok(None) => break,
+            Err(error) => {
+                abort_remi_sync_stage(conn, stage);
+                return Err(error);
+            }
+        };
+        if let Err(error) = append_remi_sync_page(conn, stage, rows) {
+            abort_remi_sync_stage(conn, stage);
+            return Err(error);
+        }
+    }
+    let count = match finish_remi_sync_stage(conn, repo, stage) {
+        Ok(count) => count,
+        Err(error) => {
+            abort_remi_sync_stage(conn, stage);
+            return Err(error);
+        }
+    };
     info!(
         "Synchronized {} packages from Remi repository {}",
         count, repo.name
@@ -339,57 +652,86 @@ pub(super) fn persist_remi_sync_rows(
     Ok(count)
 }
 
-pub(super) async fn sync_repository_remi(
-    conn: &Connection,
-    repo: &mut Repository,
+pub(super) async fn sync_repository_remi_from_db_path(
+    db_path: std::path::PathBuf,
+    repo: Repository,
 ) -> Result<usize> {
-    let synced_packages = fetch_remi_sync_rows(repo).await?;
-    persist_remi_sync_rows(conn, repo, synced_packages)
-}
+    info!(
+        "Syncing repository {} from the paginated Remi sparse index",
+        repo.name
+    );
+    let mut fetcher = RemiSparseSync::new(&repo)?;
+    let begin_path = db_path.clone();
+    let begin_repo = repo.clone();
+    let stage = run_blocking_sync(move || {
+        let conn = crate::db::open_fast(&begin_path)?;
+        begin_remi_sync_stage(&conn, &begin_repo)
+    })
+    .await?;
 
-async fn fetch_remi_metadata_with_retry(
-    client: &RepositoryClient,
-    metadata_url: &str,
-    retry_policy: &RetryConfig,
-) -> Result<RemiMetadataResponse> {
-    let max_attempts = retry_policy.max_attempts.max(1);
-    let mut last_error = None;
-
-    for attempt in 1..=max_attempts {
-        match fetch_remi_metadata_once(client, metadata_url).await {
-            Ok(response) => return Ok(response),
+    loop {
+        let rows = match fetcher.next_rows().await {
+            Ok(Some(rows)) => rows,
+            Ok(None) => break,
             Err(error) => {
-                if attempt < max_attempts {
-                    let delay = retry_policy.delay_for_attempt(attempt);
-                    warn!(
-                        "Remi metadata fetch attempt {}/{} failed: {}; retrying in {:?}",
-                        attempt, max_attempts, error, delay
-                    );
-                    tokio::time::sleep(delay).await;
-                }
-                last_error = Some(error);
+                let abort_path = db_path.clone();
+                let _ = run_blocking_sync(move || {
+                    let conn = crate::db::open_fast(&abort_path)?;
+                    abort_remi_sync_stage(&conn, stage);
+                    Ok(())
+                })
+                .await;
+                return Err(error);
             }
+        };
+        let page_path = db_path.clone();
+        if let Err(error) = run_blocking_sync(move || {
+            let conn = crate::db::open_fast(&page_path)?;
+            append_remi_sync_page(&conn, stage, rows)
+        })
+        .await
+        {
+            let abort_path = db_path.clone();
+            let _ = run_blocking_sync(move || {
+                let conn = crate::db::open_fast(&abort_path)?;
+                abort_remi_sync_stage(&conn, stage);
+                Ok(())
+            })
+            .await;
+            return Err(error);
         }
     }
 
-    Err(last_error.unwrap_or_else(|| {
-        Error::DownloadError(format!(
-            "Failed to fetch Remi metadata from {metadata_url}: no attempts were made"
-        ))
-    }))
-}
-
-async fn fetch_remi_metadata_once(
-    client: &RepositoryClient,
-    metadata_url: &str,
-) -> Result<RemiMetadataResponse> {
-    let bytes = client.download_to_bytes(metadata_url).await?;
-    serde_json::from_slice(&bytes).map_err(|error| {
-        Error::ParseError(format!(
-            "Failed to parse Remi metadata from {}: {}",
-            metadata_url, error
-        ))
+    let finish_path = db_path.clone();
+    let repository_id = stage.repository_id;
+    let finish_result = run_blocking_sync(move || {
+        let conn = crate::db::open_fast(&finish_path)?;
+        let mut persisted = Repository::find_by_id(&conn, repository_id)?.ok_or_else(|| {
+            Error::NotFound(format!(
+                "Repository {repository_id} not found during sparse sync"
+            ))
+        })?;
+        finish_remi_sync_stage(&conn, &mut persisted, stage)
     })
+    .await;
+    let count = match finish_result {
+        Ok(count) => count,
+        Err(error) => {
+            let abort_path = db_path.clone();
+            let _ = run_blocking_sync(move || {
+                let conn = crate::db::open_fast(&abort_path)?;
+                abort_remi_sync_stage(&conn, stage);
+                Ok(())
+            })
+            .await;
+            return Err(error);
+        }
+    };
+    info!(
+        "Synchronized {} packages from Remi repository {}",
+        count, repo.name
+    );
+    Ok(count)
 }
 
 /// Fetch the canonical package map from a Remi endpoint and persist it locally.
@@ -432,15 +774,18 @@ mod tests {
     use crate::db::models::RepositoryRequirementGroup as DbRequirementGroup;
     use crate::db::testing::create_test_db;
     use crate::repository::package_relation::parse_native_relation;
-    use crate::repository::remi_metadata::{RemiProvide, RemiRequirement, RemiRequirementGroup};
+    use crate::repository::remi_metadata::{
+        REMI_SPARSE_MAX_PAGE_SIZE, RemiProvide, RemiRequirement, RemiRequirementGroup,
+        RemiSparseIndexEntry, RemiSparsePackageList, RemiSparseVersionEntry,
+    };
+    use std::io::{Read, Write};
 
     fn remi_entry_for_tests(
         name: &str,
         version: &str,
         version_scheme: VersionScheme,
-    ) -> RemiPackageEntry {
-        RemiPackageEntry {
-            name: name.to_string(),
+    ) -> RemiSparseVersionEntry {
+        RemiSparseVersionEntry {
             version: version.to_string(),
             release: None,
             converted: false,
@@ -458,7 +803,8 @@ mod tests {
                     crate::repository::dependency_model::ProvideArchitectureQualifier::Implicit,
             }],
             requirement_groups: Vec::new(),
-            metadata: None,
+            size: 1024,
+            content_hash: None,
         }
     }
 
@@ -468,6 +814,7 @@ mod tests {
             7,
             "http://remi.test".to_string(),
             "fedora-44".to_string(),
+            "qemu-img".to_string(),
             remi_entry_for_tests("qemu-img", "2:10.1.0-7.fc44", VersionScheme::Rpm),
         )
         .unwrap();
@@ -481,6 +828,7 @@ mod tests {
             7,
             "https://remi.example.test".to_string(),
             "fedora-44".to_string(),
+            "hello".to_string(),
             {
                 let mut entry = remi_entry_for_tests("hello", "1.0.0", VersionScheme::Rpm);
                 entry.release = Some("2".to_string());
@@ -503,6 +851,7 @@ mod tests {
             7,
             "http://remi.test".to_string(),
             "ubuntu-26.04".to_string(),
+            "nano".to_string(),
             {
                 let mut entry = remi_entry_for_tests("nano", "8.7.1-1", VersionScheme::Debian);
                 entry.architecture = Some("amd64".to_string());
@@ -527,6 +876,7 @@ mod tests {
                 1,
                 "https://remi.example.test".to_string(),
                 public_id.to_string(),
+                "bash".to_string(),
                 remi_entry_for_tests("bash", "5.2.0", scheme),
             )
             .unwrap();
@@ -546,6 +896,7 @@ mod tests {
             1,
             "https://remi.example.test".to_string(),
             "ubuntu".to_string(),
+            "bash".to_string(),
             remi_entry_for_tests("bash", "5.2.0", VersionScheme::Debian),
         )
         .unwrap_err();
@@ -600,11 +951,13 @@ mod tests {
             repository_id,
             "https://remi.test".to_string(),
             "fedora-44".to_string(),
+            "newpkg".to_string(),
             entry,
         )
         .unwrap();
 
-        persist_remi_sync_rows(&conn, &mut repository, vec![row]).unwrap();
+        let mut packages = vec![row.package.clone()];
+        append_synced_package_rows(&conn, &mut packages, vec![row]).unwrap();
 
         let package = RepositoryPackage::find_by_repository(&conn, repository_id)
             .unwrap()
@@ -643,6 +996,7 @@ mod tests {
             7,
             "https://remi.test".to_string(),
             "fedora-44".to_string(),
+            "newpkg".to_string(),
             entry,
         )
         .unwrap_err();
@@ -651,7 +1005,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn remi_metadata_fetch_retries_truncated_json() {
+    async fn remi_sparse_entry_fetch_retries_truncated_json() {
         use crate::repository::retry::RetryConfig;
         use std::sync::{
             Arc,
@@ -683,9 +1037,9 @@ mod tests {
 
                 let attempt = server_attempts.fetch_add(1, Ordering::SeqCst);
                 let body = if attempt == 0 {
-                    r#"{"packages":[{"name":"qemu-img""#
+                    r#"{"name":"qemu-img""#
                 } else {
-                    r#"{"packages":[{"name":"qemu-img","version":"2:10.1.0-7.fc44","converted":false,"architecture":"x86_64","provides":[],"requirement_groups":[]}]}"#
+                    r#"{"name":"qemu-img","distro":"fedora","versions":[{"version":"2:10.1.0-7.fc44","converted":false,"architecture":"x86_64","provides":[],"requirement_groups":[],"size":1024,"content_hash":null}]}"#
                 };
                 let response = format!(
                     "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
@@ -703,17 +1057,249 @@ mod tests {
             jitter_factor: 0.0,
         };
         let client = RepositoryClient::new().unwrap();
-        let metadata = fetch_remi_metadata_with_retry(
+        let entry = fetch_sparse_entry_with_retry(
             &client,
-            &format!("http://{addr}/v1/fedora/metadata"),
+            &format!("http://{addr}/v1/index/fedora/qemu-img"),
             &retry,
         )
         .await
         .unwrap();
 
-        assert_eq!(metadata.packages.len(), 1);
-        assert_eq!(metadata.packages[0].name, "qemu-img");
+        assert_eq!(entry.name, "qemu-img");
+        assert_eq!(entry.versions.len(), 1);
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
         server.await.unwrap();
+    }
+
+    fn sparse_test_repo(endpoint: String, conn: &Connection) -> Repository {
+        let mut repo = Repository::new("fedora-sparse".to_string(), endpoint.clone());
+        repo.default_strategy = Some("remi".to_string());
+        repo.default_strategy_endpoint = Some(endpoint);
+        repo.source_profile = Some("fedora-44".to_string());
+        repo.insert(conn).unwrap();
+        repo
+    }
+
+    fn sparse_test_entry(name: &str) -> RemiSparseIndexEntry {
+        RemiSparseIndexEntry {
+            name: name.to_string(),
+            distro: "fedora".to_string(),
+            versions: vec![remi_entry_for_tests(name, "1.0-1.fc44", VersionScheme::Rpm)],
+        }
+    }
+
+    fn consume_synthetic_page(
+        fetcher: &mut RemiSparseSync,
+        package_count: usize,
+    ) -> Result<Vec<SyncedPackageRow>> {
+        let page = fetcher.next_page;
+        let start = (page - 1) * REMI_SPARSE_SYNC_PAGE_SIZE;
+        let end = start
+            .saturating_add(REMI_SPARSE_SYNC_PAGE_SIZE)
+            .min(package_count);
+        let packages = (start..end)
+            .map(|index| format!("pkg-{index:08}"))
+            .collect::<Vec<_>>();
+        let entries = packages
+            .iter()
+            .map(|name| (name.clone(), sparse_test_entry(name)))
+            .collect();
+        fetcher.consume_page(
+            RemiSparsePackageList {
+                distro: "fedora".to_string(),
+                packages,
+                total: package_count,
+                page,
+                per_page: REMI_SPARSE_SYNC_PAGE_SIZE,
+            },
+            entries,
+        )
+    }
+
+    #[test]
+    fn sparse_wire_contract_admits_every_emitted_field_and_bounds_name_pages() {
+        let emitted = serde_json::json!({
+            "name": "hello",
+            "distro": "fedora",
+            "versions": [{
+                "version": "1.0",
+                "release": "2",
+                "provides": [{
+                    "capability": "hello",
+                    "version": "1.0",
+                    "version_relation": "equal",
+                    "kind": "package",
+                    "raw": "hello = 1.0",
+                    "version_scheme": "rpm",
+                    "architecture_qualifier": {"kind": "implicit"}
+                }],
+                "requirement_groups": [{
+                    "kind": "depends",
+                    "behavior": "hard",
+                    "description": null,
+                    "native_text": "glibc >= 2.39",
+                    "expression_json": "{\"kind\":\"atom\",\"clause\":{\"name\":\"glibc\",\"version_constraint\":\">= 2.39\",\"capability_kind\":null,\"native_text\":null}}",
+                    "clauses": [{
+                        "capability": "glibc",
+                        "version_constraint": ">= 2.39",
+                        "kind": "package",
+                        "dependency_type": "runtime",
+                        "raw": "glibc >= 2.39"
+                    }]
+                }],
+                "architecture": "x86_64",
+                "size": 4096,
+                "converted": true,
+                "content_hash": "sha256:content"
+            }]
+        });
+        let entry: RemiSparseIndexEntry = serde_json::from_value(emitted).unwrap();
+        assert_eq!(entry.versions[0].release.as_deref(), Some("2"));
+        assert_eq!(
+            entry.versions[0].content_hash.as_deref(),
+            Some("sha256:content")
+        );
+
+        let escaped_name = "\u{1}".repeat(REMI_SPARSE_NAME_MAX_BYTES);
+        let page = RemiSparsePackageList {
+            distro: "f".repeat(REMI_SPARSE_NAME_MAX_BYTES),
+            packages: vec![escaped_name; REMI_SPARSE_MAX_PAGE_SIZE],
+            total: usize::MAX,
+            page: usize::MAX,
+            per_page: REMI_SPARSE_MAX_PAGE_SIZE,
+        };
+        let bytes = serde_json::to_vec(&page).unwrap();
+        assert!(bytes.len() as u64 <= sparse_package_list_max_bytes(REMI_SPARSE_MAX_PAGE_SIZE));
+    }
+
+    #[test]
+    fn sparse_sync_atomically_replaces_rows_and_cleans_staging_repository() {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::db::schema::ensure_current(&conn).unwrap();
+        let mut repo = sparse_test_repo("https://remi.test".to_string(), &conn);
+        let mut old = RepositoryPackage::new(
+            repo.id.unwrap(),
+            "retired".to_string(),
+            "0".to_string(),
+            VersionScheme::Rpm,
+            "old".to_string(),
+            1,
+            "https://old.invalid".to_string(),
+        );
+        old.insert(&conn).unwrap();
+
+        let mut fetcher = RemiSparseSync::new(&repo).unwrap();
+        let stage = begin_remi_sync_stage(&conn, &repo).unwrap();
+        while fetcher.names_seen < 300 {
+            let rows = consume_synthetic_page(&mut fetcher, 300).unwrap();
+            append_remi_sync_page(&conn, stage, rows).unwrap();
+        }
+        let count = finish_remi_sync_stage(&conn, &mut repo, stage).unwrap();
+
+        assert_eq!(count, 300);
+        let packages = RepositoryPackage::find_by_repository(&conn, repo.id.unwrap()).unwrap();
+        assert_eq!(packages.len(), 300);
+        assert!(!packages.iter().any(|package| package.name == "retired"));
+        assert_eq!(Repository::list_all(&conn).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn sparse_sync_failure_preserves_previous_snapshot() {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::db::schema::ensure_current(&conn).unwrap();
+        let repo = sparse_test_repo("https://remi.test".to_string(), &conn);
+        let mut old = RepositoryPackage::new(
+            repo.id.unwrap(),
+            "still-current".to_string(),
+            "1".to_string(),
+            VersionScheme::Rpm,
+            "old".to_string(),
+            1,
+            "https://old.invalid".to_string(),
+        );
+        old.insert(&conn).unwrap();
+
+        let mut fetcher = RemiSparseSync::new(&repo).unwrap();
+        let stage = begin_remi_sync_stage(&conn, &repo).unwrap();
+        let mut rows = consume_synthetic_page(&mut fetcher, 2).unwrap();
+        rows[1].package.name = rows[0].package.name.clone();
+        let error = append_remi_sync_page(&conn, stage, rows).unwrap_err();
+        abort_remi_sync_stage(&conn, stage);
+
+        assert!(error.to_string().contains("UNIQUE constraint failed"));
+        let packages = RepositoryPackage::find_by_repository(&conn, repo.id.unwrap()).unwrap();
+        assert_eq!(packages.len(), 1);
+        assert_eq!(packages[0].name, "still-current");
+        assert_eq!(Repository::list_all(&conn).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn sparse_sync_peak_rss_is_independent_of_distribution_package_count() {
+        const CHILD_ENV: &str = "CONARY_ISSUE_156_PACKAGE_COUNT";
+        const TEST_NAME: &str = "repository::sync::remi::tests::sparse_sync_peak_rss_is_independent_of_distribution_package_count";
+        if std::env::var_os(CHILD_ENV).is_none() {
+            let mut measurements = Vec::new();
+            for package_count in [512usize, 20_000] {
+                let output = std::process::Command::new(std::env::current_exe().unwrap())
+                    .args(["--exact", TEST_NAME, "--nocapture"])
+                    .env(CHILD_ENV, package_count.to_string())
+                    .output()
+                    .unwrap();
+                std::io::stdout().write_all(&output.stdout).unwrap();
+                std::io::stderr().write_all(&output.stderr).unwrap();
+                assert!(output.status.success(), "sparse RSS child failed");
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let high_water_kib = stdout
+                    .lines()
+                    .find_map(|line| line.strip_prefix("ISSUE156_VM_HWM_KIB="))
+                    .and_then(|value| value.parse::<u64>().ok())
+                    .expect("sparse RSS child did not report VmHWM");
+                measurements.push(high_water_kib);
+            }
+            let growth_kib = measurements[1].saturating_sub(measurements[0]);
+            assert!(
+                growth_kib < 32 * 1024,
+                "VmHWM grew by {growth_kib} KiB when package count grew 39x"
+            );
+            return;
+        }
+
+        let package_count = std::env::var(CHILD_ENV).unwrap().parse::<usize>().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("sparse-sync.db");
+        let conn = Connection::open(&db_path).unwrap();
+        crate::db::schema::ensure_current(&conn).unwrap();
+        let mut repo = sparse_test_repo("https://remi.test".to_string(), &conn);
+        let mut fetcher = RemiSparseSync::new(&repo).unwrap();
+        let stage = begin_remi_sync_stage(&conn, &repo).unwrap();
+        while fetcher.names_seen < package_count {
+            let rows = consume_synthetic_page(&mut fetcher, package_count).unwrap();
+            assert!(rows.len() <= REMI_SPARSE_SYNC_PAGE_SIZE);
+            append_remi_sync_page(&conn, stage, rows).unwrap();
+        }
+        let count = finish_remi_sync_stage(&conn, &mut repo, stage).unwrap();
+        assert_eq!(count, package_count);
+        drop(conn);
+
+        let high_water_kib = vm_hwm_kib().unwrap();
+        println!("ISSUE156_PACKAGE_COUNT={package_count}");
+        println!("ISSUE156_VM_HWM_KIB={high_water_kib}");
+        assert!(
+            high_water_kib < 256 * 1024,
+            "VmHWM {high_water_kib} KiB exceeded fixed 262144 KiB bound"
+        );
+    }
+
+    fn vm_hwm_kib() -> Option<u64> {
+        let mut status = String::new();
+        std::fs::File::open("/proc/self/status")
+            .ok()?
+            .read_to_string(&mut status)
+            .ok()?;
+        status.lines().find_map(|line| {
+            line.strip_prefix("VmHWM:")
+                .and_then(|value| value.split_whitespace().next())
+                .and_then(|value| value.parse().ok())
+        })
     }
 }

--- a/crates/conary-core/src/repository/sync/remi.rs
+++ b/crates/conary-core/src/repository/sync/remi.rs
@@ -15,7 +15,9 @@ use crate::repository::dependency_model::{
 };
 use crate::repository::metadata::PackageSecurityAdvisoryMetadata;
 use crate::repository::package_relation::validate_native_relation;
-use crate::repository::remi_metadata::RemiSparseResolutionVersionEntry;
+use crate::repository::remi_metadata::{
+    REMI_SPARSE_MIN_PACKAGE_SIZE, RemiSparseResolutionVersionEntry,
+};
 use crate::repository::versioning::VersionScheme;
 use rusqlite::Connection;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -48,6 +50,16 @@ pub(super) fn remi_sync_row(
         size,
         metadata,
     } = entry;
+    if version.is_empty() {
+        return Err(Error::ConfigError(format!(
+            "Remi sparse entry for '{name}' has an empty package version"
+        )));
+    }
+    if size < REMI_SPARSE_MIN_PACKAGE_SIZE {
+        return Err(Error::ConfigError(format!(
+            "Remi sparse entry for '{name}' version '{version}' has non-downloadable size {size}"
+        )));
+    }
     let profile = crate::repository::supported_profiles::profile_for_remi_target(&distro)
         .ok_or_else(|| Error::ConfigError(format!("unsupported Remi target: {distro}")))?;
     let route_slug = profile.remi_route_slug();
@@ -161,8 +173,14 @@ pub(super) fn remi_sync_row(
     let mut requirement_groups = Vec::with_capacity(wire_requirement_groups.len());
     let mut requirement_group_clauses = Vec::with_capacity(wire_requirement_groups.len());
     for (group_index, wire_group) in wire_requirement_groups.into_iter().enumerate() {
-        let group_token =
-            i64::try_from(group_index + 1).expect("Remi requirement group count cannot exceed i64");
+        let group_token = group_index
+            .checked_add(1)
+            .and_then(|token| i64::try_from(token).ok())
+            .ok_or_else(|| {
+                Error::ConfigError(format!(
+                    "Remi sparse entry for '{name}' has too many requirement groups"
+                ))
+            })?;
         validate_remi_relation_group(&wire_group, scheme)?;
         let mut group = DbRequirementGroup::new(
             0,
@@ -305,12 +323,8 @@ fn append_remi_sync_page(
     for row in &mut rows {
         row.package.repository_id = stage.staging_repository_id;
     }
-    let mut packages = rows
-        .iter()
-        .map(|row| row.package.clone())
-        .collect::<Vec<_>>();
     let tx = conn.unchecked_transaction()?;
-    let count = append_synced_package_rows(&tx, &mut packages, rows)?;
+    let count = append_synced_package_rows(&tx, rows)?;
     tx.commit()?;
     Ok(count)
 }
@@ -558,6 +572,34 @@ mod tests {
     }
 
     #[test]
+    fn remi_sync_row_rejects_non_downloadable_package_identity() {
+        let mut empty_version =
+            remi_entry_for_tests("qemu-img", "2:10.1.0-7.fc44", VersionScheme::Rpm);
+        empty_version.version.clear();
+        let error = remi_sync_row(
+            7,
+            "http://remi.test".to_string(),
+            "fedora-44".to_string(),
+            "qemu-img".to_string(),
+            empty_version,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("empty package version"));
+
+        let mut zero_size = remi_entry_for_tests("qemu-img", "2:10.1.0-7.fc44", VersionScheme::Rpm);
+        zero_size.size = 0;
+        let error = remi_sync_row(
+            7,
+            "http://remi.test".to_string(),
+            "fedora-44".to_string(),
+            "qemu-img".to_string(),
+            zero_size,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("non-downloadable size 0"));
+    }
+
+    #[test]
     fn remi_sync_row_preserves_release_and_exact_download_url() {
         let row = remi_sync_row(
             7,
@@ -691,8 +733,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut packages = vec![row.package.clone()];
-        append_synced_package_rows(&conn, &mut packages, vec![row]).unwrap();
+        append_synced_package_rows(&conn, vec![row]).unwrap();
 
         let package = RepositoryPackage::find_by_repository(&conn, repository_id)
             .unwrap()

--- a/crates/conary-core/src/repository/sync/remi.rs
+++ b/crates/conary-core/src/repository/sync/remi.rs
@@ -13,45 +13,54 @@ use crate::repository::dependency_model::{
     ConditionalRequirementBehavior, RepositoryRequirementExpression,
     RepositoryRequirementGroup as TypedRequirementGroup, RepositoryRequirementKind,
 };
+use crate::repository::metadata::PackageSecurityAdvisoryMetadata;
 use crate::repository::package_relation::validate_native_relation;
-use crate::repository::remi_metadata::{
-    REMI_SPARSE_NAME_MAX_BYTES, REMI_SPARSE_SYNC_PAGE_SIZE, RemiSparseIndexEntry,
-    RemiSparsePackageList, RemiSparseVersionEntry, sparse_package_list_max_bytes,
-};
-use crate::repository::retry::{RetryConfig, with_retry_async};
+use crate::repository::remi_metadata::RemiSparseResolutionVersionEntry;
 use crate::repository::versioning::VersionScheme;
-use futures::stream::{self, StreamExt};
 use rusqlite::Connection;
-use std::collections::HashSet;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
+use super::apply_trusted_package_security_advisory;
 use super::native::append_synced_package_rows;
 use super::support::run_blocking_sync;
 use super::types::SyncedPackageRow;
+
+mod sparse;
+
+use sparse::RemiSparseSync;
+#[cfg(test)]
+use sparse::fetch_sparse_page_with_retry;
 
 pub(super) fn remi_sync_row(
     repo_id: i64,
     endpoint: String,
     distro: String,
     name: String,
-    entry: RemiSparseVersionEntry,
+    entry: RemiSparseResolutionVersionEntry,
 ) -> Result<SyncedPackageRow> {
-    let RemiSparseVersionEntry {
+    let RemiSparseResolutionVersionEntry {
         version,
         release,
-        converted: _,
         architecture,
         provides: wire_provides,
         requirement_groups: wire_requirement_groups,
         size,
-        content_hash: _,
+        metadata,
     } = entry;
     let profile = crate::repository::supported_profiles::profile_for_remi_target(&distro)
         .ok_or_else(|| Error::ConfigError(format!("unsupported Remi target: {distro}")))?;
     let route_slug = profile.remi_route_slug();
     let public_profile_id = profile.id();
-    let package_release = release.unwrap_or_default();
+    let package_release = release
+        .or_else(|| {
+            metadata
+                .as_ref()
+                .and_then(|metadata| metadata.pointer("/identity/release"))
+                .and_then(|value| value.as_str())
+                .map(str::to_string)
+        })
+        .unwrap_or_default();
     let mut query = vec![format!("version={}", urlencoding::encode(&version))];
     if !package_release.is_empty() {
         query.push(format!("release={}", urlencoding::encode(&package_release)));
@@ -77,6 +86,42 @@ pub(super) fn remi_sync_row(
     );
     package.package_release = package_release;
     package.architecture = architecture;
+
+    let mut metadata = metadata.unwrap_or(serde_json::Value::Null);
+    if let Some(advisory_value) = metadata.get("security_advisory").cloned() {
+        match serde_json::from_value::<PackageSecurityAdvisoryMetadata>(advisory_value) {
+            Ok(advisory) => {
+                match apply_trusted_package_security_advisory(
+                    &mut package,
+                    &advisory,
+                    "remi",
+                    "unknown",
+                ) {
+                    Ok(normalized) => {
+                        if let Some(object) = metadata.as_object_mut() {
+                            object.insert("security_advisory".to_string(), normalized);
+                        }
+                    }
+                    Err(error) => {
+                        warn!(
+                            "Ignoring untrusted Remi security advisory metadata for {} {}: {}",
+                            name, version, error
+                        );
+                    }
+                }
+            }
+            Err(error) => {
+                warn!(
+                    "Ignoring malformed Remi security advisory metadata for {} {}: {}",
+                    name, version, error
+                );
+            }
+        }
+    }
+    package.metadata = match metadata {
+        serde_json::Value::Null => None,
+        ref value => Some(value.to_string()),
+    };
 
     package.source_profile = Some(public_profile_id.to_string());
 
@@ -220,315 +265,6 @@ fn validate_remi_relation_group(
     relation.alternatives = alternatives;
     relation.native_text = group.native_text.clone();
     validate_native_relation(&relation, scheme).map_err(Error::ConfigError)
-}
-
-const REMI_SPARSE_ENTRY_CONCURRENCY: usize = 16;
-
-struct RemiSparseSync {
-    client: RepositoryClient,
-    retry_policy: RetryConfig,
-    endpoint: String,
-    configured_target: String,
-    route_slug: String,
-    repo_id: i64,
-    next_page: usize,
-    expected_total_names: Option<usize>,
-    names_seen: usize,
-    last_name: Option<String>,
-}
-
-impl RemiSparseSync {
-    fn new(repo: &Repository) -> Result<Self> {
-        let configured_target = repo.source_profile.as_deref().ok_or_else(|| {
-            Error::ConfigError(format!(
-                "Repository '{}' has strategy 'remi' but no source profile configured (use --source-profile)",
-                repo.name
-            ))
-        })?;
-        let profile =
-            crate::repository::supported_profiles::profile_for_remi_target(configured_target)
-                .ok_or_else(|| {
-                    Error::ConfigError(format!("unsupported Remi target: {configured_target}"))
-                })?;
-        let endpoint = repo
-            .default_strategy_endpoint
-            .as_deref()
-            .unwrap_or(&repo.url)
-            .trim_end_matches('/')
-            .to_string();
-        let repo_id = repo
-            .id
-            .ok_or_else(|| Error::InitError("Repository has no ID".to_string()))?;
-
-        Ok(Self {
-            client: RepositoryClient::new()?,
-            retry_policy: RetryConfig::quick(),
-            endpoint,
-            configured_target: configured_target.to_string(),
-            route_slug: profile.remi_route_slug().to_string(),
-            repo_id,
-            next_page: 1,
-            expected_total_names: None,
-            names_seen: 0,
-            last_name: None,
-        })
-    }
-
-    async fn next_rows(&mut self) -> Result<Option<Vec<SyncedPackageRow>>> {
-        if self
-            .expected_total_names
-            .is_some_and(|total| self.names_seen == total)
-        {
-            return Ok(None);
-        }
-
-        let list_url = format!(
-            "{}/v1/index/{}?page={}&per_page={}",
-            self.endpoint, self.route_slug, self.next_page, REMI_SPARSE_SYNC_PAGE_SIZE
-        );
-        let list = fetch_sparse_list_with_retry(
-            &self.client,
-            &list_url,
-            &self.retry_policy,
-            REMI_SPARSE_SYNC_PAGE_SIZE,
-        )
-        .await?;
-
-        let endpoint = self.endpoint.as_str();
-        let route_slug = self.route_slug.as_str();
-        let retry_policy = &self.retry_policy;
-        let client = &self.client;
-        let fetches = stream::iter(list.packages.iter().cloned())
-            .map(|name| async move {
-                let url = format!(
-                    "{endpoint}/v1/index/{route_slug}/{}",
-                    urlencoding::encode(&name)
-                );
-                let entry = fetch_sparse_entry_with_retry(client, &url, retry_policy).await?;
-                Ok::<_, Error>((name, entry))
-            })
-            .buffer_unordered(REMI_SPARSE_ENTRY_CONCURRENCY);
-        let entries = fetches
-            .collect::<Vec<_>>()
-            .await
-            .into_iter()
-            .collect::<Result<Vec<_>>>()?;
-        self.consume_page(list, entries).map(Some)
-    }
-
-    fn consume_page(
-        &mut self,
-        list: RemiSparsePackageList,
-        entries: Vec<(String, RemiSparseIndexEntry)>,
-    ) -> Result<Vec<SyncedPackageRow>> {
-        self.validate_list_page(&list)?;
-        if entries.len() != list.packages.len() {
-            return Err(Error::ParseError(format!(
-                "Remi sparse page returned {} entries for {} package names",
-                entries.len(),
-                list.packages.len()
-            )));
-        }
-        let mut expected_names = list.packages.iter().cloned().collect::<HashSet<_>>();
-        let mut rows = Vec::new();
-        for (requested_name, entry) in entries {
-            if !expected_names.remove(&requested_name) {
-                return Err(Error::ParseError(format!(
-                    "Remi sparse page returned an unexpected or duplicate entry for '{requested_name}'"
-                )));
-            }
-            self.validate_sparse_entry(&requested_name, &entry)?;
-            let mut seen_versions = HashSet::new();
-            for version in entry.versions {
-                let key = (
-                    version.version.clone(),
-                    version.release.clone(),
-                    version.architecture.clone(),
-                );
-                if !seen_versions.insert(key) {
-                    return Err(Error::ParseError(format!(
-                        "Remi sparse entry '{}' repeats an exact version/release/architecture identity",
-                        requested_name
-                    )));
-                }
-                rows.push(remi_sync_row(
-                    self.repo_id,
-                    self.endpoint.clone(),
-                    self.configured_target.clone(),
-                    requested_name.clone(),
-                    version,
-                )?);
-            }
-        }
-        if !expected_names.is_empty() {
-            return Err(Error::ParseError(
-                "Remi sparse page omitted one or more requested package entries".to_string(),
-            ));
-        }
-
-        self.names_seen = self
-            .names_seen
-            .checked_add(list.packages.len())
-            .ok_or_else(|| Error::ParseError("Remi sparse package count overflow".to_string()))?;
-        self.last_name = list.packages.last().cloned();
-        self.next_page += 1;
-        Ok(rows)
-    }
-
-    fn validate_list_page(&mut self, list: &RemiSparsePackageList) -> Result<()> {
-        if list.distro != self.route_slug {
-            return Err(Error::ParseError(format!(
-                "Remi sparse list distro '{}' disagrees with requested route '{}'",
-                list.distro, self.route_slug
-            )));
-        }
-        if list.page != self.next_page || list.per_page != REMI_SPARSE_SYNC_PAGE_SIZE {
-            return Err(Error::ParseError(format!(
-                "Remi sparse list pagination disagrees with request: page={}, per_page={}",
-                list.page, list.per_page
-            )));
-        }
-        if list.packages.len() > REMI_SPARSE_SYNC_PAGE_SIZE {
-            return Err(Error::ParseError(format!(
-                "Remi sparse list returned {} names for a {}-name page",
-                list.packages.len(),
-                REMI_SPARSE_SYNC_PAGE_SIZE
-            )));
-        }
-        match self.expected_total_names {
-            Some(total) if total != list.total => {
-                return Err(Error::ParseError(format!(
-                    "Remi sparse list changed total package-name count during sync: {total} -> {}",
-                    list.total
-                )));
-            }
-            None => self.expected_total_names = Some(list.total),
-            _ => {}
-        }
-        if list.packages.is_empty() && self.names_seen < list.total {
-            return Err(Error::ParseError(format!(
-                "Remi sparse list ended after {} of {} package names",
-                self.names_seen, list.total
-            )));
-        }
-        if self
-            .names_seen
-            .checked_add(list.packages.len())
-            .is_none_or(|count| count > list.total)
-        {
-            return Err(Error::ParseError(
-                "Remi sparse list returned more package names than its declared total".to_string(),
-            ));
-        }
-
-        let mut previous = self.last_name.as_deref();
-        for name in &list.packages {
-            validate_sparse_name(name)?;
-            if previous.is_some_and(|prior| prior >= name.as_str()) {
-                return Err(Error::ParseError(format!(
-                    "Remi sparse package names are not globally unique and ordered at '{name}'"
-                )));
-            }
-            previous = Some(name);
-        }
-        Ok(())
-    }
-
-    fn validate_sparse_entry(
-        &self,
-        requested_name: &str,
-        entry: &RemiSparseIndexEntry,
-    ) -> Result<()> {
-        if entry.name != requested_name {
-            return Err(Error::ParseError(format!(
-                "Remi sparse entry name '{}' disagrees with requested package '{requested_name}'",
-                entry.name
-            )));
-        }
-        if entry.distro != self.route_slug {
-            return Err(Error::ParseError(format!(
-                "Remi sparse entry distro '{}' disagrees with requested route '{}'",
-                entry.distro, self.route_slug
-            )));
-        }
-        if entry.versions.is_empty() {
-            return Err(Error::ParseError(format!(
-                "Remi sparse entry '{requested_name}' has no versions"
-            )));
-        }
-        Ok(())
-    }
-}
-
-fn validate_sparse_name(name: &str) -> Result<()> {
-    if name.is_empty()
-        || name.len() > REMI_SPARSE_NAME_MAX_BYTES
-        || name.contains('/')
-        || name.contains("..")
-        || name.contains('\0')
-    {
-        return Err(Error::ParseError(format!(
-            "Remi sparse list contains invalid package name {name:?}"
-        )));
-    }
-    Ok(())
-}
-
-async fn fetch_sparse_list_with_retry(
-    client: &RepositoryClient,
-    url: &str,
-    retry_policy: &RetryConfig,
-    requested_page_size: usize,
-) -> Result<RemiSparsePackageList> {
-    with_retry_async(retry_policy, || async {
-        let response = fetch_sparse_response(client, url).await?;
-        let bytes = crate::repository::client::read_response_bytes_with_limit(
-            response,
-            sparse_package_list_max_bytes(requested_page_size),
-            url,
-        )
-        .await?;
-        serde_json::from_slice(&bytes).map_err(|error| {
-            Error::ParseError(format!(
-                "Failed to parse Remi sparse package list from {url}: {error}"
-            ))
-        })
-    })
-    .await
-}
-
-async fn fetch_sparse_entry_with_retry(
-    client: &RepositoryClient,
-    url: &str,
-    retry_policy: &RetryConfig,
-) -> Result<RemiSparseIndexEntry> {
-    with_retry_async(retry_policy, || async {
-        let response = fetch_sparse_response(client, url).await?;
-        response.json().await.map_err(|error| {
-            Error::ParseError(format!(
-                "Failed to parse Remi sparse package entry from {url}: {error}"
-            ))
-        })
-    })
-    .await
-}
-
-async fn fetch_sparse_response(client: &RepositoryClient, url: &str) -> Result<reqwest::Response> {
-    crate::repository::client::validate_url_scheme(url)?;
-    let response = client
-        .inner()
-        .get(url)
-        .timeout(crate::repository::client::TimeoutConfig::default().download)
-        .send()
-        .await
-        .map_err(|error| Error::DownloadError(format!("{error}: {url}")))?;
-    if !response.status().is_success() {
-        return Err(Error::HttpStatus {
-            status: response.status().as_u16(),
-            url: url.to_string(),
-        });
-    }
-    Ok(response)
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -775,8 +511,8 @@ mod tests {
     use crate::db::testing::create_test_db;
     use crate::repository::package_relation::parse_native_relation;
     use crate::repository::remi_metadata::{
-        REMI_SPARSE_MAX_PAGE_SIZE, RemiProvide, RemiRequirement, RemiRequirementGroup,
-        RemiSparseIndexEntry, RemiSparsePackageList, RemiSparseVersionEntry,
+        REMI_SPARSE_SYNC_PAGE_SIZE, RemiProvide, RemiRequirement, RemiRequirementGroup,
+        RemiSparsePackagePage, RemiSparseResolutionEntry, RemiSparseResolutionVersionEntry,
     };
     use std::io::{Read, Write};
 
@@ -784,11 +520,10 @@ mod tests {
         name: &str,
         version: &str,
         version_scheme: VersionScheme,
-    ) -> RemiSparseVersionEntry {
-        RemiSparseVersionEntry {
+    ) -> RemiSparseResolutionVersionEntry {
+        RemiSparseResolutionVersionEntry {
             version: version.to_string(),
             release: None,
-            converted: false,
             architecture: Some("x86_64".to_string()),
             provides: vec![RemiProvide {
                 capability: name.to_string(),
@@ -804,7 +539,7 @@ mod tests {
             }],
             requirement_groups: Vec::new(),
             size: 1024,
-            content_hash: None,
+            metadata: None,
         }
     }
 
@@ -1005,7 +740,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn remi_sparse_entry_fetch_retries_truncated_json() {
+    async fn remi_sparse_page_fetch_retries_truncated_json() {
         use crate::repository::retry::RetryConfig;
         use std::sync::{
             Arc,
@@ -1037,9 +772,9 @@ mod tests {
 
                 let attempt = server_attempts.fetch_add(1, Ordering::SeqCst);
                 let body = if attempt == 0 {
-                    r#"{"name":"qemu-img""#
+                    r#"{"distro":"fedora""#
                 } else {
-                    r#"{"name":"qemu-img","distro":"fedora","versions":[{"version":"2:10.1.0-7.fc44","converted":false,"architecture":"x86_64","provides":[],"requirement_groups":[],"size":1024,"content_hash":null}]}"#
+                    r#"{"distro":"fedora","packages":[{"name":"qemu-img","distro":"fedora","versions":[{"version":"2:10.1.0-7.fc44","architecture":"x86_64","provides":[],"requirement_groups":[],"size":1024}]}],"total":1,"page":1,"per_page":128}"#
                 };
                 let response = format!(
                     "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
@@ -1057,18 +792,72 @@ mod tests {
             jitter_factor: 0.0,
         };
         let client = RepositoryClient::new().unwrap();
-        let entry = fetch_sparse_entry_with_retry(
+        let page = fetch_sparse_page_with_retry(
             &client,
-            &format!("http://{addr}/v1/index/fedora/qemu-img"),
+            &format!("http://{addr}/v1/index/fedora?include=versions"),
             &retry,
         )
         .await
         .unwrap();
 
-        assert_eq!(entry.name, "qemu-img");
-        assert_eq!(entry.versions.len(), 1);
+        assert_eq!(page.packages[0].name, "qemu-img");
+        assert_eq!(page.packages[0].versions.len(), 1);
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
         server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn remi_sparse_sync_fetches_one_complete_http_page() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let body = serde_json::to_string(&RemiSparsePackagePage {
+            distro: "fedora".to_string(),
+            packages: vec![sparse_test_entry("alpha"), sparse_test_entry("beta")],
+            total: 2,
+            page: 1,
+            per_page: REMI_SPARSE_SYNC_PAGE_SIZE,
+        })
+        .unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            let mut buf = [0u8; 1024];
+            loop {
+                let read = stream.read(&mut buf).await.unwrap();
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buf[..read]);
+                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            String::from_utf8(request).unwrap()
+        });
+
+        let conn = Connection::open_in_memory().unwrap();
+        crate::db::schema::ensure_current(&conn).unwrap();
+        let repo = sparse_test_repo(format!("http://{addr}"), &conn);
+        let mut fetcher = RemiSparseSync::new(&repo).unwrap();
+        let rows = fetcher.next_rows().await.unwrap().unwrap();
+        assert_eq!(rows.len(), 2);
+        assert!(fetcher.next_rows().await.unwrap().is_none());
+
+        let request = server.await.unwrap();
+        assert!(
+            request
+                .starts_with("GET /v1/index/fedora?page=1&per_page=128&include=versions HTTP/1.1"),
+            "unexpected sparse sync request: {request}"
+        );
     }
 
     fn sparse_test_repo(endpoint: String, conn: &Connection) -> Repository {
@@ -1080,8 +869,8 @@ mod tests {
         repo
     }
 
-    fn sparse_test_entry(name: &str) -> RemiSparseIndexEntry {
-        RemiSparseIndexEntry {
+    fn sparse_test_entry(name: &str) -> RemiSparseResolutionEntry {
+        RemiSparseResolutionEntry {
             name: name.to_string(),
             distro: "fedora".to_string(),
             versions: vec![remi_entry_for_tests(name, "1.0-1.fc44", VersionScheme::Rpm)],
@@ -1097,79 +886,78 @@ mod tests {
         let end = start
             .saturating_add(REMI_SPARSE_SYNC_PAGE_SIZE)
             .min(package_count);
-        let packages = (start..end)
+        let entries = (start..end)
             .map(|index| format!("pkg-{index:08}"))
-            .collect::<Vec<_>>();
-        let entries = packages
-            .iter()
-            .map(|name| (name.clone(), sparse_test_entry(name)))
+            .map(|name| sparse_test_entry(&name))
             .collect();
-        fetcher.consume_page(
-            RemiSparsePackageList {
-                distro: "fedora".to_string(),
-                packages,
-                total: package_count,
-                page,
-                per_page: REMI_SPARSE_SYNC_PAGE_SIZE,
-            },
-            entries,
-        )
+        fetcher.consume_page(RemiSparsePackagePage {
+            distro: "fedora".to_string(),
+            packages: entries,
+            total: package_count,
+            page,
+            per_page: REMI_SPARSE_SYNC_PAGE_SIZE,
+        })
     }
 
     #[test]
-    fn sparse_wire_contract_admits_every_emitted_field_and_bounds_name_pages() {
+    fn sparse_wire_contract_round_trips_complete_resolution_page() {
         let emitted = serde_json::json!({
-            "name": "hello",
             "distro": "fedora",
-            "versions": [{
-                "version": "1.0",
-                "release": "2",
-                "provides": [{
-                    "capability": "hello",
+            "packages": [{
+                "name": "hello",
+                "distro": "fedora",
+                "versions": [{
                     "version": "1.0",
-                    "version_relation": "equal",
-                    "kind": "package",
-                    "raw": "hello = 1.0",
-                    "version_scheme": "rpm",
-                    "architecture_qualifier": {"kind": "implicit"}
-                }],
-                "requirement_groups": [{
-                    "kind": "depends",
-                    "behavior": "hard",
-                    "description": null,
-                    "native_text": "glibc >= 2.39",
-                    "expression_json": "{\"kind\":\"atom\",\"clause\":{\"name\":\"glibc\",\"version_constraint\":\">= 2.39\",\"capability_kind\":null,\"native_text\":null}}",
-                    "clauses": [{
-                        "capability": "glibc",
-                        "version_constraint": ">= 2.39",
+                    "release": "2",
+                    "provides": [{
+                        "capability": "hello",
+                        "version": "1.0",
+                        "version_relation": "equal",
                         "kind": "package",
-                        "dependency_type": "runtime",
-                        "raw": "glibc >= 2.39"
-                    }]
-                }],
-                "architecture": "x86_64",
-                "size": 4096,
-                "converted": true,
-                "content_hash": "sha256:content"
-            }]
+                        "raw": "hello = 1.0",
+                        "version_scheme": "rpm",
+                        "architecture_qualifier": {"kind": "implicit"}
+                    }],
+                    "requirement_groups": [{
+                        "kind": "depends",
+                        "behavior": "hard",
+                        "description": null,
+                        "native_text": "glibc >= 2.39",
+                        "expression_json": "{\"kind\":\"atom\",\"clause\":{\"name\":\"glibc\",\"version_constraint\":\">= 2.39\",\"capability_kind\":null,\"native_text\":null}}",
+                        "clauses": [{
+                            "capability": "glibc",
+                            "version_constraint": ">= 2.39",
+                            "kind": "package",
+                            "dependency_type": "runtime",
+                            "raw": "glibc >= 2.39"
+                        }]
+                    }],
+                    "architecture": "x86_64",
+                    "size": 4096,
+                    "metadata": {
+                        "security_advisory": {
+                            "id": "FEDORA-2026-0001",
+                            "source": "remi",
+                            "source_trust": "trusted",
+                            "fixed_version": "1.0"
+                        }
+                    }
+                }]
+            }],
+            "total": 1,
+            "page": 1,
+            "per_page": REMI_SPARSE_SYNC_PAGE_SIZE
         });
-        let entry: RemiSparseIndexEntry = serde_json::from_value(emitted).unwrap();
-        assert_eq!(entry.versions[0].release.as_deref(), Some("2"));
+        let page: RemiSparsePackagePage = serde_json::from_value(emitted).unwrap();
+        assert_eq!(page.packages[0].versions[0].release.as_deref(), Some("2"));
         assert_eq!(
-            entry.versions[0].content_hash.as_deref(),
-            Some("sha256:content")
+            page.packages[0].versions[0].requirement_groups[0].clauses[0].capability,
+            "glibc"
         );
-
-        let escaped_name = "\u{1}".repeat(REMI_SPARSE_NAME_MAX_BYTES);
-        let page = RemiSparsePackageList {
-            distro: "f".repeat(REMI_SPARSE_NAME_MAX_BYTES),
-            packages: vec![escaped_name; REMI_SPARSE_MAX_PAGE_SIZE],
-            total: usize::MAX,
-            page: usize::MAX,
-            per_page: REMI_SPARSE_MAX_PAGE_SIZE,
-        };
-        let bytes = serde_json::to_vec(&page).unwrap();
-        assert!(bytes.len() as u64 <= sparse_package_list_max_bytes(REMI_SPARSE_MAX_PAGE_SIZE));
+        assert_eq!(
+            page.packages[0].versions[0].metadata.as_ref().unwrap()["security_advisory"]["id"],
+            "FEDORA-2026-0001"
+        );
     }
 
     #[test]
@@ -1238,8 +1026,10 @@ mod tests {
         const CHILD_ENV: &str = "CONARY_ISSUE_156_PACKAGE_COUNT";
         const TEST_NAME: &str = "repository::sync::remi::tests::sparse_sync_peak_rss_is_independent_of_distribution_package_count";
         if std::env::var_os(CHILD_ENV).is_none() {
+            const FEDORA_SPARSE_NAME_COUNT: usize = 67_430;
+            let package_counts = [512usize, FEDORA_SPARSE_NAME_COUNT];
             let mut measurements = Vec::new();
-            for package_count in [512usize, 20_000] {
+            for package_count in package_counts {
                 let output = std::process::Command::new(std::env::current_exe().unwrap())
                     .args(["--exact", TEST_NAME, "--nocapture"])
                     .env(CHILD_ENV, package_count.to_string())
@@ -1259,7 +1049,9 @@ mod tests {
             let growth_kib = measurements[1].saturating_sub(measurements[0]);
             assert!(
                 growth_kib < 32 * 1024,
-                "VmHWM grew by {growth_kib} KiB when package count grew 39x"
+                "VmHWM grew by {growth_kib} KiB when package count grew from {} to {}",
+                package_counts[0],
+                package_counts[1]
             );
             return;
         }

--- a/crates/conary-core/src/repository/sync/remi/sparse.rs
+++ b/crates/conary-core/src/repository/sync/remi/sparse.rs
@@ -6,8 +6,8 @@ use crate::db::models::Repository;
 use crate::error::{Error, Result};
 use crate::repository::client::RepositoryClient;
 use crate::repository::remi_metadata::{
-    REMI_SPARSE_NAME_MAX_BYTES, REMI_SPARSE_SYNC_PAGE_SIZE, RemiSparsePackagePage,
-    RemiSparseResolutionEntry,
+    REMI_SPARSE_SYNC_PAGE_SIZE, RemiSparsePackagePage, RemiSparseResolutionEntry,
+    validate_remi_public_name,
 };
 use crate::repository::retry::{RetryConfig, with_retry_async};
 use std::collections::HashSet;
@@ -88,8 +88,17 @@ impl RemiSparseSync {
     ) -> Result<Vec<SyncedPackageRow>> {
         self.validate_page(&page)?;
 
+        let page_total = page.total;
         let page_name_count = page.packages.len();
         let page_last_name = page.packages.last().map(|entry| entry.name.clone());
+        let next_names_seen = self
+            .names_seen
+            .checked_add(page_name_count)
+            .ok_or_else(|| Error::ParseError("Remi sparse package count overflow".to_string()))?;
+        let next_page = self
+            .next_page
+            .checked_add(1)
+            .ok_or_else(|| Error::ParseError("Remi sparse page counter overflow".to_string()))?;
         let mut rows = Vec::new();
         for entry in page.packages {
             let requested_name = entry.name.clone();
@@ -116,16 +125,14 @@ impl RemiSparseSync {
             }
         }
 
-        self.names_seen = self
-            .names_seen
-            .checked_add(page_name_count)
-            .ok_or_else(|| Error::ParseError("Remi sparse package count overflow".to_string()))?;
+        self.names_seen = next_names_seen;
+        self.expected_total_names.get_or_insert(page_total);
         self.last_name = page_last_name.or(self.last_name.take());
-        self.next_page += 1;
+        self.next_page = next_page;
         Ok(rows)
     }
 
-    fn validate_page(&mut self, page: &RemiSparsePackagePage) -> Result<()> {
+    fn validate_page(&self, page: &RemiSparsePackagePage) -> Result<()> {
         if page.distro != self.route_slug {
             return Err(Error::ParseError(format!(
                 "Remi sparse page distro '{}' disagrees with requested route '{}'",
@@ -152,7 +159,6 @@ impl RemiSparseSync {
                     page.total
                 )));
             }
-            None => self.expected_total_names = Some(page.total),
             _ => {}
         }
         if page.packages.is_empty() && self.names_seen < page.total {
@@ -208,17 +214,11 @@ fn validate_sparse_entry(
 }
 
 fn validate_sparse_name(name: &str) -> Result<()> {
-    if name.is_empty()
-        || name.len() > REMI_SPARSE_NAME_MAX_BYTES
-        || name.contains('/')
-        || name.contains("..")
-        || name.contains('\0')
-    {
-        return Err(Error::ParseError(format!(
-            "Remi sparse page contains invalid package name {name:?}"
-        )));
-    }
-    Ok(())
+    validate_remi_public_name(name).map_err(|reason| {
+        Error::ParseError(format!(
+            "Remi sparse page contains invalid package name {name:?}: {reason}"
+        ))
+    })
 }
 
 pub(super) async fn fetch_sparse_page_with_retry(
@@ -369,5 +369,20 @@ mod tests {
             .consume_page(test_page(1, 2, Vec::new()))
             .unwrap_err();
         assert!(error.to_string().contains("ended after 0 of 2"));
+    }
+
+    #[test]
+    fn page_validation_rejects_page_counter_overflow_without_advancing_state() {
+        let mut sync = test_sync();
+        sync.next_page = usize::MAX;
+        let error = sync
+            .consume_page(test_page(usize::MAX, 1, vec![test_entry("alpha")]))
+            .unwrap_err();
+
+        assert!(error.to_string().contains("page counter overflow"));
+        assert_eq!(sync.next_page, usize::MAX);
+        assert_eq!(sync.names_seen, 0);
+        assert_eq!(sync.expected_total_names, None);
+        assert_eq!(sync.last_name, None);
     }
 }

--- a/crates/conary-core/src/repository/sync/remi/sparse.rs
+++ b/crates/conary-core/src/repository/sync/remi/sparse.rs
@@ -1,0 +1,373 @@
+// conary-core/src/repository/sync/remi/sparse.rs
+
+//! Bounded-page Remi sparse-index synchronization.
+
+use crate::db::models::Repository;
+use crate::error::{Error, Result};
+use crate::repository::client::RepositoryClient;
+use crate::repository::remi_metadata::{
+    REMI_SPARSE_NAME_MAX_BYTES, REMI_SPARSE_SYNC_PAGE_SIZE, RemiSparsePackagePage,
+    RemiSparseResolutionEntry,
+};
+use crate::repository::retry::{RetryConfig, with_retry_async};
+use std::collections::HashSet;
+
+use super::super::types::SyncedPackageRow;
+use super::remi_sync_row;
+
+pub(super) struct RemiSparseSync {
+    client: RepositoryClient,
+    retry_policy: RetryConfig,
+    endpoint: String,
+    configured_target: String,
+    route_slug: String,
+    repo_id: i64,
+    pub(super) next_page: usize,
+    expected_total_names: Option<usize>,
+    pub(super) names_seen: usize,
+    last_name: Option<String>,
+}
+
+impl RemiSparseSync {
+    pub(super) fn new(repo: &Repository) -> Result<Self> {
+        let configured_target = repo.source_profile.as_deref().ok_or_else(|| {
+            Error::ConfigError(format!(
+                "Repository '{}' has strategy 'remi' but no source profile configured (use --source-profile)",
+                repo.name
+            ))
+        })?;
+        let profile =
+            crate::repository::supported_profiles::profile_for_remi_target(configured_target)
+                .ok_or_else(|| {
+                    Error::ConfigError(format!("unsupported Remi target: {configured_target}"))
+                })?;
+        let endpoint = repo
+            .default_strategy_endpoint
+            .as_deref()
+            .unwrap_or(&repo.url)
+            .trim_end_matches('/')
+            .to_string();
+        let repo_id = repo
+            .id
+            .ok_or_else(|| Error::InitError("Repository has no ID".to_string()))?;
+
+        Ok(Self {
+            client: RepositoryClient::new()?,
+            retry_policy: RetryConfig::quick(),
+            endpoint,
+            configured_target: configured_target.to_string(),
+            route_slug: profile.remi_route_slug().to_string(),
+            repo_id,
+            next_page: 1,
+            expected_total_names: None,
+            names_seen: 0,
+            last_name: None,
+        })
+    }
+
+    pub(super) async fn next_rows(&mut self) -> Result<Option<Vec<SyncedPackageRow>>> {
+        if self
+            .expected_total_names
+            .is_some_and(|total| self.names_seen == total)
+        {
+            return Ok(None);
+        }
+
+        let page_url = format!(
+            "{}/v1/index/{}?page={}&per_page={}&include=versions",
+            self.endpoint, self.route_slug, self.next_page, REMI_SPARSE_SYNC_PAGE_SIZE
+        );
+        let page =
+            fetch_sparse_page_with_retry(&self.client, &page_url, &self.retry_policy).await?;
+        self.consume_page(page).map(Some)
+    }
+
+    pub(super) fn consume_page(
+        &mut self,
+        page: RemiSparsePackagePage,
+    ) -> Result<Vec<SyncedPackageRow>> {
+        self.validate_page(&page)?;
+
+        let page_name_count = page.packages.len();
+        let page_last_name = page.packages.last().map(|entry| entry.name.clone());
+        let mut rows = Vec::new();
+        for entry in page.packages {
+            let requested_name = entry.name.clone();
+            let mut seen_versions = HashSet::new();
+            for version in entry.versions {
+                let key = (
+                    version.version.clone(),
+                    version.release.clone(),
+                    version.architecture.clone(),
+                );
+                if !seen_versions.insert(key) {
+                    return Err(Error::ParseError(format!(
+                        "Remi sparse entry '{}' repeats an exact version/release/architecture identity",
+                        requested_name
+                    )));
+                }
+                rows.push(remi_sync_row(
+                    self.repo_id,
+                    self.endpoint.clone(),
+                    self.configured_target.clone(),
+                    requested_name.clone(),
+                    version,
+                )?);
+            }
+        }
+
+        self.names_seen = self
+            .names_seen
+            .checked_add(page_name_count)
+            .ok_or_else(|| Error::ParseError("Remi sparse package count overflow".to_string()))?;
+        self.last_name = page_last_name.or(self.last_name.take());
+        self.next_page += 1;
+        Ok(rows)
+    }
+
+    fn validate_page(&mut self, page: &RemiSparsePackagePage) -> Result<()> {
+        if page.distro != self.route_slug {
+            return Err(Error::ParseError(format!(
+                "Remi sparse page distro '{}' disagrees with requested route '{}'",
+                page.distro, self.route_slug
+            )));
+        }
+        if page.page != self.next_page || page.per_page != REMI_SPARSE_SYNC_PAGE_SIZE {
+            return Err(Error::ParseError(format!(
+                "Remi sparse page pagination disagrees with request: page={}, per_page={}",
+                page.page, page.per_page
+            )));
+        }
+        if page.packages.len() > REMI_SPARSE_SYNC_PAGE_SIZE {
+            return Err(Error::ParseError(format!(
+                "Remi sparse page returned {} entries for a {}-name page",
+                page.packages.len(),
+                REMI_SPARSE_SYNC_PAGE_SIZE
+            )));
+        }
+        match self.expected_total_names {
+            Some(total) if total != page.total => {
+                return Err(Error::ParseError(format!(
+                    "Remi sparse page changed total package-name count during sync: {total} -> {}",
+                    page.total
+                )));
+            }
+            None => self.expected_total_names = Some(page.total),
+            _ => {}
+        }
+        if page.packages.is_empty() && self.names_seen < page.total {
+            return Err(Error::ParseError(format!(
+                "Remi sparse page ended after {} of {} package names",
+                self.names_seen, page.total
+            )));
+        }
+        if self
+            .names_seen
+            .checked_add(page.packages.len())
+            .is_none_or(|count| count > page.total)
+        {
+            return Err(Error::ParseError(
+                "Remi sparse page returned more package names than its declared total".to_string(),
+            ));
+        }
+
+        let mut previous = self.last_name.as_deref();
+        for entry in &page.packages {
+            validate_sparse_entry(&self.route_slug, previous, entry)?;
+            previous = Some(entry.name.as_str());
+        }
+        Ok(())
+    }
+}
+
+fn validate_sparse_entry(
+    route_slug: &str,
+    previous_name: Option<&str>,
+    entry: &RemiSparseResolutionEntry,
+) -> Result<()> {
+    validate_sparse_name(&entry.name)?;
+    if previous_name.is_some_and(|prior| prior >= entry.name.as_str()) {
+        return Err(Error::ParseError(format!(
+            "Remi sparse package names are not globally unique and ordered at '{}'",
+            entry.name
+        )));
+    }
+    if entry.distro != route_slug {
+        return Err(Error::ParseError(format!(
+            "Remi sparse entry distro '{}' disagrees with requested route '{route_slug}'",
+            entry.distro
+        )));
+    }
+    if entry.versions.is_empty() {
+        return Err(Error::ParseError(format!(
+            "Remi sparse entry '{}' has no versions",
+            entry.name
+        )));
+    }
+    Ok(())
+}
+
+fn validate_sparse_name(name: &str) -> Result<()> {
+    if name.is_empty()
+        || name.len() > REMI_SPARSE_NAME_MAX_BYTES
+        || name.contains('/')
+        || name.contains("..")
+        || name.contains('\0')
+    {
+        return Err(Error::ParseError(format!(
+            "Remi sparse page contains invalid package name {name:?}"
+        )));
+    }
+    Ok(())
+}
+
+pub(super) async fn fetch_sparse_page_with_retry(
+    client: &RepositoryClient,
+    url: &str,
+    retry_policy: &RetryConfig,
+) -> Result<RemiSparsePackagePage> {
+    with_retry_async(retry_policy, || async {
+        let response = fetch_sparse_response(client, url).await?;
+        response.json().await.map_err(|error| {
+            Error::ParseError(format!(
+                "Failed to parse Remi sparse package page from {url}: {error}"
+            ))
+        })
+    })
+    .await
+}
+
+async fn fetch_sparse_response(client: &RepositoryClient, url: &str) -> Result<reqwest::Response> {
+    crate::repository::client::validate_url_scheme(url)?;
+    let response = client
+        .inner()
+        .get(url)
+        .timeout(crate::repository::client::TimeoutConfig::default().download)
+        .send()
+        .await
+        .map_err(|error| Error::DownloadError(format!("{error}: {url}")))?;
+    if !response.status().is_success() {
+        return Err(Error::HttpStatus {
+            status: response.status().as_u16(),
+            url: url.to_string(),
+        });
+    }
+    Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repository::dependency_model::{
+        ProvideArchitectureQualifier, ProvideVersionRelation,
+    };
+    use crate::repository::remi_metadata::{RemiProvide, RemiSparseResolutionVersionEntry};
+    use crate::repository::versioning::VersionScheme;
+
+    fn test_sync() -> RemiSparseSync {
+        let mut repo =
+            Repository::new("fedora-sparse".to_string(), "https://remi.test".to_string());
+        repo.id = Some(7);
+        repo.default_strategy = Some("remi".to_string());
+        repo.default_strategy_endpoint = Some("https://remi.test".to_string());
+        repo.source_profile = Some("fedora-44".to_string());
+        RemiSparseSync::new(&repo).unwrap()
+    }
+
+    fn test_version(name: &str) -> RemiSparseResolutionVersionEntry {
+        RemiSparseResolutionVersionEntry {
+            version: "1.0-1.fc44".to_string(),
+            release: None,
+            provides: vec![RemiProvide {
+                capability: name.to_string(),
+                version: Some("1.0-1.fc44".to_string()),
+                version_relation: Some(ProvideVersionRelation::Equal),
+                kind: "package".to_string(),
+                raw: Some(name.to_string()),
+                version_scheme: VersionScheme::Rpm,
+                architecture_qualifier: ProvideArchitectureQualifier::Implicit,
+            }],
+            requirement_groups: Vec::new(),
+            architecture: Some("x86_64".to_string()),
+            size: 1024,
+            metadata: None,
+        }
+    }
+
+    fn test_entry(name: &str) -> RemiSparseResolutionEntry {
+        RemiSparseResolutionEntry {
+            name: name.to_string(),
+            distro: "fedora".to_string(),
+            versions: vec![test_version(name)],
+        }
+    }
+
+    fn test_page(
+        page: usize,
+        total: usize,
+        packages: Vec<RemiSparseResolutionEntry>,
+    ) -> RemiSparsePackagePage {
+        RemiSparsePackagePage {
+            distro: "fedora".to_string(),
+            packages,
+            total,
+            page,
+            per_page: REMI_SPARSE_SYNC_PAGE_SIZE,
+        }
+    }
+
+    #[test]
+    fn page_validation_rejects_a_changed_total_and_cross_page_reordering() {
+        let mut changed_total = test_sync();
+        changed_total
+            .consume_page(test_page(1, 2, vec![test_entry("alpha")]))
+            .unwrap();
+        let error = changed_total
+            .consume_page(test_page(2, 3, vec![test_entry("bravo")]))
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("changed total package-name count")
+        );
+
+        let mut reordered = test_sync();
+        reordered
+            .consume_page(test_page(1, 2, vec![test_entry("bravo")]))
+            .unwrap();
+        let error = reordered
+            .consume_page(test_page(2, 2, vec![test_entry("alpha")]))
+            .unwrap_err();
+        assert!(error.to_string().contains("globally unique and ordered"));
+    }
+
+    #[test]
+    fn page_validation_rejects_unfetchable_and_duplicate_exact_versions() {
+        let mut empty_versions = test_entry("alpha");
+        empty_versions.versions.clear();
+        let error = test_sync()
+            .consume_page(test_page(1, 1, vec![empty_versions]))
+            .unwrap_err();
+        assert!(error.to_string().contains("has no versions"));
+
+        let mut duplicate = test_entry("alpha");
+        duplicate.versions.push(duplicate.versions[0].clone());
+        let error = test_sync()
+            .consume_page(test_page(1, 1, vec![duplicate]))
+            .unwrap_err();
+        assert!(error.to_string().contains("repeats an exact version"));
+    }
+
+    #[test]
+    fn page_validation_rejects_invalid_names_and_incomplete_pagination() {
+        let error = test_sync()
+            .consume_page(test_page(1, 1, vec![test_entry("../escape")]))
+            .unwrap_err();
+        assert!(error.to_string().contains("invalid package name"));
+
+        let error = test_sync()
+            .consume_page(test_page(1, 2, Vec::new()))
+            .unwrap_err();
+        assert!(error.to_string().contains("ended after 0 of 2"));
+    }
+}

--- a/crates/conary-core/src/repository/sync/tests.rs
+++ b/crates/conary-core/src/repository/sync/tests.rs
@@ -15,7 +15,9 @@ mod tests {
     };
     use crate::repository::metadata::RepositoryMetadata as JsonRepositoryMetadata;
     use crate::repository::parsers::PackageMetadata;
-    use crate::repository::remi_metadata::{RemiProvide, RemiRequirement, RemiRequirementGroup};
+    use crate::repository::remi_metadata::{
+        RemiProvide, RemiRequirement, RemiRequirementGroup, RemiSparseVersionEntry,
+    };
     use crate::repository::versioning::VersionScheme;
     use crate::trust::metadata::{TargetDescription, VerifiedTufState};
     use serde_json::json;

--- a/crates/conary-core/src/repository/sync/tests.rs
+++ b/crates/conary-core/src/repository/sync/tests.rs
@@ -16,7 +16,7 @@ mod tests {
     use crate::repository::metadata::RepositoryMetadata as JsonRepositoryMetadata;
     use crate::repository::parsers::PackageMetadata;
     use crate::repository::remi_metadata::{
-        RemiProvide, RemiRequirement, RemiRequirementGroup, RemiSparseVersionEntry,
+        RemiProvide, RemiRequirement, RemiRequirementGroup, RemiSparseResolutionVersionEntry,
     };
     use crate::repository::versioning::VersionScheme;
     use crate::trust::metadata::{TargetDescription, VerifiedTufState};

--- a/crates/conary-core/src/repository/sync/tests/native.rs
+++ b/crates/conary-core/src/repository/sync/tests/native.rs
@@ -61,13 +61,7 @@ fn test_persist_native_sync_rows_writes_normalized_capabilities() {
         requirement_groups,
         requirement_group_clauses,
     }];
-    let mut repo_packages: Vec<RepositoryPackage> = synced_packages
-        .iter()
-        .map(|row| row.package.clone())
-        .collect();
-
-    let count =
-        persist_native_sync_rows(&conn, &mut repo, &mut repo_packages, synced_packages).unwrap();
+    let count = persist_native_sync_rows(&conn, &mut repo, synced_packages).unwrap();
     assert_eq!(count, 1);
 
     let stored_packages = RepositoryPackage::find_by_repository(&conn, repo_id).unwrap();
@@ -451,10 +445,7 @@ fn test_sync_persists_distro_and_version_scheme() {
         requirement_groups: Vec::new(),
         requirement_group_clauses: Vec::new(),
     }];
-    let mut repo_packages: Vec<RepositoryPackage> =
-        synced.iter().map(|row| row.package.clone()).collect();
-
-    persist_native_sync_rows(&conn, &mut repo, &mut repo_packages, synced).unwrap();
+    persist_native_sync_rows(&conn, &mut repo, synced).unwrap();
 
     let stored = RepositoryPackage::find_by_repository(&conn, repo_id).unwrap();
     assert_eq!(stored.len(), 1);
@@ -504,10 +495,7 @@ fn test_sync_persists_debian_origin_metadata() {
         requirement_groups: Vec::new(),
         requirement_group_clauses: Vec::new(),
     }];
-    let mut repo_packages: Vec<RepositoryPackage> =
-        synced.iter().map(|row| row.package.clone()).collect();
-
-    persist_native_sync_rows(&conn, &mut repo, &mut repo_packages, synced).unwrap();
+    persist_native_sync_rows(&conn, &mut repo, synced).unwrap();
 
     let stored = RepositoryPackage::find_by_repository(&conn, repo_id).unwrap();
     assert_eq!(stored.len(), 1);
@@ -560,10 +548,7 @@ fn test_sync_persists_arch_origin_metadata() {
         requirement_groups: Vec::new(),
         requirement_group_clauses: Vec::new(),
     }];
-    let mut repo_packages: Vec<RepositoryPackage> =
-        synced.iter().map(|row| row.package.clone()).collect();
-
-    persist_native_sync_rows(&conn, &mut repo, &mut repo_packages, synced).unwrap();
+    persist_native_sync_rows(&conn, &mut repo, synced).unwrap();
 
     let stored = RepositoryPackage::find_by_repository(&conn, repo_id).unwrap();
     assert_eq!(stored.len(), 1);
@@ -634,10 +619,7 @@ fn test_sync_persists_requirement_groups_with_alternatives() {
         requirement_groups: req_groups,
         requirement_group_clauses: req_group_clauses,
     }];
-    let mut repo_packages: Vec<RepositoryPackage> =
-        synced.iter().map(|row| row.package.clone()).collect();
-
-    persist_native_sync_rows(&conn, &mut repo, &mut repo_packages, synced).unwrap();
+    persist_native_sync_rows(&conn, &mut repo, synced).unwrap();
 
     let stored = RepositoryPackage::find_by_repository(&conn, repo_id).unwrap();
     assert_eq!(stored.len(), 1);
@@ -735,10 +717,7 @@ fn test_sync_persists_conditional_requirement_behavior() {
         requirement_groups: req_groups,
         requirement_group_clauses: req_group_clauses,
     }];
-    let mut repo_packages: Vec<RepositoryPackage> =
-        synced.iter().map(|row| row.package.clone()).collect();
-
-    persist_native_sync_rows(&conn, &mut repo, &mut repo_packages, synced).unwrap();
+    persist_native_sync_rows(&conn, &mut repo, synced).unwrap();
 
     let stored = RepositoryPackage::find_by_repository(&conn, repo_id).unwrap();
     let pkg_id = stored[0].id.unwrap();

--- a/crates/conary-core/src/repository/sync/tests/native.rs
+++ b/crates/conary-core/src/repository/sync/tests/native.rs
@@ -109,9 +109,8 @@ fn test_persist_native_sync_rows_writes_normalized_capabilities() {
 }
 
 #[test]
-fn test_remi_package_entry_builds_normalized_capabilities() {
-    let entry = RemiPackageEntry {
-        name: "kernel-core".to_string(),
+fn test_remi_sparse_entry_builds_normalized_capabilities() {
+    let entry = RemiSparseVersionEntry {
         version: "6.19.6-200.fc44".to_string(),
         release: None,
         converted: false,
@@ -190,17 +189,20 @@ fn test_remi_package_entry_builds_normalized_capabilities() {
                 }],
             },
         ],
-        metadata: None,
+        size: 4096,
+        content_hash: None,
     };
 
     let row = remi_sync_row(
         7,
         "https://remi.conary.io".to_string(),
         "fedora-44".to_string(),
+        "kernel-core".to_string(),
         entry,
     )
     .unwrap();
 
+    assert_eq!(row.package.size, 4096);
     assert!(row.provides.iter().any(|provide| {
         provide.capability == "kernel-core-uname-r"
             && provide.version.as_deref() == Some("6.19.6-200.fc44.x86_64")
@@ -217,69 +219,6 @@ fn test_remi_package_entry_builds_normalized_capabilities() {
         requirement.capability == "glibc"
             && requirement.version_constraint.as_deref() == Some(">= 2.39")
     }));
-}
-
-#[test]
-fn test_remi_package_entry_marks_trusted_security_advisory() {
-    let entry = RemiPackageEntry {
-        name: "openssl".to_string(),
-        version: "3.2.1-1.fc44".to_string(),
-        release: None,
-        converted: false,
-        architecture: Some("x86_64".to_string()),
-        provides: vec![RemiProvide {
-            capability: "openssl".to_string(),
-            version: Some("3.2.1-1.fc44".to_string()),
-            version_relation: Some(
-                crate::repository::dependency_model::ProvideVersionRelation::Equal,
-            ),
-            kind: "package".to_string(),
-            raw: Some("openssl".to_string()),
-            version_scheme: VersionScheme::Rpm,
-            architecture_qualifier:
-                crate::repository::dependency_model::ProvideArchitectureQualifier::Implicit,
-        }],
-        requirement_groups: Vec::new(),
-        metadata: Some(json!({
-            "security_advisory": {
-                "id": "FEDORA-2026-0001",
-                "source": "remi",
-                "source_trust": "trusted",
-                "severity": "critical",
-                "cves": ["CVE-2026-0001", "CVE-2026-0002"],
-                "fixed_version": "3.2.1-1.fc44",
-                "url": "https://security.example.test/FEDORA-2026-0001"
-            }
-        })),
-    };
-
-    let row = remi_sync_row(
-        7,
-        "https://remi.conary.io".to_string(),
-        "fedora-44".to_string(),
-        entry,
-    )
-    .unwrap();
-
-    assert!(row.package.is_security_update);
-    assert_eq!(row.package.severity.as_deref(), Some("critical"));
-    assert_eq!(
-        row.package.cve_ids.as_deref(),
-        Some("CVE-2026-0001,CVE-2026-0002")
-    );
-    assert_eq!(row.package.advisory_id.as_deref(), Some("FEDORA-2026-0001"));
-    assert_eq!(
-        row.package.advisory_url.as_deref(),
-        Some("https://security.example.test/FEDORA-2026-0001")
-    );
-
-    let metadata: serde_json::Value =
-        serde_json::from_str(row.package.metadata.as_deref().unwrap()).unwrap();
-    assert_eq!(
-        metadata["security_advisory"]["fixed_version"],
-        "3.2.1-1.fc44"
-    );
-    assert_eq!(metadata["security_advisory"]["source_trust"], "trusted");
 }
 
 #[test]

--- a/crates/conary-core/src/repository/sync/tests/native.rs
+++ b/crates/conary-core/src/repository/sync/tests/native.rs
@@ -110,10 +110,9 @@ fn test_persist_native_sync_rows_writes_normalized_capabilities() {
 
 #[test]
 fn test_remi_sparse_entry_builds_normalized_capabilities() {
-    let entry = RemiSparseVersionEntry {
+    let entry = RemiSparseResolutionVersionEntry {
         version: "6.19.6-200.fc44".to_string(),
         release: None,
-        converted: false,
         architecture: Some("x86_64".to_string()),
         provides: vec![
             RemiProvide {
@@ -190,7 +189,7 @@ fn test_remi_sparse_entry_builds_normalized_capabilities() {
             },
         ],
         size: 4096,
-        content_hash: None,
+        metadata: None,
     };
 
     let row = remi_sync_row(
@@ -219,6 +218,75 @@ fn test_remi_sparse_entry_builds_normalized_capabilities() {
         requirement.capability == "glibc"
             && requirement.version_constraint.as_deref() == Some(">= 2.39")
     }));
+}
+
+#[test]
+fn test_remi_sparse_entry_preserves_trusted_security_advisory() {
+    let entry = RemiSparseResolutionVersionEntry {
+        version: "3.2.1-1.fc44".to_string(),
+        release: None,
+        architecture: Some("x86_64".to_string()),
+        provides: vec![RemiProvide {
+            capability: "openssl".to_string(),
+            version: Some("3.2.1-1.fc44".to_string()),
+            version_relation: Some(
+                crate::repository::dependency_model::ProvideVersionRelation::Equal,
+            ),
+            kind: "package".to_string(),
+            raw: Some("openssl".to_string()),
+            version_scheme: VersionScheme::Rpm,
+            architecture_qualifier:
+                crate::repository::dependency_model::ProvideArchitectureQualifier::Implicit,
+        }],
+        requirement_groups: Vec::new(),
+        size: 4096,
+        metadata: Some(json!({
+            "security_advisory": {
+                "id": "FEDORA-2026-0001",
+                "source": "remi",
+                "source_trust": "trusted",
+                "severity": "critical",
+                "cves": ["CVE-2026-0001", "CVE-2026-0002"],
+                "fixed_version": "3.2.1-1.fc44",
+                "url": "https://security.example.test/FEDORA-2026-0001"
+            }
+        })),
+    };
+
+    let row = remi_sync_row(
+        7,
+        "https://remi.conary.io".to_string(),
+        "fedora-44".to_string(),
+        "openssl".to_string(),
+        entry,
+    )
+    .unwrap();
+
+    assert!(row.package.is_security_update);
+    assert_eq!(row.package.severity.as_deref(), Some("critical"));
+    assert_eq!(
+        row.package.cve_ids.as_deref(),
+        Some("CVE-2026-0001,CVE-2026-0002")
+    );
+    assert_eq!(
+        row.package.advisory_id.as_deref(),
+        Some("FEDORA-2026-0001")
+    );
+    assert_eq!(
+        row.package.advisory_url.as_deref(),
+        Some("https://security.example.test/FEDORA-2026-0001")
+    );
+
+    let metadata: serde_json::Value =
+        serde_json::from_str(row.package.metadata.as_deref().unwrap()).unwrap();
+    assert_eq!(
+        metadata["security_advisory"]["fixed_version"],
+        "3.2.1-1.fc44"
+    );
+    assert_eq!(
+        metadata["security_advisory"]["source_trust"],
+        "trusted"
+    );
 }
 
 #[test]

--- a/crates/conary-core/src/repository/sync/types.rs
+++ b/crates/conary-core/src/repository/sync/types.rs
@@ -4,8 +4,6 @@ use crate::db::models::{
     RepositoryPackage, RepositoryPackageKey, RepositoryProvide, RepositoryRequirement,
     RepositoryRequirementGroup as DbRequirementGroup,
 };
-use crate::repository::remi_metadata::{RemiProvide, RemiRequirementGroup};
-
 /// A single synced package row with all its normalized capability data.
 #[derive(Debug, Clone)]
 pub(in crate::repository) struct SyncedPackageRow {
@@ -45,24 +43,4 @@ pub(in crate::repository) struct JsonPackageDelta {
     pub(in crate::repository) delta_size: i64,
     pub(in crate::repository) delta_checksum: String,
     pub(in crate::repository) target_size: i64,
-}
-
-/// Response from Remi metadata API (`GET /v1/{distro}/metadata`).
-#[derive(Debug, serde::Deserialize)]
-pub(super) struct RemiMetadataResponse {
-    pub(super) packages: Vec<RemiPackageEntry>,
-}
-
-/// Individual package entry from Remi metadata.
-#[derive(Debug, serde::Deserialize)]
-pub(super) struct RemiPackageEntry {
-    pub(super) name: String,
-    pub(super) version: String,
-    pub(super) release: Option<String>,
-    #[allow(dead_code)] // Present in wire format; not used by sync logic
-    pub(super) converted: bool,
-    pub(super) architecture: Option<String>,
-    pub(super) provides: Vec<RemiProvide>,
-    pub(super) requirement_groups: Vec<RemiRequirementGroup>,
-    pub(super) metadata: Option<serde_json::Value>,
 }

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -111,17 +111,29 @@ Each bounded page is written to a disabled staging repository. The previously
 synced repository remains the only enabled snapshot while network and parsing
 work continues. After the declared name total has been consumed, one SQLite
 transaction replaces the old rows, moves the staged rows to the repository,
-links canonical IDs, and advances `last_sync`. A failed fetch, malformed page,
-duplicate exact version identity, or persistence error deletes the stage and
-leaves the prior snapshot unchanged.
+links canonical IDs, and advances `last_sync`. A fetch, parsing, duplicate
+identity, or persistence error returned to the running command removes its
+stage and leaves the prior enabled snapshot unchanged.
+
+Sparse pages do not yet carry a server-state revision. Stable totals and global
+name ordering detect structural drift, but a same-count or content-only Remi
+update can currently span requests. Process termination can also leave a
+disabled stage because in-process error cleanup is not crash recovery.
+[Issue #163](https://github.com/ConaryLabs/Conary/issues/163) owns the typed
+server revision plus the durable per-repository lease required to reject mixed
+page sets, serialize publication, and prove an abandoned stage before cleanup.
 
 The fixed name page is the structural owner of distribution scaling:
 distribution growth increases page count, not the retained metadata set or
 HTTP request count within one page. Relation collections remain exact native
-semantics and are never truncated to satisfy a guessed byte ceiling. The
-client validates stable totals, global name ordering, page identity, non-empty
-version sets, and unique version/release/architecture identities before a
-page enters the staging repository.
+semantics and are never truncated to satisfy a guessed byte ceiling. The name
+page does not yet structurally bound independently growing version, relation,
+expression, or metadata cardinality; [issue
+#164](https://github.com/ConaryLabs/Conary/issues/164) owns typed sub-page
+continuation plus streaming server/client processing. The client validates
+stable totals, global name ordering, page identity, non-empty version sets, and
+unique version/release/architecture identities before a page enters the
+staging repository.
 
 ## Durable Repository Signing Authority
 

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-07-27
-revision: 10
-summary: Document Remi source, signing, canonical-map, repository trust, conversion, publication, and serving authority
+last_updated: 2026-07-28
+revision: 11
+summary: Document Remi source, sparse sync, signing, canonical-map, repository trust, conversion, publication, and serving authority
 ---
 
 # Remi
@@ -86,6 +86,30 @@ exact-profile handoff from successful refresh results into configured prewarm
 jobs; `apps/remi/src/server/prewarm/scheduler.rs` owns their bounded fair
 execution and complete outcome collection. HTTP handlers only publish events
 and project the shared batch.
+
+## Sparse Client Sync
+
+The Conary `remi` repository strategy consumes only Remi's sparse index. It
+pages through `GET /v1/index/{distro}` in fixed 128-name pages and fetches the
+per-name `GET /v1/index/{distro}/{name}` documents with at most 16 requests in
+flight. Each per-name document carries every version plus the exact normalized
+provides and grouped native requirements required for offline resolution.
+`GET /v1/{distro}/metadata` is not a client-sync fallback.
+
+Each bounded page is written to a disabled staging repository. The previously
+synced repository remains the only enabled snapshot while network and parsing
+work continues. After the declared name total has been consumed, one SQLite
+transaction replaces the old rows, moves the staged rows to the repository,
+links canonical IDs, and advances `last_sync`. A failed fetch, malformed page,
+duplicate exact version identity, or persistence error deletes the stage and
+leaves the prior snapshot unchanged.
+
+The sparse package-list response cap is derived from the endpoint grammar:
+the requested page size, Remi's 256-byte public-name bound, worst-case JSON
+escaping, and the fixed response envelope. Per-package responses have no
+corpus-sized cap; their structural owner is one package name across its
+versions. Distribution growth therefore increases page and request count, not
+the client's retained working set.
 
 ## Durable Repository Signing Authority
 
@@ -204,9 +228,12 @@ or a missing CCS object is data corruption or stale conversion state and
 returns an error or triggers reconversion. It is not converted into a human
 review outcome.
 
-Package detail, metadata, generated indexes, sparse indexes, search, OCI, delta,
-and download routes expose the same sanitized `scriptlets` projection. Program
-bodies and local filesystem paths are not part of that response.
+Package detail, monolithic metadata, generated indexes, search, OCI, delta, and
+download routes expose the sanitized `scriptlets` projection. Sparse index
+documents carry resolution authority—versions, provides, requirements,
+architecture, size, conversion state, and public content hash—rather than the
+diagnostic scriptlet summary. Program bodies and local filesystem paths are
+not part of any public response.
 
 ### Current Converted Artifact Serving
 

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -90,11 +90,22 @@ and project the shared batch.
 ## Sparse Client Sync
 
 The Conary `remi` repository strategy consumes only Remi's sparse index. It
-pages through `GET /v1/index/{distro}` in fixed 128-name pages and fetches the
-per-name `GET /v1/index/{distro}/{name}` documents with at most 16 requests in
-flight. Each per-name document carries every version plus the exact normalized
-provides and grouped native requirements required for offline resolution.
+pages through
+`GET /v1/index/{distro}?page=N&per_page=128&include=versions`. The typed
+expansion returns one resolution-only document per name, including every
+version plus the exact normalized provides and grouped native requirements
+needed for offline resolution, together with persisted package metadata such
+as explicitly trusted security advisories. Conversion-cache state, diagnostic
+scriptlet summaries, and content hashes stay on other public projections
+because sync does not consume them.
 `GET /v1/{distro}/metadata` is not a client-sync fallback.
+
+Remi opens SQLite once for each HTTP page, selects all visible package/version
+rows for the page together, and batch-loads their normalized provides and
+requirement groups. Historical zero-sized discovery placeholders are excluded
+by one shared wire threshold used by the name count, name page, bulk page, and
+per-name lookup; every listed name is therefore fetchable and `total` counts
+that exact set.
 
 Each bounded page is written to a disabled staging repository. The previously
 synced repository remains the only enabled snapshot while network and parsing
@@ -104,12 +115,13 @@ links canonical IDs, and advances `last_sync`. A failed fetch, malformed page,
 duplicate exact version identity, or persistence error deletes the stage and
 leaves the prior snapshot unchanged.
 
-The sparse package-list response cap is derived from the endpoint grammar:
-the requested page size, Remi's 256-byte public-name bound, worst-case JSON
-escaping, and the fixed response envelope. Per-package responses have no
-corpus-sized cap; their structural owner is one package name across its
-versions. Distribution growth therefore increases page and request count, not
-the client's retained working set.
+The fixed name page is the structural owner of distribution scaling:
+distribution growth increases page count, not the retained metadata set or
+HTTP request count within one page. Relation collections remain exact native
+semantics and are never truncated to satisfy a guessed byte ceiling. The
+client validates stable totals, global name ordering, page identity, non-empty
+version sets, and unique version/release/architecture identities before a
+page enters the staging repository.
 
 ## Durable Repository Signing Authority
 
@@ -231,9 +243,9 @@ review outcome.
 Package detail, monolithic metadata, generated indexes, search, OCI, delta, and
 download routes expose the sanitized `scriptlets` projection. Sparse index
 documents carry resolution authority—versions, provides, requirements,
-architecture, size, conversion state, and public content hash—rather than the
-diagnostic scriptlet summary. Program bodies and local filesystem paths are
-not part of any public response.
+architecture, size, persisted package metadata, conversion state, and public
+content hash—rather than the diagnostic scriptlet summary. Program bodies and
+local filesystem paths are not part of any public response.
 
 ### Current Converted Artifact Serving
 

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -112,14 +112,16 @@ requires the declared profile's package format to match the repository parser.
 Remi
 sync and package fetches translate the stored public ID to the profile-owned
 route slug. Remi sync pages through the sparse name index and incrementally
-stages each fixed-size page of per-package version/provide/requirement
-documents; one final transaction replaces the previous offline-resolution
-snapshot. It never fetches the whole-distribution metadata document or retains
-a distribution-sized package vector. Persisted package identity requires the
-exact public ID; route slugs and generic `rpm`/`deb`/`arch` format labels are
-never accepted as source-identity aliases. Native repository sync writes the
-repository's exact profile into every package row and rejects a missing or
-conflicting profile.
+stages each fixed-size `include=versions` page of resolution-only
+version/provide/requirement documents and trusted package-advisory metadata;
+one final transaction replaces the previous offline-resolution snapshot. It
+never fetches the
+whole-distribution metadata document, retains a distribution-sized package
+vector, or issues one HTTP request per package. Persisted package identity
+requires the exact public ID; route slugs and generic `rpm`/`deb`/`arch`
+format labels are never accepted as source-identity aliases. Native repository
+sync writes the repository's exact profile into every package row and rejects
+a missing or conflicting profile.
 The superseded
 `data/distros.toml` catalog was deleted in M4d.
 

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-27
-revision: 17
+last_updated: 2026-07-28
+revision: 18
 summary: Document exact profile-owned source policy, canonical map authority, native repository authority, package identity, and lifecycle handoff
 ---
 
@@ -111,10 +111,15 @@ such as `fedora` and `ubuntu` are not feed IDs. The
 requires the declared profile's package format to match the repository parser.
 Remi
 sync and package fetches translate the stored public ID to the profile-owned
-route slug. Persisted package identity requires the exact public ID; route slugs
-and generic `rpm`/`deb`/`arch` format labels are never accepted as
-source-identity aliases. Native repository sync writes the repository's exact
-profile into every package row and rejects a missing or conflicting profile.
+route slug. Remi sync pages through the sparse name index and incrementally
+stages each fixed-size page of per-package version/provide/requirement
+documents; one final transaction replaces the previous offline-resolution
+snapshot. It never fetches the whole-distribution metadata document or retains
+a distribution-sized package vector. Persisted package identity requires the
+exact public ID; route slugs and generic `rpm`/`deb`/`arch` format labels are
+never accepted as source-identity aliases. Native repository sync writes the
+repository's exact profile into every package row and rejects a missing or
+conflicting profile.
 The superseded
 `data/distros.toml` catalog was deleted in M4d.
 

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -114,14 +114,15 @@ sync and package fetches translate the stored public ID to the profile-owned
 route slug. Remi sync pages through the sparse name index and incrementally
 stages each fixed-size `include=versions` page of resolution-only
 version/provide/requirement documents and trusted package-advisory metadata;
-one final transaction replaces the previous offline-resolution snapshot. It
-never fetches the
-whole-distribution metadata document, retains a distribution-sized package
-vector, or issues one HTTP request per package. Persisted package identity
-requires the exact public ID; route slugs and generic `rpm`/`deb`/`arch`
-format labels are never accepted as source-identity aliases. Native repository
-sync writes the repository's exact profile into every package row and rejects
-a missing or conflicting profile.
+one final transaction publishes the completed local candidate over the
+previous offline-resolution snapshot. The page set is not yet pinned to one
+server revision; `docs/modules/remi.md` records that boundary and its tracked
+lease/revision fix. Sync never fetches the whole-distribution metadata
+document, retains a distribution-sized package vector, or issues one HTTP
+request per package. Persisted package identity requires the exact public ID;
+route slugs and generic `rpm`/`deb`/`arch` format labels are never accepted as
+source-identity aliases. Native repository sync writes the repository's exact
+profile into every package row and rejects a missing or conflicting profile.
 The superseded
 `data/distros.toml` catalog was deleted in M4d.
 


### PR DESCRIPTION
## Primary Issue

Refs #156

Design / Plan / Roadmap:

- `docs/modules/remi.md`
- `docs/modules/source-selection.md`
- Unblocks the supported-host bring-up in #137.

## Problem And Outcome

The Fedora Remi metadata response is larger than the client's 256 MiB decoded-body limit. Raising that limit is not viable: a scratch sync consumed 1,608 MiB peak RSS in the 2 GiB guest class used by the integration lane.

After this PR, Conary no longer downloads or retains a whole-distribution Remi document. It consumes fixed 128-name sparse pages, persists each page into a disabled staging repository, and atomically publishes the completed snapshot. Growth in package-name count increases page count rather than the retained distribution-wide client working set.

## Changes

- Let an explicitly declared package format settle non-static repository kind before the static identity probe, preserving the #137 supported-host add flow.
- Add the typed `include=versions` sparse-page projection shared by Remi and Conary.
- Build each local Remi page through one SQLite connection and batch-load exact provides and grouped requirements; multi-package model reads chunk at the connection's authoritative SQLite bind-variable limit.
- Use one shared visibility predicate for sparse totals, name lists, bulk pages, and per-name lookups so zero-sized discovery placeholders cannot be advertised as fetchable packages.
- Preserve persisted package metadata, including explicitly trusted security advisories, while omitting conversion-cache and diagnostic scriptlet state that sync does not consume.
- Persist pages into a disabled staging repository, then replace the old snapshot and advance `last_sync` in one final transaction. Returned fetch, parse, validation, or persistence failures remove the running command's stage and preserve the prior enabled snapshot.
- Validate page identity, stable totals, global name ordering, shared public-name rules, non-empty version sets, downloadable sizes, unique version/release/architecture identities, checked counters, and row/group cardinality before mutation.
- Make normalized package rows the single persistence authority instead of accepting a second equal-length package vector that could diverge.
- Add Fedora-scale RSS proof using all 67,430 currently listed names.

## Scope

- In scope: local Remi feed sparse sync, exact offline-resolution metadata, atomic replacement, repository-kind selection needed to reach the supported-host feed.
- Tracked separately: federated list/variant authority (#162), server-revision and durable staging-lease semantics (#163), and independently growing per-name version/relation cardinality (#164).
- Release/deploy and live 2 GiB guest proof remain on #156 after merge.

## Ownership / Boundary

- Owning subsystem: `resolution` and `remi` feature cards.
- Boundary changed or preserved: Remi owns typed page projection; Conary owns validation, staging, and final repository publication. Exact source-profile and native relation authority are preserved.
- Persisted state or public surface impact: adds `GET /v1/index/{distro}?page=N&per_page=128&include=versions`; successful sync replaces the existing repository snapshot without a schema change.
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

Exact local and CI head: `c12d7019e71bb28cc742cd130d6a3a33495d93af`.

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code
- [x] Updated subsystem docs or maps when the "look here first" path changed
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs

```text
cargo fmt --check
git diff --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test -p conary-core --no-fail-fast
  3141 passed; 0 failed; 2 ignored; integration targets and doctests passed
  ISSUE156_PACKAGE_COUNT=512   ISSUE156_VM_HWM_KIB=41564
  ISSUE156_PACKAGE_COUNT=67430 ISSUE156_VM_HWM_KIB=44388
cargo test -p remi --no-fail-fast
  586 library + 5 binary + 3 integration passed; 0 failed; doctests passed
cargo test -p conary --no-fail-fast
  939 library passed; 0 failed; 2 ignored; all integration targets and doctests passed
cargo test -p conary-core repository::sync:: --no-fail-fast
  44 passed; 0 failed
cargo test -p remi sparse --no-fail-fast
  22 passed; 0 failed
bash scripts/check-doc-truth.sh
  Documentation truth checks passed.
GitHub Actions pr-gate run 30402951045
  15/15 exact-head checks completed successfully.
```

Still required before #156 closes: merge/release/deploy, independent live endpoint proof, a Fedora sync inside the 2 GiB guest envelope, and resumption of TGE02/TISO01.

## Review And Merge Notes

- Review focus: shared wire completeness, bounded state transitions, batch-query ownership, exact variant identity, and final atomic replacement.
- User or developer impact: `conary repo sync` can consume the production Fedora feed without whole-distribution memory growth.
- Required-check bypass: not used