### PR TITLE
fix(generation): project mutable state into boot carriers

### DIFF
--- a/apps/conary/src/commands/composefs_ops.rs
+++ b/apps/conary/src/commands/composefs_ops.rs
@@ -231,7 +231,7 @@ fn seed_generation_mutable_state(
     }
     std::fs::create_dir_all(&state_root)?;
     let cas = conary_core::filesystem::CasStore::new(runtime_root.objects_dir())?;
-    conary_core::generation::root_manifest::materialize_state_root(
+    conary_core::generation::root_manifest::materialize_config_state_upper(
         &artifact.mutable_state,
         &cas,
         &state_root,

--- a/apps/conary/src/commands/generation/config_transaction.rs
+++ b/apps/conary/src/commands/generation/config_transaction.rs
@@ -421,7 +421,8 @@ pub(crate) fn materialize(
     let result = (|| -> Result<()> {
         // The exact mutable-state manifest is seeded at the unpublished
         // generation path before config decisions are applied. Preserve that
-        // `/etc`, `/var`, and `/srv` authority as the base of the overlay.
+        // `/etc` authority as the base of the config overlay. `/var` and
+        // `/srv` remain owned by their live mutable roots.
         if final_upper.is_dir() {
             copy_overlay_tree(&final_upper, &stage)?;
         }

--- a/crates/conary-core/src/generation/export.rs
+++ b/crates/conary-core/src/generation/export.rs
@@ -13,6 +13,9 @@ use crate::generation::artifact::{
 use crate::generation::metadata::{
     EXCLUDED_DIRS, GENERATION_METADATA_FILE, GENERATION_METADATA_SIGNATURE_FILE, ROOT_SYMLINKS,
 };
+use crate::generation::root_manifest::{
+    GENERATION_ROOT_MANIFEST_FILE, MUTABLE_STATE_MANIFEST_FILE, materialize_state_root,
+};
 
 const RUNTIME_ROOT_DIRS: &[&str] = &["usr", "etc", "boot"];
 const ESP_SIZE_MB: u64 = 512;
@@ -439,6 +442,14 @@ pub fn project_generation_rootfs(
         &artifact.generation_dir.join(CAS_MANIFEST_FILE),
         &generation_dest.join(CAS_MANIFEST_FILE),
     )?;
+    copy_file(
+        &artifact.generation_dir.join(GENERATION_ROOT_MANIFEST_FILE),
+        &generation_dest.join(GENERATION_ROOT_MANIFEST_FILE),
+    )?;
+    copy_file(
+        &artifact.generation_dir.join(MUTABLE_STATE_MANIFEST_FILE),
+        &generation_dest.join(MUTABLE_STATE_MANIFEST_FILE),
+    )?;
     copy_dir_recursive(
         &artifact.generation_dir.join(BOOT_ASSETS_DIR),
         &generation_dest.join(BOOT_ASSETS_DIR),
@@ -452,7 +463,23 @@ pub fn project_generation_rootfs(
     }
 
     create_current_symlink(staging_dir, &artifact.generation.to_string())?;
-    std::fs::create_dir_all(staging_dir.join("conary/etc-state"))?;
+    let cas = crate::filesystem::CasStore::new(&objects_dest)?;
+    materialize_state_root(&artifact.mutable_state, &cas, staging_dir)?;
+    let etc_state = staging_dir
+        .join("conary/etc-state")
+        .join(artifact.generation.to_string());
+    std::fs::create_dir_all(
+        etc_state
+            .parent()
+            .expect("generation etc-state path always has a parent"),
+    )?;
+    let materialized_etc = staging_dir.join("etc");
+    if materialized_etc.is_dir() {
+        std::fs::rename(&materialized_etc, &etc_state)?;
+    } else {
+        std::fs::create_dir(&etc_state)?;
+    }
+    std::fs::create_dir_all(staging_dir.join("conary/etc-lower"))?;
     std::fs::create_dir_all(staging_dir.join("conary/mnt"))?;
 
     for dir in RUNTIME_ROOT_DIRS.iter().chain(EXCLUDED_DIRS.iter()) {

--- a/crates/conary-core/src/generation/export/tests.rs
+++ b/crates/conary-core/src/generation/export/tests.rs
@@ -5,7 +5,13 @@ use crate::generation::artifact::{
     ArtifactWriteInputs, BootAssetsManifest, CasObjectRef, write_generation_artifact,
 };
 use crate::generation::metadata::{GENERATION_FORMAT, GenerationMetadata};
+use crate::generation::root_manifest::{
+    GENERATION_ROOT_MANIFEST_VERSION, GenerationRootEntry, MutableStateManifest,
+};
 use crate::generation::test_support::write_root_manifests_with_objects;
+use crate::payload::{
+    PayloadContentAuthority, PayloadIdentity, PayloadNode, PayloadNodeKind, ResolvedPayloadNode,
+};
 use sha2::{Digest, Sha256};
 use tempfile::TempDir;
 
@@ -121,6 +127,21 @@ impl Fixture {
 
         let cas_object = write_cas_object(&objects_dir, b"hello");
         write_root_manifests_with_objects(&generation_dir, std::slice::from_ref(&cas_object));
+        let state_object = write_cas_object(&objects_dir, b"captured mutable state");
+        MutableStateManifest {
+            version: GENERATION_ROOT_MANIFEST_VERSION,
+            entries: vec![
+                state_directory("/etc"),
+                state_regular("/etc/conary-export.conf", &state_object),
+                state_directory("/srv"),
+                state_regular("/srv/conary-export-state", &state_object),
+                state_directory("/var"),
+                state_directory("/var/lib"),
+                state_regular("/var/lib/conary-export-state", &state_object),
+            ],
+        }
+        .write_to(&generation_dir)
+        .unwrap();
         let boot_assets = BootAssetsManifest {
             version: 1,
             generation: 7,
@@ -173,6 +194,40 @@ impl Fixture {
     }
 }
 
+fn state_directory(path: &str) -> GenerationRootEntry {
+    let mut node = PayloadNode::regular(0o755);
+    node.kind = PayloadNodeKind::Directory;
+    node.mode = libc::S_IFDIR | 0o755;
+    set_test_process_ownership(&mut node);
+    GenerationRootEntry {
+        path: path.to_string(),
+        node: ResolvedPayloadNode::from_numeric_source(node).unwrap(),
+        content: None,
+    }
+}
+
+fn state_regular(path: &str, object: &CasObjectRef) -> GenerationRootEntry {
+    let mut node = PayloadNode::regular(0o640);
+    set_test_process_ownership(&mut node);
+    GenerationRootEntry {
+        path: path.to_string(),
+        node: ResolvedPayloadNode::from_numeric_source(node).unwrap(),
+        content: Some(PayloadContentAuthority {
+            sha256: object.sha256.clone(),
+            size: object.size,
+        }),
+    }
+}
+
+fn set_test_process_ownership(node: &mut PayloadNode) {
+    node.user = PayloadIdentity::Numeric {
+        id: u64::from(unsafe { libc::geteuid() }),
+    };
+    node.group = PayloadIdentity::Numeric {
+        id: u64::from(unsafe { libc::getegid() }),
+    };
+}
+
 #[test]
 fn rootfs_projection_creates_runtime_tree() {
     let fixture = Fixture::new();
@@ -186,8 +241,23 @@ fn rootfs_projection_creates_runtime_tree() {
     assert!(gen_dir.join(".conary-gen.json").is_file());
     assert!(gen_dir.join(".conary-artifact.json").is_file());
     assert!(gen_dir.join("cas-manifest.json").is_file());
+    assert!(gen_dir.join("generation-root.json").is_file());
+    assert!(gen_dir.join("mutable-state.json").is_file());
     assert!(gen_dir.join("boot-assets/manifest.json").is_file());
-    assert!(staging.join("conary/etc-state").is_dir());
+    assert_eq!(
+        std::fs::read(staging.join("conary/etc-state/7/conary-export.conf")).unwrap(),
+        b"captured mutable state"
+    );
+    assert!(!staging.join("conary/etc-state/7/etc").exists());
+    assert_eq!(
+        std::fs::read(staging.join("var/lib/conary-export-state")).unwrap(),
+        b"captured mutable state"
+    );
+    assert_eq!(
+        std::fs::read(staging.join("srv/conary-export-state")).unwrap(),
+        b"captured mutable state"
+    );
+    assert!(staging.join("conary/etc-lower").is_dir());
     assert!(staging.join("conary/mnt").is_dir());
     assert!(staging.join("usr").is_dir());
     assert!(staging.join("etc").is_dir());
@@ -225,11 +295,13 @@ fn rootfs_projection_copies_only_manifest_listed_cas_objects() {
     project_generation_rootfs(&artifact, &staging).unwrap();
 
     let objects = staging.join("conary/objects");
-    assert!(
-        crate::filesystem::object_path(&objects, &artifact.cas_objects[0].sha256)
-            .unwrap()
-            .is_file()
-    );
+    for object in &artifact.cas_objects {
+        assert!(
+            crate::filesystem::object_path(&objects, &object.sha256)
+                .unwrap()
+                .is_file()
+        );
+    }
     assert!(
         !crate::filesystem::object_path(&objects, &extra.sha256)
             .unwrap()

--- a/crates/conary-core/src/generation/root_manifest.rs
+++ b/crates/conary-core/src/generation/root_manifest.rs
@@ -14,7 +14,8 @@ use std::path::{Component, Path};
 pub use composefs::build_erofs_image_from_root_manifest;
 pub use materialize::{
     apply_resolved_payload_metadata, materialize_captured_selected_root,
-    materialize_generation_root, materialize_state_root, overlay_payload_entries,
+    materialize_config_state_upper, materialize_generation_root, materialize_state_root,
+    overlay_payload_entries,
 };
 pub use scan::{
     capture_existing_payload_node, capture_root_node, scan_payload_tree, scan_selected_root,

--- a/crates/conary-core/src/generation/root_manifest.rs
+++ b/crates/conary-core/src/generation/root_manifest.rs
@@ -342,6 +342,12 @@ fn validate_hardlinks(entries: &[GenerationRootEntry]) -> crate::Result<()> {
                         entry.path, target, primary.path
                     )));
                 }
+                if classify_root_path(&entry.path)? != classify_root_path(&primary.path)? {
+                    return Err(crate::Error::InvalidPath(format!(
+                        "hardlink group crosses generation publication domains at {}",
+                        primary.path
+                    )));
+                }
                 if entry.node.source.mode != primary.node.source.mode
                     || entry.node.source.user != primary.node.source.user
                     || entry.node.source.group != primary.node.source.group

--- a/crates/conary-core/src/generation/root_manifest/materialize.rs
+++ b/crates/conary-core/src/generation/root_manifest/materialize.rs
@@ -67,6 +67,11 @@ pub fn materialize_config_state_upper(
     let mut entries = Vec::new();
     for entry in &manifest.entries {
         if entry.path == "/etc" {
+            if !matches!(entry.node.source.kind, PayloadNodeKind::Directory) {
+                return Err(crate::Error::InvalidPath(
+                    "config-state root /etc must describe a directory".to_string(),
+                ));
+            }
             root = Some(&entry.node);
             continue;
         }

--- a/crates/conary-core/src/generation/root_manifest/materialize.rs
+++ b/crates/conary-core/src/generation/root_manifest/materialize.rs
@@ -47,6 +47,58 @@ pub fn materialize_state_root(
     materialize_entries(&manifest.entries, cas, destination)
 }
 
+/// Recreate the `/etc` subtree as an overlay upper directory.
+///
+/// Mutable-state manifests use selected-root paths such as `/etc/passwd`,
+/// while an overlay upper for `/etc` stores that node as `passwd`. This
+/// projection keeps the typed manifest as authority while removing exactly
+/// one `/etc` prefix. `/var` and `/srv` entries remain owned by their live
+/// mutable roots and are not projected into the config upper.
+pub fn materialize_config_state_upper(
+    manifest: &MutableStateManifest,
+    cas: &CasStore,
+    destination: &Path,
+) -> crate::Result<()> {
+    manifest.validate()?;
+    require_sha256_cas(cas)?;
+    prepare_empty_destination(destination)?;
+
+    let mut root = None;
+    let mut entries = Vec::new();
+    for entry in &manifest.entries {
+        if entry.path == "/etc" {
+            root = Some(&entry.node);
+            continue;
+        }
+        let Some(relative) = entry.path.strip_prefix("/etc/") else {
+            continue;
+        };
+        let mut projected = entry.clone();
+        projected.path = format!("/{relative}");
+        if let PayloadNodeKind::Hardlink { target, identity } = &entry.node.source.kind {
+            let projected_target = target.strip_prefix("/etc/").ok_or_else(|| {
+                crate::Error::InvalidPath(format!(
+                    "config-state hardlink {} targets path outside /etc: {target}",
+                    entry.path
+                ))
+            })?;
+            projected.node.source.kind = PayloadNodeKind::Hardlink {
+                target: format!("/{projected_target}"),
+                identity: identity.clone(),
+            };
+        }
+        entries.push(projected);
+    }
+
+    materialize_entries(&entries, cas, destination)?;
+    if let Some(root) = root {
+        apply_resolved_payload_metadata(destination, root)?;
+    } else {
+        fs::set_permissions(destination, fs::Permissions::from_mode(0o755))?;
+    }
+    sync_directory(destination)
+}
+
 /// Recreate a complete selected root while preserving the captured root
 /// directory metadata after state entries have been installed.
 pub fn materialize_captured_selected_root(

--- a/crates/conary-core/src/generation/root_manifest/tests.rs
+++ b/crates/conary-core/src/generation/root_manifest/tests.rs
@@ -160,6 +160,42 @@ fn selected_root_round_trip_preserves_typed_tree_and_omits_ephemeral_domains() {
 }
 
 #[test]
+fn config_state_projection_removes_exactly_one_etc_prefix() {
+    let temp = tempfile::tempdir().unwrap();
+    let source = temp.path().join("source");
+    let upper = temp.path().join("upper");
+    let cas = CasStore::new(temp.path().join("objects")).unwrap();
+    for directory in ["etc", "etc/vendor", "var", "var/lib"] {
+        std::fs::create_dir_all(source.join(directory)).unwrap();
+    }
+    std::fs::write(source.join("etc/vendor/config"), b"configured=true\n").unwrap();
+    std::fs::hard_link(
+        source.join("etc/vendor/config"),
+        source.join("etc/vendor/config-link"),
+    )
+    .unwrap();
+    std::fs::write(source.join("var/lib/state"), b"mutable\n").unwrap();
+
+    let captured = scan_selected_root(&source, &cas).unwrap();
+    materialize_config_state_upper(&captured.state, &cas, &upper).unwrap();
+
+    assert_eq!(
+        std::fs::read(upper.join("vendor/config")).unwrap(),
+        b"configured=true\n"
+    );
+    assert_eq!(
+        std::fs::metadata(upper.join("vendor/config"))
+            .unwrap()
+            .ino(),
+        std::fs::metadata(upper.join("vendor/config-link"))
+            .unwrap()
+            .ino()
+    );
+    assert!(!upper.join("etc").exists());
+    assert!(!upper.join("var").exists());
+}
+
+#[test]
 fn scanner_rejects_hardlinks_across_publication_domains() {
     let temp = tempfile::tempdir().unwrap();
     let root = temp.path().join("root");

--- a/crates/conary-core/src/generation/root_manifest/tests.rs
+++ b/crates/conary-core/src/generation/root_manifest/tests.rs
@@ -196,6 +196,73 @@ fn config_state_projection_removes_exactly_one_etc_prefix() {
 }
 
 #[test]
+fn config_state_projection_rejects_non_directory_etc_authority() {
+    let temp = tempfile::tempdir().unwrap();
+    let cas = CasStore::new(temp.path().join("objects")).unwrap();
+    let manifest = MutableStateManifest {
+        version: GENERATION_ROOT_MANIFEST_VERSION,
+        entries: vec![GenerationRootEntry {
+            path: "/etc".to_string(),
+            node: resolved(PayloadNode {
+                kind: PayloadNodeKind::Symlink {
+                    target: "usr/etc".to_string(),
+                },
+                mode: libc::S_IFLNK | 0o777,
+                user: PayloadIdentity::Numeric {
+                    id: u64::from(unsafe { libc::geteuid() }),
+                },
+                group: PayloadIdentity::Numeric {
+                    id: u64::from(unsafe { libc::getegid() }),
+                },
+                mtime: PayloadTimestamp::UNIX_EPOCH,
+                xattrs: BTreeMap::new(),
+            }),
+            content: None,
+        }],
+    };
+    manifest.validate().unwrap();
+
+    let error =
+        materialize_config_state_upper(&manifest, &cas, &temp.path().join("config-state-upper"))
+            .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("config-state root /etc must describe a directory")
+    );
+}
+
+#[test]
+fn mutable_state_manifest_rejects_hardlinks_that_cross_publication_domains() {
+    let content = b"shared mutable state";
+    let identity = "mutable-domain:shared".to_string();
+    let mut primary = regular_entry("/etc/shared", content);
+    primary.node.source.kind = PayloadNodeKind::Regular {
+        hardlink_identity: Some(identity.clone()),
+    };
+    let mut linked = primary.clone();
+    linked.path = "/var/shared".to_string();
+    linked.node.source.kind = PayloadNodeKind::Hardlink {
+        target: "/etc/shared".to_string(),
+        identity,
+    };
+    linked.content = None;
+    let manifest = MutableStateManifest {
+        version: GENERATION_ROOT_MANIFEST_VERSION,
+        entries: vec![
+            directory_entry("/etc", 0o755),
+            primary,
+            directory_entry("/var", 0o755),
+            linked,
+        ],
+    };
+    let error = manifest.validate().unwrap_err();
+
+    assert!(error.to_string().contains("publication domains"));
+}
+
+#[test]
 fn scanner_rejects_hardlinks_across_publication_domains() {
     let temp = tempfile::tempdir().unwrap();
     let root = temp.path().join("root");

--- a/crates/conary-core/tests/generation_composefs_runtime_contract.rs
+++ b/crates/conary-core/tests/generation_composefs_runtime_contract.rs
@@ -502,6 +502,11 @@ fn initramfs_generation_mounts_expose_usr_without_partial_generation_fallback() 
         "readonly carriers must seed their tmpfs upper from exported config-state authority"
     );
     assert!(
+        dracut_generator.contains("if [ ! -d \"$ETC_STATE_SEED\" ]; then")
+            && dracut_generator.contains("if [ ! -d \"$ETC_UPPER\" ]; then"),
+        "boot must fail closed instead of creating an empty /etc upper when typed state is absent"
+    );
+    assert!(
         dracut_module.contains("inst_multiple -o blkid cp grep"),
         "the initramfs must carry the copy tool required for readonly config-state seeding"
     );

--- a/crates/conary-core/tests/generation_composefs_runtime_contract.rs
+++ b/crates/conary-core/tests/generation_composefs_runtime_contract.rs
@@ -493,6 +493,18 @@ fn initramfs_generation_mounts_expose_usr_without_partial_generation_fallback() 
         dracut_generator.contains("[ -f \"$EROFS_IMG\" ] ||"),
         "dracut must hard-fail when root.erofs is absent"
     );
+    assert!(
+        dracut_generator.contains("ETC_LOWER=\"${SYSROOT}/conary/etc-lower\""),
+        "generations without immutable /etc need one explicit empty overlay lower"
+    );
+    assert!(
+        dracut_generator.contains("cp -a \"$ETC_STATE_SEED\" \"$ETC_STATE_RUNTIME\""),
+        "readonly carriers must seed their tmpfs upper from exported config-state authority"
+    );
+    assert!(
+        dracut_module.contains("inst_multiple -o blkid cp grep"),
+        "the initramfs must carry the copy tool required for readonly config-state seeding"
+    );
 
     for (label, source) in [
         ("dracut generator", dracut_generator.as_str()),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -423,7 +423,7 @@ Generation-aware package mutation
        |
   conary system generation export --format raw|qcow2
        |
-  validated self-contained artifact contract -> staged ESP/rootfs -> systemd-repart
+  validated manifests + CAS -> exact config/mutable-state projection -> staged ESP/rootfs
 ```
 
 ### Generation Lifecycle
@@ -432,11 +432,18 @@ Generation-aware package mutation
 2. **Mutate**: Apply payload changes, typed native lifecycle, CCS hooks, triggers, and config decisions inside that isolated root
 3. **Record**: Capture exact immutable and mutable-state manifests, persist the selected-root candidate, and record recoverable publication debt before committing package state
 4. **Build**: Validate the captured manifests and serialize the immutable manifest to EROFS using verified CAS content
-5. **Materialize state**: Seed the generation-local mutable-state tree from its exact manifest, then apply the ordered typed config transactions
+5. **Materialize state**: Project `/etc/...` manifest paths into the generation-local `/etc` overlay upper without retaining the `/etc` prefix, then apply the ordered typed config transactions; `/var` and `/srv` remain live mutable-root state
 6. **Publish**: Advance one persisted replay phase at a time: artifact ready, current link durable, configuration status projected, matching system state active, and generation-bound database backup durable. Only the final phase makes publication debt terminal
 7. **Recover**: Under the runtime mutation lock, resume at the persisted phase and replay each remaining idempotent effect. A matching `/conary/current` link proves only link publication; it never implies configuration projection or database backup completion
 8. **Compensate**: Rollback records a new exact compensating selected root and removes terminal candidates
 9. **GC**: Remove old generations only after retaining every recoverable publication candidate and its typed CAS roots
+
+Raw, qcow2, and ISO export copy both typed manifests and their manifest-listed
+CAS objects. Export reconstructs `/var` and `/srv` in the carrier root and
+projects `/etc` into `/conary/etc-state/<generation>` above one explicit empty
+lower directory. Read-only carriers copy that seeded config upper to runtime
+tmpfs before mounting it, so writability never replaces or bypasses the
+artifact's typed state authority.
 
 ### Generation Module (`crates/conary-core/src/generation/`)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -421,7 +421,7 @@ Generation-aware package mutation
        |
  Generation N (immutable, verified)
        |
-  conary system generation export --format raw|qcow2
+  conary system generation export --format raw|qcow2|iso
        |
   validated manifests + CAS -> exact config/mutable-state projection -> staged ESP/rootfs
 ```

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -383,6 +383,12 @@ regular-file content authority all survive. Immutable content and mutable
 state reference the same SHA-256 CAS used by package payloads. Generation,
 retry, bootstrap EROFS, and try-session materialization consume those typed
 manifests rather than reconstructing lifecycle effects from package rows.
+Generation-local config projection removes exactly one `/etc` prefix when it
+materializes the overlay upper; `/var` and `/srv` entries cannot enter that
+upper. Boot-carrier export copies both manifests, reconstructs `/var` and
+`/srv`, and seeds the same `/etc` upper from verified, manifest-listed CAS
+objects. A read-only carrier may copy that seed to tmpfs for runtime writes,
+but the copied seed is not a second state authority.
 
 A generation-aware root mutation records a typed selected-root publication
 debt and durably installs its cumulative candidate before committing the

--- a/packaging/dracut/90conary/conary-generator.sh
+++ b/packaging/dracut/90conary/conary-generator.sh
@@ -88,6 +88,29 @@ prepare_etc_state_base() {
     fi
 
     mkdir -p "$ETC_STATE_BASE"
+    if [ "$CONARY_CARRIER" = "readonly" ]; then
+        ETC_STATE_SEED="${SYSROOT}/conary/etc-state/${CONARY_GEN}"
+        ETC_STATE_RUNTIME="${ETC_STATE_BASE}/${CONARY_GEN}"
+        if [ -d "$ETC_STATE_SEED" ] && [ ! -e "$ETC_STATE_RUNTIME" ]; then
+            cp -a "$ETC_STATE_SEED" "$ETC_STATE_RUNTIME" || {
+                echo "conary: failed to seed readonly /etc state for generation ${CONARY_GEN}" >&2
+                return 1
+            }
+        fi
+    fi
+}
+
+prepare_etc_lower() {
+    ETC_LOWER="${SYSROOT}/conary/mnt/etc"
+    if [ -d "$ETC_LOWER" ]; then
+        return 0
+    fi
+
+    ETC_LOWER="${SYSROOT}/conary/etc-lower"
+    mkdir -p "$ETC_LOWER" || {
+        echo "conary: failed to prepare empty /etc lower for generation ${CONARY_GEN}" >&2
+        return 1
+    }
 }
 
 prepare_readonly_var_state() {
@@ -146,12 +169,15 @@ ensure_root_symlink lib usr/lib || exit 1
 ensure_root_symlink lib64 usr/lib64 || exit 1
 ensure_root_symlink sbin usr/sbin || exit 1
 
-# Overlayfs for /etc (writable upper on immutable composefs lower)
-if [ -d "${SYSROOT}/conary/mnt/etc" ]; then
-    prepare_etc_state_base || exit 1
-    ETC_UPPER="${ETC_STATE_BASE}/${CONARY_GEN}"
-    ETC_WORK="${ETC_STATE_BASE}/${CONARY_GEN}-work"
-    mkdir -p "$ETC_UPPER" "$ETC_WORK"
-    mount -t overlay overlay "${SYSROOT}/etc" \
-        -o "lowerdir=${SYSROOT}/conary/mnt/etc,upperdir=${ETC_UPPER},workdir=${ETC_WORK}"
-fi
+# Overlayfs for /etc. Config state is manifest-projected into the generation
+# upper; generations with no immutable /etc use the explicit empty lower.
+prepare_etc_state_base || exit 1
+prepare_etc_lower || exit 1
+ETC_UPPER="${ETC_STATE_BASE}/${CONARY_GEN}"
+ETC_WORK="${ETC_STATE_BASE}/${CONARY_GEN}-work"
+mkdir -p "$ETC_UPPER" "$ETC_WORK"
+mount -t overlay overlay "${SYSROOT}/etc" \
+    -o "lowerdir=${ETC_LOWER},upperdir=${ETC_UPPER},workdir=${ETC_WORK}" || {
+    echo "conary: failed to mount /etc overlay for generation ${CONARY_GEN}" >&2
+    exit 1
+}

--- a/packaging/dracut/90conary/conary-generator.sh
+++ b/packaging/dracut/90conary/conary-generator.sh
@@ -74,6 +74,12 @@ read_current_generation() {
 }
 
 prepare_etc_state_base() {
+    ETC_STATE_SEED="${SYSROOT}/conary/etc-state/${CONARY_GEN}"
+    if [ ! -d "$ETC_STATE_SEED" ]; then
+        echo "conary: generation ${CONARY_GEN} is missing its exported /etc state seed" >&2
+        return 1
+    fi
+
     if [ "$CONARY_CARRIER" = "readonly" ]; then
         mkdir -p "${SYSROOT}/run"
         if ! grep -q " ${SYSROOT}/run " /proc/mounts 2>/dev/null; then
@@ -89,9 +95,8 @@ prepare_etc_state_base() {
 
     mkdir -p "$ETC_STATE_BASE"
     if [ "$CONARY_CARRIER" = "readonly" ]; then
-        ETC_STATE_SEED="${SYSROOT}/conary/etc-state/${CONARY_GEN}"
         ETC_STATE_RUNTIME="${ETC_STATE_BASE}/${CONARY_GEN}"
-        if [ -d "$ETC_STATE_SEED" ] && [ ! -e "$ETC_STATE_RUNTIME" ]; then
+        if [ ! -e "$ETC_STATE_RUNTIME" ]; then
             cp -a "$ETC_STATE_SEED" "$ETC_STATE_RUNTIME" || {
                 echo "conary: failed to seed readonly /etc state for generation ${CONARY_GEN}" >&2
                 return 1
@@ -175,7 +180,11 @@ prepare_etc_state_base || exit 1
 prepare_etc_lower || exit 1
 ETC_UPPER="${ETC_STATE_BASE}/${CONARY_GEN}"
 ETC_WORK="${ETC_STATE_BASE}/${CONARY_GEN}-work"
-mkdir -p "$ETC_UPPER" "$ETC_WORK"
+if [ ! -d "$ETC_UPPER" ]; then
+    echo "conary: generation ${CONARY_GEN} has no materialized /etc upper" >&2
+    exit 1
+fi
+mkdir -p "$ETC_WORK"
 mount -t overlay overlay "${SYSROOT}/etc" \
     -o "lowerdir=${ETC_LOWER},upperdir=${ETC_UPPER},workdir=${ETC_WORK}" || {
     echo "conary: failed to mount /etc overlay for generation ${CONARY_GEN}" >&2

--- a/packaging/dracut/90conary/module-setup.sh
+++ b/packaging/dracut/90conary/module-setup.sh
@@ -28,7 +28,7 @@ install() {
     install_conary_script "$moddir/conary-generator.sh" "/sbin/conary-generator"
     install_conary_script "$moddir/conary-generator.sh" \
         "/var/lib/dracut/hooks/pre-pivot/90-conary-generator.sh"
-    inst_multiple -o blkid grep head modprobe switch_root
+    inst_multiple -o blkid cp grep head modprobe switch_root
     # Include mount.composefs if available
     inst_multiple -o mount.composefs
 }


### PR DESCRIPTION
## Primary Issue

Refs #181

Design / Plan / Roadmap: generation ownership card and `docs/ARCHITECTURE.md#system-generations`

## Problem And Outcome

Installed-runtime generation export copied the immutable image and CAS but omitted both typed root manifests and projected no mutable state. Exported Fedora therefore booted with an empty `/etc` and entered `systemd-firstboot`. The same trace showed normal publication was placing absolute `/etc/...` paths one level too deep in the overlay upper.

After this change, one typed manifest/CAS authority projects config state at the correct overlay-relative path, raw/qcow2/ISO carriers include both manifests, writable carrier roots reconstruct `/var` and `/srv`, and readonly carriers seed the exported `/etc` upper into runtime tmpfs.

## Changes

- add an exact `MutableStateManifest` to `/etc`-upper projector that strips one prefix and preserves typed metadata, content, and hardlinks
- reject non-directory `/etc` authority and hardlink groups that cross generation publication domains
- use that projector for normal generation publication
- copy both root manifests during export and reconstruct mutable state from the exported verified CAS
- move the projected `/etc` tree to `/conary/etc-state/{generation}` while retaining `/var` and `/srv` in the carrier root
- add an explicit empty `/etc` lower and fail hard if the boot overlay cannot mount
- seed readonly config state into tmpfs and include `cp` in the generated initramfs
- fail closed for both carrier types when the exported per-generation `/etc` seed or materialized upper is absent
- document the generation/export state boundary

## Scope

- In scope: generation config-state projection, raw/qcow2/ISO rootfs projection, dracut activation of exported state, focused contracts and docs
- Out of scope: fixture-manifest corrections in PR #151, Remi conversion/release work, unrelated mutable-root lifecycle behavior

## Ownership / Boundary

- Owning subsystem: generation build, publication, boot activation, and export
- Boundary changed or preserved: preserves `GenerationRootManifest`/`MutableStateManifest` plus SHA-256 CAS as the sole authority; fixes their carrier and overlay projection
- Persisted state or public surface impact: exported carrier layout now contains the manifests it already declared and populated state paths; no schema or manifest-version change
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code
- [x] Updated subsystem docs or maps when the look-here-first path changed
- [ ] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs

```text
bash scripts/agent-context.sh --path crates/conary-core/src/generation/export.rs
bash -n packaging/dracut/90conary/conary-generator.sh packaging/dracut/90conary/conary-init.sh packaging/dracut/90conary/module-setup.sh
cargo test -p conary-core generation::root_manifest --lib  # 9 passed
cargo test -p conary-core generation::builder  # 35 passed
cargo test -p conary-core generation::export  # 15 passed
cargo test -p conary-core --test generation_composefs_runtime_contract  # 17 passed
cargo test -p conary --lib commands::generation::publication  # 5 passed
cargo test -p conary --lib commands::generation::config_transaction  # 14 passed
bash scripts/check-doc-truth.sh  # passed
cargo fmt --check  # passed
cargo clippy --workspace --all-targets -- -D warnings  # passed
cargo clippy -p conary-core --all-targets -- -D warnings  # passed after final authority validation
 git diff --check  # passed
```

The corrected Group O TGE04 boot gate remains pending until this PR is reviewed/merged, PR #151 is refreshed, and the staging static binary is rebuilt.

## Review And Merge Notes

- Review focus: exact path transformation/hardlink handling, export staging order, readonly tmpfs seeding, and overlay fail-closed behavior
- User or developer impact: installed-runtime exports retain captured machine configuration and can reach normal boot instead of first-boot setup
- Required-check bypass: not used