### PR TITLE
fix(deploy): publish immutable test artifacts

### DIFF
--- a/deploy/remi-deploy-helper.sh
+++ b/deploy/remi-deploy-helper.sh
@@ -19,6 +19,7 @@ usage:
   conary-remi-deploy deploy-conary <version> <staging-dir>
   conary-remi-deploy deploy-remi <version> <bundle.tar.gz> <repositories.toml> <max-concurrent>
   conary-remi-deploy deploy-site <site|web> <staging-dir>
+  conary-remi-deploy publish-test-artifact <filename> <sha256> <staged-file>
   conary-remi-deploy install-helper <sha256> <helper>
   conary-remi-deploy inspect-remi [--require-repopulated]
   conary-remi-deploy verify-access
@@ -63,6 +64,12 @@ validate_site_target() {
         site|web) ;;
         *) die "invalid site target: $target" ;;
     esac
+}
+
+validate_artifact_filename() {
+    local filename="$1"
+    [[ "$filename" =~ ^[0-9A-Za-z][0-9A-Za-z._+-]*$ ]] ||
+        die "invalid test-artifact filename: $filename"
 }
 
 real_tmp_path() {
@@ -313,6 +320,71 @@ deploy_site() {
     rmdir "$parent" 2>/dev/null || true
 }
 
+publish_test_artifact() {
+    local filename="$1"
+    local expected_sha="$2"
+    local source_arg="$3"
+    local source
+    validate_artifact_filename "$filename"
+    validate_sha256 "$expected_sha"
+    [[ ! -L "$source_arg" ]] ||
+        die "test-artifact source must not be a symlink: $source_arg"
+    source="$(real_tmp_path "$source_arg")"
+    [[ -f "$source" && ! -L "$source" ]] ||
+        die "test-artifact source is not a plain file: $source"
+
+    local size actual_sha conary_root artifact_root target next
+    size="$(stat -c '%s' "$source")"
+    (( size > 0 )) || die "test artifact must not be empty"
+    (( size <= 8 * 1024 * 1024 * 1024 )) ||
+        die "test artifact exceeds the 8 GiB publication limit"
+    actual_sha="$(sha256sum "$source" | cut -d ' ' -f 1)"
+    [[ "$actual_sha" == "$expected_sha" ]] || die "test-artifact SHA-256 mismatch"
+
+    conary_root="$(root_path /conary)"
+    artifact_root="$(root_path /conary/test-artifacts)"
+    target="${artifact_root}/${filename}"
+    next="${artifact_root}/.${filename}.next.$$"
+    install_owned_dir 0750 "$conary_root"
+    if [[ -e "$artifact_root" || -L "$artifact_root" ]]; then
+        [[ -d "$artifact_root" && ! -L "$artifact_root" ]] ||
+            die "test-artifact root is not a plain directory: $artifact_root"
+    else
+        install_owned_dir 0755 "$artifact_root"
+    fi
+
+    if [[ -e "$target" || -L "$target" ]]; then
+        [[ -f "$target" && ! -L "$target" ]] ||
+            die "published test-artifact target is not a plain file: $target"
+        actual_sha="$(sha256sum "$target" | cut -d ' ' -f 1)"
+        [[ "$actual_sha" == "$expected_sha" ]] ||
+            die "immutable test-artifact target already exists with a different SHA-256: $target"
+        rm -f "$source"
+        printf 'Test artifact already published: %s sha256=%s size=%s\n' \
+            "$filename" "$expected_sha" "$size"
+        return
+    fi
+
+    trap 'rm -f "$next"' EXIT
+    install_owned_file 0644 "$source" "$next"
+    actual_sha="$(sha256sum "$next" | cut -d ' ' -f 1)"
+    [[ "$actual_sha" == "$expected_sha" ]] ||
+        die "staged test-artifact changed during publication"
+
+    if ! ln "$next" "$target"; then
+        [[ -f "$target" && ! -L "$target" ]] ||
+            die "test-artifact target appeared during publication: $target"
+        actual_sha="$(sha256sum "$target" | cut -d ' ' -f 1)"
+        [[ "$actual_sha" == "$expected_sha" ]] ||
+            die "immutable test-artifact target raced with a different SHA-256: $target"
+    fi
+    rm -f "$next" "$source"
+    trap - EXIT
+
+    printf 'Published test artifact: %s sha256=%s size=%s\n' \
+        "$filename" "$expected_sha" "$size"
+}
+
 install_helper() {
     local expected_sha="$1"
     local source
@@ -364,6 +436,10 @@ case "${1:-}" in
     deploy-site)
         [[ $# -eq 3 ]] || usage
         deploy_site "$2" "$3"
+        ;;
+    publish-test-artifact)
+        [[ $# -eq 4 ]] || usage
+        publish_test_artifact "$2" "$3" "$4"
         ;;
     install-helper)
         [[ $# -eq 3 ]] || usage

--- a/docs/modules/test-fixtures.md
+++ b/docs/modules/test-fixtures.md
@@ -437,9 +437,12 @@ Each fixture family should record:
   key with matching hashes and passed TGE01 under KVM in 63,320 ms.
 - **Safety notes:** Never overwrite the source image. Keep the generated
   private key mode `0600`; it is a disposable test credential, not a Remi,
-  federation, release-signing, or operator identity. Publish image/key
-  replacements only through the authenticated Remi admin test-artifact route,
-  and update every active manifest to one version before accepting the gate.
+  federation, release-signing, or operator identity. Publish small image/key
+  replacements through the authenticated Remi admin test-artifact route, or
+  large images through the digest-pinned, immutable
+  `conary-remi-deploy publish-test-artifact` operation after authenticated SSH
+  staging. Update every active manifest to one version before accepting the
+  gate.
 
 ## How To Use This Map
 

--- a/docs/operations/infrastructure.md
+++ b/docs/operations/infrastructure.md
@@ -167,6 +167,13 @@ not cover the task or when you are debugging the underlying service path itself.
   files into `/conary/releases/<version>`. The helper copies that verified
   checksum file as release evidence, refuses symlinked trust inputs, and
   requires `<artifact>.ccs.sig` whenever a staged `.ccs` artifact is present.
+- Large QEMU fixtures use the helper's bounded
+  `publish-test-artifact <filename> <sha256> <staged-file>` operation after
+  authenticated SSH staging under `/tmp`. It accepts only a plain basename and
+  regular file, enforces Remi's 8 GiB limit, verifies the caller-pinned digest
+  before publication, and creates an immutable `/conary/test-artifacts/`
+  target atomically. Repeating the exact publication is idempotent; a
+  same-name, different-digest replacement fails closed.
 - Bootstrap or repair deploy access once from an existing privileged shell with
   `sudo scripts/install-remi-deploy-access.sh`. It installs
   `deploy/remi-deploy-helper.sh` to `/usr/local/sbin/conary-remi-deploy`,

--- a/scripts/test-remi-deploy-helper.sh
+++ b/scripts/test-remi-deploy-helper.sh
@@ -231,6 +231,89 @@ test_deploy_site_rejects_unknown_target() {
     expect_fail "unknown site target" run_helper "$fake_root" deploy-site admin "$staging"
 }
 
+test_publish_test_artifact_is_verified_atomic_and_idempotent() {
+    local fake_root="${tmpdir}/root-test-artifact"
+    local staged="${tmpdir}/fedora44-guest-v1.qcow2"
+    local digest
+    write_config "$fake_root"
+    printf 'qcow2-test-bytes\n' >"$staged"
+    digest="$(sha256sum "$staged" | cut -d ' ' -f 1)"
+
+    run_helper "$fake_root" publish-test-artifact \
+        fedora44-guest-v1.qcow2 "$digest" "$staged"
+
+    local published="$fake_root/conary/test-artifacts/fedora44-guest-v1.qcow2"
+    test -f "$published"
+    test ! -L "$published"
+    test ! -e "$staged"
+    test "$(sha256sum "$published" | cut -d ' ' -f 1)" = "$digest"
+    test "$(stat -c '%a' "$published")" = "644"
+
+    printf 'qcow2-test-bytes\n' >"$staged"
+    run_helper "$fake_root" publish-test-artifact \
+        fedora44-guest-v1.qcow2 "$digest" "$staged"
+    test ! -e "$staged"
+    test "$(sha256sum "$published" | cut -d ' ' -f 1)" = "$digest"
+}
+
+test_publish_test_artifact_rejects_unverified_or_mutating_inputs() {
+    local fake_root="${tmpdir}/root-test-artifact-rejections"
+    local staged="${tmpdir}/fedora44-guest-v1-rejected.qcow2"
+    local digest
+    write_config "$fake_root"
+    printf 'original\n' >"$staged"
+    digest="$(sha256sum "$staged" | cut -d ' ' -f 1)"
+
+    expect_fail "invalid test-artifact filename" \
+        run_helper "$fake_root" publish-test-artifact \
+        ../escape.qcow2 "$digest" "$staged"
+    expect_fail "test-artifact digest mismatch" \
+        run_helper "$fake_root" publish-test-artifact \
+        fedora44-guest-v1.qcow2 \
+        0000000000000000000000000000000000000000000000000000000000000000 \
+        "$staged"
+
+    local empty="${tmpdir}/empty.qcow2"
+    : >"$empty"
+    expect_fail "empty test artifact" \
+        run_helper "$fake_root" publish-test-artifact \
+        empty.qcow2 \
+        e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 \
+        "$empty"
+
+    local oversized="${tmpdir}/oversized.qcow2"
+    truncate -s 8589934593 "$oversized"
+    expect_fail "oversized test artifact" \
+        run_helper "$fake_root" publish-test-artifact \
+        oversized.qcow2 \
+        0000000000000000000000000000000000000000000000000000000000000000 \
+        "$oversized"
+
+    local symlinked="${tmpdir}/symlinked.qcow2"
+    ln -s "$staged" "$symlinked"
+    expect_fail "symlinked test artifact" \
+        run_helper "$fake_root" publish-test-artifact \
+        symlinked.qcow2 "$digest" "$symlinked"
+
+    local directory="${tmpdir}/directory.qcow2"
+    mkdir "$directory"
+    expect_fail "directory test artifact" \
+        run_helper "$fake_root" publish-test-artifact \
+        directory.qcow2 "$digest" "$directory"
+
+    run_helper "$fake_root" publish-test-artifact \
+        fedora44-guest-v1.qcow2 "$digest" "$staged"
+    printf 'replacement\n' >"$staged"
+    local replacement_digest
+    replacement_digest="$(sha256sum "$staged" | cut -d ' ' -f 1)"
+    expect_fail "immutable test-artifact replacement" \
+        run_helper "$fake_root" publish-test-artifact \
+        fedora44-guest-v1.qcow2 "$replacement_digest" "$staged"
+    test -e "$staged"
+    test "$(sha256sum "$fake_root/conary/test-artifacts/fedora44-guest-v1.qcow2" |
+        cut -d ' ' -f 1)" = "$digest"
+}
+
 test_deploy_remi_uses_candidate_owned_transition() {
     local fake_root="${tmpdir}/root-remi"
     local bundle="${tmpdir}/remi-0.8.0.tar.gz"
@@ -309,6 +392,8 @@ main() {
     test_deploy_site_replaces_site_root_from_staging
     test_deploy_site_replaces_web_root_from_staging
     test_deploy_site_rejects_unknown_target
+    test_publish_test_artifact_is_verified_atomic_and_idempotent
+    test_publish_test_artifact_rejects_unverified_or_mutating_inputs
     test_deploy_remi_uses_candidate_owned_transition
     test_deploy_remi_rejects_malformed_authority_root
     test_install_helper_requires_exact_digest


### PR DESCRIPTION
## Primary Issue

Closes #170

Design / Plan / Roadmap: #137 requires the clean-host `fedora44-guest-v1` fixture before its QEMU gate can be accepted; #154 may retire this guest-image lane later.

## Problem And Outcome

Production correctly denies the SSH deploy account direct writes under `/conary`, but the root-owned helper had no bounded operation for publishing a large QEMU source image. After merge, an authenticated deploy can stage one file under `/tmp` and publish it by pinned digest without gaining a root shell or mutable artifact authority.

## Changes

- Add `publish-test-artifact <filename> <sha256> <staged-file>` to the root-owned Remi deploy helper.
- Require a plain basename, non-empty regular non-symlink `/tmp` input, and size at or below Remi's 8 GiB limit.
- Verify the caller-pinned SHA-256, install a mode-0644 `conary:conary` candidate, and publish atomically with no-replace hard-link semantics.
- Make exact repeats idempotent and reject same-name/different-digest replacement.
- Cover success, repeat, traversal, digest mismatch, empty/oversized input, symlink/directory input, and immutable-name collision in the fake-root smoke suite.
- Document the large-fixture publication boundary in the operations and fixture-owner docs.

## Scope

- In scope: least-privilege publication into `/conary/test-artifacts/` for #137's current QEMU fixture lane.
- Out of scope: publishing `fedora44-guest-v1.qcow2` itself, changing Remi's public/admin routes, changing QEMU behavior, or implementing #154's future proof architecture.

## Ownership / Boundary

- Owning subsystem: production Remi deployment helper and QEMU source-image fixture operations.
- Boundary changed or preserved: preserves the unprivileged SSH account and immutable artifact-name boundaries; adds one typed privileged operation.
- Persisted state or public surface impact: may create one immutable file below `/conary/test-artifacts/`; no existing artifact can be replaced.
- [x] Checked `docs/modules/feature-ownership.md`; `agent-context --path deploy/remi-deploy-helper.sh` reports no matching feature card, and map validation passes.

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected helper verification directly
- [x] Updated the owning operations and fixture maps
- [x] No broader interaction gate is assigned to this path
- [x] Primary issue acceptance criteria are fully represented by this PR

```text
bash -n deploy/remi-deploy-helper.sh scripts/test-remi-deploy-helper.sh
bash scripts/test-remi-deploy-helper.sh
bash scripts/check-doc-truth.sh
bash scripts/test-doc-truth.sh
bash scripts/agent-context.sh --validate
cargo fmt --check
git diff --check
```

Observed: helper smoke passed; documentation truth and self-tests passed; feature ownership map validation passed (16 cards); formatting and diff checks were clean. `shellcheck` is not installed on this host, so no shellcheck result is claimed.

## Review And Merge Notes

- Review focus: immutable no-replace publication, staging-path validation, and cleanup on every failure path.
- User or developer impact: enables #137's versioned QEMU image to be made available from an empty cache without broad host privileges.
- Required-check bypass: not used