### PR TITLE
fix(adopt): use DNF5 installed-reason contract

### DIFF
--- a/crates/conary-core/src/packages/rpm_query.rs
+++ b/crates/conary-core/src/packages/rpm_query.rs
@@ -539,6 +539,41 @@ mod tests {
     }
 
     #[test]
+    fn a_present_but_failing_dnf5_remains_the_authority() {
+        let mut calls = Vec::new();
+
+        let error = query_user_installed_with(|authority, command, args| {
+            calls.push((
+                authority,
+                command.to_string(),
+                args.iter()
+                    .map(|arg| (*arg).to_string())
+                    .collect::<Vec<_>>(),
+            ));
+            Err(InstallReasonAuthorityError::CommandFailed {
+                authority,
+                command: command.to_string(),
+                status: Some(2),
+                stderr: "invalid selector composition".to_string(),
+            })
+        })
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            InstallReasonAuthorityError::CommandFailed {
+                authority: "DNF5",
+                status: Some(2),
+                ..
+            }
+        ));
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "DNF5");
+        assert_eq!(calls[0].1, "dnf5");
+        assert_eq!(calls[0].2, DNF5_USER_INSTALLED_ARGS);
+    }
+
+    #[test]
     fn test_installed_rpm_info_full_version() {
         let info = InstalledRpmInfo {
             name: "test".to_string(),

--- a/crates/conary-core/src/packages/rpm_query.rs
+++ b/crates/conary-core/src/packages/rpm_query.rs
@@ -19,6 +19,21 @@ use tracing::debug;
 const RPM_PACKAGE_RECORD_FORMAT: &str = "%{NEVRA}\x1e%{NAME}\x1e%{VERSION}\x1e%{RELEASE}\x1e%{EPOCH}\x1e%{ARCH}\x1e%{DESCRIPTION}\x1e%{SUMMARY}\x1e%{LICENSE}\x1e%{URL}\x1e%{VENDOR}\x1e%{SOURCERPM}\x1e%{BUILDHOST}\x1e%{INSTALLTIME}\x1f";
 const RPM_FILE_RECORD_FORMAT: &str = "[%{FILENAMES}\x1e%{LONGFILESIZES}\x1e%{FILEMTIMES}\x1e%{FILEDIGESTS}\x1e%{FILEMODES:octal}\x1e%{FILEUSERNAME}\x1e%{FILEGROUPNAME}\x1e%{FILELINKTOS}\x1f]";
 const RPM_OWNER_RECORD_FORMAT: &str = "%{NAME}\x1f";
+const DNF5_USER_INSTALLED_ARGS: &[&str] = &[
+    "--setopt=disable_excludes=*",
+    "repoquery",
+    "--userinstalled",
+    "--queryformat",
+    r"%{name}.%{arch}\n",
+];
+const DNF4_USER_INSTALLED_ARGS: &[&str] = &[
+    "--disableexcludes=all",
+    "repoquery",
+    "--installed",
+    "--userinstalled",
+    "--queryformat",
+    r"%{name}.%{arch}\n",
+];
 
 /// Information about an installed RPM package
 #[derive(Debug, Clone)]
@@ -340,40 +355,35 @@ pub fn query_all_packages() -> Result<Vec<InstalledPackageRecord<InstalledRpmInf
 
 /// Query DNF's exact user-installed package set.
 ///
-/// DNF4 and DNF5 both document `repoquery --installed --userinstalled` as the
-/// package-manager authority for this set. Their distinct documented options
-/// disable configured excludes so the result cannot silently omit installed
-/// packages. A host with RPM but no DNF authority returns a typed error.
+/// DNF4 documents `repoquery --installed --userinstalled`, while DNF5 5.4.1.0
+/// makes those selectors mutually exclusive because `--userinstalled` is
+/// itself installed-only. DNF5's typed `filter_userinstalled` first restricts
+/// to installed packages, then excludes dependency and weak-dependency
+/// reasons (upstream tag 5.4.1.0, `dnf5/commands/repoquery/repoquery.cpp` and
+/// `libdnf5/rpm/package_query.cpp`). Keep the two source-derived command
+/// grammars separate rather than assuming DNF4 flag composition applies to
+/// DNF5. Their distinct documented options disable configured excludes so the
+/// result cannot silently omit installed packages. A host with RPM but no DNF
+/// authority returns a typed error.
 pub fn query_user_installed()
 -> std::result::Result<std::collections::HashSet<String>, InstallReasonAuthorityError> {
     debug!("Querying user-installed RPM packages via DNF authority");
+    query_user_installed_with(query_package_names)
+}
 
-    let dnf5 = query_package_names(
-        "DNF5",
-        "dnf5",
-        &[
-            "--setopt=disable_excludes=*",
-            "repoquery",
-            "--installed",
-            "--userinstalled",
-            "--queryformat",
-            "%{name}.%{arch}\n",
-        ],
-    );
+fn query_user_installed_with(
+    mut query: impl FnMut(
+        &'static str,
+        &str,
+        &[&str],
+    ) -> std::result::Result<HashSet<String>, InstallReasonAuthorityError>,
+) -> std::result::Result<HashSet<String>, InstallReasonAuthorityError> {
+    let dnf5 = query("DNF5", "dnf5", DNF5_USER_INSTALLED_ARGS);
     match dnf5 {
         Ok(packages) => Ok(packages),
-        Err(error) if error.is_command_unavailable() => query_package_names(
-            "DNF4",
-            "dnf",
-            &[
-                "--disableexcludes=all",
-                "repoquery",
-                "--installed",
-                "--userinstalled",
-                "--queryformat",
-                "%{name}.%{arch}\n",
-            ],
-        ),
+        Err(error) if error.is_command_unavailable() => {
+            query("DNF4", "dnf", DNF4_USER_INSTALLED_ARGS)
+        }
         Err(error) => Err(error),
     }
 }
@@ -468,6 +478,64 @@ mod tests {
             vec!["filesystem", "bash"]
         );
         assert!(parse_owner_records("file is not owned by any package").is_err());
+    }
+
+    #[test]
+    fn dnf5_userinstalled_is_an_installed_only_selector_not_a_composable_filter() {
+        let expected = HashSet::from(["fixture.x86_64".to_string()]);
+        let mut calls = Vec::new();
+
+        let packages = query_user_installed_with(|authority, command, args| {
+            calls.push((
+                authority,
+                command.to_string(),
+                args.iter()
+                    .map(|arg| (*arg).to_string())
+                    .collect::<Vec<_>>(),
+            ));
+            Ok(expected.clone())
+        })
+        .unwrap();
+
+        assert_eq!(packages, expected);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "DNF5");
+        assert_eq!(calls[0].1, "dnf5");
+        assert!(calls[0].2.contains(&"--userinstalled".to_string()));
+        assert!(!calls[0].2.contains(&"--installed".to_string()));
+        assert_eq!(calls[0].2, DNF5_USER_INSTALLED_ARGS);
+    }
+
+    #[test]
+    fn only_a_missing_dnf5_command_falls_back_to_dnf4s_distinct_grammar() {
+        let expected = HashSet::from(["fixture.x86_64".to_string()]);
+        let mut calls = Vec::new();
+
+        let packages = query_user_installed_with(|authority, command, args| {
+            calls.push((
+                authority,
+                command.to_string(),
+                args.iter()
+                    .map(|arg| (*arg).to_string())
+                    .collect::<Vec<_>>(),
+            ));
+            if command == "dnf5" {
+                return Err(InstallReasonAuthorityError::CommandUnavailable {
+                    authority,
+                    command: command.to_string(),
+                });
+            }
+            Ok(expected.clone())
+        })
+        .unwrap();
+
+        assert_eq!(packages, expected);
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[1].0, "DNF4");
+        assert_eq!(calls[1].1, "dnf");
+        assert!(calls[1].2.contains(&"--installed".to_string()));
+        assert!(calls[1].2.contains(&"--userinstalled".to_string()));
+        assert_eq!(calls[1].2, DNF4_USER_INSTALLED_ARGS);
     }
 
     #[test]

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -370,6 +370,15 @@ package-manager state. It is not Conary's foreign-package acquisition path and
 does not prove source-independent cross-distro conversion or lifecycle
 execution.
 
