### PR TITLE
fix(ccs): require authored architecture authority

### DIFF
--- a/apps/conary/src/commands/ccs/init.rs
+++ b/apps/conary/src/commands/ccs/init.rs
@@ -212,6 +212,42 @@ license = "MIT"
         assert_eq!(manifest.package.license.as_deref(), Some("MIT"));
         assert_eq!(manifest.package.release.as_str(), "1");
         assert_eq!(manifest.package.kind, PackageKindTagV2::Package);
+        assert_eq!(
+            manifest
+                .package
+                .platform
+                .as_ref()
+                .and_then(|platform| platform.arch.as_deref()),
+            Some(conary_core::ccs::manifest::DEFAULT_CONARY_ARCHITECTURE)
+        );
+    }
+
+    #[tokio::test]
+    async fn default_init_writes_explicit_noarch_authority() {
+        let temp = tempfile::tempdir().unwrap();
+
+        cmd_ccs_init(
+            temp.path().to_str().unwrap(),
+            Some("demo".to_string()),
+            "0.1.0",
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let content = std::fs::read_to_string(temp.path().join("ccs.toml")).unwrap();
+        assert!(content.contains("[package.platform]"));
+        assert!(content.contains("arch = \"noarch\""));
+        let manifest = CcsManifest::parse(&content).unwrap();
+        assert_eq!(
+            manifest
+                .package
+                .platform
+                .as_ref()
+                .and_then(|platform| platform.arch.as_deref()),
+            Some(conary_core::ccs::manifest::DEFAULT_CONARY_ARCHITECTURE)
+        );
     }
 
     #[tokio::test]

--- a/apps/conary/src/commands/ccs/install/command_reinstall_tests.rs
+++ b/apps/conary/src/commands/ccs/install/command_reinstall_tests.rs
@@ -66,3 +66,104 @@ async fn ccs_install_reinstall_dry_run_does_not_mutate_db() {
         "dry-run reinstall must not delete the existing installed trove"
     );
 }
+
+#[tokio::test]
+async fn default_authored_package_upgrades_with_explicit_architecture_authority() {
+    use conary_core::ccs::{BuildResult, CcsManifest};
+    use conary_core::db::models::InstalledRequirementGroup;
+    use conary_core::repository::dependency_model::RepositoryRequirementKind;
+    use conary_core::repository::versioning::VersionScheme;
+
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let install_root = temp_dir.path().join("root");
+    let db_path = temp_dir.path().join("conary.db");
+    let db_path_str = db_path.to_str().unwrap();
+
+    std::fs::create_dir_all(&install_root).unwrap();
+    conary_core::db::init(db_path_str).unwrap();
+    super::test_support::stage_test_boot_assets(temp_dir.path());
+    super::test_support::seed_test_init_trove(db_path_str, temp_dir.path());
+
+    let package_result = |version: &str| {
+        let mut manifest = CcsManifest::new_minimal("authored-upgrade", version);
+        manifest.requirements.push(
+            conary_core::repository::requirement::parse_native_requirement(
+                RepositoryRequirementKind::Depends,
+                VersionScheme::Conary,
+                "test-init",
+            )
+            .unwrap(),
+        );
+        BuildResult {
+            manifest,
+            components: HashMap::new(),
+            files: Vec::new(),
+            payloads: Vec::new(),
+            total_size: 0,
+            chunked: false,
+            chunk_stats: None,
+        }
+    };
+
+    let first_package = temp_dir.path().join("authored-upgrade-1.ccs");
+    let first_policy =
+        super::test_support::write_signed_test_package(&package_result("1.0.0"), &first_package);
+    cmd_ccs_install(
+        first_package.to_str().unwrap(),
+        db_path_str,
+        install_root.to_str().unwrap(),
+        false,
+        Some(first_policy.to_string_lossy().into_owned()),
+        None,
+        crate::commands::SandboxMode::Always,
+        true,
+        false,
+    )
+    .await
+    .unwrap();
+
+    let conn = conary_core::db::open(db_path_str).unwrap();
+    let installed =
+        conary_core::db::models::Trove::find_by_name(&conn, "authored-upgrade").unwrap();
+    assert_eq!(installed.len(), 1);
+    assert_eq!(
+        installed[0].architecture.as_deref(),
+        Some(conary_core::ccs::manifest::DEFAULT_CONARY_ARCHITECTURE)
+    );
+    assert_eq!(
+        InstalledRequirementGroup::find_by_trove(&conn, installed[0].id.unwrap())
+            .unwrap()
+            .len(),
+        1,
+        "the replacement preflight must evaluate a persisted requirement"
+    );
+    drop(conn);
+
+    let second_package = temp_dir.path().join("authored-upgrade-2.ccs");
+    let second_policy =
+        super::test_support::write_signed_test_package(&package_result("2.0.0"), &second_package);
+    cmd_ccs_install(
+        second_package.to_str().unwrap(),
+        db_path_str,
+        install_root.to_str().unwrap(),
+        false,
+        Some(second_policy.to_string_lossy().into_owned()),
+        None,
+        crate::commands::SandboxMode::Always,
+        true,
+        false,
+    )
+    .await
+    .unwrap();
+
+    let conn = conary_core::db::open(db_path_str).unwrap();
+    let installed =
+        conary_core::db::models::Trove::find_by_name(&conn, "authored-upgrade").unwrap();
+    assert_eq!(installed.len(), 1);
+    assert_eq!(installed[0].version, "2.0.0");
+    assert_eq!(
+        installed[0].architecture.as_deref(),
+        Some(conary_core::ccs::manifest::DEFAULT_CONARY_ARCHITECTURE)
+    );
+}

