### PR TITLE
fix(install): classify selected-root alias domains

### DIFF
--- a/apps/conary/src/commands/install/shared_directory.rs
+++ b/apps/conary/src/commands/install/shared_directory.rs
@@ -246,18 +246,23 @@ pub(crate) fn capture_existing_directory_materializations(
 ) -> Result<Vec<FileEntry>> {
     let mut captured = BTreeMap::new();
     for anchor in FileEntry::find_all_ordered(conn)? {
-        if classify_root_path(&anchor.path)? == RootPathDomain::EphemeralMountOrUser {
+        let claims = DirectoryClaim::find_retaining_path(conn, &anchor.path)?;
+        if claims.is_empty() && !matches!(anchor.node.source.kind, PayloadNodeKind::Directory) {
             continue;
         }
-        let claims = DirectoryClaim::find_retaining_path(conn, &anchor.path)?;
-        if claims.is_empty() {
-            if matches!(anchor.node.source.kind, PayloadNodeKind::Directory) {
-                return Err(anyhow!(
-                    "Tracked directory materialization {} has no package claim",
-                    anchor.path
-                ));
-            }
+        let effective_path =
+            conary_core::filesystem::selected_root::selected_root_effective_package_path(
+                selected_root,
+                &anchor.path,
+            )?;
+        if classify_root_path(&effective_path)? == RootPathDomain::EphemeralMountOrUser {
             continue;
+        }
+        if claims.is_empty() {
+            return Err(anyhow!(
+                "Tracked directory materialization {} has no package claim",
+                anchor.path
+            ));
         }
         let selected_root_node =
             conary_core::filesystem::selected_root::capture_selected_root_node(

--- a/apps/conary/src/commands/install/shared_directory/tests.rs
+++ b/apps/conary/src/commands/install/shared_directory/tests.rs
@@ -526,6 +526,66 @@ fn rollback_capture_excludes_only_generation_ephemeral_directory_claims() {
 }
 
 #[test]
+fn rollback_capture_classifies_effective_selected_root_alias_domains() {
+    let (_db_root, db_path) = crate::commands::test_helpers::create_test_db();
+    let conn = conary_core::db::open(db_path).unwrap();
+    let owner = insert_trove(&conn, "aliased-layout");
+    for path in ["/var/run/faillock", "/lib/vendor"] {
+        FileEntry::new(path.to_string(), resolved_directory(0o755), None, owner)
+            .insert(&conn)
+            .unwrap();
+    }
+
+    let selected_root = tempfile::tempdir().unwrap();
+    physical_directory(selected_root.path(), "/var");
+    physical_symlink(selected_root.path(), "/var/run", "../run");
+    physical_directory(selected_root.path(), "/usr/lib/vendor");
+    physical_symlink(selected_root.path(), "/lib", "usr/lib");
+
+    let captured =
+        capture_existing_directory_materializations(&conn, selected_root.path()).unwrap();
+
+    assert_eq!(captured.len(), 1);
+    assert_eq!(captured[0].path, "/lib/vendor");
+    assert_eq!(
+        captured[0].node,
+        conary_core::filesystem::selected_root::capture_selected_root_node(
+            selected_root.path(),
+            "/lib/vendor",
+        )
+        .unwrap()
+        .unwrap()
+    );
+}
+
+#[test]
+fn rollback_capture_still_rejects_missing_non_ephemeral_materialization() {
+    let (_db_root, db_path) = crate::commands::test_helpers::create_test_db();
+    let conn = conary_core::db::open(db_path).unwrap();
+    let owner = insert_trove(&conn, "missing-layout");
+    FileEntry::new(
+        "/usr/lib/missing".to_string(),
+        resolved_directory(0o755),
+        None,
+        owner,
+    )
+    .insert(&conn)
+    .unwrap();
+
+    let selected_root = tempfile::tempdir().unwrap();
+    physical_directory(selected_root.path(), "/usr/lib");
+
+    let error =
+        capture_existing_directory_materializations(&conn, selected_root.path()).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("Tracked directory materialization /usr/lib/missing is absent"),
+        "{error:#}"
+    );
+}
+
+#[test]
 fn pinned_upstream_directory_sources_are_exact() {
     assert_eq!(UPSTREAM_DIRECTORY_MATERIALIZATION_INPUTS.len(), 4);
     let mut formats = BTreeSet::new();

--- a/crates/conary-core/src/filesystem/selected_root.rs
+++ b/crates/conary-core/src/filesystem/selected_root.rs
@@ -17,6 +17,31 @@ pub struct SelectedRootSymlinkTarget {
     pub node: ResolvedPayloadNode,
 }
 
+/// Resolve symlinks in a package path's selected-root ancestors without
+/// following the leaf itself.
+///
+/// The returned spelling is absolute and root-relative. If an ancestor
+/// symlink points into a tree that is intentionally absent from the selected
+/// root, the missing tail is retained lexically after the proven symlink
+/// target. This lets callers classify the current effective path domain while
+/// preserving the original package spelling as ownership authority.
+pub fn selected_root_effective_package_path(root: &Path, package_path: &str) -> Result<String> {
+    validate_selected_root(root)?;
+    let relative = root_relative_package_path(package_path)?;
+    let relative = resolve_leaf_without_following_with_policy(
+        root,
+        &relative,
+        package_path,
+        MissingAncestorPolicy::PreserveMissingTail,
+    )?;
+    let relative = relative.to_str().ok_or_else(|| {
+        Error::InvalidPath(format!(
+            "effective selected-root path for {package_path} is not UTF-8"
+        ))
+    })?;
+    Ok(format!("/{relative}"))
+}
+
 /// Capture the exact leaf node named by a package path without following it.
 pub fn capture_selected_root_node(
     root: &Path,
@@ -88,6 +113,26 @@ fn resolve_leaf_without_following(
     relative: &Path,
     package_path: &str,
 ) -> Result<PathBuf> {
+    resolve_leaf_without_following_with_policy(
+        root,
+        relative,
+        package_path,
+        MissingAncestorPolicy::Reject,
+    )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MissingAncestorPolicy {
+    Reject,
+    PreserveMissingTail,
+}
+
+fn resolve_leaf_without_following_with_policy(
+    root: &Path,
+    relative: &Path,
+    package_path: &str,
+    missing_ancestor_policy: MissingAncestorPolicy,
+) -> Result<PathBuf> {
     let file_name = relative.file_name().ok_or_else(|| {
         Error::InvalidPath(format!(
             "package path {package_path} has no selected-root leaf"
@@ -97,7 +142,7 @@ fn resolve_leaf_without_following(
     let resolved_parent = if parent.as_os_str().is_empty() {
         PathBuf::new()
     } else {
-        resolve_existing_root_relative_path(root, parent, package_path)?
+        resolve_root_relative_path(root, parent, package_path, missing_ancestor_policy)?
     };
     Ok(resolved_parent.join(file_name))
 }
@@ -142,6 +187,15 @@ fn resolve_existing_root_relative_path(
     relative: &Path,
     package_path: &str,
 ) -> Result<PathBuf> {
+    resolve_root_relative_path(root, relative, package_path, MissingAncestorPolicy::Reject)
+}
+
+fn resolve_root_relative_path(
+    root: &Path,
+    relative: &Path,
+    package_path: &str,
+    missing_ancestor_policy: MissingAncestorPolicy,
+) -> Result<PathBuf> {
     let mut pending = components(relative)?;
     let mut resolved = PathBuf::new();
     let mut symlink_depth = 0usize;
@@ -151,6 +205,14 @@ fn resolve_existing_root_relative_path(
         let candidate = root.join(&candidate_relative);
         let metadata = match fs::symlink_metadata(&candidate) {
             Ok(metadata) => metadata,
+            Err(error)
+                if error.kind() == std::io::ErrorKind::NotFound
+                    && missing_ancestor_policy == MissingAncestorPolicy::PreserveMissingTail =>
+            {
+                resolved.push(component);
+                resolved.extend(pending);
+                return Ok(resolved);
+            }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                 return Err(Error::NotFound(format!(
                     "selected-root path {} is unavailable while resolving {package_path}: {error}",
@@ -280,6 +342,40 @@ mod tests {
         symlink("../../outside", root.path().join("nested/escape")).unwrap();
         let error = capture_selected_root_node(root.path(), "/nested/escape/node").unwrap_err();
         assert!(matches!(error, Error::PathTraversal(_)));
+    }
+
+    #[test]
+    fn effective_package_path_resolves_aliases_before_a_missing_leaf_tree() {
+        let root = tempfile::tempdir().unwrap();
+        fs::create_dir_all(root.path().join("var")).unwrap();
+        symlink("../run", root.path().join("var/run")).unwrap();
+
+        assert_eq!(
+            selected_root_effective_package_path(root.path(), "/var/run/faillock").unwrap(),
+            "/run/faillock"
+        );
+
+        fs::create_dir_all(root.path().join("usr/lib/sub")).unwrap();
+        symlink("usr/lib", root.path().join("lib")).unwrap();
+        assert_eq!(
+            selected_root_effective_package_path(root.path(), "/lib/sub/missing").unwrap(),
+            "/usr/lib/sub/missing"
+        );
+    }
+
+    #[test]
+    fn effective_package_path_rejects_escaping_and_looping_ancestors() {
+        let root = tempfile::tempdir().unwrap();
+        fs::create_dir_all(root.path().join("nested")).unwrap();
+        symlink("../../outside", root.path().join("nested/escape")).unwrap();
+        let escape =
+            selected_root_effective_package_path(root.path(), "/nested/escape/node").unwrap_err();
+        assert!(matches!(escape, Error::PathTraversal(_)));
+
+        symlink("loop", root.path().join("loop")).unwrap();
+        let loop_error =
+            selected_root_effective_package_path(root.path(), "/loop/node").unwrap_err();
+        assert!(matches!(loop_error, Error::PathTraversal(_)));
     }
 
     #[test]

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -474,6 +474,12 @@ claim-aware payload view rather than treating the anchor as the sole owner.
 
 Rollback captures directory claims and the independently materialized node
 before any package in a single or batch transaction mutates the selected root.
+It resolves only the package path's existing selected-root ancestor symlinks
+before applying the finite publication-domain contract. Thus a native spelling
+such as `/var/run/example` retains its package ownership identity while its
+effective `/run/example` materialization is excluded as ephemeral; aliases
+into non-ephemeral domains still require exact captured nodes. Missing
+non-ephemeral nodes and escaping or looping aliases fail before mutation.
 Restoration first rebuilds all package bases, then all anchors, then all claims,
 so cross-package and cyclic claim graphs do not depend on insertion order.
 Additive RPM or CCS metadata changes restore the prior materialized node even


### PR DESCRIPTION
## Primary Issue

Refs #179

Design / Plan / Roadmap: issue acceptance contract; no roadmap change.

## Problem And Outcome

Fedora records `/var/run/faillock`, while the selected root proves `/var/run -> ../run` and intentionally omits the ephemeral `/run` tree. Rollback capture classified the package spelling as mutable before following the ancestor alias, then rejected the intentionally absent effective node.

After this change, rollback capture classifies the effective selected-root path after bounded ancestor-symlink resolution. The package spelling remains ownership authority; aliases into the finite ephemeral domain are excluded, non-ephemeral aliases still require an exact node, and missing non-ephemeral paths or unsafe aliases still fail before mutation.

## Changes

- Add one selected-root primitive that resolves ancestor symlinks without following the package-path leaf.
- Preserve a missing tail after a proven alias so an intentionally absent domain such as `/run` can still be classified.
- Apply the finite root-domain contract to that effective path before directory rollback capture.
- Add regression coverage for `/var/run/faillock`, non-ephemeral aliases, missing non-ephemeral nodes, multi-component aliases, escapes, and loops.
- Record the alias/domain rollback contract in the lifecycle specification.

## Scope

- In scope: selected-root path resolution and pre-mutation shared-directory rollback capture.
- Out of scope: changing package ownership spellings, schema/state migration, generation boot behavior, or the separate TGE04 first-boot failure.

## Ownership / Boundary

- Owning subsystem: install/shared-directory transactions and selected-root filesystem inspection.
- Boundary changed or preserved: preserves preflight-before-mutation and original package ownership; changes only domain classification to use the effective selected-root path.
- Persisted state or public surface impact: no schema change; existing current-schema state is interpreted through exact selected-root alias authority during transaction preflight.
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code (not applicable)
- [x] Updated subsystem docs or maps when the "look here first" path changed (path did not change; owning specification updated)
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs (corrected TGE05 remains the live merge proof)

```text
cargo test -p conary-core --lib filesystem::selected_root
# 8 passed

cargo test -p conary --lib commands::install::shared_directory
# 13 passed, 1 ignored (network conformance)

cargo test -p conary --lib commands::install
# 159 passed, 1 ignored (network conformance)

cargo test -p conary-core --lib db::models::directory_claim
# 19 passed

cargo test -p conary-core --lib db::models::package_payload_ownership
# 5 passed

cargo test -p conary --lib commands::remove
# 11 passed

cargo test -p conary --test live_host_mutation_safety
# 21 passed

cargo test -p conary --test conversion_integration
# 16 passed

cargo test -p conary --test query_scripts
# 15 passed

bash scripts/check-doc-truth.sh
# Documentation truth checks passed.

cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
git diff --check
# passed
```

## Review And Merge Notes

- Review focus: missing-tail semantics stop only after an observed absent ancestor; the leaf remains unfollowed; non-directory rows without claims stay outside directory rollback capture.
- User or developer impact: signed CCS installs on an adopted usr-merged Fedora root advance past `/var/run/faillock` rollback preflight.
- Required-check bypass: not used