+System-wide adoption preserves the native manager's explicit-versus-dependency
+reason for every installed package. On RPM systems, Conary uses each
+generation's documented DNF contract rather than reading DNF's internal state:
+DNF5's `repoquery --userinstalled` is itself an installed-only selector, while
+DNF4 composes `repoquery --installed --userinstalled`. Configured excludes are
+disabled through the corresponding generation's documented option. A missing
+manager or malformed result is a typed failure; Conary never treats every RPM
+as explicitly installed.
+
 Apply consumes that plan, rechecks file ownership inside its database
 transaction, and only then writes checkpoints, package metadata, CAS objects,
 changesets, and the state snapshot. Track and full adoption both preserve


### PR DESCRIPTION
## Primary Issue

Refs #160

Design / Plan / Roadmap: `docs/modules/source-selection.md`

## Problem And Outcome

Fedora 44 ships DNF5 5.4.1.0, whose `--userinstalled` selector is already
installed-only and explicitly conflicts with `--installed`. Conary composed
the DNF4 flags for both generations, so whole-system adoption failed before it
could classify any RPM install reasons.

After this change, DNF5 and DNF4 use separate source-derived command grammars.
A present but failing DNF5 remains authoritative and typed; only a missing DNF5
command falls back to DNF4.

## Changes