--- a/apps/conary/src/commands/ccs/install/test_support.rs
+++ b/apps/conary/src/commands/ccs/install/test_support.rs
@@ -122,6 +122,8 @@ pub(super) fn seed_test_root_layout(
             TroveType::Package,
             conary_core::repository::versioning::VersionScheme::Conary,
         );
+        trove.architecture =
+            Some(conary_core::ccs::manifest::DEFAULT_CONARY_ARCHITECTURE.to_string());
         trove.installed_by_changeset_id = Some(changeset_id);
         let trove_id = trove.insert(tx)?;
         let mut component = Component::new(trove_id, "runtime".to_string());
@@ -204,7 +206,10 @@ pub(super) fn seed_test_init_trove(db_path: &str, db_dir: &std::path::Path) {
             "test-init".to_string(),
             "1.0.0".to_string(),
             TroveType::Package,
-        conary_core::repository::versioning::VersionScheme::Conary);
+            conary_core::repository::versioning::VersionScheme::Conary,
+        );
+        trove.architecture =
+            Some(conary_core::ccs::manifest::DEFAULT_CONARY_ARCHITECTURE.to_string());
         trove.installed_by_changeset_id = Some(changeset_id);
         let trove_id = trove.insert(tx)?;
 

--- a/apps/conary/src/commands/ccs/templates.rs
+++ b/apps/conary/src/commands/ccs/templates.rs
@@ -63,6 +63,14 @@ mod tests {
         assert_eq!(manifest.package.version, "0.1.0");
         assert_eq!(manifest.package.release.as_str(), "1");
         assert_eq!(manifest.package.kind, PackageKindTagV2::Package);
+        assert_eq!(
+            manifest
+                .package
+                .platform
+                .as_ref()
+                .and_then(|platform| platform.arch.as_deref()),
+            Some(conary_core::ccs::manifest::DEFAULT_CONARY_ARCHITECTURE)
+        );
     }
 
     #[test]

