### PR TITLE
fix(ccs): sign file capability authority

### DIFF
--- a/apps/conary/src/commands/remi_publish.rs
+++ b/apps/conary/src/commands/remi_publish.rs
@@ -211,6 +211,7 @@ mod tests {
             requirements: Vec::new(),
             relations: Vec::new(),
             capabilities: None,
+            file_capabilities: Vec::new(),
             components: BTreeMap::from([(
                 "main".to_string(),
                 ComponentAuthorityV2 {

--- a/apps/conary/tests/packaging_m4a.rs
+++ b/apps/conary/tests/packaging_m4a.rs
@@ -179,6 +179,7 @@ fn v2_authority(name: &str) -> AuthorityDocumentV2 {
         requirements: Vec::new(),
         relations: Vec::new(),
         capabilities: None,
+        file_capabilities: Vec::new(),
         components: BTreeMap::from([(
             "main".to_string(),
             ComponentAuthorityV2 {

--- a/apps/conary/tests/packaging_m4c.rs
+++ b/apps/conary/tests/packaging_m4c.rs
@@ -361,6 +361,7 @@ fn release_artifact_with_attestation(
         requirements: Vec::new(),
         relations: Vec::new(),
         capabilities: None,
+        file_capabilities: Vec::new(),
         components: BTreeMap::from([(
             "main".to_string(),
             ComponentAuthorityV2 {

--- a/apps/remi/src/server/release_publish.rs
+++ b/apps/remi/src/server/release_publish.rs
@@ -790,6 +790,7 @@ mod tests {
             requirements: Vec::new(),
             relations: Vec::new(),
             capabilities: None,
+            file_capabilities: Vec::new(),
             components: BTreeMap::from([(
                 "main".to_string(),
                 ComponentAuthorityV2 {
@@ -902,6 +903,7 @@ mod tests {
             requirements: Vec::new(),
             relations: Vec::new(),
             capabilities: None,
+            file_capabilities: Vec::new(),
             components: BTreeMap::from([(
                 "main".to_string(),
                 ComponentAuthorityV2 {

--- a/crates/conary-core/src/ccs/budget.rs
+++ b/crates/conary-core/src/ccs/budget.rs
@@ -68,6 +68,8 @@ pub enum BudgetDimension {
     FileCount,
     ComponentCount,
     ConfigCount,
+    FileCapabilityCount,
+    FileCapabilityNameCount,
     ProvideCount,
     RequirementCount,
     RelationCount,
@@ -103,6 +105,8 @@ impl BudgetDimension {
             Self::FileCount => "file-count",
             Self::ComponentCount => "component-count",
             Self::ConfigCount => "config-count",
+            Self::FileCapabilityCount => "file-capability-count",
+            Self::FileCapabilityNameCount => "file-capability-name-count",
             Self::ProvideCount => "provide-count",
             Self::RequirementCount => "requirement-count",
             Self::RelationCount => "relation-count",
@@ -212,6 +216,7 @@ pub struct AuthorityCensus {
     pub files: u64,
     pub components: u64,
     pub config_entries: u64,
+    pub file_capabilities: u64,
     pub payload_objects: u64,
     pub payload_bytes: u64,
     pub path_bytes: u64,
@@ -321,6 +326,8 @@ pub struct CcsStructuralBudget {
     pub max_files: u64,
     pub max_components: u64,
     pub max_config_entries: u64,
+    pub max_file_capabilities: u64,
+    pub max_file_capability_names: u64,
     pub max_provides: u64,
     pub max_requirement_groups: u64,
     pub max_relation_groups: u64,
@@ -353,6 +360,8 @@ impl CcsStructuralBudget {
         max_files: 1 << 20,
         max_components: 1024,
         max_config_entries: 1 << 20,
+        max_file_capabilities: 1 << 20,
+        max_file_capability_names: crate::ccs::manifest::LINUX_FILE_CAPABILITY_NAMES.len() as u64,
         max_provides: 1 << 16,
         max_requirement_groups: 1 << 16,
         max_relation_groups: 1 << 16,
@@ -692,6 +701,33 @@ impl CcsStructuralBudget {
             self.max_relation_groups,
         )?;
         self.admit_lifecycle(&authority.lifecycle)?;
+        census.file_capabilities = authority.file_capabilities.len() as u64;
+        admit(
+            BudgetDimension::FileCapabilityCount,
+            "file_capabilities",
+            census.file_capabilities,
+            self.max_file_capabilities,
+        )?;
+        for capability in &authority.file_capabilities {
+            self.admit_path(&capability.path, "file_capabilities.path")?;
+            census.path_bytes = sum(
+                "file_capabilities.path",
+                [census.path_bytes, capability.path.len() as u64],
+            )?;
+            admit(
+                BudgetDimension::FileCapabilityNameCount,
+                "file_capabilities.capabilities",
+                capability.capabilities.len() as u64,
+                self.max_file_capability_names,
+            )?;
+            for name in &capability.capabilities {
+                self.admit_name(name, "file_capabilities.capabilities")?;
+                census.name_bytes = sum(
+                    "file_capabilities.capabilities",
+                    [census.name_bytes, name.len() as u64],
+                )?;
+            }
+        }
 
         let mut bytes = 0_u64;
         for (field, encoded) in [
@@ -705,6 +741,10 @@ impl CcsStructuralBudget {
             (
                 "capabilities",
                 encoded_len(&authority.capabilities, "capabilities")?,
+            ),
+            (
+                "file_capabilities",
+                encoded_len(&authority.file_capabilities, "file_capabilities")?,
             ),
             (
                 "components",

--- a/crates/conary-core/src/ccs/budget/tests.rs
+++ b/crates/conary-core/src/ccs/budget/tests.rs
@@ -1,6 +1,7 @@
 // conary-core/src/ccs/budget/tests.rs
 
 use super::*;
+use crate::ccs::manifest::FileCapability;
 use crate::ccs::v2::schema::{
     ComponentAuthorityV2, ConfigAuthorityV2, ConfigSemanticsV2, ConflictPolicyV2,
     LifecycleScriptExecutionV2, LifecycleScriptV2, PackageDataV2,
@@ -338,6 +339,49 @@ fn near_limit_values_on_each_dimension_stay_admissible() {
     CCS_BUDGET
         .admit_encoded_authority(&census, authority.to_cbor().unwrap().len() as u64)
         .unwrap();
+}
+
+#[test]
+fn signed_file_capabilities_are_structurally_budgeted() {
+    let mut authority = AuthorityDocumentV2::package_for_tests("file-capable-budget");
+    authority.file_capabilities = vec![FileCapability {
+        path: "/usr/bin/hello".to_string(),
+        capabilities: vec!["cap_net_bind_service".to_string()],
+        permitted: true,
+        effective: true,
+        inheritable: false,
+    }];
+
+    let census = CCS_BUDGET.admit_authority(&authority).unwrap();
+
+    assert_eq!(census.file_capabilities, 1);
+    CCS_BUDGET
+        .admit_encoded_authority(&census, authority.to_cbor().unwrap().len() as u64)
+        .unwrap();
+
+    let count_budget = CcsStructuralBudget {
+        max_file_capabilities: 0,
+        ..CCS_BUDGET
+    };
+    assert_eq!(
+        count_budget
+            .admit_authority(&authority)
+            .unwrap_err()
+            .dimension,
+        BudgetDimension::FileCapabilityCount
+    );
+
+    let name_budget = CcsStructuralBudget {
+        max_file_capability_names: 0,
+        ..CCS_BUDGET
+    };
+    assert_eq!(
+        name_budget
+            .admit_authority(&authority)
+            .unwrap_err()
+            .dimension,
+        BudgetDimension::FileCapabilityNameCount
+    );
 }
 
 #[test]

--- a/crates/conary-core/src/ccs/manifest.rs
+++ b/crates/conary-core/src/ccs/manifest.rs
@@ -27,7 +27,7 @@ use crate::repository::{
     requirement::validate_requirement_group,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::Path;
 use thiserror::Error;
 
@@ -293,8 +293,15 @@ impl CcsManifest {
                 ManifestError::Invalid(format!("invalid package relation authority: {error}"))
             })?;
         }
+        let mut file_capability_paths = BTreeSet::new();
         for capability in &self.file_capabilities {
             capability.validate()?;
+            if !file_capability_paths.insert(capability.path.as_str()) {
+                return Err(ManifestError::Invalid(format!(
+                    "file_capabilities path '{}' is declared more than once",
+                    capability.path
+                )));
+            }
         }
         if let Some(capabilities) = &self.capabilities {
             capabilities

--- a/crates/conary-core/src/ccs/manifest/hooks.rs
+++ b/crates/conary-core/src/ccs/manifest/hooks.rs
@@ -219,10 +219,17 @@ impl FileCapability {
                 self.path
             )));
         }
+        let mut seen = BTreeSet::new();
         for capability in &self.capabilities {
             if !is_supported_linux_file_capability(capability) {
                 return Err(ManifestError::Invalid(format!(
                     "unknown Linux file capability '{}' for {}",
+                    capability, self.path
+                )));
+            }
+            if !seen.insert(capability) {
+                return Err(ManifestError::Invalid(format!(
+                    "duplicate Linux file capability '{}' for {}",
                     capability, self.path
                 )));
             }

--- a/crates/conary-core/src/ccs/manifest/tests.rs
+++ b/crates/conary-core/src/ccs/manifest/tests.rs
@@ -601,6 +601,50 @@ inheritable = false
 }
 
 #[test]
+fn test_manifest_rejects_duplicate_file_capability_authority() {
+    let mut manifest = CcsManifest::new_minimal("file-capable", "1.0.0");
+    manifest.file_capabilities = vec![FileCapability {
+        path: "/usr/bin/server".to_string(),
+        capabilities: vec![
+            "cap_net_bind_service".to_string(),
+            "cap_net_bind_service".to_string(),
+        ],
+        permitted: true,
+        effective: true,
+        inheritable: false,
+    }];
+    let duplicate_name = manifest.validate().unwrap_err();
+    assert!(
+        duplicate_name
+            .to_string()
+            .contains("duplicate Linux file capability")
+    );
+
+    manifest.file_capabilities = vec![
+        FileCapability {
+            path: "/usr/bin/server".to_string(),
+            capabilities: vec!["cap_net_bind_service".to_string()],
+            permitted: true,
+            effective: true,
+            inheritable: false,
+        },
+        FileCapability {
+            path: "/usr/bin/server".to_string(),
+            capabilities: vec!["cap_net_raw".to_string()],
+            permitted: true,
+            effective: true,
+            inheritable: false,
+        },
+    ];
+    let duplicate_path = manifest.validate().unwrap_err();
+    assert!(
+        duplicate_path
+            .to_string()
+            .contains("declared more than once")
+    );
+}
+
+#[test]
 fn test_manifest_accepts_inheritable_file_capabilities() {
     let toml = r#"
 [package]

--- a/crates/conary-core/src/ccs/package.rs
+++ b/crates/conary-core/src/ccs/package.rs
@@ -430,6 +430,61 @@ arch = "noarch"
     }
 
     #[test]
+    fn signed_v2_file_capabilities_round_trip_to_verified_install_manifest() {
+        let temp = tempfile::tempdir().unwrap();
+        let source_dir = temp.path().join("src");
+        fs::create_dir_all(source_dir.join("usr/bin")).unwrap();
+        fs::write(source_dir.join("usr/bin/server"), b"#!/bin/sh\n").unwrap();
+        let manifest = CcsManifest::parse(
+            r#"
+[package]
+name = "file-capable"
+version = "1.0.0"
+version_scheme = "conary"
+release = "1"
+kind = "package"
+description = "file capability fixture"
+license = "MIT"
+
+[package.platform]
+arch = "noarch"
+
+[[file_capabilities]]
+path = "/usr/bin/server"
+capabilities = ["cap_net_bind_service"]
+permitted = true
+effective = true
+inheritable = false
+"#,
+        )
+        .unwrap();
+        let result = CcsBuilder::new(manifest, &source_dir)
+            .unwrap()
+            .build()
+            .unwrap();
+        let package_path = temp.path().join("file-capable.ccs");
+        let signing_key = SigningKeyPair::generate();
+        write_signed_current_ccs_package(&result, &package_path, &signing_key, false).unwrap();
+
+        let verification = verify_test_package(&package_path, &signing_key);
+        let package =
+            CcsPackage::from_verified_archive(package_path.to_str().unwrap(), &verification)
+                .unwrap();
+
+        assert_eq!(verification.authority().file_capabilities.len(), 1);
+        assert_eq!(
+            package.manifest().file_capabilities,
+            verification.authority().file_capabilities
+        );
+        assert_eq!(
+            package.manifest().file_capabilities[0]
+                .to_setcap_spec()
+                .unwrap(),
+            "cap_net_bind_service=+ep"
+        );
+    }
+
+    #[test]
     fn test_extract_rejects_truncated_content() {
         let (_temp, package_path, signing_key) = build_test_package();
         let corrupted_path = package_path.with_file_name("truncated.ccs");

--- a/crates/conary-core/src/ccs/package/v2_projection.rs
+++ b/crates/conary-core/src/ccs/package/v2_projection.rs
@@ -24,6 +24,7 @@ pub(super) fn install_manifest_from_v2(
     manifest.requirements = authority.requirements.clone();
     manifest.relations = authority.relations.clone();
     manifest.capabilities = authority.capabilities.clone();
+    manifest.file_capabilities = authority.file_capabilities.clone();
     manifest.config.files = config_files_from_v2_authority(authority)?;
 
     crate::ccs::v2::lifecycle::apply_authority_to_manifest(&authority.lifecycle, &mut manifest)
@@ -177,5 +178,22 @@ mod tests {
         let manifest = install_manifest_from_v2(&authority, None, None).unwrap();
 
         assert_eq!(manifest.capabilities, Some(declaration));
+    }
+
+    #[test]
+    fn verified_v2_file_capabilities_are_preserved_in_the_install_projection() {
+        let mut authority = AuthorityDocumentV2::package_for_tests("file-capability-projection");
+        let declaration = crate::ccs::manifest::FileCapability {
+            path: "/usr/bin/hello".to_string(),
+            capabilities: vec!["cap_net_bind_service".to_string()],
+            permitted: true,
+            effective: true,
+            inheritable: false,
+        };
+        authority.file_capabilities = vec![declaration.clone()];
+
+        let manifest = install_manifest_from_v2(&authority, None, None).unwrap();
+
+        assert_eq!(manifest.file_capabilities, vec![declaration]);
     }
 }

--- a/crates/conary-core/src/ccs/v2/authoring.rs
+++ b/crates/conary-core/src/ccs/v2/authoring.rs
@@ -140,6 +140,8 @@ pub fn project_build_result_authority_to_v2(
     }
 
     let config_authority = config_authority_for_manifest(&input.build.manifest, input.build)?;
+    let file_capabilities =
+        file_capability_authority_for_manifest(&input.build.manifest, input.build)?;
     let files = input
         .build
         .files
@@ -250,6 +252,7 @@ pub fn project_build_result_authority_to_v2(
         requirements: project_requirements(&input.build.manifest),
         relations: input.build.manifest.relations.clone(),
         capabilities: input.build.manifest.capabilities.clone(),
+        file_capabilities,
         components,
         lifecycle,
         provenance: ProvenanceAuthorityV2 {
@@ -413,6 +416,34 @@ fn config_authority_for_manifest(
     }
 
     Ok(authority)
+}
+
+fn file_capability_authority_for_manifest(
+    manifest: &crate::ccs::manifest::CcsManifest,
+    build: &BuildResult,
+) -> Result<Vec<crate::ccs::manifest::FileCapability>> {
+    let canonical =
+        super::file_capabilities::canonicalize_file_capabilities(&manifest.file_capabilities)?;
+    let build_files = build
+        .files
+        .iter()
+        .map(|file| (file.path.as_str(), &file.node.kind))
+        .collect::<BTreeMap<_, _>>();
+    for capability in &canonical {
+        let Some(kind) = build_files.get(capability.path.as_str()) else {
+            bail!(
+                "file capability target {} is absent from signed build output",
+                capability.path
+            );
+        };
+        if !matches!(kind, crate::payload::PayloadNodeKind::Regular { .. }) {
+            bail!(
+                "file capability target {} is not a regular signed build output file",
+                capability.path
+            );
+        }
+    }
+    Ok(canonical)
 }
 
 fn select_default_component(build: &BuildResult) -> Result<String> {

--- a/crates/conary-core/src/ccs/v2/authoring/tests.rs
+++ b/crates/conary-core/src/ccs/v2/authoring/tests.rs
@@ -111,6 +111,98 @@ fn projection_preserves_exact_package_capability_authority() {
 }
 
 #[test]
+fn projection_signs_canonical_file_capability_authority() {
+    let mut build = test_support::single_file_build_result_at(
+        "file-capable",
+        "0.1.0",
+        "/usr/bin/file-capable",
+        b"#!/bin/sh\n",
+    );
+    build.manifest.file_capabilities = vec![crate::ccs::manifest::FileCapability {
+        path: "/usr/bin/file-capable".to_string(),
+        capabilities: vec![
+            "cap_net_raw".to_string(),
+            "cap_net_bind_service".to_string(),
+        ],
+        permitted: true,
+        effective: true,
+        inheritable: false,
+    }];
+
+    let projected = project_build_result_to_v2(V2AuthoringInput {
+        build: &build,
+        local_dev: true,
+        debug_toml: None,
+    })
+    .unwrap();
+
+    assert_eq!(projected.authority.file_capabilities.len(), 1);
+    assert_eq!(
+        projected.authority.file_capabilities[0].capabilities,
+        ["cap_net_bind_service", "cap_net_raw"]
+    );
+}
+
+#[test]
+fn projection_rejects_file_capability_without_exact_regular_build_output() {
+    let mut build = test_support::single_file_build_result_at(
+        "file-capable",
+        "0.1.0",
+        "/usr/bin/file-capable",
+        b"#!/bin/sh\n",
+    );
+    build.manifest.file_capabilities = vec![crate::ccs::manifest::FileCapability {
+        path: "/usr/bin/missing".to_string(),
+        capabilities: vec!["cap_net_bind_service".to_string()],
+        permitted: true,
+        effective: true,
+        inheritable: false,
+    }];
+    let error = project_build_result_to_v2(V2AuthoringInput {
+        build: &build,
+        local_dev: true,
+        debug_toml: None,
+    })
+    .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("absent from signed build output")
+    );
+
+    build.manifest.file_capabilities[0].path = "/usr/bin/file-capable".to_string();
+    let mut symlink_node = crate::payload::PayloadNode::regular(0o777);
+    symlink_node.kind = crate::payload::PayloadNodeKind::Symlink {
+        target: "file-capable-real".to_string(),
+    };
+    symlink_node.mode = libc::S_IFLNK | 0o777;
+    build.files[0].node = symlink_node.clone();
+    build.files[0].content = None;
+    build.components.get_mut("runtime").unwrap().files[0].node = symlink_node.clone();
+    build.components.get_mut("runtime").unwrap().files[0].content = None;
+    build.components.get_mut("runtime").unwrap().size = 0;
+    build.payloads[0] = crate::packages::payload::PackagePayloadFile::new(
+        "/usr/bin/file-capable".to_string(),
+        symlink_node,
+        None,
+        None,
+    )
+    .unwrap();
+    build.total_size = 0;
+    let error = project_build_result_to_v2(V2AuthoringInput {
+        build: &build,
+        local_dev: true,
+        debug_toml: None,
+    })
+    .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("not a regular signed build output file")
+    );
+}
+
+#[test]
 fn projection_gives_payloadless_packages_an_explicit_empty_default_component() {
     let mut build = test_support::minimal_file_build_result("empty", "0.1.0", b"discarded");
     build.files.clear();

--- a/crates/conary-core/src/ccs/v2/debug_projection.rs
+++ b/crates/conary-core/src/ccs/v2/debug_projection.rs
@@ -9,6 +9,7 @@ pub fn validate_debug_toml_projection(
     manifest: &crate::ccs::manifest::CcsManifest,
 ) -> Result<()> {
     validate_config_projection(authority, manifest)?;
+    validate_file_capability_projection(authority, manifest)?;
     validate_requirement_projection(authority, manifest)?;
     validate_lifecycle_projection(authority, manifest)?;
     Ok(())
@@ -26,6 +27,18 @@ pub(crate) fn reject_unsupported_debug_toml_install_authority(
             "v2 debug TOML contains unsupported install authority fields: {}",
             unsupported.join(", ")
         );
+    }
+    Ok(())
+}
+
+fn validate_file_capability_projection(
+    authority: &AuthorityDocumentV2,
+    manifest: &crate::ccs::manifest::CcsManifest,
+) -> Result<()> {
+    let debug =
+        super::file_capabilities::canonicalize_file_capabilities(&manifest.file_capabilities)?;
+    if debug != authority.file_capabilities {
+        bail!("debug TOML file capability projection does not match signed authority");
     }
     Ok(())
 }
@@ -201,6 +214,43 @@ action = "restart"
         assert!(error.to_string().contains("debug TOML"));
         assert!(error.to_string().contains("conary-example.service"));
         assert!(error.to_string().contains("other.service"));
+    }
+
+    #[test]
+    fn rejects_debug_file_capability_mismatch_with_signed_authority() {
+        let toml = r#"
+[package]
+name = "demo"
+version = "0.1.0"
+version_scheme = "conary"
+release = "1"
+kind = "package"
+description = "demo package"
+
+[[file_capabilities]]
+path = "/usr/bin/hello"
+capabilities = ["cap_net_raw"]
+permitted = true
+effective = true
+inheritable = false
+"#;
+        let mut authority = AuthorityDocumentV2::package_for_tests("demo");
+        authority.file_capabilities = vec![crate::ccs::manifest::FileCapability {
+            path: "/usr/bin/hello".to_string(),
+            capabilities: vec!["cap_net_bind_service".to_string()],
+            permitted: true,
+            effective: true,
+            inheritable: false,
+        }];
+        let manifest = crate::ccs::manifest::CcsManifest::parse(toml).unwrap();
+
+        let error = super::validate_debug_toml_projection(&authority, &manifest).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("file capability projection does not match signed authority")
+        );
     }
 
     #[test]

--- a/crates/conary-core/src/ccs/v2/file_capabilities.rs
+++ b/crates/conary-core/src/ccs/v2/file_capabilities.rs
@@ -1,0 +1,25 @@
+// conary-core/src/ccs/v2/file_capabilities.rs
+
+//! Canonical signed projection for Linux file capability declarations.
+
+use crate::ccs::manifest::FileCapability;
+use anyhow::{Result, bail};
+use std::collections::BTreeMap;
+
+pub(crate) fn canonicalize_file_capabilities(
+    capabilities: &[FileCapability],
+) -> Result<Vec<FileCapability>> {
+    let mut by_path = BTreeMap::new();
+    for capability in capabilities {
+        capability.validate()?;
+        let mut canonical = capability.clone();
+        canonical.capabilities.sort();
+        if by_path.insert(canonical.path.clone(), canonical).is_some() {
+            bail!(
+                "file capability path {} is declared more than once",
+                capability.path
+            );
+        }
+    }
+    Ok(by_path.into_values().collect())
+}

--- a/crates/conary-core/src/ccs/v2/identity.rs
+++ b/crates/conary-core/src/ccs/v2/identity.rs
@@ -12,9 +12,21 @@ pub struct ContentIdentityProjectionV2<'a> {
     pub provides: &'a [ProvidedCapabilityV2],
     pub requirements: &'a [RepositoryRequirementGroup],
     pub relations: &'a [RepositoryRequirementGroup],
+    #[serde(skip_serializing_if = "referenced_option_is_none")]
+    pub capabilities: &'a Option<crate::capability::CapabilityDeclaration>,
+    #[serde(skip_serializing_if = "referenced_slice_is_empty")]
+    pub file_capabilities: &'a [crate::ccs::manifest::FileCapability],
     pub components: &'a std::collections::BTreeMap<String, ComponentAuthorityV2>,
     pub lifecycle: &'a LifecycleAuthorityV2,
     pub provenance: ProvenanceAuthorityV2,
+}
+
+fn referenced_option_is_none<T>(value: &&Option<T>) -> bool {
+    value.is_none()
+}
+
+fn referenced_slice_is_empty<T>(value: &&[T]) -> bool {
+    value.is_empty()
 }
 
 pub fn compute_v2_content_identity(authority: &AuthorityDocumentV2) -> Result<String> {
@@ -26,6 +38,8 @@ pub fn compute_v2_content_identity(authority: &AuthorityDocumentV2) -> Result<St
         provides: &authority.provides,
         requirements: &authority.requirements,
         relations: &authority.relations,
+        capabilities: &authority.capabilities,
+        file_capabilities: &authority.file_capabilities,
         components: &authority.components,
         lifecycle: &authority.lifecycle,
         provenance,
@@ -58,6 +72,44 @@ mod tests {
     }
 
     #[test]
+    fn absent_capability_authority_preserves_the_prior_identity_projection() {
+        #[derive(serde::Serialize)]
+        struct PriorProjection<'a> {
+            identity: &'a PackageIdentityV2,
+            kind: &'a PackageKindV2,
+            provides: &'a [ProvidedCapabilityV2],
+            requirements: &'a [RepositoryRequirementGroup],
+            relations: &'a [RepositoryRequirementGroup],
+            components: &'a std::collections::BTreeMap<String, ComponentAuthorityV2>,
+            lifecycle: &'a LifecycleAuthorityV2,
+            provenance: ProvenanceAuthorityV2,
+        }
+
+        let authority = crate::ccs::v2::test_support::package_authority_with_one_file("id");
+        assert!(authority.capabilities.is_none());
+        assert!(authority.file_capabilities.is_empty());
+        let mut provenance = authority.provenance.clone();
+        provenance.foreign_conversion_boundary_hash = None;
+        let prior = PriorProjection {
+            identity: &authority.identity,
+            kind: &authority.kind,
+            provides: &authority.provides,
+            requirements: &authority.requirements,
+            relations: &authority.relations,
+            components: &authority.components,
+            lifecycle: &authority.lifecycle,
+            provenance,
+        };
+        let prior_bytes = crate::ccs::attestation::canonical_json_bytes(&prior).unwrap();
+        let prior_identity = crate::hash::sha256_prefixed(&prior_bytes);
+
+        assert_eq!(
+            compute_v2_content_identity(&authority).unwrap(),
+            prior_identity
+        );
+    }
+
+    #[test]
     fn authority_changes_change_identity() {
         let mut authority = crate::ccs::v2::test_support::package_authority_with_one_file("id");
         let first = compute_v2_content_identity(&authority).unwrap();
@@ -85,6 +137,34 @@ mod tests {
                 ),
             ),
         );
+
+        let second = compute_v2_content_identity(&authority).unwrap();
+
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn package_capability_changes_change_identity() {
+        let mut authority = crate::ccs::v2::test_support::package_authority_with_one_file("id");
+        let first = compute_v2_content_identity(&authority).unwrap();
+        authority.capabilities = Some(crate::capability::CapabilityDeclaration::default());
+
+        let second = compute_v2_content_identity(&authority).unwrap();
+
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn file_capability_changes_change_identity() {
+        let mut authority = crate::ccs::v2::test_support::package_authority_with_one_file("id");
+        let first = compute_v2_content_identity(&authority).unwrap();
+        authority.file_capabilities = vec![crate::ccs::manifest::FileCapability {
+            path: "/usr/bin/hello".to_string(),
+            capabilities: vec!["cap_net_bind_service".to_string()],
+            permitted: true,
+            effective: true,
+            inheritable: false,
+        }];
 
         let second = compute_v2_content_identity(&authority).unwrap();
 

--- a/crates/conary-core/src/ccs/v2/mod.rs
+++ b/crates/conary-core/src/ccs/v2/mod.rs
@@ -5,6 +5,7 @@ pub mod authoring;
 pub mod component_view;
 pub mod debug_projection;
 pub mod diagnostics;
+pub(crate) mod file_capabilities;
 pub mod identity;
 pub(crate) mod lifecycle;
 pub(crate) mod manifest_projection;

--- a/crates/conary-core/src/ccs/v2/reader.rs
+++ b/crates/conary-core/src/ccs/v2/reader.rs
@@ -326,6 +326,36 @@ description = "hello"
     }
 
     #[test]
+    fn rejects_file_capability_authority_added_after_signing() {
+        let mut authority =
+            crate::ccs::v2::schema::AuthorityDocumentV2::package_for_tests("capability-tamper");
+        let signed_raw = authority.to_cbor().unwrap();
+        let key = SigningKeyPair::generate();
+        let signature = key.sign(&signed_raw);
+        let policy = TrustPolicy::strict(vec![signature.public_key.clone()]);
+        authority.file_capabilities = vec![crate::ccs::manifest::FileCapability {
+            path: "/usr/bin/hello".to_string(),
+            capabilities: vec!["cap_net_bind_service".to_string()],
+            permitted: true,
+            effective: true,
+            inheritable: false,
+        }];
+        let tampered_raw = authority.to_cbor().unwrap();
+
+        let error = read_authority_document(
+            &tampered_raw,
+            Some(&serde_json::to_string(&signature).unwrap()),
+            None,
+            None,
+            None,
+            &policy,
+        )
+        .unwrap_err();
+
+        assert!(format!("{error:#}").contains("verify CCS v2 MANIFEST signature"));
+    }
+
+    #[test]
     fn rejects_unsupported_signature_algorithms() {
         let authority = crate::ccs::v2::schema::AuthorityDocumentV2::package_for_tests("algo");
         let raw = authority.to_cbor().unwrap();

--- a/crates/conary-core/src/ccs/v2/schema.rs
+++ b/crates/conary-core/src/ccs/v2/schema.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 use crate::capability::CapabilityDeclaration;
+use crate::ccs::manifest::FileCapability;
 use crate::payload::{PayloadContentAuthority, PayloadNode};
 use crate::repository::dependency_model::{
     DebianMultiArch, ProvideArchitectureQualifier, ProvideVersionRelation,
@@ -26,6 +27,13 @@ pub struct AuthorityDocumentV2 {
     pub relations: Vec<RepositoryRequirementGroup>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub capabilities: Option<CapabilityDeclaration>,
+    /// Exact Linux file capability declarations bound to signed package files.
+    ///
+    /// Debug TOML is never install authority; authored declarations are
+    /// canonicalized into this signed field and verified before projection
+    /// back into the install manifest.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub file_capabilities: Vec<FileCapability>,
     #[serde(default)]
     pub components: BTreeMap<String, ComponentAuthorityV2>,
     #[serde(default)]
@@ -473,6 +481,7 @@ impl AuthorityDocumentV2 {
             requirements: Vec::new(),
             relations: Vec::new(),
             capabilities: None,
+            file_capabilities: Vec::new(),
             components: BTreeMap::new(),
             lifecycle: LifecycleAuthorityV2::default(),
             provenance: ProvenanceAuthorityV2 {
@@ -537,6 +546,24 @@ mod tests {
         let decoded = AuthorityDocumentV2::from_cbor(&bytes).unwrap();
 
         assert_eq!(decoded.capabilities, authority.capabilities);
+        super::super::validation::validate_authority(&decoded).unwrap();
+    }
+
+    #[test]
+    fn file_capabilities_round_trip_in_signed_v2_authority() {
+        let mut authority = AuthorityDocumentV2::package_for_tests("file-capable");
+        authority.file_capabilities = vec![FileCapability {
+            path: "/usr/bin/hello".to_string(),
+            capabilities: vec!["cap_net_bind_service".to_string()],
+            permitted: true,
+            effective: true,
+            inheritable: false,
+        }];
+
+        let bytes = authority.to_cbor().unwrap();
+        let decoded = AuthorityDocumentV2::from_cbor(&bytes).unwrap();
+
+        assert_eq!(decoded.file_capabilities, authority.file_capabilities);
         super::super::validation::validate_authority(&decoded).unwrap();
     }
 

--- a/crates/conary-core/src/ccs/v2/validation.rs
+++ b/crates/conary-core/src/ccs/v2/validation.rs
@@ -1,12 +1,14 @@
 // conary-core/src/ccs/v2/validation.rs
 
 mod config;
+mod file_capabilities;
 mod identity;
 
 use super::diagnostics::{V2Diagnostic, V2DiagnosticCode, V2ValidationError};
 use super::schema::*;
 use crate::ccs::budget::{AuthorityCensus, CCS_BUDGET};
 use config::{validate_config_authority, validate_package_policy};
+use file_capabilities::validate_file_capabilities;
 use identity::{validate_identity, validate_provides};
 
 pub fn validate_authority(authority: &AuthorityDocumentV2) -> Result<(), V2ValidationError> {
@@ -120,6 +122,7 @@ fn validate_authority_common(
             validate_component_defaults(authority, &mut diagnostics);
             validate_package_policy(&data.policy, "kind.package.policy", &mut diagnostics);
             validate_files(data, authority, &mut diagnostics);
+            validate_file_capabilities(data, &authority.file_capabilities, &mut diagnostics);
             validate_config_authority(data, authority, &mut diagnostics);
             validate_component_totals(data, authority, &mut diagnostics);
             validate_lifecycle(&authority.lifecycle, &mut diagnostics);
@@ -216,7 +219,16 @@ fn validate_files(
     authority: &AuthorityDocumentV2,
     diagnostics: &mut Vec<V2Diagnostic>,
 ) {
+    let mut paths = std::collections::BTreeSet::new();
     for file in &data.files {
+        if !paths.insert(file.path.as_str()) {
+            diagnostics.push(V2Diagnostic::error(
+                V2DiagnosticCode::KindContractViolation,
+                format!("signed file path {} is declared more than once", file.path),
+                Some("kind.package.files.path".to_string()),
+                "declare one exact signed file authority record per package path",
+            ));
+        }
         if file.path.trim().is_empty() || file.component.trim().is_empty() {
             diagnostics.push(V2Diagnostic::error(
                 V2DiagnosticCode::MissingAuthority,
@@ -541,10 +553,13 @@ fn reject_group_redirect_payload_authority(
     authority: &AuthorityDocumentV2,
     diagnostics: &mut Vec<V2Diagnostic>,
 ) {
-    if !authority.components.is_empty() || authority.lifecycle != LifecycleAuthorityV2::default() {
+    if !authority.components.is_empty()
+        || !authority.file_capabilities.is_empty()
+        || authority.lifecycle != LifecycleAuthorityV2::default()
+    {
         diagnostics.push(V2Diagnostic::error(
             V2DiagnosticCode::KindContractViolation,
-            "v2 group and redirect packages must not carry file components or lifecycle payload authority",
+            "v2 group and redirect packages must not carry file, file-capability, component, or lifecycle payload authority",
             Some("components".to_string()),
             "move file/lifecycle authority to package kind payloads only",
         ));

--- a/crates/conary-core/src/ccs/v2/validation/file_capabilities.rs
+++ b/crates/conary-core/src/ccs/v2/validation/file_capabilities.rs
@@ -1,0 +1,142 @@
+// conary-core/src/ccs/v2/validation/file_capabilities.rs
+
+//! Signed Linux file-capability validation against exact package payload authority.
+
+use super::super::diagnostics::{V2Diagnostic, V2DiagnosticCode};
+use super::super::schema::PackageDataV2;
+use crate::ccs::manifest::FileCapability;
+use crate::payload::PayloadNodeKind;
+
+pub(super) fn validate_file_capabilities(
+    data: &PackageDataV2,
+    capabilities: &[FileCapability],
+    diagnostics: &mut Vec<V2Diagnostic>,
+) {
+    match super::super::file_capabilities::canonicalize_file_capabilities(capabilities) {
+        Ok(canonical) if canonical != capabilities => diagnostics.push(V2Diagnostic::error(
+            V2DiagnosticCode::KindContractViolation,
+            "signed file capability authority is not in canonical path and capability-name order",
+            Some("file_capabilities".to_string()),
+            "sort declarations by path and each declaration's Linux capability names",
+        )),
+        Err(error) => diagnostics.push(V2Diagnostic::error(
+            V2DiagnosticCode::KindContractViolation,
+            format!("invalid signed file capability authority: {error}"),
+            Some("file_capabilities".to_string()),
+            "declare each valid Linux file capability path exactly once",
+        )),
+        Ok(_) => {}
+    }
+
+    for (index, capability) in capabilities.iter().enumerate() {
+        let field = format!("file_capabilities[{index}].path");
+        let Some(file) = data.files.iter().find(|file| file.path == capability.path) else {
+            diagnostics.push(V2Diagnostic::error(
+                V2DiagnosticCode::KindContractViolation,
+                format!(
+                    "file capability target {} has no matching signed package file",
+                    capability.path
+                ),
+                Some(field),
+                "bind file capabilities only to exact signed package file paths",
+            ));
+            continue;
+        };
+        if !matches!(file.node.kind, PayloadNodeKind::Regular { .. }) {
+            diagnostics.push(V2Diagnostic::error(
+                V2DiagnosticCode::KindContractViolation,
+                format!(
+                    "file capability target {} is not a regular signed package file",
+                    capability.path
+                ),
+                Some(field),
+                "bind Linux file capabilities only to regular signed payload files",
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ccs::v2::diagnostics::V2DiagnosticCode;
+    use crate::ccs::v2::schema::{AuthorityDocumentV2, PackageKindV2};
+    use crate::ccs::v2::validation::validate_authority;
+
+    fn file_capability(path: &str, names: &[&str]) -> FileCapability {
+        FileCapability {
+            path: path.to_string(),
+            capabilities: names.iter().map(|name| (*name).to_string()).collect(),
+            permitted: true,
+            effective: true,
+            inheritable: false,
+        }
+    }
+
+    #[test]
+    fn accepts_canonical_capability_bound_to_regular_signed_file() {
+        let mut authority = AuthorityDocumentV2::package_for_tests("capable");
+        authority.file_capabilities =
+            vec![file_capability("/usr/bin/hello", &["cap_net_bind_service"])];
+
+        validate_authority(&authority).unwrap();
+    }
+
+    #[test]
+    fn rejects_missing_and_non_regular_signed_targets() {
+        let mut missing = AuthorityDocumentV2::package_for_tests("missing-target");
+        missing.file_capabilities = vec![file_capability(
+            "/usr/bin/missing",
+            &["cap_net_bind_service"],
+        )];
+        let error = validate_authority(&missing).unwrap_err();
+        assert!(error.diagnostics.iter().any(|diagnostic| {
+            diagnostic.field.as_deref() == Some("file_capabilities[0].path")
+                && diagnostic
+                    .message
+                    .contains("no matching signed package file")
+        }));
+
+        let mut symlink = AuthorityDocumentV2::package_for_tests("symlink-target");
+        let PackageKindV2::Package(data) = &mut symlink.kind else {
+            panic!("fixture should be a package");
+        };
+        data.files[0].node.kind = PayloadNodeKind::Symlink {
+            target: "hello-real".to_string(),
+        };
+        data.files[0].node.mode = libc::S_IFLNK | 0o777;
+        data.files[0].content = None;
+        symlink.file_capabilities =
+            vec![file_capability("/usr/bin/hello", &["cap_net_bind_service"])];
+        let error = validate_authority(&symlink).unwrap_err();
+        assert!(error.diagnostics.iter().any(|diagnostic| {
+            diagnostic.field.as_deref() == Some("file_capabilities[0].path")
+                && diagnostic
+                    .message
+                    .contains("not a regular signed package file")
+        }));
+    }
+
+    #[test]
+    fn rejects_duplicate_paths_and_noncanonical_capability_names() {
+        let declaration = file_capability("/usr/bin/hello", &["cap_net_bind_service"]);
+        let mut duplicate = AuthorityDocumentV2::package_for_tests("duplicate");
+        duplicate.file_capabilities = vec![declaration.clone(), declaration];
+        let error = validate_authority(&duplicate).unwrap_err();
+        assert!(error.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == V2DiagnosticCode::KindContractViolation
+                && diagnostic.message.contains("declared more than once")
+        }));
+
+        let mut unordered = AuthorityDocumentV2::package_for_tests("unordered");
+        unordered.file_capabilities = vec![file_capability(
+            "/usr/bin/hello",
+            &["cap_net_raw", "cap_net_bind_service"],
+        )];
+        let error = validate_authority(&unordered).unwrap_err();
+        assert!(error.diagnostics.iter().any(|diagnostic| {
+            diagnostic.field.as_deref() == Some("file_capabilities")
+                && diagnostic.message.contains("canonical")
+        }));
+    }
+}

--- a/docs/modules/ccs.md
+++ b/docs/modules/ccs.md
@@ -597,11 +597,14 @@ exact directory claim even when dpkg or libalpm semantics preserve the
 currently visible directory metadata. See
 [`docs/specs/foreign-package-lifecycle-contracts.md`](../specs/foreign-package-lifecycle-contracts.md#shared-directory-ownership-and-materialization).
 
-For `[[file_capabilities]]`, Conary persists the signed authority in the
-selected-root transaction, attaches `security.capability` while building the
-runtime generation inputs, and reports the resulting xattr count through
-`conary system generation info`. There is no mutable live-root application
-path.
+For `[[file_capabilities]]`, the v2 writer canonicalizes the declarations into
+signed authority and verification proves each unique path names an exact
+regular signed payload file. The verified install projection never consults
+debug TOML. The selected-root transaction applies `security.capability` before
+capturing the publication candidate and persists the same declaration for
+database-derived generation and rollback authority. Generation metadata
+reports the resulting xattr count through `conary system generation info`.
+There is no mutable live-root application path.
 
 Implementation routing: `apps/conary/src/commands/ccs/install.rs` is the
 stable command hub. Command execution lives in

--- a/docs/specs/ccs-format-v2.md
+++ b/docs/specs/ccs-format-v2.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-07-29
-revision: 6
+revision: 7
 summary: Canonical signed CCS v2 authority, archive, payload, and trust contract
 ---
 
@@ -60,6 +60,8 @@ contains:
 - exact payload paths, node variants, content digests and sizes, component
   ownership, per-path config semantics (`noreplace`, `ghost`, and
   `remove_on_upgrade`), and conflict policy;
+- canonical Linux file-capability declarations bound to exact signed regular
+  payload paths;
 - source-independent declarative lifecycle plus any converted package's exact
   native lifecycle ABI;
 - provenance identities and hashes for hermetic evidence, build attestations,
@@ -95,8 +97,9 @@ architecture qualifier, and either no version authority or a paired typed
 relation and version boundary. RPM may use all five ordered relations; Debian,
 Arch, and Conary providers may use only equality. The package self-provider is
 exact equality with the signed package version. Package version is never a
-fallback for a missing provider version. Requirements, relations, and this
-complete provider authority all participate in CCS content identity.
+fallback for a missing provider version. Requirements, relations, complete
+provider authority, package capability declarations, and file-capability
+declarations all participate in CCS content identity.
 
 An ordinary config declaration identifies exactly one signed regular-file or
 symlink payload whose `FileAuthorityV2.config` repeats the same semantics.
@@ -104,6 +107,14 @@ RPM ghost config and Debian remove-on-upgrade declarations are package
 authority without incoming payload and require the corresponding signed native
 source contract. Verified package construction projects these exact
 declarations into the package transaction interface.
+
+Each file-capability declaration names exactly one signed regular payload file
+and carries a non-empty, canonical list of Linux capability names plus the
+permitted, effective, and inheritable sets. Declaration paths are unique and
+canonically ordered. Missing targets, non-regular targets, duplicate paths or
+capability names, and debug-TOML disagreement are rejected before package
+construction. Verified installation projects only this signed field; it never
+recovers capability authority from `MANIFEST.toml` or from payload xattrs.
 
 `ConflictPolicyV2::Replace` and `PackagePolicyV2.allow_host_mutation = true`
 are rejected until typed transaction consumers implement them. Signed fields
@@ -134,8 +145,8 @@ limit table and no fixed serialized-byte ceiling on `MANIFEST`.
 The budget states explicit dimensions, each with its own typed diagnostic:
 
 - counts: payload nodes, payload objects, components, config declarations,
-  provides, requirement groups, relation groups, lifecycle entries, and archive
-  entries;
+  file-capability declarations and names, provides, requirement groups,
+  relation groups, lifecycle entries, and archive entries;
 - per-item lengths: install-path bytes and path-component depth, identifier
   bytes, link-target bytes, xattr count, xattr name and value bytes, and
   lifecycle script body bytes;


### PR DESCRIPTION
## Primary Issue

Refs #186

Design / Plan / Roadmap: Refs #137, #179

## Problem And Outcome

Authored `[[file_capabilities]]` existed only in debug/authoring TOML. CCS v2 signing dropped it, and verified installation reconstructed an empty declaration set, so generation publication had no authority to apply `security.capability`.

After merge, exact canonical file-capability declarations are signed, validated against regular signed payload paths, included in content identity, checked against debug TOML, and projected into the verified install manifest. Packages with no capability authority preserve the prior content-identity projection.

## Changes

- Add canonical signed v2 file-capability authority and structural-budget dimensions.
- Reject invalid names, duplicate names/paths, noncanonical order, missing targets, non-regular targets, group/redirect payload authority, debug/signed drift, and post-signing tampering.
- Project only verified signed declarations into installation and cover the full authoring -> signing/reading -> package manifest boundary.
- Bind package and file capability declarations into content identity while canonically omitting absent fields.
- Update CCS format revision 7 and subsystem routing/behavior documentation.

## Scope

- In scope: CCS v2 authoring, signed schema, validation, identity, archive verification, install projection, structural budgets, focused fixtures, and canonical docs.
- Out of scope: PR #151 fixture changes and the live Fedora 44 TGE05 acceptance run; issue #186 remains open until that supported-host proof passes.

## Ownership / Boundary

- Owning subsystem: CCS v2 native package authority (`ccs`).
- Boundary changed or preserved: changes the signed authoring/verification/install authority boundary; debug TOML remains non-authoritative.
- Persisted state or public surface impact: CCS v2 signed schema gains an optional canonical field; format spec revision advances to 7. Empty capability fields remain absent from content identity, preserving identities for packages without capability authority.
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code
- [x] Updated subsystem docs or maps when the "look here first" path changed
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs

```text
- bash scripts/agent-context.sh --feature ccs
- cargo test -p conary-core ccs::v2 --no-fail-fast
  - 72 passed
- cargo test -p conary-core ccs::budget --no-fail-fast
  - 12 passed
- cargo test -p conary-core ccs::package --no-fail-fast
  - 13 passed
- cargo test -p conary-core ccs::archive_reader
  - 7 passed
- cargo test -p conary-core ccs::verify
  - 11 passed
- cargo test -p conary-core ccs::manifest
  - 33 passed
- cargo test -p conary --lib commands::install --no-fail-fast
  - 159 passed, 1 ignored pinned-network test
- cargo test -p conary-core generation::builder --no-fail-fast
  - 35 passed
- cargo test -p conary --test packaging_m4a
  - 3 passed
- cargo test -p conary --test packaging_m4b
  - 8 passed
- cargo test -p conary --test packaging_m4c
  - 1 passed
- cargo test -p conary --test packaging_m4d --no-fail-fast
  - 3 passed
- cargo test -p conary --test packaging_m4e
  - 3 passed
- cargo test -p remi release_upload_ --no-fail-fast
  - 7 passed
- cargo test -p conary-core repository::static_repo::publish_gate --no-fail-fast
  - 17 passed
- bash scripts/check-doc-truth.sh
  - passed
- cargo fmt --check
  - passed
- cargo clippy --workspace --all-targets -- -D warnings
  - passed
- git diff --check
  - passed
```

## Review And Merge Notes

- Review focus: signed authority completeness, canonical validation, debug-TOML non-authority, content-identity compatibility for absent fields, and verified install projection.
- User or developer impact: authored Linux file capabilities now survive CCS v2 signing and reach generation publication authority.
- Required-check bypass: not used