### PR TITLE
chore(release): prepare Conary v0.14.0 and Remi 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [remi-v0.9.0] - 2026-07-29
+
+### Added
+- add typed result vocabulary for the just-works gate (#114)
+
+### Fixed
+- sync Remi through bounded sparse pages (#161)
+- derive archive decode bounds from the structural owner (#134)
+- stream native authoring instead of buffering whole packages (#136)
+- decode pax xattrs with libarchive's exact writer grammar (#128)
+- derive hardlink metadata from transaction rule (#126)
+- replace the fixed authority ceiling with a shared structural budget (#120)
+- match pacman's authenticated Arch key semantics (#119)
+- decide traversal on exact bytes, not character class (#115)
+- make serving readiness evidence bearing (#113)
+
+## [v0.14.0] - 2026-07-29
+
+### Added
+- add typed result vocabulary for the just-works gate (#114)
+
+### Changed
+- give brand tokens and shared assets one owner (#144)
+
+### Fixed
+- sync Remi through bounded sparse pages (#161)
+- derive archive decode bounds from the structural owner (#134)
+- stream native authoring instead of buffering whole packages (#136)
+- decode pax xattrs with libarchive's exact writer grammar (#128)
+- derive hardlink metadata from transaction rule (#126)
+- replace the fixed authority ceiling with a shared structural budget (#120)
+- match pacman's authenticated Arch key semantics (#119)
+- decide traversal on exact bytes, not character class (#115)
+- make serving readiness evidence bearing (#113)
+
 ## [remi-v0.8.5] - 2026-07-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,7 +994,7 @@ checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "conary"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "conary-bootstrap"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "tokio",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "conary-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "alpm-types",
  "anyhow",
@@ -4857,7 +4857,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remi"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Merge validation](https://github.com/ConaryLabs/Conary/actions/workflows/merge-validation.yml/badge.svg?branch=main)](https://github.com/ConaryLabs/Conary/actions/workflows/merge-validation.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![v0.13.0](https://img.shields.io/badge/version-0.13.0-orange.svg)](CHANGELOG.md)
+[![Release candidate: v0.14.0](https://img.shields.io/badge/release_candidate-v0.14.0-orange.svg)](CHANGELOG.md)
 
 **Website:** [conary.io](https://conary.io) | **Packages:** [remi.conary.io](https://remi.conary.io) | **Discussions:** [GitHub Discussions](https://github.com/ConaryLabs/Conary/discussions)
 
@@ -54,11 +54,11 @@ attach only a reviewed support bundle.
 
 ## Try It
 
-Download the pinned preview release from
-[v0.13.0](https://github.com/ConaryLabs/Conary/releases/tag/v0.13.0), verify
-the package against its published `SHA256SUMS`, and install it only on a VM or
-non-critical host. Release artifact evidence is tracked in
-[docs/operations/release-artifact-matrix.md](docs/operations/release-artifact-matrix.md).
+Release candidate `v0.14.0` is not tester-authoritative until the
+[release artifact matrix](docs/operations/release-artifact-matrix.md) records
+its exact publication, checksums, deployment, and released-package proof. Do
+not download or install the candidate before that gate opens. Once verified,
+install it only on a VM or non-critical host.
 
 Then choose a source whose package format differs from the host and run the
 complete bounded loop:
@@ -133,7 +133,7 @@ first when the command supports it.
 - Native transaction-history import is not implemented.
 - Non-x86_64 generation boot assets are still reserved.
 - The 0.13 schema hard cut is not readable by the 0.12 CCS self-update parser;
-  install the 0.13 native package fresh instead of attempting that in-place
+  install the 0.14 native package fresh instead of attempting that in-place
   update.
 - SBOM/provenance sidecars are not published for the current preview suite.
 

--- a/apps/conary/Cargo.toml
+++ b/apps/conary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conary"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]

--- a/apps/conary/man/conary.1
+++ b/apps/conary/man/conary.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH conary 1  "conary 0.13.0"
+.TH conary 1  "conary 0.14.0"
 .SH NAME
 conary \- Early\-preview Linux package manager with native\-package adoption
 .SH SYNOPSIS
@@ -81,6 +81,6 @@ Daily workflow examples:
 
 Advanced packaging and platform commands: run \*(Aqconary \-\-help\-advanced\*(Aq
 .SH VERSION
-v0.13.0
+v0.14.0
 .SH AUTHORS
 Conary Project

--- a/apps/remi/Cargo.toml
+++ b/apps/remi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remi"
-version = "0.8.5"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]

--- a/crates/conary-bootstrap/Cargo.toml
+++ b/crates/conary-bootstrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conary-bootstrap"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]

--- a/crates/conary-core/Cargo.toml
+++ b/crates/conary-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conary-core"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]

--- a/docs/guides/agent-assisted-tester-loop.md
+++ b/docs/guides/agent-assisted-tester-loop.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-07-26
-revision: 12
-summary: Pin the agent-supervised cross-distro package tester loop to v0.13.0
+last_updated: 2026-07-29
+revision: 13
+summary: Pin the agent-supervised cross-distro package tester loop to v0.14.0
 ---
 
 # Agent-Assisted Tester Loop
@@ -14,9 +14,11 @@ stays responsible for approving every command that mutates system state.
 Use a disposable VM, a snapshot, or a non-critical host. Do not run this loop
 first on an irreplaceable daily driver.
 
-This guide is pinned to `v0.13.0`. Do not begin the loop unless that release
-page publishes the package for this host plus `SHA256SUMS`, and do not continue
-when the downloaded package fails checksum verification.
+This guide is pinned to `v0.14.0`. Do not begin the loop until the
+[current release artifact matrix](https://github.com/ConaryLabs/Conary/blob/main/docs/operations/release-artifact-matrix.md)
+records that tag as published and independently verified, and the release page
+publishes the package for this host plus `SHA256SUMS`. Do not continue when the
+downloaded package fails checksum verification.
 
 ## Copy-Paste Agent Prompt
 
@@ -26,19 +28,19 @@ Paste this into the agent running inside the VM or snapshot:
 I want you to help me run the Conary first external tester loop on this host.
 
 Read this guide first:
-https://github.com/ConaryLabs/Conary/blob/v0.13.0/docs/guides/agent-assisted-tester-loop.md
+https://github.com/ConaryLabs/Conary/blob/v0.14.0/docs/guides/agent-assisted-tester-loop.md
 
 Goal: install, inspect, update-preview, and remove a package whose source
 format differs from this host's native package format with pinned Conary
-v0.13.0, then draft a pre-alpha tester feedback issue. You are testing the user-facing
+v0.14.0, then draft a pre-alpha tester feedback issue. You are testing the user-facing
 cross-distro package-manager flow, not developing Conary itself.
 
 Safety rules:
 - Stop immediately if this is not a VM, snapshot, or explicitly non-critical
   host.
 - Confirm distro, architecture, kernel, and sudo before installing anything.
-- Use only the pinned v0.13.0 release from
-  https://github.com/ConaryLabs/Conary/releases/tag/v0.13.0 and confirm its
+- Use only the pinned v0.14.0 release from
+  https://github.com/ConaryLabs/Conary/releases/tag/v0.14.0 and confirm its
   release page provides the package for this host plus SHA256SUMS.
 - Verify SHA256SUMS for every downloaded artifact before installation.
 - Run dry-run commands before live commands when the loop provides both.
@@ -64,7 +66,7 @@ Stop and do not install Conary if any of these are true:
 - the host is not Fedora 44, Ubuntu 26.04 LTS, or Arch Linux;
 - the host is not `x86_64`;
 - `sudo -v` fails;
-- the pinned `v0.13.0` release page does not provide the package for this host
+- the pinned `v0.14.0` release page does not provide the package for this host
   plus `SHA256SUMS`;
 - downloaded artifact checksums do not match `SHA256SUMS`;
 - the agent or human cannot explain what a live mutation command is about to
@@ -100,45 +102,45 @@ support. Those only matter for generation-model features outside this test.
 Create a clean work directory:
 
 ```bash
-mkdir -p "$HOME/conary-preview-v0.13.0"
-cd "$HOME/conary-preview-v0.13.0"
+mkdir -p "$HOME/conary-preview-v0.14.0"
+cd "$HOME/conary-preview-v0.14.0"
 ```
 
 Download `SHA256SUMS` and the package for the current distro from:
 
 ```text
-https://github.com/ConaryLabs/Conary/releases/tag/v0.13.0
+https://github.com/ConaryLabs/Conary/releases/tag/v0.14.0
 ```
 
 Use exactly one package. Fedora 44:
 
 ```bash
-base="https://github.com/ConaryLabs/Conary/releases/download/v0.13.0"
+base="https://github.com/ConaryLabs/Conary/releases/download/v0.14.0"
 curl -fLO "$base/SHA256SUMS"
-curl -fLO "$base/conary-0.13.0-1.fc44.x86_64.rpm"
+curl -fLO "$base/conary-0.14.0-1.fc44.x86_64.rpm"
 ```
 
 Ubuntu 26.04 LTS:
 
 ```bash
-base="https://github.com/ConaryLabs/Conary/releases/download/v0.13.0"
+base="https://github.com/ConaryLabs/Conary/releases/download/v0.14.0"
 curl -fLO "$base/SHA256SUMS"
-curl -fLO "$base/conary_0.13.0-1_amd64.deb"
+curl -fLO "$base/conary_0.14.0-1_amd64.deb"
 ```
 
 Arch Linux:
 
 ```bash
-base="https://github.com/ConaryLabs/Conary/releases/download/v0.13.0"
+base="https://github.com/ConaryLabs/Conary/releases/download/v0.14.0"
 curl -fLO "$base/SHA256SUMS"
-curl -fLO "$base/conary-0.13.0-1-x86_64.pkg.tar.zst"
+curl -fLO "$base/conary-0.14.0-1-x86_64.pkg.tar.zst"
 ```
 
 Downloaded package names:
 
-- Fedora 44: `conary-0.13.0-1.fc44.x86_64.rpm`
-- Ubuntu 26.04 LTS: `conary_0.13.0-1_amd64.deb`
-- Arch Linux: `conary-0.13.0-1-x86_64.pkg.tar.zst`
+- Fedora 44: `conary-0.14.0-1.fc44.x86_64.rpm`
+- Ubuntu 26.04 LTS: `conary_0.14.0-1_amd64.deb`
+- Arch Linux: `conary-0.14.0-1-x86_64.pkg.tar.zst`
 
 Verify the downloaded package against `SHA256SUMS`:
 
@@ -155,19 +157,19 @@ Ask the human before running the matching install command.
 Fedora 44:
 
 ```bash
-sudo dnf install ./conary-0.13.0-1.fc44.x86_64.rpm
+sudo dnf install ./conary-0.14.0-1.fc44.x86_64.rpm
 ```
 
 Ubuntu 26.04 LTS:
 
 ```bash
-sudo apt install ./conary_0.13.0-1_amd64.deb
+sudo apt install ./conary_0.14.0-1_amd64.deb
 ```
 
 Arch Linux:
 
 ```bash
-sudo pacman -U ./conary-0.13.0-1-x86_64.pkg.tar.zst
+sudo pacman -U ./conary-0.14.0-1-x86_64.pkg.tar.zst
 ```
 
 Then record:

--- a/docs/operations/external-tester-outreach.md
+++ b/docs/operations/external-tester-outreach.md
@@ -1,8 +1,8 @@
 ---
-last_updated: 2026-07-27
-revision: 5
+last_updated: 2026-07-29
+revision: 6
 status: postponed
-target_release: v0.13.0
+target_release: v0.14.0
 summary: Postponed multi-venue launch packet for the first cross-distro tester loop
 ---
 
@@ -11,15 +11,16 @@ summary: Postponed multi-venue launch packet for the first cross-distro tester l
 > **POSTPONED; NO NEW DATE IS ASSIGNED:** the current qualifying milestone is
 > 0/10. The two earlier supported-host reports remain useful adoption and
 > onboarding evidence, but neither installed a source package whose format
-> differed from the host's native format. Release `v0.13.0` is now the
-> published and verified tester baseline. Do not publish the copy below until
-> the separate external cached-history and venue-eligibility gates are closed.
+> differed from the host's native format. Release candidate `v0.14.0` is not
+> yet publication or tester authority. Do not publish the copy below until its
+> release proof and the separate external cached-history and venue-eligibility
+> gates are closed.
 
-`v0.13.0` is the pinned release for this packet. The release artifact matrix
-records its published tag, checksums, signature, installed-binary proof, live
-deployment, and released-package cross-distro lifecycle. The maintainer assigns
-fresh dates only after the remaining external gates close, then posts manually
-and remains available to answer comments.
+`v0.14.0` is the target release for this packet. It becomes pinned only after
+the release artifact matrix records its published tag, checksums, signature,
+installed-binary proof, live deployment, and released-package cross-distro
+lifecycle. The maintainer assigns fresh dates only after every remaining gate
+closes, then posts manually and remains available to answer comments.
 
 ## Show HN Submission
 
@@ -69,10 +70,10 @@ the executor enforcement contract automatically. Unsupported requirements fail
 before mutation; there is no capability-approval bypass.
 
 Agent-assisted walkthrough, including download and checksum verification:
-https://github.com/ConaryLabs/Conary/blob/v0.13.0/docs/guides/agent-assisted-tester-loop.md
+https://github.com/ConaryLabs/Conary/blob/v0.14.0/docs/guides/agent-assisted-tester-loop.md
 
 Pinned release:
-https://github.com/ConaryLabs/Conary/releases/tag/v0.13.0
+https://github.com/ConaryLabs/Conary/releases/tag/v0.14.0
 
 Privacy-safe feedback form:
 https://github.com/ConaryLabs/Conary/issues/new?template=pre_alpha_feedback.md
@@ -111,13 +112,13 @@ The pinned guide asks an agent to preflight a disposable supported VM, verify
 the release checksum, select a source format different from the host format,
 explain the complete dry-run, ask before live mutations, keep a private
 transcript, and draft privacy-safe feedback:
-https://github.com/ConaryLabs/Conary/blob/v0.13.0/docs/guides/agent-assisted-tester-loop.md
+https://github.com/ConaryLabs/Conary/blob/v0.14.0/docs/guides/agent-assisted-tester-loop.md
 
 Repository:
 https://github.com/ConaryLabs/Conary
 
 Pinned release:
-https://github.com/ConaryLabs/Conary/releases/tag/v0.13.0
+https://github.com/ConaryLabs/Conary/releases/tag/v0.14.0
 
 I'm interested both in product defects and in whether repo-owned instructions
 make Codex useful as a supervised systems-test operator. Exact failures,
@@ -149,11 +150,11 @@ contracts while owning the transaction and rollback on the target.
 The guide tells Claude Code to confirm a disposable supported VM, verify the
 pinned release checksum, inspect the complete dry-run, ask before every live
 mutation, keep a private transcript, and draft privacy-safe feedback:
-https://github.com/ConaryLabs/Conary/blob/v0.13.0/docs/guides/agent-assisted-tester-loop.md
+https://github.com/ConaryLabs/Conary/blob/v0.14.0/docs/guides/agent-assisted-tester-loop.md
 
 Repository and pinned release:
 https://github.com/ConaryLabs/Conary
-https://github.com/ConaryLabs/Conary/releases/tag/v0.13.0
+https://github.com/ConaryLabs/Conary/releases/tag/v0.14.0
 
 The useful feedback is where a source-native contract fails, whether Conary
 explains it precisely, whether install/update/remove behave consistently, and
@@ -184,13 +185,13 @@ failed attempts are useful evidence.
   reports as non-qualifying historical evidence.
 - [x] Rewrite the venue copy around the cross-distro package loop.
 - [x] Retire the passed 2026-07-20 through 2026-07-22 dates.
-- [x] Publish immutable `v0.13.0` with RPM, DEB, Arch, CCS, checksums, and the
+- [ ] Publish immutable `v0.14.0` with RPM, DEB, Arch, CCS, checksums, and the
   required signature and installed-binary evidence.
-- [x] Record exact cross-distro install/query/update-preview/remove proof for
+- [ ] Record exact cross-distro install/query/update-preview/remove proof for
   the released binary on supported hosts.
-- [x] Deploy the exact release sites and independently verify live status and
+- [ ] Deploy the exact release sites and independently verify live status and
   body claims.
-- [x] Update the release artifact matrix and milestone tracker with exact
+- [ ] Update the release artifact matrix and milestone tracker with exact
   release, deployment, and Remi population evidence.
 - [ ] Obtain GitHub Support confirmation that cached pre-rewrite pull-request
   and commit views have been dereferenced.

--- a/docs/operations/release-artifact-matrix.md
+++ b/docs/operations/release-artifact-matrix.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-07-27
-revision: 19
-summary: Record the verified post-hard-cut release suite and its limited-preview evidence
+last_updated: 2026-07-29
+revision: 20
+summary: Track the v0.14.0 and Remi 0.9.0 release candidates without treating pending proof as authority
 ---
 
 # Release Artifact Matrix
@@ -17,119 +17,69 @@ the absolute run date, distro, suite, and pass counts.
 
 ## Current Release Suite
 
-Issue #86 produced a split immutable lineage rather than pretending that four
-products published at different times came from one commit:
+Issue #165 prepares Conary `v0.14.0` and `remi-v0.9.0`. Neither candidate is
+current release or production authority yet. Their tag objects, reviewed
+commits, workflow runs, assets, checksums, deployment results, and independent
+behavior proof remain pending below. The previously verified release suite
+continues to serve users until every applicable gate is complete.
 
-- `v0.13.0` and the current `remi-v0.8.5` peel to
-  `6f1429c362ac161f1ef817233e72ee9c9a031c11`;
-- `conaryd-v0.7.0` and `conary-test-v0.9.0` peel to
-  `a231276a900bbe8a8ccb6a0942f104cba2ab86b4`;
-- published Remi 0.8.0 through 0.8.4 releases remain immutable recovery
-  evidence, but none is current production authority.
-
-Conary and Remi are deployed and independently identified below. Conary's
-published native-package lifecycle matrix passed on all three supported hosts,
-so the bounded pre-alpha preview is open. Broad outreach remains separately
-postponed.
+The build-only conaryd and conary-test releases retain their existing immutable
+lineage. Broad external outreach remains separately postponed at 0/10
+qualifying completions.
 
 | Product | Artifact classes | Release workflow | Source authority | Release URL | Required evidence | Preview support | Known caveats | Source-build fallback |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `conary` | binary, `.ccs`, `.rpm`, `.deb`, `.pkg.tar.zst` | `.github/workflows/release-build.yml`, `scripts/release.sh conary`, `scripts/release-matrix.sh` | annotated tag object `f8298522fd7fe95a4994184ae20c34cf64096818`, commit `6f1429c362ac161f1ef817233e72ee9c9a031c11` | https://github.com/ConaryLabs/Conary/releases/tag/v0.13.0 | exact publication, checksums, GitHub digests, detached signature, current binary/self-update, deployment, endpoint, site, released-package lifecycle, SBOM, and provenance status recorded below | limited pre-alpha preview | disposable, snapshotted, or explicitly non-critical x86_64 Fedora 44, Ubuntu 26.04 LTS, and Arch hosts only; the intentional schema hard cut requires a fresh native-package install from 0.12 | `cargo build -p conary` |
-| `remi` | binary and deploy bundle | `.github/workflows/release-build.yml`, `scripts/release.sh remi`, `scripts/release-matrix.sh` | annotated tag object `1d9b8588fe01453bab20f1a7956e4aa9d6263702`, commit `6f1429c362ac161f1ef817233e72ee9c9a031c11` | https://github.com/ConaryLabs/Conary/releases/tag/remi-v0.8.5 | exact publication, checksums, installed identity, signature, protected deployment, current schema/source/signing state, conversions, full health, public converted CCS, SBOM, and provenance status recorded below | live operator service | conversion defects are explicit engineering work in #98, #99, and #102 through #105; unknown `/v1` paths currently receive the SPA fallback instead of an API 404 and are tracked in #67 | `cargo build -p remi` |
-| `conaryd` | binary and tarball | `.github/workflows/release-build.yml`, `scripts/release.sh conaryd`, `scripts/release-matrix.sh` | annotated tag object `381ee55cd051234dd78647ef5d7a8c3250c6b9df`, commit `a231276a900bbe8a8ccb6a0942f104cba2ab86b4` | https://github.com/ConaryLabs/Conary/releases/tag/conaryd-v0.7.0 | exact publication, three-asset inventory, matching independent/GitHub checksums, raw/tar identity, binary version, build-only routing, signature, SBOM, and provenance status recorded below | release artifact only; no deployment | Forge staging remains paused; package jobs retain the CLI live-mutation acknowledgement boundary | `cargo build -p conaryd` |
-| `conary-test` | binary and tarball | `.github/workflows/release-build.yml`, `scripts/release.sh conary-test`, `scripts/release-matrix.sh` | annotated tag object `6c4a8cb4bb2c6e89f359a8ceb89ac40a5ce06890`, commit `a231276a900bbe8a8ccb6a0942f104cba2ab86b4` | https://github.com/ConaryLabs/Conary/releases/tag/conary-test-v0.9.0 | exact publication, three-asset inventory, matching independent/GitHub checksums, raw/tar identity, binary version, suite inventory, build-only routing, signature, SBOM, and provenance status recorded below | release artifact only; no deployment | QEMU/KVM suites require a capable local host while remote validation is paused | `cargo build -p conary-test` |
+| `conary` | binary, `.ccs`, `.rpm`, `.deb`, `.pkg.tar.zst` | `.github/workflows/release-build.yml`, `scripts/release.sh conary`, `scripts/release-matrix.sh` | candidate `v0.14.0`; annotated tag object and reviewed commit pending | https://github.com/ConaryLabs/Conary/releases/tag/v0.14.0 | publication, checksums, GitHub digests, detached signature, current binary/self-update, deployment, endpoint, site, released-package lifecycle, SBOM, and provenance proof all pending | not yet preview-supported | use only after this matrix records complete proof; supported scope will remain disposable, snapshotted, or explicitly non-critical x86_64 Fedora 44, Ubuntu 26.04 LTS, and Arch hosts | `cargo build -p conary` |
+| `remi` | binary and deploy bundle | `.github/workflows/release-build.yml`, `scripts/release.sh remi`, `scripts/release-matrix.sh` | candidate `remi-v0.9.0`; annotated tag object and reviewed commit pending | https://github.com/ConaryLabs/Conary/releases/tag/remi-v0.9.0 | publication, checksums, installed identity, signature, protected deployment, current schema/source/signing state, conversions, full health, public converted CCS, SBOM, and provenance proof all pending | not yet production authority | the prior verified deployment remains authoritative until exact release and live proof complete | `cargo build -p remi` |
+| `conaryd` | binary and tarball | `.github/workflows/release-build.yml`, `scripts/release.sh conaryd`, `scripts/release-matrix.sh` | annotated tag object `381ee55cd051234dd78647ef5d7a8c3250c6b9df`, commit `a231276a900bbe8a8ccb6a0942f104cba2ab86b4` | https://github.com/ConaryLabs/Conary/releases/tag/conaryd-v0.7.0 | exact publication, checksums, raw/tar identity, binary version, build-only routing, signature, SBOM, and provenance recorded below | release artifact only; no deployment | Forge staging remains paused; package jobs retain the CLI live-mutation acknowledgement boundary | `cargo build -p conaryd` |
+| `conary-test` | binary and tarball | `.github/workflows/release-build.yml`, `scripts/release.sh conary-test`, `scripts/release-matrix.sh` | annotated tag object `6c4a8cb4bb2c6e89f359a8ceb89ac40a5ce06890`, commit `a231276a900bbe8a8ccb6a0942f104cba2ab86b4` | https://github.com/ConaryLabs/Conary/releases/tag/conary-test-v0.9.0 | exact publication, checksums, raw/tar identity, binary version, suite inventory, build-only routing, signature, SBOM, and provenance recorded below | release artifact only; no deployment | QEMU/KVM suites require a capable local host while remote validation is paused | `cargo build -p conary-test` |
 
 ## Recorded Evidence
 
-### Conary 0.13.0
+### Conary 0.14.0 candidate
 
-- The release published at `2026-07-27T11:57:44Z`. Exact-tag
-  release-build run `30261256730` passed the workspace gate and all four
-  package builders.
-- Independent downloads found exactly seven assets. Their SHA-256 values
-  matched the GitHub REST digests:
-  - `SHA256SUMS`:
-    `ce67a7199f8adafec8d1a47a29d5b3ccd0c32068fff0804653251daa35d436c7`
-  - `conary-0.13.0-1-x86_64.pkg.tar.zst`:
-    `a2905964c1272ab0e7c963102429501fa4ab05a6b569b8b1d1f02b5be4e20997`
-  - `conary-0.13.0-1.fc44.x86_64.rpm`:
-    `f65adc8cad33e46c26d3aa6dcb0d47a89382857e5ece0f7fe6da7b787d4d76d8`
-  - `conary-0.13.0.ccs`:
-    `9f6bb7208aaf196a73a482d32aec918cb032857a002c85ecc40c51e4c44bd927`
-  - `conary-0.13.0.ccs.sig`:
-    `b47bde4d29394558dd0bd15554dc6e79f05776886f0c63807a0c3a644eb01a00`
-  - `conary_0.13.0-1_amd64.deb`:
-    `c67ea72ac8b8a3d061b6f0bf943fab1bb15258cfc7d6d3d0b0dea9bf2b472b9c`
-  - `metadata.json`:
-    `386f3ef51846d20186a6a42fda1dc14c8f0bda56db46ba57445974ec2ae26a90`
-- All five `SHA256SUMS` entries passed. Metadata names product `conary`,
-  version `0.13.0`, tag `v0.13.0`, live `release_bundle` deployment, and
-  `dry_run: false`. Extracted RPM and DEB binaries report `conary 0.13.0`;
-  the Arch package declares `conary 0.13.0-1 x86_64`.
-- The official 0.12 binary and embedded release key verified the detached
-  signature over the CCS digest. A copied released 0.13.0 RPM binary then
-  initialized an isolated database, reported itself current, forced a signed
-  download, verified and extracted the CCS, replaced only its copied binary,
-  and again reported `conary 0.13.0` and current.
-- The 0.12 binary intentionally cannot parse the current CCS component
-  manifest after the schema hard cut. This suite does not restore a legacy
-  parser: install the 0.13 native package fresh instead of claiming an
-  in-place 0.12-to-0.13 self-update.
-- Deploy job `deploy-conary` in run `30263948968` passed. The server's
-  `/conary/releases/latest` selects `0.13.0`; all seven deployed hashes match
-  the release; the self-update endpoint reports version `0.13.0`, the exact
-  CCS hash and size, and a signature. Both sites were built from the exact tag:
-  conary.io and its install guide serve `v0.13.0`, while an unknown route
-  returns the branded HTTP 404.
-- Run `30263948968` completed successfully. Its immutable RPM, DEB, and Arch
-  packages installed through the native package managers on Fedora 44, Ubuntu
-  26.04 LTS, and Arch; each host passed the one owned Cartesian
-  native-cross-source lifecycle suite, and the aggregate
-  `release-artifact-proof` job passed.
-- No SBOM or provenance sidecars are published. The CCS has both its embedded
-  package authority and the separately verified release-digest signature.
+- Owned manifests, packaging metadata, the generated man page, site release
+  data, tester guide, and changelog are prepared for `v0.14.0` on issue #165.
+- The annotated tag object and peeled reviewed commit are pending.
+- Exact-tag release-build and publication are pending. No asset inventory,
+  checksum, GitHub digest, detached-signature, installed-binary, or forced
+  self-update result is claimed.
+- Protected deployment, public endpoint identity, exact-tag site content,
+  branded HTTP 404, and released native-package lifecycle proof are pending.
+- SBOM and provenance status will be recorded from the published asset
+  inventory rather than inferred from the candidate tree.
 
-### Remi 0.8.5
+Expected package asset names after successful publication are:
 
-- Exact-tag release-build run `30259180128` passed, and the release published
-  at `2026-07-27T11:09:12Z`.
-- Independent downloads found exactly three assets whose SHA-256 values
-  matched GitHub: `metadata.json`
-  `e036548d3469a1ffd28d8687ffae1fb7b88662d7d284a7cbbe08015dc2f79bc8`,
-  raw binary
-  `ad949c026578bbadc8f45402d167b577f28fec5c3780839ac27c09d4718f008d`,
-  and tarball
-  `dfae67f91adc268009bd6f8e128ffd1f8103d82efe92d729da319e88bf3cc42a`.
-  Raw and tarred binaries are identical and report `remi 0.8.5`.
-- Protected deploy run `30260847616` passed. Independent inspection reports
-  schema epoch `conary-current-v1`, revision 21, five configured and populated
-  sources, 98,266 repository packages, exact signing profiles `arch`,
-  `fedora-44`, and `ubuntu-26.04`, and 2,368 current conversions at the final
-  release check.
-- Full public health passes 10/10. A Fedora `curl` request returns a converted,
-  native-free CCS artifact. No detached binary signature, SBOM, or provenance
-  sidecar is published for this release.
+- `conary-0.14.0-1.fc44.x86_64.rpm`
+- `conary_0.14.0-1_amd64.deb`
+- `conary-0.14.0-1-x86_64.pkg.tar.zst`
+- `conary-0.14.0.ccs`
+- `conary-0.14.0.ccs.sig`
+- `SHA256SUMS`
+- `metadata.json`
+
+### Remi 0.9.0 candidate
+
+- The owned manifest and changelog are prepared for `remi-v0.9.0` on issue
+  #165.
+- The annotated tag object, peeled reviewed commit, exact-tag release-build,
+  publication, three-asset inventory, checksums, binary identity, signature,
+  SBOM, and provenance status are pending.
+- Protected deployment and independent schema, revision, source population,
+  signing-profile, conversion, full-health, and public converted-CCS proof are
+  pending. The candidate must not replace current production authority before
+  those checks pass.
 
 ### conaryd 0.7.0 and conary-test 0.9.0
 
 - Release-build runs `30225403876` and `30225404886` passed at their shared
   immutable commit; deploy-routing runs `30226301835` and `30226177794`
   selected `no-deploy-required`, as the matrix requires.
-- conaryd published at `2026-07-26T23:56:22Z`. Its metadata, raw binary, and
-  tarball hashes are respectively
-  `a9c902fad9dc9be09608a0d8e3e699fa7178d727822bc507d18bdc503b25d612`,
-  `3e1559b13386ddd1effedc96a1f083c200e1b3bed2d062135b5e687143c259b3`,
-  and `6bacb205a945150a6bfd4039370d54b5dc5a56599b63a4c51ac9e675fc5bf1f6`.
-  Independent downloads match GitHub, raw and tarred binaries are identical,
-  and the binary reports `conaryd 0.7.0`.
-- conary-test published at `2026-07-26T23:52:48Z`. Its metadata, raw binary,
-  and tarball hashes are respectively
-  `ba29e17684039588340e58c4363db1c38f064781f58c030c326952c75c8480f9`,
-  `1d8a4c7fa78c2e20955fd43c4e8c55ee263b768e8e743a19cbd657667feb5ecc`,
-  and `e1476e24c6aa78f079d5374590f034bcd26860be0da98c4fd15ef31a7204f967`.
-  Independent downloads match GitHub, raw and tarred binaries are identical,
-  the binary reports `conary-test 0.9.0`, and `list` exposes the native
-  cross-source lifecycle plus the complete owned suite inventory.
+- Independent downloads matched GitHub checksums, raw and tarred binaries were
+  identical, and the binaries reported their owned versions. conary-test
+  exposed the native cross-source lifecycle and complete owned suite
+  inventory.
 - Neither build-only product publishes a detached signature, SBOM, or
   provenance sidecar.
 

--- a/docs/roadmaps/external-tester-milestone.md
+++ b/docs/roadmaps/external-tester-milestone.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-27
-revision: 5
+last_updated: 2026-07-29
+revision: 6
 status: active
 current_result: 0/10
 summary: Outcome tracker for Conary's first cross-distro external tester milestone
@@ -35,26 +35,19 @@ but does not count as a completion.
 
 ## Release Gate
 
-The pinned tester release is the verified immutable `v0.13.0` recorded in
-`docs/operations/release-artifact-matrix.md`. Its release gate is complete:
+Release candidate `v0.14.0` is the intended pinned tester release. Its release
+gate remains open until `docs/operations/release-artifact-matrix.md` records:
 
-- annotated tag object `f8298522fd7fe95a4994184ae20c34cf64096818`
-  peels to `6f1429c362ac161f1ef817233e72ee9c9a031c11`;
-- release-build run `30261256730` published the exact seven-asset suite, and
-  independent downloads matched all five checksum entries and every GitHub
-  digest;
-- the detached CCS signature, current 0.13 binary identity, signed forced
-  self-update, deployed release directory, and public self-update endpoint
-  agree;
-- the schema hard cut is explicit: install the 0.13 native package fresh
-  instead of attempting to self-update the incompatible 0.12 CCS parser;
-- deploy-and-proof run `30263948968` installed the immutable RPM, DEB, and
-  Arch packages natively and passed the Cartesian lifecycle on Fedora 44,
-  Ubuntu 26.04 LTS, and Arch;
-- exact-tag Conary sites serve 0.13.0 with a real branded 404, and compatible
-  `remi-v0.8.5` production passes full health with all five sources populated
-  and real conversions for every public profile;
-- signature, SBOM, and provenance statuses are explicit in the release matrix.
+- the annotated tag object and reviewed commit;
+- a terminal exact-tag release-build and the complete seven-asset inventory;
+- matching independent checksums and GitHub digests;
+- detached CCS signature, installed-binary, and self-update proof;
+- exact-tag deployment plus independent endpoint and site verification;
+- native RPM, DEB, and Arch installation and the Cartesian lifecycle proof on
+  Fedora 44, Ubuntu 26.04 LTS, and Arch;
+- compatible `remi-v0.9.0` production identity, schema/source/signing state,
+  full health, and a real public converted CCS artifact;
+- explicit signature, SBOM, and provenance status.
 
 Release proof is not an external-user completion. The result therefore remains
 0/10, and broad outreach remains postponed by the separate cached-history and

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -4,7 +4,7 @@
 # Builds from a vendored source tarball (no network access needed during build).
 
 pkgname=conary
-pkgver=0.13.0
+pkgver=0.14.0
 pkgrel=1
 pkgdesc='Early-preview Linux package manager with native-package adoption'
 arch=('x86_64')

--- a/packaging/ccs/ccs.toml
+++ b/packaging/ccs/ccs.toml
@@ -11,7 +11,7 @@ requirements = [
 
 [package]
 name = "conary"
-version = "0.13.0"
+version = "0.14.0"
 version_scheme = "conary"
 release = "1"
 kind = "package"

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,9 @@
+conary (0.14.0-1) unstable; urgency=medium
+
+  * Release 0.14.0
+
+ -- Conary Contributors <contributors@conary.io>  Wed, 29 Jul 2026 00:26:45 +0200
+
 conary (0.13.0-1) unstable; urgency=medium
 
   * Release 0.13.0

--- a/packaging/rpm/conary.spec
+++ b/packaging/rpm/conary.spec
@@ -1,7 +1,7 @@
 %global crate conary
 
 Name:           conary
-Version:        0.13.0
+Version:        0.14.0
 Release:        1%{?dist}
 Summary:        Early-preview Linux package manager with native-package adoption
 

--- a/site/src/lib/preview-release.ts
+++ b/site/src/lib/preview-release.ts
@@ -6,8 +6,8 @@ export type PreviewTarget = {
 	installCommand: string;
 };
 
-const version = '0.13.0';
-const tag = 'v0.13.0';
+const version = '0.14.0';
+const tag = 'v0.14.0';
 const releaseUrl = `https://github.com/ConaryLabs/Conary/releases/tag/${tag}`;
 const downloadBaseUrl = `https://github.com/ConaryLabs/Conary/releases/download/${tag}`;
 
@@ -24,22 +24,22 @@ export const previewRelease = {
 			id: 'fedora',
 			name: 'Fedora 44',
 			profile: 'fedora-44',
-			asset: 'conary-0.13.0-1.fc44.x86_64.rpm',
-			installCommand: 'sudo dnf install ./conary-0.13.0-1.fc44.x86_64.rpm'
+			asset: 'conary-0.14.0-1.fc44.x86_64.rpm',
+			installCommand: 'sudo dnf install ./conary-0.14.0-1.fc44.x86_64.rpm'
 		},
 		{
 			id: 'ubuntu',
 			name: 'Ubuntu 26.04 LTS',
 			profile: 'ubuntu-26.04',
-			asset: 'conary_0.13.0-1_amd64.deb',
-			installCommand: 'sudo apt install ./conary_0.13.0-1_amd64.deb'
+			asset: 'conary_0.14.0-1_amd64.deb',
+			installCommand: 'sudo apt install ./conary_0.14.0-1_amd64.deb'
 		},
 		{
 			id: 'arch',
 			name: 'Arch Linux',
 			profile: 'arch',
-			asset: 'conary-0.13.0-1-x86_64.pkg.tar.zst',
-			installCommand: 'sudo pacman -U ./conary-0.13.0-1-x86_64.pkg.tar.zst'
+			asset: 'conary-0.14.0-1-x86_64.pkg.tar.zst',
+			installCommand: 'sudo pacman -U ./conary-0.14.0-1-x86_64.pkg.tar.zst'
 		}
 	] satisfies PreviewTarget[]
 } as const;


### PR DESCRIPTION
## Primary Issue

Refs #165

Design / Plan / Roadmap: `docs/operations/release-artifact-matrix.md`

## Problem And Outcome

Conary and Remi need reviewed, version-aligned source authority before immutable release tags can be published. After merge, the reviewed commit will own Conary 0.14.0 and Remi 0.9.0 across manifests, packaging, generated help, and public release surfaces, while publication and deployment evidence remain explicitly pending.

## Changes

- bump Conary, conary-core, and conary-bootstrap to 0.14.0 and Remi to 0.9.0
- align Cargo.lock, RPM/DEB/Arch/CCS packaging, generated man page, and changelog
- pin the site and tester guide to v0.14.0 assets
- put README, release matrix, milestone, and postponed outreach packet into an explicit candidate state without inventing tag, asset, CI, deployment, or live proof

## Scope

- In scope: reviewed release source, owned versions, packaging identity, candidate public truth, and pre-publication verification
- Out of scope: tag creation, GitHub release publication, deployment, live endpoint proof, released native-package lifecycle proof, and final evidence recording; issue #165 remains open for those gates

## Ownership / Boundary

- Owning subsystem: release
- Boundary changed or preserved: preserves the exact-tag reviewed-commit boundary and keeps pending candidates separate from publication authority
- Persisted state or public surface impact: no schema change; candidate version/help/site/tester surfaces advance to v0.14.0 and explicitly block use until recorded proof exists
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed (no runtime behavior changed; existing release truth and ownership tests cover this slice)
- [x] Ran affected-package verification directly when touching service or daemon code (manifest-only Remi change; release-card and workspace verification run)
- [x] Updated subsystem docs or maps when the "look here first" path changed (not applicable; routing is unchanged)
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs

```text
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p conary-core --example sign_hash
- cargo test -p conary --test release_ccs_manifest
- cargo test -p conary-test container::image
- cargo run -p conary-test -- list
- bash scripts/check-doc-truth.sh
- bash scripts/test-doc-truth.sh
- bash scripts/check-release-matrix.sh
- bash scripts/test-release-matrix.sh
- bash scripts/release-cargo-audit.sh
- bash scripts/test-deploy-sites.sh
- npm ci --prefix site
- npm run check --prefix site
- npm run build --prefix site
- bash scripts/release-matrix.sh assert-owned-version conary 0.14.0
- bash scripts/release-matrix.sh assert-owned-version remi 0.9.0
- git diff --check
```

The RustSec audit completed with its two repository-allowed warnings (`RUSTSEC-2026-0173` for unmaintained `proc-macro-error2` and yanked `spin` 0.9.8); no vulnerability failure was reported.

## Review And Merge Notes

- Review focus: version ownership completeness and the candidate-versus-published truth boundary
- User or developer impact: no candidate should be installed until the matrix is replaced with exact successful release/deployment evidence
- Required-check bypass: not used