--- a/apps/conary/tests/conversion_integration.rs
+++ b/apps/conary/tests/conversion_integration.rs
@@ -501,7 +501,7 @@ fn test_empty_package_conversion() {
         name: "empty-pkg".to_string(),
         version: "1.0.0".to_string(),
         version_scheme: VersionScheme::Rpm,
-        architecture: None, // No architecture
+        architecture: Some("noarch".to_string()),
         debian_multi_arch: None,
         description: None, // No description
         files: vec![],     // No files

--- a/crates/conary-core/src/ccs/archive_reader.rs
+++ b/crates/conary-core/src/ccs/archive_reader.rs
@@ -336,7 +336,7 @@ impl InspectionState {
         }
 
         Ok(UntrustedCcsArchive {
-            manifest: install_manifest_projection(&authority),
+            manifest: untrusted_manifest_projection(&authority),
             components: crate::ccs::v2::component_view::components(&authority),
             census: self.census,
             v2_authority: authority,
@@ -369,19 +369,17 @@ fn require_format_version_2(raw: &[u8]) -> anyhow::Result<()> {
     }
 }
 
-fn install_manifest_projection(authority: &AuthorityDocumentV2) -> CcsManifest {
-    let mut manifest =
-        CcsManifest::new_minimal(&authority.identity.name, &authority.identity.version);
-    manifest.package.version_scheme = authority.identity.version_scheme;
-    manifest.package.release = authority.identity.release.clone();
-    manifest.package.kind = authority.identity.kind;
+fn untrusted_manifest_projection(authority: &AuthorityDocumentV2) -> CcsManifest {
+    let mut manifest = crate::ccs::v2::project_manifest_identity(
+        authority,
+        format!(
+            "Untrusted inspection projection for CCS v2 {:?}",
+            authority.identity.kind
+        ),
+    );
     manifest.requirements = authority.requirements.clone();
     manifest.relations = authority.relations.clone();
     manifest.native_lifecycle = authority.lifecycle.native_lifecycle.clone();
-    manifest.package.description = format!(
-        "Untrusted inspection projection for CCS v2 {:?}",
-        authority.identity.kind
-    );
     manifest
 }
 

--- a/crates/conary-core/src/ccs/archive_reader/tests.rs
+++ b/crates/conary-core/src/ccs/archive_reader/tests.rs
@@ -58,6 +58,23 @@ fn inspection_is_explicitly_untrusted_and_v2_only() {
 
     assert_eq!(archive.v2_authority.identity.name, "current");
     assert_eq!(archive.manifest.package.name, "current");
+    assert_eq!(
+        archive
+            .manifest
+            .package
+            .platform
+            .as_ref()
+            .and_then(|platform| platform.arch.as_deref()),
+        archive.v2_authority.identity.architecture.as_deref()
+    );
+    assert_eq!(
+        archive.manifest.package.debian_multi_arch,
+        archive.v2_authority.identity.debian_multi_arch
+    );
+    assert_eq!(
+        archive.manifest.requirements,
+        archive.v2_authority.requirements
+    );
     assert!(archive.signature_raw.is_some());
     assert_eq!(archive.census.files, 1);
     assert!(has_current_ccs_archive_contract(path).unwrap());

--- a/crates/conary-core/src/ccs/convert/converter/tests.rs
+++ b/crates/conary-core/src/ccs/convert/converter/tests.rs
@@ -483,6 +483,29 @@ fn conversion_preserves_exact_source_architecture_tokens_in_signed_identity() {
 }
 
 #[test]
+fn conversion_rejects_missing_source_architecture_authority() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let converter = passive_test_converter(temp_dir.path());
+    let mut metadata = make_test_metadata();
+    metadata.architecture = None;
+
+    let error = converter
+        .convert_in_memory_for_test(
+            &metadata,
+            &make_test_files(),
+            "rpm",
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        ConversionError::BuildError(message)
+            if message.contains("v2 package identity architecture is required")
+    ));
+}
+
+#[test]
 fn converted_rpm_preserves_exact_config_and_ghost_authority() {
     let temp_dir = tempfile::tempdir().unwrap();
     let mut metadata = make_test_metadata();

--- a/crates/conary-core/src/ccs/manifest.rs
+++ b/crates/conary-core/src/ccs/manifest.rs
@@ -31,6 +31,9 @@ use std::collections::HashMap;
 use std::path::Path;
 use thiserror::Error;
 
+/// Explicit architecture-independent token for native Conary-authored packages.
+pub const DEFAULT_CONARY_ARCHITECTURE: &str = "noarch";
+
 #[derive(Error, Debug)]
 pub enum ManifestError {
     #[error("Failed to read manifest file: {0}")]
@@ -341,7 +344,10 @@ impl CcsManifest {
                 license: None,
                 homepage: None,
                 repository: None,
-                platform: None,
+                platform: Some(Platform {
+                    arch: Some(DEFAULT_CONARY_ARCHITECTURE.to_string()),
+                    ..Platform::default()
+                }),
                 authors: None,
             },
             provides: Provides::default(),

--- a/crates/conary-core/src/ccs/manifest/tests.rs
+++ b/crates/conary-core/src/ccs/manifest/tests.rs
@@ -81,6 +81,17 @@ fn test_generate_minimal() {
     let toml = manifest.to_toml().unwrap();
     assert!(toml.contains("name = \"test\""));
     assert!(toml.contains("version = \"0.1.0\""));
+    assert!(toml.contains("[package.platform]"));
+    assert!(toml.contains("arch = \"noarch\""));
+    let decoded = CcsManifest::parse(&toml).unwrap();
+    assert_eq!(
+        decoded
+            .package
+            .platform
+            .as_ref()
+            .and_then(|platform| platform.arch.as_deref()),
+        Some(DEFAULT_CONARY_ARCHITECTURE)
+    );
 }
 
 #[test]

--- a/crates/conary-core/src/ccs/package.rs
+++ b/crates/conary-core/src/ccs/package.rs
@@ -310,6 +310,9 @@ release = "1"
 kind = "package"
 description = "test fixture"
 license = "MIT"
+
+[package.platform]
+arch = "noarch"
 "#,
         )
         .unwrap();
@@ -393,6 +396,9 @@ release = "1"
 kind = "package"
 description = "symlink fixture"
 license = "MIT"
+
+[package.platform]
+arch = "noarch"
 "#,
         )
         .unwrap();

--- a/crates/conary-core/src/ccs/package/v2_projection.rs
+++ b/crates/conary-core/src/ccs/package/v2_projection.rs
@@ -4,7 +4,7 @@
 
 use crate::ccs::attestation::{BuildAttestationEnvelope, ForeignConversionBoundary};
 use crate::ccs::builder::FileEntry;
-use crate::ccs::manifest::{CcsManifest, Platform};
+use crate::ccs::manifest::CcsManifest;
 use crate::ccs::v2::AuthorityDocumentV2;
 use crate::ccs::v2::schema::{DependencyKindV2, PackageKindV2};
 use crate::error::{Error, Result};
@@ -16,22 +16,10 @@ pub(super) fn install_manifest_from_v2(
     build_attestation: Option<BuildAttestationEnvelope>,
     foreign_conversion_boundary: Option<ForeignConversionBoundary>,
 ) -> Result<CcsManifest> {
-    let mut manifest =
-        CcsManifest::new_minimal(&authority.identity.name, &authority.identity.version);
-    manifest.package.version_scheme = authority.identity.version_scheme;
-    manifest.package.release = authority.identity.release.clone();
-    manifest.package.kind = authority.identity.kind;
-    manifest.package.platform =
-        if authority.identity.platform.is_some() || authority.identity.architecture.is_some() {
-            Some(Platform {
-                os: authority.identity.platform.clone().unwrap_or_default(),
-                arch: authority.identity.architecture.clone(),
-                ..Platform::default()
-            })
-        } else {
-            None
-        };
-    manifest.package.description = format!("CCS v2 {}", authority.identity.name);
+    let mut manifest = crate::ccs::v2::project_manifest_identity(
+        authority,
+        format!("CCS v2 {}", authority.identity.name),
+    );
 
     manifest.requirements = authority.requirements.clone();
     manifest.relations = authority.relations.clone();

--- a/crates/conary-core/src/ccs/v2/authoring.rs
+++ b/crates/conary-core/src/ccs/v2/authoring.rs
@@ -55,6 +55,25 @@ pub fn lint_manifest_for_v2_authoring(
             blocks_publish: true,
         });
     }
+    if manifest
+        .package
+        .platform
+        .as_ref()
+        .and_then(|platform| platform.arch.as_deref())
+        .is_none_or(|architecture| architecture.trim().is_empty())
+    {
+        findings.push(AuthoringFinding {
+            code: "m4b-missing-architecture",
+            bucket: AuthoringFindingBucket::Contract,
+            severity: AuthoringFindingSeverity::Error,
+            field: Some("package.platform.arch"),
+            message: "v2 package authoring requires exact architecture authority".to_string(),
+            suggestion: "set arch = \"noarch\" under [package.platform] for an architecture-independent Conary package, or use the exact target architecture token",
+            blocks_build: true,
+            blocks_local_test: true,
+            blocks_publish: true,
+        });
+    }
     if manifest.components.default.len() != 1 || manifest.components.default[0].trim().is_empty() {
         findings.push(AuthoringFinding {
             code: "m4b-default-component",

--- a/crates/conary-core/src/ccs/v2/authoring/tests.rs
+++ b/crates/conary-core/src/ccs/v2/authoring/tests.rs
@@ -51,6 +51,10 @@ fn projection_builds_complete_local_dev_package_authority() {
     assert_eq!(projected.authority.identity.name, "hello");
     assert_eq!(projected.authority.identity.release, "1");
     assert_eq!(
+        projected.authority.identity.architecture.as_deref(),
+        Some(crate::ccs::manifest::DEFAULT_CONARY_ARCHITECTURE)
+    );
+    assert_eq!(
         projected.authority.provenance.hardening_level.as_deref(),
         Some("host")
     );
@@ -60,6 +64,26 @@ fn projection_builds_complete_local_dev_package_authority() {
             .payloads
             .iter()
             .any(|payload| payload.path == "/hello")
+    );
+}
+
+#[test]
+fn projection_rejects_missing_architecture_authority() {
+    let mut build = test_support::minimal_file_build_result("hello", "0.1.0", b"hello\n");
+    build.manifest.package.platform = None;
+
+    let error = project_build_result_to_v2(V2AuthoringInput {
+        build: &build,
+        local_dev: true,
+        debug_toml: None,
+    })
+    .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("package identity architecture is required"),
+        "expected architecture diagnostic, got {error}"
     );
 }
 
@@ -293,6 +317,27 @@ fn lint_manifest_reports_empty_release() {
 
     assert!(findings.iter().any(|f| f.field == Some("package.release")));
     assert!(findings.iter().all(|f| f.blocks_build));
+}
+
+#[test]
+fn lint_manifest_rejects_missing_or_empty_architecture_authority() {
+    for platform in [
+        None,
+        Some(crate::ccs::manifest::Platform {
+            arch: Some("  ".to_string()),
+            ..Default::default()
+        }),
+    ] {
+        let mut manifest = crate::ccs::manifest::CcsManifest::new_minimal("hello", "0.1.0");
+        manifest.package.platform = platform;
+
+        let findings = lint_manifest_for_v2_authoring(&manifest);
+        assert!(findings.iter().any(|finding| {
+            finding.code == "m4b-missing-architecture"
+                && finding.field == Some("package.platform.arch")
+                && finding.blocks_build
+        }));
+    }
 }
 
 #[test]

--- a/crates/conary-core/src/ccs/v2/manifest_projection.rs
+++ b/crates/conary-core/src/ccs/v2/manifest_projection.rs
@@ -1,0 +1,61 @@
+// conary-core/src/ccs/v2/manifest_projection.rs
+
+//! Shared projection of signed v2 identity into the compatibility manifest.
+
+use super::AuthorityDocumentV2;
+use crate::ccs::manifest::{CcsManifest, Platform};
+
+pub(crate) fn project_manifest_identity(
+    authority: &AuthorityDocumentV2,
+    description: String,
+) -> CcsManifest {
+    let mut manifest =
+        CcsManifest::new_minimal(&authority.identity.name, &authority.identity.version);
+    manifest.package.version_scheme = authority.identity.version_scheme;
+    manifest.package.release = authority.identity.release.clone();
+    manifest.package.kind = authority.identity.kind;
+    manifest.package.debian_multi_arch = authority.identity.debian_multi_arch;
+    manifest.package.platform =
+        if authority.identity.platform.is_some() || authority.identity.architecture.is_some() {
+            Some(Platform {
+                os: authority.identity.platform.clone().unwrap_or_default(),
+                arch: authority.identity.architecture.clone(),
+                ..Platform::default()
+            })
+        } else {
+            None
+        };
+    manifest.package.description = description;
+    manifest
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repository::dependency_model::DebianMultiArch;
+    use crate::repository::versioning::VersionScheme;
+
+    #[test]
+    fn exact_v2_identity_overwrites_native_authoring_defaults() {
+        let mut authority = AuthorityDocumentV2::package_for_tests("identity-projection");
+        authority.identity.version_scheme = VersionScheme::Debian;
+        authority.identity.release = "7".to_string();
+        authority.identity.architecture = Some("all".to_string());
+        authority.identity.debian_multi_arch = Some(DebianMultiArch::Foreign);
+        authority.identity.platform = None;
+
+        let manifest = project_manifest_identity(&authority, "untrusted inspection".to_string());
+
+        assert_eq!(manifest.package.version_scheme, VersionScheme::Debian);
+        assert_eq!(manifest.package.release, "7");
+        assert_eq!(manifest.package.kind, authority.identity.kind);
+        assert_eq!(
+            manifest.package.debian_multi_arch,
+            Some(DebianMultiArch::Foreign)
+        );
+        let platform = manifest.package.platform.as_ref().unwrap();
+        assert_eq!(platform.os, "");
+        assert_eq!(platform.arch.as_deref(), Some("all"));
+        assert_eq!(manifest.package.description, "untrusted inspection");
+    }
+}

--- a/crates/conary-core/src/ccs/v2/mod.rs
+++ b/crates/conary-core/src/ccs/v2/mod.rs
@@ -7,6 +7,7 @@ pub mod debug_projection;
 pub mod diagnostics;
 pub mod identity;
 pub(crate) mod lifecycle;
+pub(crate) mod manifest_projection;
 pub mod reader;
 pub mod schema;
 #[cfg(test)]
@@ -21,6 +22,7 @@ pub use diagnostics::{V2Diagnostic, V2DiagnosticCode, V2ValidationError};
 pub use identity::{
     ContentIdentityProjectionV2, compute_v2_content_identity, compute_v2_file_merkle_root,
 };
+pub(crate) use manifest_projection::project_manifest_identity;
 pub use reader::{ReadAuthorityV2, read_authority_document};
 pub use schema::{
     AuthorityDocumentV2, DependencyEntryV2, FORMAT_VERSION_V2, PackageKindTagV2, PackageKindV2,

--- a/crates/conary-core/src/ccs/v2/validation.rs
+++ b/crates/conary-core/src/ccs/v2/validation.rs
@@ -694,6 +694,20 @@ mod tests {
     }
 
     #[test]
+    fn rejects_missing_or_empty_identity_architecture() {
+        for architecture in [None, Some("  ".to_string())] {
+            let mut authority = AuthorityDocumentV2::package_for_tests("bad-architecture");
+            authority.identity.architecture = architecture;
+
+            let error = validate_authority(&authority).unwrap_err();
+            assert!(error.diagnostics.iter().any(|diagnostic| {
+                diagnostic.code == V2DiagnosticCode::MissingAuthority
+                    && diagnostic.field.as_deref() == Some("identity.architecture")
+            }));
+        }
+    }
+
+    #[test]
     fn rejects_symlink_with_invalid_signed_target() {
         let mut authority = AuthorityDocumentV2::package_for_tests("bad-link");
         let PackageKindV2::Package(data) = &mut authority.kind else {

--- a/crates/conary-core/src/ccs/v2/validation/identity.rs
+++ b/crates/conary-core/src/ccs/v2/validation/identity.rs
@@ -45,6 +45,19 @@ pub(super) fn validate_identity(
             "set identity.release to a positive decimal CCS build release",
         ));
     }
+    if authority
+        .identity
+        .architecture
+        .as_deref()
+        .is_none_or(|architecture| architecture.trim().is_empty())
+    {
+        diagnostics.push(V2Diagnostic::error(
+            V2DiagnosticCode::MissingAuthority,
+            "v2 package identity architecture is required",
+            Some("identity.architecture".to_string()),
+            "encode the exact source-native architecture token; architecture-independent Conary packages use noarch",
+        ));
+    }
     match (
         authority.identity.version_scheme,
         authority.identity.debian_multi_arch,

--- a/docs/modules/ccs.md
+++ b/docs/modules/ccs.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-07-29
-revision: 51
+revision: 52
 summary: Convert foreign packages into source-independent CCS lifecycle transactions and export CCS as native packages
 ---
 
@@ -46,6 +46,7 @@ CcsBuilder::new(manifest, source_dir)
 | `CcsPackage` | package.rs | Parsed .ccs file ready for installation via PackageFormat trait |
 | CCS package projection | package/v2_projection.rs | Project verified signed v2 authority into install-time package data |
 | `AuthorityDocumentV2` | v2/schema.rs | Signed CCS v2 native package authority |
+| v2 manifest identity projection | v2/manifest_projection.rs | Project one exact signed identity into install and untrusted-inspection compatibility manifests |
 | `CcsStructuralBudget` | budget.rs | Single owner of every CCS structural and operator-resource limit; authoring preflight and verification both admit against it |
 | `AuthorityCensus` | budget.rs | Exact structural measurement of one authority document; derives that package's byte ceilings |
 | Component view | v2/component_view.rs | Derives component and file views from signed authority instead of a duplicated archive projection |
@@ -300,6 +301,10 @@ for source-backed collection, policy transforms, and archive emission, and
 into signed v2 authority. `crates/conary-core/src/ccs/v2/lifecycle.rs` owns the
 exact bidirectional projection between manifest lifecycle declarations, signed
 v2 lifecycle authority, and the install-interface manifest projection.
+`crates/conary-core/src/ccs/v2/manifest_projection.rs` is the sole projection
+of signed package identity into both install and untrusted-inspection
+compatibility manifests, so authoring defaults cannot overwrite native
+architecture or Debian `Multi-Arch` authority.
 `crates/conary-core/src/ccs/v2/validation/identity.rs` owns exact package
 identity and typed provider validation; the validation hub owns orchestration.
 `crates/conary-core/src/ccs/v2/validation/config.rs` owns exact per-path config

--- a/docs/modules/ccs.md
+++ b/docs/modules/ccs.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-07-29
-revision: 50
+revision: 51
 summary: Convert foreign packages into source-independent CCS lifecycle transactions and export CCS as native packages
 ---
 
@@ -419,6 +419,13 @@ conary ccs build --local-dev
 conary ccs verify package.ccs
 conary ccs test package.ccs --dry-run
 ```
+
+`ccs init` writes `[package.platform]` with the explicit Conary `noarch`
+architecture token. That token is signed architecture-independent authority,
+not an omitted value for the target to infer. Authors of architecture-specific
+payloads must replace it with the exact target architecture token before
+building. Authoring lint and signed-v2 verification reject missing or blank
+architecture authority before installation.
 
 Config-only packages can be authored and contract-tested directly:
 

--- a/docs/specs/ccs-format-v2.md
+++ b/docs/specs/ccs-format-v2.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-27
-revision: 5
+last_updated: 2026-07-29
+revision: 6
 summary: Canonical signed CCS v2 authority, archive, payload, and trust contract
 ---
 
@@ -83,6 +83,12 @@ is a format-independent wildcard. The release remains part of exact identity
 through repository selection, SAT output, installation, state snapshots,
 rollback, and display, so two packages with the same name/version but different
 release cannot collide or be re-resolved to one another.
+
+The native authoring template emits Conary `noarch` explicitly for an
+architecture-independent package. Authors replace it with an exact target
+token when payloads are architecture-specific. Missing and blank architecture
+authority are rejected by authoring preflight and signed-v2 validation;
+consumers never substitute the current host architecture.
 
 Each provided capability signs its exact kind, name, version scheme,
 architecture qualifier, and either no version authority or a paired typed


### PR DESCRIPTION
## Primary Issue

Refs #184

Design / Plan / Roadmap:
- `docs/specs/ccs-format-v2.md`
- `docs/modules/ccs.md`
- Parent supported-host proof: #137 / #179 / #151

## Problem And Outcome

The default `ccs init` path emitted no package architecture. CCS v2 authoring signed that absence, initial install persisted an architectureless identity, and the first replacement install then failed when exact dependency evaluation correctly rejected the malformed installed package.

After this change, native Conary authoring emits explicit signed `noarch` authority, authoring and signed-v2 validation reject missing or blank architecture, and a default-authored package survives an actual version-1 to version-2 replacement with its persisted dependency group evaluated.

## Changes

- Make `CcsManifest::new_minimal` carry explicit Conary `noarch` platform authority, covering default and named `ccs init` templates.
- Add blocking authoring lint and signed-v2 identity validation for absent or blank architecture.
- Add a transactional two-install regression that persists one typed dependency, confirms `noarch` in installed state, and upgrades through replacement evaluation.
- Centralize signed v2 identity projection so install and untrusted inspection preserve exact architecture and Debian `Multi-Arch` authority instead of inheriting authoring defaults.
- Keep converted Debian `all`, Arch `any`, and RPM `noarch` tokens exact; no resolver fallback or host-architecture inference was added.
- Correct native conversion and signed package-writer fixtures to carry their actual `noarch` authority, and prove that genuinely missing source architecture fails closed.
- Document the generated default and the requirement to replace it for architecture-specific payloads.

## Scope

- In scope: native CCS manifest generation, v2 authoring/verification admission, exact v2 compatibility projection, CCS replacement-install contract proof, owning documentation.
- Out of scope: migration of disposable pre-alpha state, resolver relaxation, native token normalization, PR #151 supported-host execution itself.

## Ownership / Boundary

- Owning subsystem: `ccs`, with `resolution` and `install` interaction gates.
- Boundary changed or preserved: authoring now emits what strict dependency evaluation already requires; resolver fail-closed behavior is preserved; signed identity has one compatibility-projection owner.
- Persisted state or public surface impact: newly authored packages persist explicit `noarch`; generated `ccs.toml` and validation diagnostics change; no schema migration.
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code (not applicable; no service/daemon code changed)
- [x] Updated subsystem docs or maps when the "look here first" path changed (owning docs updated; top-level routing unchanged)
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs (live TGE05 proof remains after merge)

```text
cargo test -p conary-core ccs::manifest
cargo test -p conary-core ccs::v2
cargo test -p conary-core ccs::verify
cargo test -p conary-core ccs::archive_reader
cargo test -p conary-core ccs::package::v2_projection
cargo test -p conary-core ccs::convert::converter::tests
cargo test -p conary-core resolver
cargo test -p conary-core transaction::package_relations
cargo test -p conary-core conversion_preserves_exact_source_architecture_tokens_in_signed_identity
cargo test -p conary-core --lib
cargo test -p conary --lib commands::ccs
cargo test -p conary --lib commands::install
cargo test -p conary --test conversion_integration
cargo test -p conary --test conversion_integration golden_conversion
cargo test --workspace --exclude conary-test
cargo fmt --check
bash scripts/check-doc-truth.sh
cargo clippy --workspace --all-targets -- -D warnings
```

Observed local results on the final source state: manifest 32/32; v2 61/61; verify 11/11; archive reader 7/7; install projection 3/3; converter tests 19/19; resolver 118/118; package relations 16/16; CCS commands 47/47; install 159 passed with the one documented network conformance test ignored; conversion integration 16/16; conversion golden 4/4; exact native architecture-token preservation passed; all 3,161 core library tests passed except the two documented ignores; and the exact workspace command passed across Conary, core, Remi, conaryd, integration suites, and doctests. The version-1/version-2 transactional regression passed and printed `Architecture: noarch` for both installs. Documentation truth, formatting, and zero-warning workspace Clippy passed.

Exact-head CI: run 30435616779 passed all 15 jobs on `5969f4f4e2182bde7d0bd961e22eb3e3a01b1fc1`.

## Review And Merge Notes

- Review focus: the explicit Conary `noarch` default, producer/consumer admission symmetry, shared exact identity projection, and the replacement-install regression.
- User or developer impact: freshly generated manifests gain `[package.platform]`; architecture-specific authors must replace the visible default before build.
- Required-check bypass: not used
