### PR TITLE
release(remi): prepare 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [remi-v0.9.1] - 2026-07-29
+
+### Fixed
+- classify selected-root alias domains (#180)
+- preserve root ownership anchors (#178)
+- use DNF5 installed-reason contract (#172)
+- publish immutable test artifacts (#171)
+
 ## [remi-v0.9.0] - 2026-07-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4857,7 +4857,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remi"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/apps/remi/Cargo.toml
+++ b/apps/remi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remi"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]


### PR DESCRIPTION
## Primary Issue

Refs #177

Design / Plan / Roadmap: `docs/operations/release-artifact-matrix.md`

## Problem And Outcome

Remi 0.9.0 predates the reviewed RPM root-ownership-anchor fix from #178, so the public Fedora conversion path cannot yet prove issue #177's acceptance criteria. This PR prepares the smallest reviewed Remi 0.9.1 release packet. After merge, the exact reviewed merge commit can be tagged, built, deployed, and independently exercised before #177 is closed.

## Changes

- bump the Remi crate and lockfile version from 0.9.0 to 0.9.1
- add the Remi 0.9.1 changelog entry for the already-merged fixes in #171, #172, #178, and #180
- leave tag creation, release build, deployment, and live Fedora proof outside this PR until exact-head CI and review complete

## Scope

- In scope: Remi version metadata and release notes for 0.9.1
- Out of scope: new runtime behavior, compatibility paths, tag creation, deployment, and live acceptance closure

## Ownership / Boundary

- Owning subsystem: release assembly and Remi service packaging
- Boundary changed or preserved: preserves the reviewed runtime authority; only release identity and notes change
- Persisted state or public surface impact: no persisted-state change in this PR; the later immutable tag will publish Remi 0.9.1
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Existing regression coverage was added and reviewed in the linked behavior PRs
- [x] Ran affected-package verification directly when touching service or daemon code
- [x] No subsystem routing path changed
- [x] Ran the release card's focused proof; workflow interaction gates are unchanged
- [x] Issue #177 remains open for tag, deploy, and live Fedora proof

```text
bash scripts/check-release-matrix.sh
bash scripts/test-release-matrix.sh
cargo test -p conary-core --example sign_hash
cargo test -p conary --test release_ccs_manifest
cargo test -p conary-test container::image
cargo test -p remi
bash scripts/check-doc-truth.sh
cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
```

Observed locally: release policy and fixtures passed; signer and shipping-manifest tests passed; 7 container image tests passed; Remi completed 591 tests (586 library, 5 binary, 3 CLI integration, 2 ignored doctests) with no failures; docs truth, formatting, and workspace warning-denied Clippy passed.

## Review And Merge Notes

- Review focus: exact 0.9.1 version alignment and changelog accuracy against already-merged PRs
- User or developer impact: enables an immutable Remi 0.9.1 tag and production proof after merge
- Required-check bypass: not used