### PR TITLE
fix(rpm): preserve root ownership anchors

### DIFF
--- a/crates/conary-core/src/packages/rpm/payload.rs
+++ b/crates/conary-core/src/packages/rpm/payload.rs
@@ -33,6 +33,13 @@ pub(super) fn parse_stream(package: &Package, payload: Box<dyn Read>) -> Result<
     let records = header_records(package)?;
     let spool = PayloadSpool::new(stream::required_spool_bytes(&records)?)?;
     let members = stream::parse_members(package, payload, &records, &spool)?;
+    project_records(&records, members)
+}
+
+fn project_records(
+    records: &[HeaderRecord],
+    members: Vec<stream::PayloadMember>,
+) -> Result<PackagePayload> {
     let mut payload_by_index = HashMap::with_capacity(members.len());
     for member in members {
         let header_index = member.header_index;
@@ -65,7 +72,7 @@ pub(super) fn parse_stream(package: &Package, payload: Box<dyn Read>) -> Result<
         ));
     }
 
-    let hardlink_sets = hardlinks::sets(&records)?;
+    let hardlink_sets = hardlinks::sets(records)?;
     let mut group_by_index = HashMap::new();
     for set in &hardlink_sets {
         for index in set.member_indexes() {
@@ -78,11 +85,17 @@ pub(super) fn parse_stream(package: &Package, payload: Box<dyn Read>) -> Result<
         if record.ghost {
             continue;
         }
+        if record.is_root_anchor() {
+            payload_by_index
+                .remove(&index)
+                .expect("payload completeness checked");
+            continue;
+        }
         if let Some(set) = group_by_index.get(&index) {
             if index != set.emission_index() {
                 continue;
             }
-            output.extend(set.project(&records, &mut payload_by_index)?);
+            output.extend(set.project(records, &mut payload_by_index)?);
         } else {
             let member = payload_by_index
                 .remove(&index)
@@ -471,8 +484,8 @@ fn parse_error(message: impl Into<String>) -> Error {
 #[cfg(test)]
 mod tests {
     use super::{
-        RpmFileDigestAlgorithm, apply_capability_operation, digest_hex, parse,
-        parse_file_capabilities,
+        HeaderRecord, RpmFileDigestAlgorithm, apply_capability_operation, digest_hex, parse,
+        parse_file_capabilities, project_records,
     };
     use crate::payload::PayloadNodeKind;
     use rpm::IndexTag;
@@ -543,6 +556,42 @@ mod tests {
         assert!(file.content_authority.is_none());
         assert!(file.source().is_none());
         assert!(file.to_extracted_in_memory().unwrap().content.is_empty());
+    }
+
+    #[test]
+    fn rpm_root_anchor_is_consumed_without_becoming_payload_authority() {
+        let records = [HeaderRecord {
+            path: "/".to_string(),
+            path_kind: super::header::HeaderPathKind::RootAnchor,
+            mode: libc::S_IFDIR | 0o555,
+            user: "root".to_string(),
+            group: "root".to_string(),
+            mtime: 1,
+            size: 0,
+            ghost: false,
+            digest: None,
+            link_target: None,
+            caps: None,
+            ima_signature: None,
+            device: 1,
+            inode: 1,
+            rdev: 0,
+            nlink: Some(1),
+        }];
+        let members = vec![super::stream::PayloadMember {
+            header_index: 0,
+            archive_position: 0,
+            content_size: 0,
+            sha256: None,
+            source: None,
+        }];
+
+        let payload = project_records(&records, members).unwrap();
+
+        assert!(
+            payload.files().is_empty(),
+            "the selected root is a container boundary, not RPM payload mutation authority"
+        );
     }
 
     #[test]

--- a/crates/conary-core/src/packages/rpm/payload/hardlinks.rs
+++ b/crates/conary-core/src/packages/rpm/payload/hardlinks.rs
@@ -263,6 +263,7 @@ mod tests {
     fn record(path: &str, device: u32, inode: u32, size: u64) -> HeaderRecord {
         HeaderRecord {
             path: path.to_string(),
+            path_kind: super::super::header::HeaderPathKind::Deployable,
             mode: libc::S_IFREG | 0o644,
             user: "root".to_string(),
             group: "root".to_string(),

--- a/crates/conary-core/src/packages/rpm/payload/header.rs
+++ b/crates/conary-core/src/packages/rpm/payload/header.rs
@@ -234,6 +234,7 @@ fn validate_root_anchor(record: &HeaderRecord, flags: FileFlags) -> Result<()> {
         || record.link_target.is_some()
         || record.caps.is_some()
         || record.ima_signature.is_some()
+        || record.size != 0
         || record.rdev != 0
     {
         return Err(parse_error(
@@ -479,6 +480,15 @@ mod tests {
         linked.link_target = Some("usr".to_string());
         assert!(
             validate_root_anchor(&linked, FileFlags::empty())
+                .unwrap_err()
+                .to_string()
+                .contains("non-directory payload metadata")
+        );
+
+        let mut sized = root_record();
+        sized.size = 1;
+        assert!(
+            validate_root_anchor(&sized, FileFlags::empty())
                 .unwrap_err()
                 .to_string()
                 .contains("non-directory payload metadata")

--- a/crates/conary-core/src/packages/rpm/payload/header.rs
+++ b/crates/conary-core/src/packages/rpm/payload/header.rs
@@ -10,13 +10,13 @@
 use crate::error::Result;
 use crate::packages::archive_utils::normalize_path;
 use rpm::{FileFlags, IndexSignatureTag, IndexTag, Package};
-use std::path::Path;
 
 use super::{exact_identity, exact_text, parse_error};
 
 #[derive(Debug, Clone)]
 pub(super) struct HeaderRecord {
     pub(super) path: String,
+    pub(super) path_kind: HeaderPathKind,
     pub(super) mode: u32,
     pub(super) user: String,
     pub(super) group: String,
@@ -31,6 +31,18 @@ pub(super) struct HeaderRecord {
     pub(super) inode: u32,
     pub(super) rdev: u16,
     pub(super) nlink: Option<u32>,
+}
+
+impl HeaderRecord {
+    pub(super) fn is_root_anchor(&self) -> bool {
+        self.path_kind == HeaderPathKind::RootAnchor
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum HeaderPathKind {
+    Deployable,
+    RootAnchor,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -129,29 +141,21 @@ pub(super) fn header_records(package: &Package) -> Result<Vec<HeaderRecord>> {
                 directories.len()
             ))
         })?;
-        let raw_path = Path::new(directory).join(basenames[index]);
-        let raw_path = raw_path
-            .to_str()
-            .ok_or_else(|| parse_error(format!("RPM header path at index {index} is not UTF-8")))?;
-        let path = normalize_path(raw_path)
-            .map_err(|error| parse_error(format!("invalid RPM header path: {error}")))?;
-        if raw_path != path {
-            return Err(parse_error(format!(
-                "RPM header path {raw_path:?} is not canonical absolute form {path:?}"
-            )));
-        }
+        let (path, path_kind) = rpm_header_path(directory, basenames[index])?;
         if !seen_paths.insert(path.clone()) {
             return Err(parse_error(format!("duplicate RPM header path {path}")));
         }
 
-        records.push(HeaderRecord {
+        let file_flags = FileFlags::from_bits_retain(flags[index]);
+        let record = HeaderRecord {
             path: path.clone(),
+            path_kind,
             mode: u32::from(modes[index]),
             user: exact_identity(users[index], "user", &path)?,
             group: exact_identity(groups[index], "group", &path)?,
             mtime: mtimes[index],
             size: sizes[index],
-            ghost: FileFlags::from_bits_retain(flags[index]).contains(FileFlags::GHOST),
+            ghost: file_flags.contains(FileFlags::GHOST),
             digest: declared_digest(digest_algorithm, digests[index], &path)?,
             link_target: (!links[index].is_empty())
                 .then(|| exact_text(links[index], "symlink target", &path))
@@ -170,9 +174,73 @@ pub(super) fn header_records(package: &Package) -> Result<Vec<HeaderRecord>> {
             inode: inodes[index],
             rdev: rdevs[index],
             nlink: nlinks.as_ref().map(|values| values[index]),
-        });
+        };
+        validate_root_anchor(&record, file_flags)?;
+        records.push(record);
     }
     Ok(records)
+}
+
+/// RPM represents the filesystem root as `DIRNAMES="/"` plus an empty
+/// `BASENAMES` value. The upstream filesystem state machine handles that empty
+/// basename explicitly rather than treating `/` as an ordinary payload path:
+/// <https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/lib/fsm.cc#L71-L82>.
+///
+/// Keep that source-format ownership anchor distinct from a path Conary may
+/// deploy below a selected root. All other entries still pass through the
+/// shared deployment-path authority.
+fn rpm_header_path(directory: &str, basename: &str) -> Result<(String, HeaderPathKind)> {
+    if directory == "/" && basename.is_empty() {
+        return Ok(("/".to_string(), HeaderPathKind::RootAnchor));
+    }
+
+    // RPM reconstructs the filename by concatenating its directory and
+    // basename tables. Do not import host Path joining semantics here.
+    let raw_path = format!("{directory}{basename}");
+    let path = normalize_path(&raw_path)
+        .map_err(|error| parse_error(format!("invalid RPM header path: {error}")))?;
+    if raw_path != path {
+        return Err(parse_error(format!(
+            "RPM header path {raw_path:?} is not canonical absolute form {path:?}"
+        )));
+    }
+    Ok((path, HeaderPathKind::Deployable))
+}
+
+fn validate_root_anchor(record: &HeaderRecord, flags: FileFlags) -> Result<()> {
+    if !record.is_root_anchor() {
+        if record.path == "/" {
+            return Err(parse_error(
+                "RPM filesystem root cannot be classified as a deployable path",
+            ));
+        }
+        return Ok(());
+    }
+    if record.path != "/" {
+        return Err(parse_error(
+            "RPM root ownership classification requires the exact / header path",
+        ));
+    }
+    if record.mode & libc::S_IFMT != libc::S_IFDIR {
+        return Err(parse_error("RPM root ownership anchor must be a directory"));
+    }
+    if !flags.is_empty() {
+        return Err(parse_error(format!(
+            "RPM root ownership anchor carries unsupported file flags {:#x}",
+            flags.bits()
+        )));
+    }
+    if record.digest.is_some()
+        || record.link_target.is_some()
+        || record.caps.is_some()
+        || record.ima_signature.is_some()
+        || record.rdev != 0
+    {
+        return Err(parse_error(
+            "RPM root ownership anchor carries non-directory payload metadata",
+        ));
+    }
+    Ok(())
 }
 
 fn file_digest_algorithm(package: &Package) -> Result<RpmFileDigestAlgorithm> {
@@ -340,5 +408,80 @@ mod tests {
         .unwrap()
         .unwrap();
         assert_eq!(digest.hex, "a9993e364706816aba3e25717850c26c9cd0d89d");
+    }
+
+    fn root_record() -> HeaderRecord {
+        HeaderRecord {
+            path: "/".to_string(),
+            path_kind: HeaderPathKind::RootAnchor,
+            mode: libc::S_IFDIR | 0o555,
+            user: "root".to_string(),
+            group: "root".to_string(),
+            mtime: 1,
+            size: 0,
+            ghost: false,
+            digest: None,
+            link_target: None,
+            caps: None,
+            ima_signature: None,
+            device: 1,
+            inode: 1,
+            rdev: 0,
+            nlink: Some(1),
+        }
+    }
+
+    #[test]
+    fn exact_rpm_root_triplet_is_a_source_ownership_anchor() {
+        assert_eq!(
+            rpm_header_path("/", "").unwrap(),
+            ("/".to_string(), HeaderPathKind::RootAnchor)
+        );
+        assert!(rpm_header_path("", "/").is_err());
+        assert!(rpm_header_path("/", ".").is_err());
+        assert_eq!(
+            rpm_header_path("/usr/share/", "fixture").unwrap(),
+            ("/usr/share/fixture".to_string(), HeaderPathKind::Deployable)
+        );
+    }
+
+    #[test]
+    fn root_anchor_rejects_mutating_or_ambiguous_metadata() {
+        let record = root_record();
+        validate_root_anchor(&record, FileFlags::empty()).unwrap();
+
+        let mut deployable_root = record.clone();
+        deployable_root.path_kind = HeaderPathKind::Deployable;
+        assert!(
+            validate_root_anchor(&deployable_root, FileFlags::empty())
+                .unwrap_err()
+                .to_string()
+                .contains("cannot be classified as a deployable path")
+        );
+
+        let mut regular = record.clone();
+        regular.mode = libc::S_IFREG | 0o555;
+        assert!(
+            validate_root_anchor(&regular, FileFlags::empty())
+                .unwrap_err()
+                .to_string()
+                .contains("must be a directory")
+        );
+
+        assert!(
+            validate_root_anchor(&record, FileFlags::GHOST)
+                .unwrap_err()
+                .to_string()
+                .contains("unsupported file flags")
+        );
+
+        let mut linked = record;
+        linked.link_target = Some("usr".to_string());
+        assert!(
+            validate_root_anchor(&linked, FileFlags::empty())
+                .unwrap_err()
+                .to_string()
+                .contains("non-directory payload metadata")
+        );
     }
 }

--- a/crates/conary-core/src/packages/rpm/payload/stream.rs
+++ b/crates/conary-core/src/packages/rpm/payload/stream.rs
@@ -129,6 +129,32 @@ fn decoder<'a>(
         .map_err(|error| parse_error(format!("create RPM {label} payload decoder: {error}")))
 }
 
+/// Associate one standard CPIO name with RPM's absolute header path.
+///
+/// RPM removes one optional `./` prefix and one optional leading `/` before
+/// comparing a CPIO name with its DIRNAMES/BASENAMES tables. The independent
+/// prefix steps make `""`, `"./"`, `"/"`, and `".//"` equivalent archive
+/// spellings of the header's exact root entry. See `rpmfnFindFN()` at the
+/// pinned upstream revision:
+/// <https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/lib/rpmfi.cc#L388-L435>.
+fn rpm_cpio_header_path(name: &str) -> Result<String> {
+    let without_dot = name.strip_prefix("./").unwrap_or(name);
+    let relative = without_dot.strip_prefix('/').unwrap_or(without_dot);
+    if relative.is_empty() {
+        return Ok("/".to_string());
+    }
+
+    let raw_path = format!("/{relative}");
+    let path = normalize_path(&raw_path)
+        .map_err(|error| parse_error(format!("invalid RPM CPIO path: {error}")))?;
+    if raw_path != path {
+        return Err(parse_error(format!(
+            "RPM CPIO path {name:?} does not identify canonical header path {path:?}"
+        )));
+    }
+    Ok(path)
+}
+
 struct RpmPayloadReader<'a> {
     reader: Box<dyn Read + 'a>,
     records: &'a [HeaderRecord],
@@ -283,8 +309,7 @@ impl<'a> RpmPayloadReader<'a> {
             }
             return Ok(true);
         }
-        let path = normalize_path(&name)
-            .map_err(|error| parse_error(format!("invalid RPM CPIO path: {error}")))?;
+        let path = rpm_cpio_header_path(&name)?;
         let index = *self
             .standard_path_indexes
             .get(path.as_str())
@@ -467,6 +492,7 @@ mod tests {
     fn header_record(mode: u32, size: u64, link_target: Option<&str>) -> HeaderRecord {
         HeaderRecord {
             path: "/usr/lib/.build-id/fixture".to_string(),
+            path_kind: super::super::header::HeaderPathKind::Deployable,
             mode,
             user: "root".to_string(),
             group: "root".to_string(),
@@ -515,6 +541,44 @@ mod tests {
             copy_exact_payload(&mut reader, &mut StopWriter, u64::from(u32::MAX) + 1).unwrap_err();
         assert!(error.to_string().contains("injected bounded sink stop"));
         assert!(reader.max_requested <= PAYLOAD_IO_BUFFER_SIZE);
+    }
+
+    #[test]
+    fn rpm_cpio_root_spellings_map_only_to_the_header_root_anchor() {
+        for name in ["", "./", "/", ".//"] {
+            assert_eq!(
+                rpm_cpio_header_path(name).unwrap(),
+                "/",
+                "name was {name:?}"
+            );
+        }
+        for name in [".", "//", "./.", "../", "./../root"] {
+            assert!(
+                rpm_cpio_header_path(name).is_err(),
+                "{name:?} must not alias the RPM root anchor"
+            );
+        }
+    }
+
+    #[test]
+    fn rpm_cpio_paths_follow_upstream_prefix_and_exact_match_grammar() {
+        for name in [
+            "usr/share/fixture",
+            "./usr/share/fixture",
+            "/usr/share/fixture",
+        ] {
+            assert_eq!(
+                rpm_cpio_header_path(name).unwrap(),
+                "/usr/share/fixture",
+                "name was {name:?}"
+            );
+        }
+        for name in ["usr//share/fixture", "usr/./share/fixture", "usr/../etc"] {
+            assert!(
+                rpm_cpio_header_path(name).is_err(),
+                "{name:?} must not normalize into different header authority"
+            );
+        }
     }
 
     #[test]

--- a/crates/conary-core/tests/native_abi.rs
+++ b/crates/conary-core/tests/native_abi.rs
@@ -16,7 +16,7 @@ use conary_core::packages::traits::{
 use conary_core::packages::{arch::ArchPackage, deb::DebPackage, rpm::RpmPackage};
 use flate2::{Compression, write::GzEncoder};
 use std::collections::BTreeSet;
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{Cursor, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -377,6 +377,38 @@ fn conversion_preserves_upstream_native_entries_in_ccs_scriptlet_bundle() {
     let arch_path = write_arch_fixture(temp.path());
     let arch = ArchPackage::parse(arch_path.to_str().expect("utf8 arch path")).expect("parse arch");
     assert_conversion_preserves_native_entries(&arch, &arch_path, "arch", "arch");
+}
+
+/// Live source artifact for issue #177:
+/// https://dl.fedoraproject.org/pub/fedora/linux/releases/44/Everything/x86_64/os/Packages/f/filesystem-3.18-52.fc44.x86_64.rpm
+///
+/// Kept opt-in so ordinary tests remain hermetic; the exact Fedora release URL
+/// and digest make the external proof reproducible without checking a 1.4 MiB
+/// package binary into the repository.
+#[test]
+#[ignore = "requires CONARY_RPM_ROOT_ANCHOR_FIXTURE pointing to the pinned Fedora 44 filesystem RPM"]
+fn pinned_fedora_filesystem_root_anchor_parses_and_converts() {
+    let path = PathBuf::from(
+        std::env::var("CONARY_RPM_ROOT_ANCHOR_FIXTURE")
+            .expect("set CONARY_RPM_ROOT_ANCHOR_FIXTURE to the pinned Fedora filesystem RPM"),
+    );
+    let bytes = fs::read(&path).expect("read pinned Fedora filesystem RPM");
+    assert_eq!(bytes.len(), 1_398_770);
+    assert_eq!(
+        conary_core::hash::sha256(&bytes),
+        "7abc643d653bf2773c38e183e0e33489cab4880c8a540b315fcd7fff09c6c52c"
+    );
+
+    let package = RpmPackage::parse(path.to_str().expect("UTF-8 fixture path"))
+        .expect("parse pinned Fedora filesystem RPM");
+
+    assert_eq!(package.name(), "filesystem");
+    assert_eq!(package.version(), "3.18-52.fc44");
+    assert!(
+        package.files().iter().all(|file| file.path != "/"),
+        "the RPM root ownership anchor must not become deployable payload authority"
+    );
+    assert_conversion_preserves_native_entries(&package, &path, "rpm", "fedora-44");
 }
 
 fn native_slots(package: &impl PackageFormat) -> BTreeSet<&str> {

--- a/docs/modules/ccs.md
+++ b/docs/modules/ccs.md
@@ -171,10 +171,11 @@ handles that empty basename as `/`, while
 associates the corresponding standard CPIO entry after RPM's exact optional
 `./` and `/` prefix removal. Conary preserves that entry through header/CPIO
 association and completeness validation as a typed source ownership anchor.
-It accepts only an unflagged directory without content-bearing metadata and a
-zero-content CPIO member. The selected root is the transaction container, not
-a deployable package path, so conversion consumes the anchor without emitting
-a CCS payload node or install/remove claim for `/`.
+It accepts only an unflagged directory with zero declared size, no
+content-bearing metadata, and a zero-content CPIO member. The selected root is
+the transaction container, not a deployable package path, so conversion
+consumes the anchor without emitting a CCS payload node or install/remove claim
+for `/`.
 
 RPM hardlink projection follows the transaction rule pinned at upstream commit
 `a8f0192aee1c08bd1454ed2ac6ebaf506004b55c`.

--- a/docs/modules/ccs.md
+++ b/docs/modules/ccs.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-28
-revision: 49
+last_updated: 2026-07-29
+revision: 50
 summary: Convert foreign packages into source-independent CCS lifecycle transactions and export CCS as native packages
 ---
 
@@ -162,6 +162,19 @@ proves that equality, projection retains the target as symlink variant data
 without inventing regular-file content authority. Any mismatched target or
 length still fails, and every other non-regular node must carry zero payload
 bytes.
+
+RPM may encode the filesystem root itself as `DIRNAMES="/"` plus an empty
+`BASENAMES` value. At the pinned upstream revision,
+[`fsmFsPath`](https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/lib/fsm.cc#L71-L82)
+handles that empty basename as `/`, while
+[`rpmfnFindFN`](https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/lib/rpmfi.cc#L388-L435)
+associates the corresponding standard CPIO entry after RPM's exact optional
+`./` and `/` prefix removal. Conary preserves that entry through header/CPIO
+association and completeness validation as a typed source ownership anchor.
+It accepts only an unflagged directory without content-bearing metadata and a
+zero-content CPIO member. The selected root is the transaction container, not
+a deployable package path, so conversion consumes the anchor without emitting
+a CCS payload node or install/remove claim for `/`.
 
 RPM hardlink projection follows the transaction rule pinned at upstream commit
 `a8f0192aee1c08bd1454ed2ac6ebaf506004b55c`.

--- a/docs/modules/test-fixtures.md
+++ b/docs/modules/test-fixtures.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-28
-revision: 24
+last_updated: 2026-07-29
+revision: 25
 summary: Map fixture ownership, including source-built and published-package cross-source lifecycle proof and the public v4 QEMU image contract
 ---
 
@@ -41,6 +41,7 @@ Each fixture family should record:
 | `m4d-supported-profile-cutover` | Repository feed profiles | `cargo test -p conary-core supported_profiles`; `cargo test -p conary --test packaging_m4d`; `cargo test -p remi route` |
 | `native-lifecycle-query-fixtures` | Native lifecycle query surfaces | `cargo test -p conary --test query_scripts` |
 | `rpm-hardlink-transaction` | RPM payload projection and CCS conversion | `cargo test -p conary-core packages::rpm::payload`; `cargo test -p conary --test conversion_integration golden_conversion` |
+| `rpm-root-anchor-conversion` | RPM root ownership parsing and CCS omission | `cargo test -p conary-core packages::rpm::payload`; opt-in pinned-artifact test below |
 | `remi-native-ccs-publication` | Remi native publication | `cargo test -p remi release_upload_`; `cargo test -p conary --test packaging_m4c` |
 | `remi-converted-artifact-serving` | Remi conversion persistence and serving | `cargo test -p remi conversion` |
 | `remi-test-artifact-fixtures` | Remi artifact handlers | `cargo test -p remi test_upload_fixture`; `cargo test -p remi test_public_fixture_get_and_head` |
@@ -108,6 +109,35 @@ Each fixture family should record:
 - **Safety notes:** The fixture is public package data. Native-oracle commands
   run only in a disposable test image/root; never install it into the host,
   production Remi, `/conary/data`, or `/etc/conary`.
+
+### rpm-root-anchor-conversion
+
+- **Owner:** RPM header and CPIO projection:
+  `crates/conary-core/src/packages/rpm/payload/{header,stream}.rs`; CCS omission:
+  `crates/conary-core/src/packages/rpm/payload.rs`.
+- **Purpose:** Prove that RPM's exact `/` ownership entry remains part of
+  source header/payload validation but cannot become selected-root install or
+  remove authority.
+- **Fixture source:** Fedora 44
+  [`filesystem-3.18-52.fc44.x86_64.rpm`](https://dl.fedoraproject.org/pub/fedora/linux/releases/44/Everything/x86_64/os/Packages/f/filesystem-3.18-52.fc44.x86_64.rpm),
+  downloaded only for the opt-in test. Exact size: 1,398,770 bytes. SHA-256:
+  `7abc643d653bf2773c38e183e0e33489cab4880c8a540b315fcd7fff09c6c52c`.
+  Unit tests construct the neighboring malformed metadata and CPIO path forms
+  without network access.
+- **Consumes:** RPM payload unit tests and
+  `pinned_fedora_filesystem_root_anchor_parses_and_converts` in
+  `crates/conary-core/tests/native_abi.rs`.
+- **Fast proof:** `cargo test -p conary-core packages::rpm::payload`.
+- **External artifact proof:** set `CONARY_RPM_ROOT_ANCHOR_FIXTURE` to the
+  exact pinned RPM, then run `cargo test -p conary-core --test native_abi
+  pinned_fedora_filesystem_root_anchor_parses_and_converts -- --ignored`.
+- **Medium proof:** `cargo test -p conary --test conversion_integration
+  golden_conversion`; `cargo test -p remi conversion`.
+- **Regeneration:** Do not replace the pinned identity in response to repository
+  drift. Add a separately identified artifact when a later RPM grammar needs
+  proof.
+- **Safety notes:** Download and parse/convert only. Do not install the native
+  RPM on the host or let its root metadata modify a test destination.
 
 ### host-executable-interface-fixtures
 

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-27
-revision: 34
+last_updated: 2026-07-29
+revision: 35
 summary: Define source-independent lifecycle, generation activation, and configuration transactions for RPM, Debian, and Arch packages
 ---
 
@@ -406,6 +406,26 @@ internal transaction graph expose no script-suppression option. A dry run may
 plan and report lifecycle without executing it because it performs no mutation;
 an applied transaction must execute the complete typed graph or fail before its
 first mutation.
+
+### Source Root Ownership Anchors
+
+The selected root is the transaction container and cannot also be a package
+payload path. An RPM may nevertheless declare that root in its source file
+table as `DIRNAMES="/"` plus an empty `BASENAMES` value. RPM's pinned
+[`fsmFsPath`](https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/lib/fsm.cc#L71-L82)
+and
+[`rpmfnFindFN`](https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/lib/rpmfi.cc#L388-L435)
+contracts establish that header identity and its standard-CPIO association.
+
+The RPM parser retains the exact root entry long enough to prove parallel
+header-array validity, uniqueness, archive association, zero payload content,
+and completeness. It accepts only an unflagged directory without a digest,
+link target, file capabilities, IMA signature, or device-node identity.
+Conversion then consumes the source ownership anchor without creating a CCS
+payload node, installed file row, directory claim, or remove authority for
+`/`. Every non-root path still must become one canonical below-root deployment
+path through the shared source-path authority; the root exception cannot
+normalize another spelling into mutation authority.
 
 ### Shared Directory Ownership And Materialization
 

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -418,9 +418,10 @@ and
 contracts establish that header identity and its standard-CPIO association.
 
 The RPM parser retains the exact root entry long enough to prove parallel
-header-array validity, uniqueness, archive association, zero payload content,
-and completeness. It accepts only an unflagged directory without a digest,
-link target, file capabilities, IMA signature, or device-node identity.
+header-array validity, uniqueness, archive association, zero declared size,
+zero payload content, and completeness. It accepts only an unflagged directory
+without a digest, link target, file capabilities, IMA signature, or device-node
+identity.
 Conversion then consumes the source ownership anchor without creating a CCS
 payload node, installed file row, directory claim, or remove authority for
 `/`. Every non-root path still must become one canonical below-root deployment


### PR DESCRIPTION
## Primary Issue

Refs #177

Design / Plan / Roadmap:

- `docs/modules/ccs.md`
- `docs/specs/foreign-package-lifecycle-contracts.md`
- `docs/modules/test-fixtures.md`

## Problem And Outcome

Live Remi 0.9.0 rejected Fedora 44's `filesystem` RPM because the RPM header legitimately declares `/`, while Conary sent every header path through a below-root deployment-path parser.

After this change, RPM's exact root ownership entry remains part of header/CPIO association and completeness validation but cannot become CCS install/remove authority. The pinned Fedora artifact parses and converts without emitting a `/` payload node.

The issue remains open through patch release, deployment, and terminal public conversion proof.

## Changes

- add an explicit `Deployable` versus `RootAnchor` RPM header-path classification
- reconstruct RPM DIRNAMES/BASENAMES by source-format concatenation instead of host `Path` semantics
- preserve RPM's pinned standard-CPIO prefix grammar, including its exact root spellings
- require the root anchor to be an unflagged directory with zero declared size and no content-bearing or device-node metadata
- consume the validated root member without emitting a package payload node
- add contract tests for malformed neighboring forms and an opt-in real Fedora artifact conversion
- record the authority and fixture contracts in canonical documentation

## Scope

- In scope: RPM file-header/CPIO root authority, CCS payload omission, conversion proof
- Out of scope: installed-system adoption root handling (#175), general selected-root materialization, unrelated QEMU export failures

## Ownership / Boundary

- Owning subsystem: CCS authoring, conversion, install, and native lifecycle execution
- Boundary changed or preserved: source RPM root ownership is validated at the format boundary; the shared deployment-path owner still rejects `/`
- Persisted state or public surface impact: no schema change; newly converted CCS artifacts omit source root ownership while public Remi conversion accepts Fedora `filesystem`
- [x] Checked `docs/modules/feature-ownership.md` through `bash scripts/agent-context.sh --path crates/conary-core/src/packages/rpm/payload/header.rs`

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code
- [x] Updated subsystem docs or maps when the "look here first" path changed
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs

```text
cargo test -p conary-core packages::rpm::payload
# 28 passed, 0 failed

CONARY_RPM_ROOT_ANCHOR_FIXTURE=/tmp/conary-rpm-root-anchor.ReVlJS/filesystem-3.18-52.fc44.x86_64.rpm \
  cargo test -p conary-core --test native_abi \
  pinned_fedora_filesystem_root_anchor_parses_and_converts -- --ignored
# 1 passed, 0 failed
# fixture: 1,398,770 bytes
# sha256: 7abc643d653bf2773c38e183e0e33489cab4880c8a540b315fcd7fff09c6c52c

cargo test -p conary --test conversion_integration golden_conversion
# 4 passed, 0 failed

cargo test -p remi conversion
# 70 library tests passed plus 1 CLI test, 0 failed

cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
bash scripts/check-doc-truth.sh
git diff --check
# all passed
```

## Review And Merge Notes

- Review focus: exact RPM prefix/path association; root metadata fail-closed envelope; proof that projection consumes rather than persists `/`
- User or developer impact: Fedora `filesystem` can be converted without granting a package authority over the selected root itself
- Required-check bypass: not used