- Remove the invalid `--installed` selector from the DNF5 query only.
- Encode the DNF5 and DNF4 argument contracts separately.
- Test exact selector composition and the command-unavailable fallback boundary.
- Correct the source-selection documentation to describe the documented
  native-manager interfaces rather than internal DNF state.

## Scope

- In scope: RPM install-reason discovery through documented DNF5/DNF4
  repoquery contracts.
- Out of scope: direct reads of DNF internal TOML/SQLite state; speculative
  changes to APT or ALPM authority paths; unrelated adoption behavior.

## Ownership / Boundary

- Owning subsystem: Adoption, unadoption, and native-authority handoff.
- Boundary changed or preserved: preserves DNF as the native install-reason
  authority while correcting the per-generation command grammar.
- Persisted state or public surface impact: no schema change; Fedora adoption
  can progress past install-reason discovery.
- [x] Checked `docs/modules/feature-ownership.md` through
  `scripts/agent-context.sh --feature adopt`.

## Verification

- [x] Listed the exact verification commands run below.
- [x] Added or updated tests when behavior changed.
- [x] Ran affected-package verification directly.
- [x] Updated the owning subsystem documentation.
- [x] Ran the adoption card's focused proof.
- [x] Updated the primary issue; live Fedora QEMU proof remains before closure.

```text
cargo fmt --check
cargo test -p conary-core --lib packages::rpm_query
cargo test -p conary-core
cargo test -p conary --lib adopt::native_handoff
cargo test -p conary --lib adopt::unadopt
bash scripts/check-doc-truth.sh
bash scripts/test-doc-truth.sh
bash scripts/agent-context.sh --validate
git diff --check
```

Observed results: RPM query 11/11; `conary-core` 3,144 passed and 2 ignored,
with all integration and doc tests passing; adoption focused suites 6/6 and
7/7; documentation truth and all 16 ownership cards passed.

## Review And Merge Notes

- Review focus: exact DNF5/DNF4 argument contracts and the no-fallback-on-error
  boundary.
- User or developer impact: Fedora 44 whole-system adoption no longer invokes
  an impossible DNF5 selector combination.
- Live Fedora proof: intentionally remains on #160 and the blocked #137 QEMU
  fixture before the issue closes.
- Required-check bypass: not used.
