### PR TITLE
fix(adoption): preserve captured root continuity

### DIFF
--- a/apps/conary/src/commands/adopt/system.rs
+++ b/apps/conary/src/commands/adopt/system.rs
@@ -13,20 +13,22 @@ use super::outcome::{BulkAdoptionFailure, BulkAdoptionFailureStage, BulkAdoption
 use anyhow::Result;
 use conary_core::db::backup::CheckpointReason;
 use conary_core::db::models::{
-    Changeset, ChangesetStatus, ExistingDirectoryMaterialization, InstallReason, InstallSource,
-    ProvideEntry, Trove, TroveType,
+    Changeset, ChangesetStatus, DirectoryClaim, ExistingDirectoryMaterialization, FileEntry,
+    InstallReason, InstallSource, ProvideEntry, Trove, TroveType,
 };
 use conary_core::packages::{
     InstalledPackageIdentity, SystemPackageManager, dpkg_query, pacman_query, rpm_query,
 };
 use conary_core::repository::dependency_model::RepositoryRequirementGroup;
-use std::collections::HashSet;
+use std::collections::HashMap;
 use tracing::warn;
 
+mod captured_root;
 mod live_root;
+use captured_root::{
+    capture_live_selected_root, ensure_complete_native_partition, synchronize_captured_root,
+};
 use live_root::adopt_live_root_as_full_package;
-#[cfg(test)]
-use live_root::{live_root_db_path, should_visit_live_root_path};
 
 fn parse_package_pattern(field: &str, pattern: Option<&str>) -> Result<Option<glob::Pattern>> {
     pattern
@@ -62,6 +64,7 @@ struct PackageData {
     requirements: Vec<RepositoryRequirementGroup>,
     provides: Vec<String>,
     is_dependency: bool,
+    promote_trove_id: Option<i64>,
 }
 
 struct PackagePersistenceFailure {
@@ -142,14 +145,23 @@ pub async fn cmd_adopt_system(
     })?;
     let include_pattern = parse_package_pattern("--pattern", pattern)?;
     let exclude_pattern = parse_package_pattern("--exclude", exclude)?;
+    let complete_full_root_scope = full && pattern.is_none() && exclude.is_none() && !explicit_only;
 
     let mut conn = open_db(db_path)?;
 
     // Get list of already-tracked packages to avoid duplicates
-    let tracked_packages: HashSet<String> = Trove::list_all(&conn)?
-        .into_iter()
-        .filter_map(|trove| Some(trove.native_package_identity?.selector().to_string()))
-        .collect();
+    let mut tracked_packages = HashMap::new();
+    for trove in Trove::list_all(&conn)? {
+        let Some(identity) = trove.native_package_identity.as_ref() else {
+            continue;
+        };
+        let selector = identity.selector().to_string();
+        if tracked_packages.insert(selector.clone(), trove).is_some() {
+            return Err(anyhow::anyhow!(
+                "Native package identity {selector} is tracked by more than one trove"
+            ));
+        }
+    }
 
     // Get every exact installed package-manager record. The typed selector is
     // kept distinct from the package name so multilib/multiarch variants
@@ -178,6 +190,12 @@ pub async fn cmd_adopt_system(
             .collect(),
         _ => return Err(anyhow::anyhow!("Unsupported package manager")),
     };
+    if complete_full_root_scope {
+        ensure_complete_native_partition(
+            &tracked_packages,
+            installed.iter().map(|package| package.identity.selector()),
+        )?;
+    }
 
     // Exact install-reason authority is required. An empty set means the
     // package manager explicitly reported no user-installed packages; query
@@ -227,13 +245,18 @@ pub async fn cmd_adopt_system(
 
     if dry_run {
         let mut to_adopt = 0;
+        let mut to_promote = 0;
         let mut already_tracked = 0;
         let mut explicit_count = 0;
         let mut dep_count = 0;
 
         for package in &installed {
-            if tracked_packages.contains(package.identity.selector()) {
-                already_tracked += 1;
+            if let Some(tracked) = tracked_packages.get(package.identity.selector()) {
+                if full && tracked.install_source == InstallSource::AdoptedTrack {
+                    to_promote += 1;
+                } else {
+                    already_tracked += 1;
+                }
             } else {
                 to_adopt += 1;
                 if !user_installed.contains(&package.identity.install_reason_selector()) {
@@ -247,6 +270,9 @@ pub async fn cmd_adopt_system(
         println!("Dry run: would adopt {} packages\n", to_adopt);
         println!("Summary:");
         println!("  Would adopt: {} packages", to_adopt);
+        if full {
+            println!("  Would CAS-back: {} track-only packages", to_promote);
+        }
         println!("    Explicit: {}", explicit_count);
         println!("    Dependency: {}", dep_count);
         println!("  Already tracked: {} packages", already_tracked);
@@ -262,7 +288,7 @@ pub async fn cmd_adopt_system(
             considered_packages,
             already_tracked_packages: installed
                 .iter()
-                .filter(|package| tracked_packages.contains(package.identity.selector()))
+                .filter(|package| tracked_packages.contains_key(package.identity.selector()))
                 .map(|package| package.identity.selector().to_string())
                 .collect(),
             ..Default::default()
@@ -293,6 +319,7 @@ pub async fn cmd_adopt_system(
     ));
 
     let mut adopted_count = 0;
+    let mut promoted_count = 0;
     let mut skipped_count = 0;
     let mut error_count = 0;
     let mut adopted_packages = Vec::new();
@@ -311,8 +338,19 @@ pub async fn cmd_adopt_system(
 
     for package in &installed {
         let selector = package.identity.selector();
-        // Skip already-tracked packages
-        if tracked_packages.contains(selector) {
+        let promote_trove_id = tracked_packages
+            .get(selector)
+            .filter(|trove| full && trove.install_source == InstallSource::AdoptedTrack)
+            .map(|trove| {
+                trove.id.ok_or_else(|| {
+                    anyhow::anyhow!("Tracked package {selector} has no database identity")
+                })
+            })
+            .transpose()?;
+        // Full mode promotes track-only authority to exact CAS-backed
+        // authority. Every other already-tracked source is already at least as
+        // authoritative as this command requests.
+        if tracked_packages.contains_key(selector) && promote_trove_id.is_none() {
             skipped_count += 1;
             already_tracked_packages.push(selector.to_string());
             progress.skip_package();
@@ -336,37 +374,45 @@ pub async fn cmd_adopt_system(
                 continue;
             }
         };
-        let requirements = match super::requirements::query_package_requirements(pkg_mgr, selector)
-        {
-            Ok(d) => d,
-            Err(e) => {
-                warn!("Failed to query deps for '{}': {}; skipping", selector, e);
-                progress.fail_package(selector, &e.to_string());
-                error_count += 1;
-                failures.push(BulkAdoptionFailure::new(
-                    selector,
-                    BulkAdoptionFailureStage::RequirementQuery,
-                    e.to_string(),
-                ));
-                continue;
-            }
-        };
-        let provides: Vec<String> = match query_pm_provides(pkg_mgr, selector) {
-            Ok(p) => p,
-            Err(e) => {
-                warn!(
-                    "Failed to query provides for '{}': {}; skipping",
-                    selector, e
-                );
-                progress.fail_package(selector, &e.to_string());
-                error_count += 1;
-                failures.push(BulkAdoptionFailure::new(
-                    selector,
-                    BulkAdoptionFailureStage::ProvideQuery,
-                    e.to_string(),
-                ));
-                continue;
-            }
+        let (requirements, provides) = if promote_trove_id.is_some() {
+            // Track adoption already persisted the native metadata. Promotion
+            // changes only its payload authority from discovery hashes to
+            // privately captured CAS content.
+            (Vec::new(), Vec::new())
+        } else {
+            let requirements =
+                match super::requirements::query_package_requirements(pkg_mgr, selector) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        warn!("Failed to query deps for '{}': {}; skipping", selector, e);
+                        progress.fail_package(selector, &e.to_string());
+                        error_count += 1;
+                        failures.push(BulkAdoptionFailure::new(
+                            selector,
+                            BulkAdoptionFailureStage::RequirementQuery,
+                            e.to_string(),
+                        ));
+                        continue;
+                    }
+                };
+            let provides: Vec<String> = match query_pm_provides(pkg_mgr, selector) {
+                Ok(p) => p,
+                Err(e) => {
+                    warn!(
+                        "Failed to query provides for '{}': {}; skipping",
+                        selector, e
+                    );
+                    progress.fail_package(selector, &e.to_string());
+                    error_count += 1;
+                    failures.push(BulkAdoptionFailure::new(
+                        selector,
+                        BulkAdoptionFailureStage::ProvideQuery,
+                        e.to_string(),
+                    ));
+                    continue;
+                }
+            };
+            (requirements, provides)
         };
 
         // Capture exact live nodes and bytes outside the transaction. Full
@@ -402,17 +448,42 @@ pub async fn cmd_adopt_system(
             requirements,
             provides,
             is_dependency,
+            promote_trove_id,
         });
     }
 
+    // A complete, unfiltered full adoption captures one global selected-root
+    // snapshot after every package payload was captured successfully. The
+    // database transaction below partitions that exact snapshot without using
+    // package names or the native database as generation-time authority.
+    let captured_selected_root = if complete_full_root_scope && error_count == 0 {
+        Some(capture_live_selected_root(
+            db_path,
+            cas.as_ref()
+                .expect("complete full-root capture requires an initialized CAS"),
+        )?)
+    } else {
+        None
+    };
+
     // DB-only transaction: all PM queries and CAS writes are already done.
     write_db_checkpoint(db_path, CheckpointReason::PreMutation)?;
+    let mut captured_root_sync = None;
     let changeset_id = conary_core::db::transaction(&mut conn, |tx| {
         let changeset_id = changeset.insert(tx)?;
 
         for pkg in &pre_collected {
             let selector = pkg.identity.selector();
             let persisted = execute_package_savepoint(tx, || {
+                if let Some(trove_id) = pkg.promote_trove_id {
+                    promote_track_package(tx, changeset_id, &pkg.identity, trove_id, &pkg.files)
+                        .map_err(|error| PackagePersistenceFailure {
+                            stage: BulkAdoptionFailureStage::MetadataInsert,
+                            message: error.to_string(),
+                        })?;
+                    return Ok::<bool, PackagePersistenceFailure>(true);
+                }
+
                 let mut trove = Trove::new_with_source(
                     pkg.identity.name().to_string(),
                     pkg.identity.version(),
@@ -475,13 +546,18 @@ pub async fn cmd_adopt_system(
                         }
                     })?;
                 }
-                Ok::<i64, PackagePersistenceFailure>(trove_id)
+                Ok::<bool, PackagePersistenceFailure>(false)
             })?;
 
             match persisted {
-                PackageSavepointOutcome::Committed(_) => {
-                    adopted_count += 1;
-                    adopted_packages.push(selector.to_string());
+                PackageSavepointOutcome::Committed(promoted) => {
+                    if promoted {
+                        promoted_count += 1;
+                        already_tracked_packages.push(selector.to_string());
+                    } else {
+                        adopted_count += 1;
+                        adopted_packages.push(selector.to_string());
+                    }
                     progress.complete_package(selector);
                 }
                 PackageSavepointOutcome::RolledBack(error) => {
@@ -500,12 +576,23 @@ pub async fn cmd_adopt_system(
             }
         }
 
+        // A package persistence failure means the native ownership partition
+        // is incomplete. Do not misclassify that package's paths as unowned.
+        if error_count == 0
+            && let Some(captured) = captured_selected_root.as_ref()
+        {
+            captured_root_sync = Some(synchronize_captured_root(tx, changeset_id, captured)?);
+        }
+
         changeset.update_status(tx, ChangesetStatus::Applied)?;
         Ok(changeset_id)
     })?;
 
     // Create state snapshot for rollback safety
-    if adopted_count > 0 {
+    if adopted_count > 0
+        || promoted_count > 0
+        || captured_root_sync.as_ref().is_some_and(|sync| sync.changed)
+    {
         create_state_snapshot(
             &conn,
             changeset_id,
@@ -517,14 +604,26 @@ pub async fn cmd_adopt_system(
     let mode_desc = if full { "full" } else { "track" };
     if error_count > 0 {
         progress.finish_with_error(&format!(
-            "Adopted {} packages, {} skipped, {} errors ({})",
-            adopted_count, skipped_count, error_count, mode_desc
+            "Adopted {} packages, CAS-backed {}, {} skipped, {} errors ({})",
+            adopted_count, promoted_count, skipped_count, error_count, mode_desc
         ));
     } else {
         progress.finish(&format!(
-            "Adopted {} packages, {} skipped ({})",
-            adopted_count, skipped_count, mode_desc
+            "Adopted {} packages, CAS-backed {}, {} skipped ({})",
+            adopted_count, promoted_count, skipped_count, mode_desc
         ));
+    }
+    if let Some(sync) = captured_root_sync {
+        println!(
+            "  Captured root: {} unowned entries, {} package-owned entries{}",
+            sync.captured_entries,
+            sync.package_entries,
+            if sync.changed {
+                ""
+            } else {
+                " (already current)"
+            }
+        );
     }
     Ok(BulkAdoptionOutcome {
         considered_packages,
@@ -532,6 +631,74 @@ pub async fn cmd_adopt_system(
         already_tracked_packages,
         failures,
     })
+}
+
+fn promote_track_package(
+    tx: &rusqlite::Connection,
+    changeset_id: i64,
+    identity: &InstalledPackageIdentity,
+    trove_id: i64,
+    files: &[CapturedAdoptionFile],
+) -> conary_core::Result<()> {
+    let trove = Trove::find_by_id(tx, trove_id)?.ok_or_else(|| {
+        conary_core::Error::NotFound(format!(
+            "track-only trove {} disappeared before full-adoption commit",
+            identity.selector()
+        ))
+    })?;
+    if trove.install_source != InstallSource::AdoptedTrack
+        || trove.native_package_identity.as_ref() != Some(identity)
+    {
+        return Err(conary_core::Error::ConflictError(format!(
+            "track-only authority for {} changed after full-adoption planning",
+            identity.selector()
+        )));
+    }
+
+    for captured in files {
+        let path = &captured.source.0;
+        let existing = FileEntry::find_by_path(tx, path)?.ok_or_else(|| {
+            conary_core::Error::NotFound(format!(
+                "track-only package {} lost its file authority for {path}",
+                identity.selector()
+            ))
+        })?;
+        let owns_path = existing.trove_id == trove_id
+            || DirectoryClaim::find_by_path(tx, path)?
+                .iter()
+                .any(|claim| claim.trove_id == trove_id);
+        if !owns_path {
+            return Err(conary_core::Error::ConflictError(format!(
+                "track-only package {} no longer owns {path}",
+                identity.selector()
+            )));
+        }
+        FileEntry::reconcile_selected_root_materialization(
+            tx,
+            path,
+            &captured.node,
+            captured.content.as_ref(),
+        )?;
+    }
+
+    let updated = tx.execute(
+        "UPDATE troves
+         SET install_source = ?1, installed_by_changeset_id = ?2
+         WHERE id = ?3 AND install_source = ?4",
+        rusqlite::params![
+            InstallSource::AdoptedFull.as_str(),
+            changeset_id,
+            trove_id,
+            InstallSource::AdoptedTrack.as_str()
+        ],
+    )?;
+    if updated != 1 {
+        return Err(conary_core::Error::ConflictError(format!(
+            "track-only package {} was not promoted exactly",
+            identity.selector()
+        )));
+    }
+    Ok(())
 }
 
 const LIVE_ROOT_PACKAGE_NAME: &str = "conary-live-root";
@@ -578,7 +745,7 @@ fn query_pm_provides(pkg_mgr: SystemPackageManager, name: &str) -> Result<Vec<St
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::Path;
+    use conary_core::payload::{PayloadContentAuthority, PayloadNode, ResolvedPayloadNode};
 
     #[test]
     fn package_pattern_matches_with_upstream_glob_semantics() {
@@ -652,45 +819,82 @@ mod tests {
     }
 
     #[test]
-    fn live_root_adoption_excludes_runtime_and_conary_state() {
-        for path in [
-            "/var/lib/conary/conary.db",
-            "/run/systemd/private",
-            "/tmp/build",
-            "/dev/null",
-            "/proc/cpuinfo",
-            "/sys/kernel",
-            "/mnt/scratch",
-            "/media/disk",
-            "/conary/objects/aa/bb",
-        ] {
-            assert!(
-                !should_visit_live_root_path(Path::new(path)).unwrap(),
-                "{path} should be excluded"
-            );
-        }
-
-        for path in [
-            "/usr/sbin/init",
-            "/usr/lib/systemd/systemd",
-            "/etc/os-release",
-            "/boot/EFI/BOOT/BOOTX64.EFI",
-        ] {
-            assert!(
-                should_visit_live_root_path(Path::new(path)).unwrap(),
-                "{path} should be included"
-            );
-        }
-    }
-
-    #[test]
-    fn live_root_db_path_maps_test_root_to_absolute_generation_path() {
-        let root = Path::new("/tmp/conary-live-root");
-        let path = root.join("usr/sbin/init");
-
-        assert_eq!(
-            live_root_db_path(root, &path).unwrap(),
-            "/usr/sbin/init".to_string()
+    fn full_adoption_promotes_track_authority_without_changing_path_ownership() {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("conary.db");
+        conary_core::db::init(&db_path).unwrap();
+        let mut conn = conary_core::db::open(&db_path).unwrap();
+        let identity = InstalledPackageIdentity::rpm(
+            "fixture-1-1.x86_64",
+            "fixture",
+            None,
+            "1",
+            "1",
+            "x86_64",
+        )
+        .unwrap();
+        let mut original = Trove::new_with_source(
+            "fixture".to_string(),
+            "1-1".to_string(),
+            TroveType::Package,
+            InstallSource::AdoptedTrack,
+            conary_core::repository::versioning::VersionScheme::Rpm,
         );
+        original.architecture = Some("x86_64".to_string());
+        original.native_package_identity = Some(identity.clone());
+        let trove_id = original.insert(&conn).unwrap();
+        let old_content = PayloadContentAuthority {
+            sha256: conary_core::hash::sha256(b"old"),
+            size: 3,
+        };
+        let old_node =
+            ResolvedPayloadNode::from_numeric_source(PayloadNode::regular(0o644)).unwrap();
+        FileEntry::new(
+            "/usr/bin/fixture".to_string(),
+            old_node,
+            Some(old_content),
+            trove_id,
+        )
+        .insert(&conn)
+        .unwrap();
+
+        let new_content = PayloadContentAuthority {
+            sha256: conary_core::hash::sha256(b"new exact bytes"),
+            size: 15,
+        };
+        let new_node =
+            ResolvedPayloadNode::from_numeric_source(PayloadNode::regular(0o755)).unwrap();
+        let captured = CapturedAdoptionFile {
+            source: (
+                "/usr/bin/fixture".to_string(),
+                15,
+                i32::try_from(libc::S_IFREG | 0o755).unwrap(),
+                None,
+                None,
+                None,
+                None,
+            ),
+            node: new_node.clone(),
+            content: Some(new_content.clone()),
+        };
+
+        let tx = conn.transaction().unwrap();
+        let mut changeset = Changeset::new("promote fixture".to_string());
+        let changeset_id = changeset.insert(&tx).unwrap();
+        promote_track_package(&tx, changeset_id, &identity, trove_id, &[captured]).unwrap();
+        changeset
+            .update_status(&tx, ChangesetStatus::Applied)
+            .unwrap();
+        tx.commit().unwrap();
+
+        let promoted = Trove::find_by_id(&conn, trove_id).unwrap().unwrap();
+        assert_eq!(promoted.install_source, InstallSource::AdoptedFull);
+        assert_eq!(promoted.installed_by_changeset_id, Some(changeset_id));
+        let file = FileEntry::find_by_path(&conn, "/usr/bin/fixture")
+            .unwrap()
+            .unwrap();
+        assert_eq!(file.trove_id, trove_id);
+        assert_eq!(file.node, new_node);
+        assert_eq!(file.content, Some(new_content));
     }
 }

--- a/apps/conary/src/commands/adopt/system/captured_root.rs
+++ b/apps/conary/src/commands/adopt/system/captured_root.rs
@@ -1,0 +1,610 @@
+// apps/conary/src/commands/adopt/system/captured_root.rs
+
+//! Exact unowned selected-root continuity for full system adoption.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{Context, Result};
+use conary_core::db::models::{
+    DirectoryClaim, ExistingDirectoryMaterialization, FileEntry, InstallSource, ProvideEntry,
+    Trove, TroveType,
+};
+use conary_core::filesystem::CasStore;
+use conary_core::generation::root_manifest::{
+    CapturedSelectedRoot, GenerationRootEntry, SelectedRootCaptureExclusions,
+    scan_selected_root_with_exclusions,
+};
+use conary_core::repository::versioning::VersionScheme;
+use conary_core::runtime_root::ConaryRuntimeRoot;
+use rusqlite::Transaction;
+
+use super::LIVE_ROOT_PACKAGE_NAME;
+
+const CAPTURED_ROOT_VERSION: &str = "snapshot";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct CapturedRootSync {
+    pub(super) captured_entries: usize,
+    pub(super) package_entries: usize,
+    pub(super) changed: bool,
+}
+
+pub(super) fn ensure_complete_native_partition<'a>(
+    tracked_packages: &HashMap<String, Trove>,
+    installed_selectors: impl IntoIterator<Item = &'a str>,
+) -> Result<()> {
+    let installed = installed_selectors.into_iter().collect::<HashSet<_>>();
+    let mut stale = tracked_packages
+        .iter()
+        .filter(|(selector, trove)| {
+            trove.install_source == InstallSource::AdoptedTrack
+                && !installed.contains(selector.as_str())
+        })
+        .map(|(selector, _)| selector.clone())
+        .collect::<Vec<_>>();
+    stale.sort();
+    if stale.is_empty() {
+        return Ok(());
+    }
+    Err(anyhow::anyhow!(
+        "Complete full-system adoption found track-only native identities absent from the current package-manager inventory: {}. Refresh or unadopt that stale authority before retrying",
+        stale.join(", ")
+    ))
+}
+
+pub(super) fn capture_live_selected_root(
+    db_path: &str,
+    cas: &CasStore,
+) -> Result<CapturedSelectedRoot> {
+    let exclusions = capture_exclusions(db_path)?;
+    scan_selected_root_with_exclusions(Path::new("/"), cas, &exclusions)
+        .map_err(anyhow::Error::from)
+        .context("failed to capture exact selected-root continuity state")
+}
+
+pub(super) fn synchronize_captured_root(
+    tx: &Transaction<'_>,
+    changeset_id: i64,
+    captured: &CapturedSelectedRoot,
+) -> conary_core::Result<CapturedRootSync> {
+    let mut entries = captured
+        .generation
+        .entries
+        .iter()
+        .chain(&captured.state.entries)
+        .cloned()
+        .collect::<Vec<_>>();
+    entries.sort_by(|left, right| left.path.cmp(&right.path));
+
+    let captured_troves = Trove::list_all(tx)?
+        .into_iter()
+        .filter(|trove| trove.install_source == InstallSource::CapturedRoot)
+        .collect::<Vec<_>>();
+    if let Some(sync) = matching_existing_authority(tx, &entries, &captured_troves)? {
+        return Ok(sync);
+    }
+
+    // Deleting the prior synthetic authority is transaction-local. The schema
+    // reanchors shared directory materializations to surviving package claims
+    // before cascading paths that only the captured root owned.
+    for trove in captured_troves {
+        let trove_id = trove.id.ok_or_else(|| {
+            conary_core::Error::MissingId(format!(
+                "captured-root trove {} has no database identity",
+                trove.name
+            ))
+        })?;
+        Trove::delete(tx, trove_id)?;
+    }
+
+    let captured_trove_id = insert_captured_root_trove(tx, changeset_id)?;
+    let mut captured_entries = 0;
+    let mut package_entries = 0;
+    for entry in entries {
+        if FileEntry::find_by_path(tx, &entry.path)?.is_some() {
+            FileEntry::reconcile_selected_root_materialization(
+                tx,
+                &entry.path,
+                &entry.node,
+                entry.content.as_ref(),
+            )?;
+            package_entries += 1;
+        } else {
+            let mut file = FileEntry::new(entry.path, entry.node, entry.content, captured_trove_id);
+            file.insert_or_replace(tx, ExistingDirectoryMaterialization::ApplyIncoming)?;
+            captured_entries += 1;
+        }
+    }
+
+    Ok(CapturedRootSync {
+        captured_entries,
+        package_entries,
+        changed: true,
+    })
+}
+
+fn matching_existing_authority(
+    tx: &Transaction<'_>,
+    entries: &[GenerationRootEntry],
+    captured_troves: &[Trove],
+) -> conary_core::Result<Option<CapturedRootSync>> {
+    let [captured_trove] = captured_troves else {
+        return Ok(None);
+    };
+    if captured_trove.name != LIVE_ROOT_PACKAGE_NAME
+        || captured_trove.version != CAPTURED_ROOT_VERSION
+    {
+        return Ok(None);
+    }
+    let captured_trove_id = captured_trove.id.ok_or_else(|| {
+        conary_core::Error::MissingId(format!(
+            "captured-root trove {} has no database identity",
+            captured_trove.name
+        ))
+    })?;
+    let captured_paths = FileEntry::find_by_trove(tx, captured_trove_id)?
+        .into_iter()
+        .map(|file| file.path)
+        .chain(
+            DirectoryClaim::find_by_trove(tx, captured_trove_id)?
+                .into_iter()
+                .map(|claim| claim.path),
+        )
+        .collect::<HashSet<_>>();
+    let expected_paths = entries
+        .iter()
+        .map(|entry| entry.path.as_str())
+        .collect::<HashSet<_>>();
+    if captured_paths
+        .iter()
+        .any(|path| !expected_paths.contains(path.as_str()))
+    {
+        return Ok(None);
+    }
+
+    let mut captured_entries = 0;
+    let mut package_entries = 0;
+    for entry in entries {
+        let Some(existing) = FileEntry::find_by_path(tx, &entry.path)? else {
+            return Ok(None);
+        };
+        if existing.node != entry.node || existing.content != entry.content {
+            return Ok(None);
+        }
+        let claims = DirectoryClaim::find_retaining_path(tx, &entry.path)?;
+        let has_package_owner = existing.trove_id != captured_trove_id
+            || claims
+                .iter()
+                .any(|claim| claim.trove_id != captured_trove_id);
+        let has_captured_owner = existing.trove_id == captured_trove_id
+            || claims
+                .iter()
+                .any(|claim| claim.trove_id == captured_trove_id);
+        if has_package_owner {
+            if has_captured_owner {
+                return Ok(None);
+            }
+            package_entries += 1;
+        } else {
+            if !has_captured_owner {
+                return Ok(None);
+            }
+            captured_entries += 1;
+        }
+    }
+
+    Ok(Some(CapturedRootSync {
+        captured_entries,
+        package_entries,
+        changed: false,
+    }))
+}
+
+fn insert_captured_root_trove(tx: &Transaction<'_>, changeset_id: i64) -> conary_core::Result<i64> {
+    let mut trove = Trove::new_with_source(
+        LIVE_ROOT_PACKAGE_NAME.to_string(),
+        CAPTURED_ROOT_VERSION.to_string(),
+        TroveType::Package,
+        InstallSource::CapturedRoot,
+        VersionScheme::Conary,
+    );
+    trove.architecture = Some(std::env::consts::ARCH.to_string());
+    trove.description =
+        Some("Exact selected-root continuity state without a package owner".to_string());
+    trove.installed_by_changeset_id = Some(changeset_id);
+    trove.selection_reason = Some("Captured during complete full-system adoption".to_string());
+    let trove_id = trove.insert(tx)?;
+
+    let mut provide = ProvideEntry::new(
+        trove_id,
+        LIVE_ROOT_PACKAGE_NAME.to_string(),
+        Some(CAPTURED_ROOT_VERSION.to_string()),
+        VersionScheme::Conary,
+    );
+    provide.insert_or_ignore(tx)?;
+    Ok(trove_id)
+}
+
+fn capture_exclusions(db_path: &str) -> Result<SelectedRootCaptureExclusions> {
+    let runtime = ConaryRuntimeRoot::from_db_path(PathBuf::from(db_path));
+    let runtime_root = absolute_normalized(runtime.root())?;
+    let database = absolute_normalized(runtime.db_path())?;
+    if runtime_root == Path::new("/") {
+        return Err(anyhow::anyhow!(
+            "Conary runtime root cannot be / during selected-root capture"
+        ));
+    }
+
+    let mut exclusions = Vec::new();
+    push_exclusion(&mut exclusions, &runtime_root)?;
+    push_database_exclusions(&mut exclusions, &database)?;
+
+    if let Some(resolved_runtime_root) = resolve_existing_authority(&runtime_root)? {
+        if resolved_runtime_root == Path::new("/") {
+            return Err(anyhow::anyhow!(
+                "Conary runtime root {} resolves to / during selected-root capture",
+                runtime_root.display()
+            ));
+        }
+        push_exclusion(&mut exclusions, &resolved_runtime_root)?;
+    }
+    if let Some(resolved_database_parent) =
+        resolve_existing_authority(database.parent().unwrap_or(Path::new("/")))?
+        && resolved_database_parent != Path::new("/")
+    {
+        push_exclusion(&mut exclusions, &resolved_database_parent)?;
+    }
+    if let Some(resolved_database) = resolve_existing_authority(&database)? {
+        push_database_exclusions(&mut exclusions, &resolved_database)?;
+    }
+
+    SelectedRootCaptureExclusions::new(exclusions)
+        .map_err(anyhow::Error::from)
+        .context("invalid Conary runtime capture boundary")
+}
+
+fn push_database_exclusions(exclusions: &mut Vec<String>, database: &Path) -> Result<()> {
+    if let Some(parent) = database.parent().filter(|parent| *parent != Path::new("/")) {
+        push_exclusion(exclusions, parent)?;
+    }
+    let database = database.to_str().with_context(|| {
+        format!(
+            "Conary database exclusion is not valid UTF-8: {}",
+            database.display()
+        )
+    })?;
+    for suffix in ["", "-wal", "-shm", "-journal"] {
+        exclusions.push(format!("{database}{suffix}"));
+    }
+    Ok(())
+}
+
+fn push_exclusion(exclusions: &mut Vec<String>, path: &Path) -> Result<()> {
+    if path == Path::new("/") {
+        return Err(anyhow::anyhow!(
+            "selected-root capture cannot exclude the complete root"
+        ));
+    }
+    exclusions.push(
+        path.to_str()
+            .with_context(|| {
+                format!(
+                    "Conary runtime exclusion is not valid UTF-8: {}",
+                    path.display()
+                )
+            })?
+            .to_string(),
+    );
+    Ok(())
+}
+
+fn resolve_existing_authority(path: &Path) -> Result<Option<PathBuf>> {
+    match std::fs::canonicalize(path) {
+        Ok(resolved) => absolute_normalized(&resolved).map(Some),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error).with_context(|| {
+            format!(
+                "failed to resolve Conary runtime authority {}",
+                path.display()
+            )
+        }),
+    }
+}
+
+fn absolute_normalized(path: &Path) -> Result<PathBuf> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    let mut normalized = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::RootDir => normalized.push("/"),
+            Component::Normal(value) => normalized.push(value),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if normalized != Path::new("/") {
+                    normalized.pop();
+                }
+            }
+            Component::Prefix(_) => {
+                return Err(anyhow::anyhow!(
+                    "Conary runtime path has an unsupported platform prefix: {}",
+                    path.display()
+                ));
+            }
+        }
+    }
+    Ok(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use conary_core::db::models::{Changeset, ChangesetStatus};
+    use conary_core::generation::root_manifest::{
+        SelectedRootCaptureExclusions, scan_selected_root_with_exclusions,
+    };
+    use conary_core::payload::PayloadNodeKind;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn insert_changeset(tx: &Transaction<'_>, description: &str) -> i64 {
+        let mut changeset = Changeset::new(description.to_string());
+        let id = changeset.insert(tx).unwrap();
+        changeset
+            .update_status(tx, ChangesetStatus::Applied)
+            .unwrap();
+        id
+    }
+
+    #[test]
+    fn full_capture_partitions_package_and_unowned_authority_exactly() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("root");
+        let cas = CasStore::new(temp.path().join("objects")).unwrap();
+        for directory in [
+            "conary/objects",
+            "etc/systemd/system/multi-user.target.wants",
+            "run",
+            "usr/bin",
+            "var/lib/conary",
+        ] {
+            std::fs::create_dir_all(root.join(directory)).unwrap();
+        }
+        std::fs::write(root.join("conary/objects/private"), b"runtime").unwrap();
+        std::fs::write(root.join("run/private"), b"ephemeral").unwrap();
+        std::fs::write(root.join("var/lib/conary/conary.db"), b"runtime").unwrap();
+        std::fs::write(root.join("etc/owned-primary"), b"hardlinked").unwrap();
+        std::fs::hard_link(
+            root.join("etc/owned-primary"),
+            root.join("etc/unowned-link"),
+        )
+        .unwrap();
+        std::fs::set_permissions(
+            root.join("etc/owned-primary"),
+            std::fs::Permissions::from_mode(0o640),
+        )
+        .unwrap();
+        std::os::unix::fs::symlink(
+            "/usr/sbin/sshd",
+            root.join("etc/systemd/system/multi-user.target.wants/sshd.service"),
+        )
+        .unwrap();
+        std::fs::write(root.join("usr/bin/owned"), b"package").unwrap();
+
+        let exclusions = SelectedRootCaptureExclusions::new(vec![
+            "/conary".to_string(),
+            "/var/lib/conary".to_string(),
+        ])
+        .unwrap();
+        let captured = scan_selected_root_with_exclusions(&root, &cas, &exclusions).unwrap();
+        let entries = captured
+            .generation
+            .entries
+            .iter()
+            .chain(&captured.state.entries)
+            .map(|entry| (entry.path.as_str(), entry))
+            .collect::<std::collections::HashMap<_, _>>();
+
+        let db_path = temp.path().join("conary.db");
+        conary_core::db::init(&db_path).unwrap();
+        let mut conn = conary_core::db::open(&db_path).unwrap();
+        let tx = conn.transaction().unwrap();
+        let changeset_id = insert_changeset(&tx, "seed package");
+        let mut package = Trove::new_with_source(
+            "native-package".to_string(),
+            "1-1".to_string(),
+            TroveType::Package,
+            InstallSource::AdoptedFull,
+            VersionScheme::Rpm,
+        );
+        package.architecture = Some("x86_64".to_string());
+        package.native_package_identity = Some(
+            conary_core::packages::InstalledPackageIdentity::rpm(
+                "native-package-1-1.x86_64",
+                "native-package",
+                None,
+                "1",
+                "1",
+                "x86_64",
+            )
+            .unwrap(),
+        );
+        package.installed_by_changeset_id = Some(changeset_id);
+        let package_id = package.insert(&tx).unwrap();
+        for path in [
+            "/etc",
+            "/etc/owned-primary",
+            "/usr",
+            "/usr/bin",
+            "/usr/bin/owned",
+        ] {
+            let entry = entries[path];
+            let mut node = entry.node.clone();
+            if path == "/etc/owned-primary" {
+                node.source.kind = PayloadNodeKind::Regular {
+                    hardlink_identity: None,
+                };
+            }
+            let mut file =
+                FileEntry::new(path.to_string(), node, entry.content.clone(), package_id);
+            file.insert_or_replace(&tx, ExistingDirectoryMaterialization::ApplyIncoming)
+                .unwrap();
+        }
+
+        let first_changeset = insert_changeset(&tx, "capture selected root");
+        let first = synchronize_captured_root(&tx, first_changeset, &captured).unwrap();
+        assert!(first.changed);
+        assert!(first.captured_entries > 0);
+        assert!(first.package_entries >= 5);
+
+        let captured_trove = Trove::list_all(&tx)
+            .unwrap()
+            .into_iter()
+            .find(|trove| trove.install_source == InstallSource::CapturedRoot)
+            .unwrap();
+        let captured_id = captured_trove.id.unwrap();
+        assert_eq!(
+            FileEntry::find_by_path(&tx, "/etc/owned-primary")
+                .unwrap()
+                .unwrap()
+                .trove_id,
+            package_id
+        );
+        assert_eq!(
+            FileEntry::find_by_path(&tx, "/etc/unowned-link")
+                .unwrap()
+                .unwrap()
+                .trove_id,
+            captured_id
+        );
+        let primary = FileEntry::find_by_path(&tx, "/etc/owned-primary")
+            .unwrap()
+            .unwrap();
+        let linked = FileEntry::find_by_path(&tx, "/etc/unowned-link")
+            .unwrap()
+            .unwrap();
+        let PayloadNodeKind::Regular {
+            hardlink_identity: Some(primary_identity),
+        } = primary.node.source.kind
+        else {
+            panic!("package-owned hardlink primary lost its typed identity");
+        };
+        let PayloadNodeKind::Hardlink { identity, target } = linked.node.source.kind else {
+            panic!("captured-root hardlink lost its typed link authority");
+        };
+        assert_eq!(identity, primary_identity);
+        assert_eq!(target, "/etc/owned-primary");
+        assert!(
+            FileEntry::find_by_path(
+                &tx,
+                "/etc/systemd/system/multi-user.target.wants/sshd.service"
+            )
+            .unwrap()
+            .is_some()
+        );
+        for excluded in ["/conary", "/run", "/var/lib/conary"] {
+            assert!(
+                FileEntry::find_all_ordered(&tx)
+                    .unwrap()
+                    .iter()
+                    .all(|file| file.path != excluded
+                        && !file.path.starts_with(&format!("{excluded}/")))
+            );
+        }
+
+        let second_changeset = insert_changeset(&tx, "repeat selected-root capture");
+        let second = synchronize_captured_root(&tx, second_changeset, &captured).unwrap();
+        assert!(!second.changed);
+        assert_eq!(second.captured_entries, first.captured_entries);
+        assert_eq!(second.package_entries, first.package_entries);
+        assert_eq!(
+            Trove::list_all(&tx)
+                .unwrap()
+                .iter()
+                .filter(|trove| trove.install_source == InstallSource::CapturedRoot)
+                .count(),
+            1
+        );
+        tx.commit().unwrap();
+    }
+
+    #[test]
+    fn runtime_capture_exclusions_follow_default_and_isolated_database_roots() {
+        let default = capture_exclusions("/var/lib/conary/conary.db").unwrap();
+        assert!(default.excludes("/conary/objects/aa"));
+        assert!(default.excludes("/var/lib/conary/conary.db"));
+        assert!(default.excludes("/var/lib/conary/conary.db-wal"));
+        assert!(!default.excludes("/var/lib/conary-adjacent/state"));
+
+        let isolated = capture_exclusions("target/captured-root-test/conary.db").unwrap();
+        let cwd = std::env::current_dir().unwrap();
+        let isolated_root = cwd.join("target/captured-root-test");
+        assert!(isolated.excludes(isolated_root.to_str().unwrap()));
+    }
+
+    #[test]
+    fn runtime_capture_exclusions_cover_lexical_and_resolved_aliases() {
+        let temp = tempfile::tempdir().unwrap();
+        let resolved = temp.path().join("resolved-runtime");
+        let alias = temp.path().join("runtime-alias");
+        std::fs::create_dir_all(&resolved).unwrap();
+        std::fs::write(resolved.join("conary.db"), b"database").unwrap();
+        std::os::unix::fs::symlink(&resolved, &alias).unwrap();
+
+        let exclusions = capture_exclusions(alias.join("conary.db").to_str().unwrap()).unwrap();
+
+        assert!(exclusions.excludes(alias.join("objects").to_str().unwrap()));
+        assert!(exclusions.excludes(resolved.join("objects").to_str().unwrap()));
+        assert!(exclusions.excludes(resolved.join("conary.db-wal").to_str().unwrap()));
+    }
+
+    #[test]
+    fn runtime_capture_rejects_a_root_runtime_authority() {
+        let error = capture_exclusions("/conary.db").unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("runtime root cannot be / during selected-root capture"),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn complete_root_capture_detects_stale_track_only_authority() {
+        fn trove(name: &str, source: InstallSource) -> Trove {
+            Trove::new_with_source(
+                name.to_string(),
+                "1-1".to_string(),
+                TroveType::Package,
+                source,
+                VersionScheme::Rpm,
+            )
+        }
+
+        let tracked = HashMap::from([
+            (
+                "current-1-1.x86_64".to_string(),
+                trove("current", InstallSource::AdoptedTrack),
+            ),
+            (
+                "stale-1-1.x86_64".to_string(),
+                trove("stale", InstallSource::AdoptedTrack),
+            ),
+            (
+                "repository-1-1.x86_64".to_string(),
+                trove("repository", InstallSource::Repository),
+            ),
+        ]);
+
+        let error = ensure_complete_native_partition(&tracked, ["current-1-1.x86_64"]).unwrap_err();
+
+        assert!(error.to_string().contains("stale-1-1.x86_64"), "{error:#}");
+        assert!(
+            !error.to_string().contains("repository-1-1.x86_64"),
+            "{error:#}"
+        );
+    }
+}

--- a/apps/conary/src/commands/adopt/system/live_root.rs
+++ b/apps/conary/src/commands/adopt/system/live_root.rs
@@ -1,19 +1,15 @@
 // apps/conary/src/commands/adopt/system/live_root.rs
 
-//! Synthetic live-root adoption and CAS capture.
+//! Full selected-root adoption when no native package manager is present.
 
 use super::{
-    FileInfoTuple, LIVE_ROOT_PACKAGE_NAME, capture_package_files, create_state_snapshot, open_db,
-    write_db_checkpoint,
+    LIVE_ROOT_PACKAGE_NAME, captured_root::capture_live_selected_root,
+    captured_root::synchronize_captured_root, create_state_snapshot, open_db, write_db_checkpoint,
 };
-use anyhow::{Context, Result};
+use anyhow::Result;
 use conary_core::db::backup::CheckpointReason;
-use conary_core::db::models::{
-    Changeset, ChangesetStatus, ExistingDirectoryMaterialization, InstallSource, ProvideEntry,
-    Trove, TroveType,
-};
-use std::path::Path;
-use walkdir::WalkDir;
+use conary_core::db::models::{Changeset, ChangesetStatus};
+use conary_core::filesystem::CasStore;
 
 pub(super) fn adopt_live_root_as_full_package(
     db_path: &str,
@@ -29,223 +25,41 @@ pub(super) fn adopt_live_root_as_full_package(
     }
 
     println!(
-        "No supported package manager found; adopting the live root as one CAS-backed package"
+        "No supported package manager found; capturing exact selected-root continuity as {LIVE_ROOT_PACKAGE_NAME}"
     );
-
-    let mut conn = open_db(db_path)?;
-    let tracked_packages: std::collections::HashSet<String> = Trove::list_all(&conn)?
-        .into_iter()
-        .map(|t| t.name)
-        .collect();
-    if tracked_packages.contains(LIVE_ROOT_PACKAGE_NAME) {
-        println!("Live root is already adopted as {LIVE_ROOT_PACKAGE_NAME}; nothing to do");
-        return Ok(());
-    }
-
-    let files = collect_live_root_file_info(Path::new("/"))?;
     if dry_run {
-        println!("Dry run: would adopt 1 synthetic package");
+        println!("Dry run: would synchronize 1 typed captured-root authority");
         println!("  Package: {LIVE_ROOT_PACKAGE_NAME}");
-        println!("  Files: {}", files.len());
         println!("  Mode: full (CAS storage)");
         return Ok(());
     }
 
-    let objects_dir = conary_core::db::paths::objects_dir(db_path);
-    let cas = conary_core::filesystem::CasStore::new(&objects_dir)?;
-    let captured_files = capture_package_files(LIVE_ROOT_PACKAGE_NAME, &files, Some(&cas))?;
+    let cas = CasStore::new(conary_core::db::paths::objects_dir(db_path))?;
+    let captured = capture_live_selected_root(db_path, &cas)?;
+    let mut conn = open_db(db_path)?;
     let mut changeset = Changeset::new(format!(
-        "Adopt live root as CAS-backed package ({LIVE_ROOT_PACKAGE_NAME})"
+        "Synchronize selected-root authority ({LIVE_ROOT_PACKAGE_NAME})"
     ));
+
     write_db_checkpoint(db_path, CheckpointReason::PreMutation)?;
-    let changeset_id = conary_core::db::transaction(&mut conn, |tx| {
+    let (changeset_id, sync) = conary_core::db::transaction(&mut conn, |tx| {
         let changeset_id = changeset.insert(tx)?;
-        let mut trove = Trove::new_with_source(
-            LIVE_ROOT_PACKAGE_NAME.to_string(),
-            live_root_adoption_version(),
-            TroveType::Package,
-            InstallSource::CapturedRoot,
-            conary_core::repository::versioning::VersionScheme::Conary,
-        );
-        trove.architecture = Some(std::env::consts::ARCH.to_string());
-        trove.description = Some(
-            "Synthetic CAS-backed package imported from a system without a native package manager"
-                .to_string(),
-        );
-        trove.installed_by_changeset_id = Some(changeset_id);
-        trove.selection_reason = Some(
-            "Captured live root because no supported package manager was available".to_string(),
-        );
-        let trove_id = trove.insert(tx)?;
-
-        for captured in &captured_files {
-            let mut file_entry = captured.file_entry(trove_id);
-            file_entry.insert_or_replace(tx, ExistingDirectoryMaterialization::ApplyIncoming)?;
-        }
-
-        let mut provide = ProvideEntry::new(
-            trove_id,
-            LIVE_ROOT_PACKAGE_NAME.to_string(),
-            Some(live_root_adoption_version()),
-            trove.version_scheme,
-        );
-        provide.insert_or_ignore(tx)?;
-
+        let sync = synchronize_captured_root(tx, changeset_id, &captured)?;
         changeset.update_status(tx, ChangesetStatus::Applied)?;
-        Ok(changeset_id)
+        Ok((changeset_id, sync))
     })?;
-
-    create_state_snapshot(
-        &conn,
-        changeset_id,
-        &format!("Adopt live root as {LIVE_ROOT_PACKAGE_NAME}"),
-    )?;
+    if sync.changed {
+        create_state_snapshot(
+            &conn,
+            changeset_id,
+            &format!("Synchronize selected root as {LIVE_ROOT_PACKAGE_NAME}"),
+        )?;
+    }
     write_db_checkpoint(db_path, CheckpointReason::PostSuccess)?;
 
     println!(
-        "Adopted live root as {LIVE_ROOT_PACKAGE_NAME}: {} files (full)",
-        captured_files.len()
+        "Synchronized {LIVE_ROOT_PACKAGE_NAME}: {} unowned entries, {} package-owned entries (full)",
+        sync.captured_entries, sync.package_entries
     );
-
     Ok(())
-}
-
-fn live_root_adoption_version() -> String {
-    "snapshot".to_string()
-}
-
-fn collect_live_root_file_info(root: &Path) -> Result<Vec<FileInfoTuple>> {
-    let mut files = Vec::new();
-    let mut walker = WalkDir::new(root).follow_links(false).into_iter();
-
-    while let Some(entry) = walker.next() {
-        let entry = entry?;
-        let path = entry.path();
-        if !should_visit_live_root_path(path)? {
-            if entry.file_type().is_dir() {
-                walker.skip_current_dir();
-            }
-            continue;
-        }
-        if path == root {
-            continue;
-        }
-
-        let metadata = std::fs::symlink_metadata(path)?;
-        let link_target = if metadata.file_type().is_symlink() {
-            Some(read_live_root_link_target(path)?)
-        } else {
-            None
-        };
-        let size = if let Some(target) = &link_target {
-            i64::try_from(target.len())?
-        } else {
-            i64::try_from(metadata.len())?
-        };
-
-        files.push((
-            live_root_db_path(root, path)?,
-            size,
-            live_root_file_mode(&metadata),
-            None,
-            Some("root".to_string()),
-            Some("root".to_string()),
-            link_target,
-        ));
-    }
-
-    Ok(files)
-}
-
-fn read_live_root_link_target(path: &Path) -> Result<String> {
-    let target = std::fs::read_link(path)?;
-    target.into_os_string().into_string().map_err(|target| {
-        anyhow::anyhow!(
-            "Cannot adopt symlink {} because its target is not valid UTF-8: {:?}",
-            path.display(),
-            target
-        )
-    })
-}
-
-#[cfg(unix)]
-fn live_root_file_mode(metadata: &std::fs::Metadata) -> i32 {
-    use std::os::unix::fs::PermissionsExt;
-
-    #[allow(clippy::cast_possible_wrap)]
-    {
-        metadata.permissions().mode() as i32
-    }
-}
-
-#[cfg(not(unix))]
-fn live_root_file_mode(_metadata: &std::fs::Metadata) -> i32 {
-    0
-}
-
-pub(super) fn live_root_db_path(root: &Path, path: &Path) -> Result<String> {
-    if root == Path::new("/") {
-        return path.to_str().map(str::to_string).with_context(|| {
-            format!(
-                "Cannot adopt live-root path {} because it is not valid UTF-8",
-                path.display()
-            )
-        });
-    }
-    let rel = path.strip_prefix(root)?;
-    let rel = rel.to_str().with_context(|| {
-        format!(
-            "Cannot adopt live-root path {} because it is not valid UTF-8",
-            path.display()
-        )
-    })?;
-    Ok(format!("/{rel}"))
-}
-
-pub(super) fn should_visit_live_root_path(path: &Path) -> Result<bool> {
-    let path = path.to_str().with_context(|| {
-        format!(
-            "Cannot classify live-root path {} because it is not valid UTF-8",
-            path.display()
-        )
-    })?;
-    Ok(!conary_core::generation::metadata::is_excluded(path)
-        && path != "/conary"
-        && !path.starts_with("/conary/"))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::ffi::OsString;
-    use std::os::unix::ffi::OsStringExt;
-    use std::os::unix::fs::symlink;
-
-    #[test]
-    fn live_root_paths_with_distinct_invalid_bytes_fail_closed() {
-        let root = Path::new("/captured");
-        let first = root.join(OsString::from_vec(vec![b'n', b'a', b'm', b'e', 0x80]));
-        let second = root.join(OsString::from_vec(vec![b'n', b'a', b'm', b'e', 0x81]));
-
-        assert!(live_root_db_path(root, &first).is_err());
-        assert!(live_root_db_path(root, &second).is_err());
-    }
-
-    #[test]
-    fn live_root_symlink_with_invalid_byte_target_fails_closed() {
-        let root = tempfile::tempdir().unwrap();
-        symlink(
-            OsString::from_vec(vec![b't', b'a', b'r', b'g', b'e', b't', 0x80]),
-            root.path().join("link"),
-        )
-        .unwrap();
-
-        let error = read_live_root_link_target(&root.path().join("link")).unwrap_err();
-        assert!(
-            error
-                .to_string()
-                .contains("because its target is not valid UTF-8"),
-            "{error:#}"
-        );
-    }
 }

--- a/apps/conary/tests/integration/remi/manifests/phase3-group-o-generation-export.toml
+++ b/apps/conary/tests/integration/remi/manifests/phase3-group-o-generation-export.toml
@@ -146,7 +146,7 @@ exit_code = 0
 [[test]]
 id = "TGE05"
 name = "installed_runtime_generation_export_preserves_file_capability_xattrs"
-description = "Export baseline and upgraded installed-runtime generations, then boot both qcow2 artifacts to prove security.capability rollback-equivalent behavior"
+description = "Export baseline and upgraded installed-runtime generations, then boot both qcow2 artifacts to prove captured-root lifecycle continuity and security.capability rollback-equivalent behavior"
 timeout = 10800
 group = "generation-export"
 
@@ -207,6 +207,11 @@ copy_to_guest = [
 commands = [
     "EXPECTED=$(cat /tmp/expected-generation); grep -q \"conary.generation=$EXPECTED\" /proc/cmdline",
     "EXPECTED=$(cat /tmp/expected-generation); TARGET=$(readlink /conary/current); test \"$TARGET\" = \"generations/$EXPECTED\" || test \"$TARGET\" = \"$EXPECTED\" || test \"$(readlink -f /conary/current)\" = \"/conary/generations/$EXPECTED\"",
+    "test -L /etc/systemd/system/dbus.service",
+    "test -L /etc/systemd/system/multi-user.target.wants/sshd.service",
+    "test -L /etc/systemd/system/multi-user.target.wants/NetworkManager.service",
+    "test -s /etc/ssh/authorized_keys/root",
+    "grep -q '/etc/ssh/authorized_keys/%u' /etc/ssh/sshd_config",
     "test -x /usr/bin/group-o-cap-demo",
     "if command -v getcap >/dev/null 2>&1; then OUT=$(getcap -n /usr/bin/group-o-cap-demo 2>/dev/null || true); printf '%s\\n' \"$OUT\"; test -z \"$OUT\"; elif command -v getfattr >/dev/null 2>&1; then ! getfattr --only-values -n security.capability /usr/bin/group-o-cap-demo >/tmp/group-o-cap.bin 2>/dev/null; elif command -v attr >/dev/null 2>&1; then ! attr -q -g security.capability /usr/bin/group-o-cap-demo >/tmp/group-o-cap.bin 2>/dev/null; elif command -v python3 >/dev/null 2>&1; then python3 -c 'import os,sys; raise SystemExit(0 if \"security.capability\" not in os.listxattr(sys.argv[1]) else 1)' /usr/bin/group-o-cap-demo; else echo 'missing capability inspection helper' >&2; exit 1; fi",
     "echo installed-runtime-generation-file-capability-baseline-ok",
@@ -231,6 +236,11 @@ copy_to_guest = [
 commands = [
     "EXPECTED=$(cat /tmp/expected-generation); grep -q \"conary.generation=$EXPECTED\" /proc/cmdline",
     "EXPECTED=$(cat /tmp/expected-generation); TARGET=$(readlink /conary/current); test \"$TARGET\" = \"generations/$EXPECTED\" || test \"$TARGET\" = \"$EXPECTED\" || test \"$(readlink -f /conary/current)\" = \"/conary/generations/$EXPECTED\"",
+    "test -L /etc/systemd/system/dbus.service",
+    "test -L /etc/systemd/system/multi-user.target.wants/sshd.service",
+    "test -L /etc/systemd/system/multi-user.target.wants/NetworkManager.service",
+    "test -s /etc/ssh/authorized_keys/root",
+    "grep -q '/etc/ssh/authorized_keys/%u' /etc/ssh/sshd_config",
     "test -x /usr/bin/group-o-cap-demo",
     "if command -v getcap >/dev/null 2>&1; then OUT=$(getcap -n /usr/bin/group-o-cap-demo 2>/dev/null || true); printf '%s\\n' \"$OUT\"; printf '%s\\n' \"$OUT\" | grep -Eq 'cap_net_bind_service=ep'; elif command -v python3 >/dev/null 2>&1; then python3 -c 'import os,sys; expected=bytes.fromhex(\"0100000200040000000000000000000000000000\"); actual=os.getxattr(sys.argv[1], \"security.capability\"); raise SystemExit(0 if actual == expected else 1)' /usr/bin/group-o-cap-demo; elif command -v getfattr >/dev/null 2>&1 && command -v od >/dev/null 2>&1; then getfattr --only-values -n security.capability /usr/bin/group-o-cap-demo 2>/dev/null | od -An -tx1 -v | tr -d ' \\n' | grep -qx '0100000200040000000000000000000000000000'; elif command -v attr >/dev/null 2>&1 && command -v od >/dev/null 2>&1; then attr -q -g security.capability /usr/bin/group-o-cap-demo 2>/dev/null | od -An -tx1 -v | tr -d ' \\n' | grep -qx '0100000200040000000000000000000000000000'; else echo 'missing capability inspection helper' >&2; exit 1; fi",
     "echo installed-runtime-generation-file-capability-enabled-ok",

--- a/crates/conary-core/src/db/models/file_entry.rs
+++ b/crates/conary-core/src/db/models/file_entry.rs
@@ -197,12 +197,33 @@ impl FileEntry {
                 anchor_policy.as_str()
             )));
         }
-        let existing = Self::find_by_path(tx, path)?.ok_or_else(|| {
+        Self::reconcile_selected_root_materialization(tx, path, node, None)?;
+        Ok(())
+    }
+
+    /// Reconcile one tracked path to exact selected-root materialization
+    /// without changing its package owner, component, timestamp, or directory
+    /// claim graph.
+    ///
+    /// This is used when one complete root scan establishes hardlink topology
+    /// and node/content authority across package ownership boundaries.
+    pub fn reconcile_selected_root_materialization(
+        conn: &Connection,
+        path: &str,
+        node: &ResolvedPayloadNode,
+        content: Option<&PayloadContentAuthority>,
+    ) -> Result<bool> {
+        let candidate = Self::new(path.to_string(), node.clone(), content.cloned(), i64::MIN);
+        candidate.validate()?;
+        let existing = Self::find_by_path(conn, path)?.ok_or_else(|| {
             Error::NotFound(format!(
-                "selected-root directory materialization {path} has no files anchor"
+                "selected-root materialization {path} has no files anchor"
             ))
         })?;
-        for claim in super::DirectoryClaim::find_retaining_path(tx, path)? {
+        if existing.node == *node && existing.content.as_ref() == content {
+            return Ok(false);
+        }
+        for claim in super::DirectoryClaim::find_retaining_path(conn, path)? {
             let accepted = if claim.path == path {
                 claim.anchor_policy.accepts(&node.source.kind)
             } else {
@@ -217,13 +238,24 @@ impl FileEntry {
             }
         }
         let node_json = canonical_node_json(node)?;
-        tx.execute(
+        let content_size = persisted_content_size(content)?;
+        let updated = conn.execute(
             "UPDATE files
-             SET payload_node_json = ?1, content_sha256 = NULL, content_size = NULL
-             WHERE id = ?2",
-            params![node_json, existing.id],
+             SET payload_node_json = ?1, content_sha256 = ?2, content_size = ?3
+             WHERE id = ?4",
+            params![
+                node_json,
+                content.map(|authority| &authority.sha256),
+                content_size,
+                existing.id
+            ],
         )?;
-        Ok(())
+        if updated != 1 {
+            return Err(Error::InternalError(format!(
+                "selected-root materialization {path} was not reconciled exactly"
+            )));
+        }
+        Ok(true)
     }
 
     /// Restore one exact materialized directory anchor inside a caller-owned

--- a/crates/conary-core/src/db/models/trove.rs
+++ b/crates/conary-core/src/db/models/trove.rs
@@ -72,6 +72,19 @@ impl InstallSource {
                 | InstallSource::CapturedRoot
         )
     }
+
+    /// Returns true when this source carries complete selected-root authority
+    /// that can be projected into a generation.
+    pub fn is_generation_input(&self) -> bool {
+        matches!(
+            self,
+            InstallSource::AdoptedFull
+                | InstallSource::Taken
+                | InstallSource::Repository
+                | InstallSource::File
+                | InstallSource::CapturedRoot
+        )
+    }
 }
 
 /// Reason why a package was installed
@@ -954,5 +967,19 @@ mod tests {
     fn test_taken_is_not_adopted() {
         assert!(!InstallSource::Taken.is_adopted());
         assert!(!InstallSource::CapturedRoot.is_adopted());
+    }
+
+    #[test]
+    fn complete_selected_root_sources_are_generation_inputs() {
+        for source in [
+            InstallSource::AdoptedFull,
+            InstallSource::Taken,
+            InstallSource::File,
+            InstallSource::Repository,
+            InstallSource::CapturedRoot,
+        ] {
+            assert!(source.is_generation_input(), "{source}");
+        }
+        assert!(!InstallSource::AdoptedTrack.is_generation_input());
     }
 }

--- a/crates/conary-core/src/generation/builder/runtime_inputs.rs
+++ b/crates/conary-core/src/generation/builder/runtime_inputs.rs
@@ -19,16 +19,6 @@ type RuntimeXattrs = BTreeMap<String, Vec<u8>>;
 type CapabilityTargetKey = (i64, String);
 type RuntimeCapabilityXattrs = HashMap<CapabilityTargetKey, RuntimeXattrs>;
 
-pub(super) fn is_generation_input_source(source: InstallSource) -> bool {
-    matches!(
-        source,
-        InstallSource::AdoptedFull
-            | InstallSource::Taken
-            | InstallSource::Repository
-            | InstallSource::File
-    )
-}
-
 #[derive(Debug)]
 pub(super) struct RuntimeGenerationInputs {
     pub generation: GenerationRootManifest,
@@ -82,7 +72,8 @@ pub(super) fn collect_runtime_generation_inputs(
                 file.path, file.trove_id
             )));
         };
-        let mut generation_owner = is_generation_input_source((*anchor_source).clone())
+        let mut generation_owner = anchor_source
+            .is_generation_input()
             .then_some((*anchor_package_name, file.trove_id));
         for claim in DirectoryClaim::find_retaining_path(conn, &file.path)? {
             let Some((claim_package_name, claim_source)) = trove_map.get(&claim.trove_id) else {
@@ -91,7 +82,7 @@ pub(super) fn collect_runtime_generation_inputs(
                     file.path, claim.trove_id
                 )));
             };
-            if generation_owner.is_none() && is_generation_input_source((*claim_source).clone()) {
+            if generation_owner.is_none() && claim_source.is_generation_input() {
                 generation_owner = Some((*claim_package_name, claim.trove_id));
             }
         }
@@ -175,7 +166,7 @@ fn collect_runtime_capability_xattrs(
                 ),
             ));
         };
-        if !is_generation_input_source((*source).clone()) {
+        if !source.is_generation_input() {
             return Err(capability_input_error(
                 package_name,
                 &row.path,
@@ -446,6 +437,40 @@ mod tests {
         let inputs = collect_runtime_generation_inputs(&conn, &troves, files, root.path()).unwrap();
         assert_eq!(inputs.adopted_track_count, 1);
         assert!(inputs.generation.entries.is_empty());
+    }
+
+    #[test]
+    fn captured_root_is_exact_generation_and_mutable_state_authority() {
+        let (_tmp, conn) = create_test_db();
+        let root = selected_root();
+        let troves = vec![trove(1, "captured-root", InstallSource::CapturedRoot)];
+        let files = vec![
+            directory("/etc", 1),
+            regular("/etc/sshd_config", b"configured", 1),
+            directory("/usr", 1),
+            regular("/usr/local-state", b"captured", 1),
+        ];
+
+        let inputs = collect_runtime_generation_inputs(&conn, &troves, files, root.path()).unwrap();
+
+        assert_eq!(
+            inputs
+                .generation
+                .entries
+                .iter()
+                .map(|entry| entry.path.as_str())
+                .collect::<Vec<_>>(),
+            ["/usr", "/usr/local-state"]
+        );
+        assert_eq!(
+            inputs
+                .state
+                .entries
+                .iter()
+                .map(|entry| entry.path.as_str())
+                .collect::<Vec<_>>(),
+            ["/etc", "/etc/sshd_config"]
+        );
     }
 
     #[test]

--- a/crates/conary-core/src/generation/root_manifest.rs
+++ b/crates/conary-core/src/generation/root_manifest.rs
@@ -18,7 +18,8 @@ pub use materialize::{
     overlay_payload_entries,
 };
 pub use scan::{
-    capture_existing_payload_node, capture_root_node, scan_payload_tree, scan_selected_root,
+    SelectedRootCaptureExclusions, capture_existing_payload_node, capture_root_node,
+    scan_payload_tree, scan_selected_root, scan_selected_root_with_exclusions,
 };
 
 pub const GENERATION_ROOT_MANIFEST_FILE: &str = "generation-root.json";
@@ -383,7 +384,14 @@ fn entries_by_path(entries: &[GenerationRootEntry]) -> BTreeMap<&str, &Generatio
 
 fn validate_root_path(path: &str) -> crate::Result<()> {
     let parsed = Path::new(path);
-    if !parsed.is_absolute() || path == "/" || path.ends_with('/') {
+    if !parsed.is_absolute()
+        || path == "/"
+        || path.ends_with('/')
+        || path
+            .split('/')
+            .skip(1)
+            .any(|component| component.is_empty() || component == "." || component == "..")
+    {
         return Err(crate::Error::InvalidPath(format!(
             "root manifest path must be a normalized absolute non-root path: {path:?}"
         )));

--- a/crates/conary-core/src/generation/root_manifest/scan.rs
+++ b/crates/conary-core/src/generation/root_manifest/scan.rs
@@ -26,8 +26,54 @@ struct Candidate {
     domain: RootPathDomain,
 }
 
+/// Exact selected-root subtrees that are owned by the capture runtime itself.
+///
+/// The finite publication domains remain authoritative for `/run`, device/API
+/// trees, user state, and other ephemeral paths. These exclusions are only for
+/// additional absolute subtrees such as Conary's CAS and database directory,
+/// whose contents must never become inputs to their own capture.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelectedRootCaptureExclusions {
+    subtrees: Vec<String>,
+}
+
+impl SelectedRootCaptureExclusions {
+    pub fn new(mut subtrees: Vec<String>) -> crate::Result<Self> {
+        for subtree in &subtrees {
+            super::validate_root_path(subtree)?;
+        }
+        subtrees.sort();
+        subtrees.dedup();
+        Ok(Self { subtrees })
+    }
+
+    pub fn empty() -> Self {
+        Self {
+            subtrees: Vec::new(),
+        }
+    }
+
+    pub fn excludes(&self, path: &str) -> bool {
+        self.subtrees.iter().any(|subtree| {
+            path == subtree
+                || path
+                    .strip_prefix(subtree)
+                    .is_some_and(|suffix| suffix.starts_with('/'))
+        })
+    }
+}
+
 pub fn scan_selected_root(root: &Path, cas: &CasStore) -> crate::Result<CapturedSelectedRoot> {
-    let (root_node, candidates, hardlinks) = inspect_payload_tree(root, false, "selected-root")?;
+    scan_selected_root_with_exclusions(root, cas, &SelectedRootCaptureExclusions::empty())
+}
+
+pub fn scan_selected_root_with_exclusions(
+    root: &Path,
+    cas: &CasStore,
+    exclusions: &SelectedRootCaptureExclusions,
+) -> crate::Result<CapturedSelectedRoot> {
+    let (root_node, candidates, hardlinks) =
+        inspect_payload_tree(root, false, "selected-root", exclusions)?;
 
     let mut immutable = Vec::new();
     let mut state = Vec::new();
@@ -67,7 +113,12 @@ pub fn scan_payload_tree(
     cas: &CasStore,
     hardlink_namespace: &str,
 ) -> crate::Result<(ResolvedPayloadNode, Vec<GenerationRootEntry>)> {
-    let (root_node, candidates, hardlinks) = inspect_payload_tree(root, true, hardlink_namespace)?;
+    let (root_node, candidates, hardlinks) = inspect_payload_tree(
+        root,
+        true,
+        hardlink_namespace,
+        &SelectedRootCaptureExclusions::empty(),
+    )?;
     let entries = candidates
         .iter()
         .enumerate()
@@ -80,6 +131,7 @@ fn inspect_payload_tree(
     root: &Path,
     include_ephemeral: bool,
     hardlink_namespace: &str,
+    exclusions: &SelectedRootCaptureExclusions,
 ) -> crate::Result<(ResolvedPayloadNode, Vec<Candidate>, HardlinkPlan)> {
     if hardlink_namespace.is_empty() || hardlink_namespace.contains('\0') {
         return Err(crate::Error::InvalidPath(
@@ -100,11 +152,12 @@ fn inspect_payload_tree(
             if entry.depth() == 0 {
                 return true;
             }
-            include_ephemeral
-                || root_manifest_path(root, entry.path())
-                    .ok()
-                    .and_then(|path| classify_root_path(&path).ok())
-                    != Some(RootPathDomain::EphemeralMountOrUser)
+            let Ok(path) = root_manifest_path(root, entry.path()) else {
+                return true;
+            };
+            !exclusions.excludes(&path)
+                && (include_ephemeral
+                    || classify_root_path(&path).ok() != Some(RootPathDomain::EphemeralMountOrUser))
         });
     for entry in walker {
         let entry = entry.map_err(|error| {
@@ -117,6 +170,9 @@ fn inspect_payload_tree(
             continue;
         }
         let path = root_manifest_path(root, entry.path())?;
+        if exclusions.excludes(&path) {
+            continue;
+        }
         let domain = classify_root_path(&path)?;
         if !include_ephemeral && domain == RootPathDomain::EphemeralMountOrUser {
             continue;

--- a/crates/conary-core/src/generation/root_manifest/scan.rs
+++ b/crates/conary-core/src/generation/root_manifest/scan.rs
@@ -13,18 +13,30 @@ use crate::payload::{
 };
 use std::collections::BTreeMap;
 use std::ffi::CString;
+use std::fs::OpenOptions;
+use std::io::Read;
+use std::os::fd::AsRawFd;
 use std::os::unix::ffi::OsStrExt;
-use std::os::unix::fs::{FileTypeExt, MetadataExt};
+use std::os::unix::fs::{FileTypeExt, MetadataExt, OpenOptionsExt};
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
 #[derive(Debug)]
-struct Candidate {
-    path: String,
-    filesystem_path: PathBuf,
-    metadata: std::fs::Metadata,
+struct CapturedCandidate {
+    entry: GenerationRootEntry,
     domain: RootPathDomain,
+    identity: FilesystemIdentity,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct FilesystemIdentity {
+    device: u64,
+    inode: u64,
+}
+
+// A live selected root has no global filesystem snapshot. Keep the retry budget
+// local to one node so unrelated paths are never read again after a conflict.
+const STABLE_NODE_CAPTURE_ATTEMPTS: usize = 8;
 
 /// Exact selected-root subtrees that are owned by the capture runtime itself.
 ///
@@ -72,16 +84,17 @@ pub fn scan_selected_root_with_exclusions(
     cas: &CasStore,
     exclusions: &SelectedRootCaptureExclusions,
 ) -> crate::Result<CapturedSelectedRoot> {
-    let (root_node, candidates, hardlinks) =
-        inspect_payload_tree(root, false, "selected-root", exclusions)?;
+    let (root_node, candidates) =
+        capture_payload_tree(root, cas, false, "selected-root", exclusions)?;
 
     let mut immutable = Vec::new();
     let mut state = Vec::new();
-    for (index, candidate) in candidates.iter().enumerate() {
-        let entry = capture_candidate(candidate, index, &hardlinks, cas)?;
+    for candidate in candidates {
         match candidate.domain {
-            RootPathDomain::Immutable => immutable.push(entry),
-            RootPathDomain::ConfigState | RootPathDomain::MutableState => state.push(entry),
+            RootPathDomain::Immutable => immutable.push(candidate.entry),
+            RootPathDomain::ConfigState | RootPathDomain::MutableState => {
+                state.push(candidate.entry);
+            }
             RootPathDomain::EphemeralMountOrUser => unreachable!("filtered above"),
         }
     }
@@ -113,26 +126,27 @@ pub fn scan_payload_tree(
     cas: &CasStore,
     hardlink_namespace: &str,
 ) -> crate::Result<(ResolvedPayloadNode, Vec<GenerationRootEntry>)> {
-    let (root_node, candidates, hardlinks) = inspect_payload_tree(
+    let (root_node, candidates) = capture_payload_tree(
         root,
+        cas,
         true,
         hardlink_namespace,
         &SelectedRootCaptureExclusions::empty(),
     )?;
     let entries = candidates
-        .iter()
-        .enumerate()
-        .map(|(index, candidate)| capture_candidate(candidate, index, &hardlinks, cas))
-        .collect::<crate::Result<Vec<_>>>()?;
+        .into_iter()
+        .map(|candidate| candidate.entry)
+        .collect();
     Ok((root_node, entries))
 }
 
-fn inspect_payload_tree(
+fn capture_payload_tree(
     root: &Path,
+    cas: &CasStore,
     include_ephemeral: bool,
     hardlink_namespace: &str,
     exclusions: &SelectedRootCaptureExclusions,
-) -> crate::Result<(ResolvedPayloadNode, Vec<Candidate>, HardlinkPlan)> {
+) -> crate::Result<(ResolvedPayloadNode, Vec<CapturedCandidate>)> {
     if hardlink_namespace.is_empty() || hardlink_namespace.contains('\0') {
         return Err(crate::Error::InvalidPath(
             "payload-tree hardlink namespace must be non-empty and NUL-free".to_string(),
@@ -177,23 +191,19 @@ fn inspect_payload_tree(
         if !include_ephemeral && domain == RootPathDomain::EphemeralMountOrUser {
             continue;
         }
-        let metadata = std::fs::symlink_metadata(entry.path()).map_err(|error| {
-            crate::Error::IoError(format!(
-                "failed to inspect selected-root path {}: {error}",
-                entry.path().display()
-            ))
-        })?;
-        candidates.push(Candidate {
+        // Capture beside discovery. Holding this metadata until the complete
+        // walk ends makes ordinary mutable state inherently racy.
+        candidates.push(capture_path_stably(
             path,
-            filesystem_path: entry.path().to_path_buf(),
-            metadata,
+            entry.path().to_path_buf(),
             domain,
-        });
+            cas,
+        )?);
     }
-    candidates.sort_by(|left, right| left.path.cmp(&right.path));
+    candidates.sort_by(|left, right| left.entry.path.cmp(&right.entry.path));
 
-    let hardlinks = plan_hardlinks(&candidates, hardlink_namespace)?;
-    Ok((root_node, candidates, hardlinks))
+    assign_hardlinks(&mut candidates, hardlink_namespace)?;
+    Ok((root_node, candidates))
 }
 
 /// Capture exact metadata authority for the selected-root directory itself.
@@ -228,35 +238,34 @@ pub fn capture_existing_payload_node(path: &Path) -> crate::Result<ResolvedPaylo
     node_from_metadata(path, &metadata, kind)
 }
 
-#[derive(Debug)]
-struct HardlinkPlan {
-    role_by_index: BTreeMap<usize, HardlinkRole>,
-}
-
-#[derive(Debug)]
-enum HardlinkRole {
-    Primary { identity: String },
-    Link { identity: String, target: String },
-}
-
-fn plan_hardlinks(
-    candidates: &[Candidate],
+fn assign_hardlinks(
+    candidates: &mut [CapturedCandidate],
     hardlink_namespace: &str,
-) -> crate::Result<HardlinkPlan> {
-    let mut inode_members = BTreeMap::<(u64, u64), Vec<usize>>::new();
+) -> crate::Result<()> {
+    let mut inode_members = BTreeMap::<FilesystemIdentity, Vec<usize>>::new();
     for (index, candidate) in candidates.iter().enumerate() {
-        if candidate.metadata.file_type().is_dir() {
+        if matches!(candidate.entry.node.source.kind, PayloadNodeKind::Directory) {
             continue;
         }
         inode_members
-            .entry((candidate.metadata.dev(), candidate.metadata.ino()))
+            .entry(candidate.identity)
             .or_default()
             .push(index);
     }
 
-    let mut role_by_index = BTreeMap::new();
+    let mut groups = inode_members
+        .into_values()
+        .filter(|members| members.len() > 1)
+        .collect::<Vec<_>>();
+    groups.sort_by(|left, right| {
+        candidates[left[0]]
+            .entry
+            .path
+            .cmp(&candidates[right[0]].entry.path)
+    });
+
     let mut identity_number = 0_u64;
-    for members in inode_members.values().filter(|members| members.len() > 1) {
+    for members in groups {
         let primary = members[0];
         let primary_domain = candidates[primary].domain;
         if members
@@ -265,109 +274,240 @@ fn plan_hardlinks(
         {
             return Err(crate::Error::NotImplemented(format!(
                 "hardlink group crosses generation publication domains at {}",
-                candidates[primary].path
+                candidates[primary].entry.path
             )));
         }
-        if !candidates[primary].metadata.file_type().is_file() {
+        if !matches!(
+            candidates[primary].entry.node.source.kind,
+            PayloadNodeKind::Regular { .. }
+        ) {
             return Err(crate::Error::NotImplemented(format!(
                 "non-regular hardlink groups are not representable by the shared payload node at {}",
-                candidates[primary].path
+                candidates[primary].entry.path
             )));
         }
+
         identity_number += 1;
         let identity = format!("{hardlink_namespace}:hardlink:{identity_number}");
-        role_by_index.insert(
-            primary,
-            HardlinkRole::Primary {
-                identity: identity.clone(),
-            },
-        );
-        for index in members.iter().skip(1) {
-            role_by_index.insert(
-                *index,
-                HardlinkRole::Link {
-                    identity: identity.clone(),
-                    target: candidates[primary].path.clone(),
-                },
-            );
-        }
-    }
-    Ok(HardlinkPlan { role_by_index })
-}
-
-fn capture_candidate(
-    candidate: &Candidate,
-    index: usize,
-    hardlinks: &HardlinkPlan,
-    cas: &CasStore,
-) -> crate::Result<GenerationRootEntry> {
-    if let Some(HardlinkRole::Link { identity, target }) = hardlinks.role_by_index.get(&index) {
-        let node = node_from_metadata(
-            &candidate.filesystem_path,
-            &candidate.metadata,
-            PayloadNodeKind::Hardlink {
-                target: target.clone(),
-                identity: identity.clone(),
-            },
-        )?;
-        return Ok(GenerationRootEntry {
-            path: candidate.path.clone(),
-            node,
-            content: None,
-        });
-    }
-
-    let mut kind = kind_from_metadata(&candidate.filesystem_path, &candidate.metadata)?;
-    if let Some(HardlinkRole::Primary { identity }) = hardlinks.role_by_index.get(&index) {
-        let PayloadNodeKind::Regular { hardlink_identity } = &mut kind else {
-            unreachable!("hardlink planner accepts only regular primary nodes");
+        let primary_path = candidates[primary].entry.path.clone();
+        let PayloadNodeKind::Regular { hardlink_identity } =
+            &mut candidates[primary].entry.node.source.kind
+        else {
+            unreachable!("regular hardlink primary was checked above");
         };
         *hardlink_identity = Some(identity.clone());
-    }
-    let node = node_from_metadata(&candidate.filesystem_path, &candidate.metadata, kind)?;
-    let content = if matches!(node.source.kind, PayloadNodeKind::Regular { .. }) {
-        let digest = cas
-            .store_file_copy_from_existing(&candidate.filesystem_path)
-            .map_err(|error| {
-                crate::Error::IoError(format!(
-                    "failed to capture selected-root regular file {} in CAS: {error}",
-                    candidate.filesystem_path.display()
-                ))
-            })?;
-        let after = std::fs::symlink_metadata(&candidate.filesystem_path)?;
-        ensure_unchanged_during_capture(candidate, &after)?;
-        Some(PayloadContentAuthority {
-            sha256: digest,
-            size: candidate.metadata.len(),
-        })
-    } else {
-        None
-    };
-    Ok(GenerationRootEntry {
-        path: candidate.path.clone(),
-        node,
-        content,
-    })
-}
+        let primary_node = candidates[primary].entry.node.clone();
 
-fn ensure_unchanged_during_capture(
-    before: &Candidate,
-    after: &std::fs::Metadata,
-) -> crate::Result<()> {
-    if before.metadata.dev() != after.dev()
-        || before.metadata.ino() != after.ino()
-        || before.metadata.len() != after.len()
-        || before.metadata.mtime() != after.mtime()
-        || before.metadata.mtime_nsec() != after.mtime_nsec()
-        || before.metadata.ctime() != after.ctime()
-        || before.metadata.ctime_nsec() != after.ctime_nsec()
-    {
-        return Err(crate::Error::ConflictError(format!(
-            "selected-root path changed during manifest capture: {}",
-            before.filesystem_path.display()
-        )));
+        for index in members.into_iter().skip(1) {
+            let mut node = primary_node.clone();
+            node.source.kind = PayloadNodeKind::Hardlink {
+                target: primary_path.clone(),
+                identity: identity.clone(),
+            };
+            node.validate()
+                .map_err(|error| crate::Error::InvalidPath(error.to_string()))?;
+            candidates[index].entry.node = node;
+            candidates[index].entry.content = None;
+        }
     }
     Ok(())
+}
+
+fn capture_path_stably(
+    path: String,
+    filesystem_path: PathBuf,
+    domain: RootPathDomain,
+    cas: &CasStore,
+) -> crate::Result<CapturedCandidate> {
+    capture_path_stably_with_observer(path, filesystem_path, domain, cas, &mut |_, _| {})
+}
+
+fn capture_path_stably_with_observer(
+    path: String,
+    filesystem_path: PathBuf,
+    domain: RootPathDomain,
+    cas: &CasStore,
+    observer: &mut impl FnMut(usize, &Path),
+) -> crate::Result<CapturedCandidate> {
+    for attempt in 1..=STABLE_NODE_CAPTURE_ATTEMPTS {
+        let before = std::fs::symlink_metadata(&filesystem_path).map_err(|error| {
+            crate::Error::IoError(format!(
+                "failed to inspect selected-root path {}: {error}",
+                filesystem_path.display()
+            ))
+        })?;
+        let captured = if before.file_type().is_file() {
+            capture_regular_attempt(&filesystem_path, &before, cas, attempt, observer)?
+        } else {
+            capture_non_regular_attempt(&filesystem_path, &before)?
+        };
+        if let Some(captured) = captured {
+            return Ok(CapturedCandidate {
+                entry: GenerationRootEntry {
+                    path,
+                    node: captured.node,
+                    content: captured.content,
+                },
+                domain,
+                identity: captured.identity,
+            });
+        }
+        std::thread::yield_now();
+    }
+
+    Err(crate::Error::ConflictError(format!(
+        "selected-root path did not remain stable during any of {STABLE_NODE_CAPTURE_ATTEMPTS} per-node capture attempts: {}",
+        filesystem_path.display()
+    )))
+}
+
+#[derive(Debug)]
+struct CapturedNodeSnapshot {
+    node: ResolvedPayloadNode,
+    content: Option<PayloadContentAuthority>,
+    identity: FilesystemIdentity,
+}
+
+fn capture_regular_attempt(
+    path: &Path,
+    discovered: &std::fs::Metadata,
+    cas: &CasStore,
+    attempt: usize,
+    observer: &mut impl FnMut(usize, &Path),
+) -> crate::Result<Option<CapturedNodeSnapshot>> {
+    // Bind content, metadata, and xattrs to one descriptor. Reopening the path
+    // for CAS ingestion would restore the same path-replacement race.
+    let mut file = match OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(error) => {
+            if std::fs::symlink_metadata(path)
+                .is_ok_and(|after| !metadata_snapshot_matches(discovered, &after))
+            {
+                return Ok(None);
+            }
+            return Err(crate::Error::IoError(format!(
+                "failed to open selected-root regular file {}: {error}",
+                path.display()
+            )));
+        }
+    };
+    let before = file.metadata().map_err(|error| {
+        crate::Error::IoError(format!(
+            "failed to inspect open selected-root file {}: {error}",
+            path.display()
+        ))
+    })?;
+    if !before.file_type().is_file() || !same_filesystem_node(discovered, &before) {
+        return Ok(None);
+    }
+
+    let xattrs = read_xattrs_from_fd(&file, path)?;
+    observer(attempt, path);
+
+    let mut bytes = Vec::new();
+    file.by_ref()
+        .take(before.len().saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(|error| {
+            crate::Error::IoError(format!(
+                "failed to read selected-root regular file {}: {error}",
+                path.display()
+            ))
+        })?;
+    let after = file.metadata().map_err(|error| {
+        crate::Error::IoError(format!(
+            "failed to re-inspect open selected-root file {}: {error}",
+            path.display()
+        ))
+    })?;
+    let Ok(path_after) = std::fs::symlink_metadata(path) else {
+        return Ok(None);
+    };
+    let byte_count = u64::try_from(bytes.len()).map_err(|_| {
+        crate::Error::IoError(format!(
+            "selected-root regular file is too large to capture: {}",
+            path.display()
+        ))
+    })?;
+    if !metadata_snapshot_matches(&before, &after)
+        || !metadata_snapshot_matches(&after, &path_after)
+        || byte_count != before.len()
+    {
+        return Ok(None);
+    }
+
+    let node = node_from_metadata_and_xattrs(
+        path,
+        &before,
+        PayloadNodeKind::Regular {
+            hardlink_identity: None,
+        },
+        xattrs,
+    )?;
+    let digest = cas.store_private_copy(&bytes).map_err(|error| {
+        crate::Error::IoError(format!(
+            "failed to capture selected-root regular file {} in CAS: {error}",
+            path.display()
+        ))
+    })?;
+    Ok(Some(CapturedNodeSnapshot {
+        node,
+        content: Some(PayloadContentAuthority {
+            sha256: digest,
+            size: byte_count,
+        }),
+        identity: filesystem_identity(&before),
+    }))
+}
+
+fn capture_non_regular_attempt(
+    path: &Path,
+    before: &std::fs::Metadata,
+) -> crate::Result<Option<CapturedNodeSnapshot>> {
+    let kind = kind_from_metadata(path, before);
+    let node = kind.and_then(|kind| node_from_metadata(path, before, kind));
+    let Ok(after) = std::fs::symlink_metadata(path) else {
+        return Ok(None);
+    };
+    if !metadata_snapshot_matches(before, &after) {
+        return Ok(None);
+    }
+    Ok(Some(CapturedNodeSnapshot {
+        node: node?,
+        content: None,
+        identity: filesystem_identity(before),
+    }))
+}
+
+fn filesystem_identity(metadata: &std::fs::Metadata) -> FilesystemIdentity {
+    FilesystemIdentity {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+    }
+}
+
+fn same_filesystem_node(left: &std::fs::Metadata, right: &std::fs::Metadata) -> bool {
+    left.dev() == right.dev()
+        && left.ino() == right.ino()
+        && left.mode() & libc::S_IFMT == right.mode() & libc::S_IFMT
+}
+
+fn metadata_snapshot_matches(left: &std::fs::Metadata, right: &std::fs::Metadata) -> bool {
+    same_filesystem_node(left, right)
+        && left.mode() == right.mode()
+        && left.nlink() == right.nlink()
+        && left.uid() == right.uid()
+        && left.gid() == right.gid()
+        && left.rdev() == right.rdev()
+        && left.len() == right.len()
+        && left.mtime() == right.mtime()
+        && left.mtime_nsec() == right.mtime_nsec()
+        && left.ctime() == right.ctime()
+        && left.ctime_nsec() == right.ctime_nsec()
 }
 
 fn kind_from_metadata(path: &Path, metadata: &std::fs::Metadata) -> crate::Result<PayloadNodeKind> {
@@ -421,6 +561,15 @@ fn node_from_metadata(
     metadata: &std::fs::Metadata,
     kind: PayloadNodeKind,
 ) -> crate::Result<ResolvedPayloadNode> {
+    node_from_metadata_and_xattrs(path, metadata, kind, read_xattrs(path)?)
+}
+
+fn node_from_metadata_and_xattrs(
+    path: &Path,
+    metadata: &std::fs::Metadata,
+    kind: PayloadNodeKind,
+    xattrs: BTreeMap<String, Vec<u8>>,
+) -> crate::Result<ResolvedPayloadNode> {
     let nanoseconds = u32::try_from(metadata.mtime_nsec()).map_err(|_| {
         crate::Error::InvalidPath(format!(
             "selected-root path has invalid negative mtime nanoseconds: {}",
@@ -440,7 +589,7 @@ fn node_from_metadata(
             seconds: metadata.mtime(),
             nanoseconds,
         },
-        xattrs: read_xattrs(path)?,
+        xattrs,
     };
     node.validate()
         .map_err(|error| crate::Error::InvalidPath(error.to_string()))?;
@@ -556,10 +705,124 @@ fn read_xattrs(path: &Path) -> crate::Result<BTreeMap<String, Vec<u8>>> {
     Ok(xattrs)
 }
 
+fn read_xattrs_from_fd(
+    file: &std::fs::File,
+    path: &Path,
+) -> crate::Result<BTreeMap<String, Vec<u8>>> {
+    let fd = file.as_raw_fd();
+    let names_len = unsafe { libc::flistxattr(fd, std::ptr::null_mut(), 0) };
+    if names_len < 0 {
+        return Err(xattr_error("list", path));
+    }
+    if names_len == 0 {
+        return Ok(BTreeMap::new());
+    }
+    let names_len = usize::try_from(names_len).map_err(|_| {
+        crate::Error::InvalidPath(format!(
+            "selected-root xattr name list is too large at {}",
+            path.display()
+        ))
+    })?;
+    let mut names = vec![0_u8; names_len];
+    let actual =
+        unsafe { libc::flistxattr(fd, names.as_mut_ptr().cast::<libc::c_char>(), names.len()) };
+    if actual < 0 {
+        return Err(xattr_error("list", path));
+    }
+    names.truncate(usize::try_from(actual).map_err(|_| {
+        crate::Error::InvalidPath(format!(
+            "selected-root xattr name list length is invalid at {}",
+            path.display()
+        ))
+    })?);
+
+    let mut xattrs = BTreeMap::new();
+    for raw_name in names
+        .split(|byte| *byte == 0)
+        .filter(|name| !name.is_empty())
+    {
+        let name = std::str::from_utf8(raw_name).map_err(|_| {
+            crate::Error::NotImplemented(format!(
+                "selected-root xattr name is not UTF-8 at {}",
+                path.display()
+            ))
+        })?;
+        let c_name = CString::new(raw_name).expect("xattr names are NUL-separated");
+        let value_len = unsafe { libc::fgetxattr(fd, c_name.as_ptr(), std::ptr::null_mut(), 0) };
+        if value_len < 0 {
+            return Err(xattr_error(&format!("read {name}"), path));
+        }
+        let value_len = usize::try_from(value_len).map_err(|_| {
+            crate::Error::InvalidPath(format!(
+                "selected-root xattr value is too large for {name} at {}",
+                path.display()
+            ))
+        })?;
+        let mut value = vec![0_u8; value_len];
+        if value_len > 0 {
+            let actual = unsafe {
+                libc::fgetxattr(
+                    fd,
+                    c_name.as_ptr(),
+                    value.as_mut_ptr().cast::<libc::c_void>(),
+                    value.len(),
+                )
+            };
+            if actual < 0 {
+                return Err(xattr_error(&format!("read {name}"), path));
+            }
+            value.truncate(usize::try_from(actual).map_err(|_| {
+                crate::Error::InvalidPath(format!(
+                    "selected-root xattr value length is invalid for {name} at {}",
+                    path.display()
+                ))
+            })?);
+        }
+        xattrs.insert(name.to_string(), value);
+    }
+    Ok(xattrs)
+}
+
 fn xattr_error(operation: &str, path: &Path) -> crate::Error {
     crate::Error::IoError(format!(
         "failed to {operation} xattrs for selected-root path {}: {}",
         path.display(),
         std::io::Error::last_os_error()
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn regular_capture_restarts_only_the_node_that_changed() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("system.journal");
+        let cas = CasStore::new(temp.path().join("objects")).unwrap();
+        std::fs::write(&path, b"journal before capture").unwrap();
+
+        let final_bytes = b"journal state after a concurrent append";
+        let mut attempts = 0;
+        let captured = capture_path_stably_with_observer(
+            "/var/log/journal/system.journal".to_string(),
+            path,
+            RootPathDomain::MutableState,
+            &cas,
+            &mut |attempt, path| {
+                attempts += 1;
+                if attempt == 1 {
+                    std::fs::write(path, final_bytes).unwrap();
+                }
+            },
+        )
+        .unwrap();
+
+        assert_eq!(attempts, 2);
+        assert_eq!(captured.entry.path, "/var/log/journal/system.journal");
+        assert_eq!(captured.domain, RootPathDomain::MutableState);
+        let content = captured.entry.content.unwrap();
+        assert_eq!(content.size, final_bytes.len() as u64);
+        assert_eq!(cas.retrieve(&content.sha256).unwrap(), final_bytes);
+    }
 }

--- a/crates/conary-core/src/generation/root_manifest/tests.rs
+++ b/crates/conary-core/src/generation/root_manifest/tests.rs
@@ -47,6 +47,77 @@ fn root_path_domains_are_an_exact_finite_contract() {
 }
 
 #[test]
+fn capture_exclusions_are_normalized_exact_subtree_authority() {
+    for invalid in [
+        "",
+        "/",
+        "conary",
+        "/conary/",
+        "/var//lib/conary",
+        "/var/./lib/conary",
+        "/var/lib/../lib/conary",
+    ] {
+        let error = SelectedRootCaptureExclusions::new(vec![invalid.to_string()]).unwrap_err();
+        assert!(
+            error.to_string().contains("normalized absolute non-root"),
+            "{invalid:?}: {error}"
+        );
+    }
+}
+
+#[test]
+fn selected_root_capture_excludes_only_declared_runtime_subtrees() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().join("root");
+    let cas = CasStore::new(temp.path().join("objects")).unwrap();
+    for directory in [
+        "conary",
+        "conary/objects",
+        "conary-adjacent",
+        "var",
+        "var/lib",
+        "var/lib/conary",
+        "var/lib/conary-adjacent",
+    ] {
+        std::fs::create_dir_all(root.join(directory)).unwrap();
+    }
+    std::fs::write(root.join("conary/objects/private"), b"runtime").unwrap();
+    std::fs::write(root.join("conary-adjacent/retained"), b"selected root").unwrap();
+    std::fs::write(root.join("var/lib/conary/conary.db"), b"runtime").unwrap();
+    std::fs::write(
+        root.join("var/lib/conary-adjacent/retained"),
+        b"selected root",
+    )
+    .unwrap();
+
+    let exclusions = SelectedRootCaptureExclusions::new(vec![
+        "/var/lib/conary".to_string(),
+        "/conary".to_string(),
+        "/conary".to_string(),
+    ])
+    .unwrap();
+    let captured = scan_selected_root_with_exclusions(&root, &cas, &exclusions).unwrap();
+    let paths = captured
+        .generation
+        .entries
+        .iter()
+        .chain(&captured.state.entries)
+        .map(|entry| entry.path.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(!paths.iter().any(|path| path.starts_with("/conary/")));
+    assert!(
+        !paths
+            .iter()
+            .any(|path| path.starts_with("/var/lib/conary/"))
+    );
+    assert!(paths.contains(&"/conary-adjacent/retained"));
+    assert!(paths.contains(&"/var/lib/conary-adjacent/retained"));
+    assert!(paths.contains(&"/var"));
+    assert!(paths.contains(&"/var/lib"));
+}
+
+#[test]
 fn mutable_state_transaction_derives_exact_touched_paths() {
     let before = MutableStateManifest {
         version: GENERATION_ROOT_MANIFEST_VERSION,

--- a/crates/conary-core/src/generation/root_manifest/tests.rs
+++ b/crates/conary-core/src/generation/root_manifest/tests.rs
@@ -231,6 +231,53 @@ fn selected_root_round_trip_preserves_typed_tree_and_omits_ephemeral_domains() {
 }
 
 #[test]
+fn hardlink_identities_are_stable_across_inode_reallocation() {
+    let temp = tempfile::tempdir().unwrap();
+    let source = temp.path().join("source");
+    let destination = temp.path().join("destination");
+    let cas = CasStore::new(temp.path().join("objects")).unwrap();
+    std::fs::create_dir_all(source.join("usr/bin")).unwrap();
+
+    // Create the lexically later group first so source inode order is the
+    // opposite of materialization order.
+    std::fs::write(source.join("usr/bin/zeta"), b"zeta").unwrap();
+    std::fs::hard_link(
+        source.join("usr/bin/zeta"),
+        source.join("usr/bin/zeta-link"),
+    )
+    .unwrap();
+    std::fs::write(source.join("usr/bin/alpha"), b"alpha").unwrap();
+    std::fs::hard_link(
+        source.join("usr/bin/alpha"),
+        source.join("usr/bin/alpha-link"),
+    )
+    .unwrap();
+
+    let captured = scan_selected_root(&source, &cas).unwrap();
+    let identities = captured
+        .generation
+        .entries
+        .iter()
+        .filter_map(|entry| match &entry.node.source.kind {
+            PayloadNodeKind::Regular {
+                hardlink_identity: Some(identity),
+            } => Some((entry.path.as_str(), identity.as_str())),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        identities,
+        [
+            ("/usr/bin/alpha", "selected-root:hardlink:1"),
+            ("/usr/bin/zeta", "selected-root:hardlink:2"),
+        ]
+    );
+
+    materialize_captured_selected_root(&captured, &cas, &destination).unwrap();
+    assert_eq!(scan_selected_root(&destination, &cas).unwrap(), captured);
+}
+
+#[test]
 fn config_state_projection_removes_exactly_one_etc_prefix() {
     let temp = tempfile::tempdir().unwrap();
     let source = temp.path().join("source");

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -393,6 +393,20 @@ Conary can build and select immutable system-generation artifacts using EROFS
 images and Linux composefs. This remains an advanced, explicitly gated path in
 the limited preview.
 
+Full system adoption establishes the first complete generation input without
+turning unowned host state into package ownership. One exact selected-root scan
+preserves package-owned anchors and directory claims, reconciles their
+materialized node/content authority, and assigns only the remaining retained
+paths to one `CapturedRoot` trove. `AdoptedFull`, `Taken`, `Repository`, `File`,
+and `CapturedRoot` are the finite complete generation-input sources;
+`AdoptedTrack` remains metadata-only. The scanner excludes the finite
+ephemeral/API/device/user domains plus Conary's own normalized runtime and
+database subtrees through both lexical and resolved path authority, and refuses
+a runtime root that resolves to `/`. It preserves numeric ownership, full mode and node type,
+timestamps, symlink targets, CAS content, xattrs, and global hardlink topology.
+Generation runtime collection consumes that persisted authority without
+consulting a native package manager or its database.
+
 ### Architecture
 
 ```

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -68,13 +68,20 @@ baseline covered `TGE01` and `TGE02`. The active Fedora 44 suite now covers:
 - `TGE01`: metadata-only installed generations fail closed before artifact publication
 - `TGE03`: CAS-backed installed generations fail closed when an included CAS object is missing
 - `TGE04`: a full CAS-backed installed runtime generation exports to qcow2 and boots under UEFI
-- `TGE05`: exported installed-runtime generations preserve capability-absent and capability-present `security.capability` state for the same payload path, with rollback-equivalent proof through separate exported artifacts
+- `TGE05`: exported installed-runtime generations retain full-adoption
+  `CapturedRoot` lifecycle aliases, service enablement, and SSH authorization
+  state in both carriers, then preserve capability-absent and
+  capability-present `security.capability` state for the same package-owned
+  path with rollback-equivalent proof through separate exported artifacts
 - `TGE02`: bootstrap-run generation artifact exports to qcow2 and boots under UEFI
 
 Keep this suite in the Phase 3 rotation for regressions in generation artifact
 export, QEMU fixture copying, scratch-disk handling, CAS integrity checks,
 guest SSH access, exported-image boot, and generation file-capability xattr
-preservation. Group P adds the focused ISO generation-carrier path:
+preservation. TGE05 must not reconstruct adopted lifecycle state in the
+carrier fixture: it directly asserts the `/etc` aliases, wants links, and SSH
+configuration captured before the initial generation build. Group P adds the
+focused ISO generation-carrier path:
 
 Current 2026-07-16 W1 Group O local KVM evidence is green. The source fixture
 is `minimal-boot-v4`, expanded to 20 GiB for full CAS adoption and paired with

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-07-27
-revision: 55
-summary: Route exact Remi signing, serialized selected-root mutation, typed rollback lineage, canonical-map authority, typed generation GC, exact release authority, and subsystem proof through current feature owners.
+last_updated: 2026-07-29
+revision: 56
+summary: Route exact Remi signing, serialized selected-root mutation, full-adoption captured-root continuity, typed rollback lineage, canonical-map authority, typed generation GC, exact release authority, and subsystem proof through current feature owners.
 ---
 
 # Assistant Subsystem Map
@@ -182,6 +182,14 @@ commands.
   `runtime` component.
 - Adoption preserves native package-manager authority until explicit takeover or
   selected-generation handoff.
+- Complete unfiltered full-system adoption starts in
+  `apps/conary/src/commands/adopt/system.rs`; its exact unowned-root partition
+  is owned by `adopt/system/captured_root.rs`, the finite scanner and runtime
+  exclusions by `crates/conary-core/src/generation/root_manifest/scan.rs`, and
+  generation consumption by
+  `crates/conary-core/src/generation/builder/runtime_inputs.rs`. `CapturedRoot`
+  preserves continuity state only; package anchors and claims remain the
+  install/update/remove ownership authority.
 - Single-package adoption preview and apply share the planner in
   `apps/conary/src/commands/adopt/packages.rs`; preview stops before every
   SQLite, checkpoint, CAS, native-PM, hook, generation, and live-root write.

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-07-28
-revision: 18
-summary: Document exact profile-owned source policy, canonical map authority, native repository authority, package identity, and lifecycle handoff
+last_updated: 2026-07-29
+revision: 19
+summary: Document exact profile-owned source policy, canonical map authority, native repository authority, package identity, full-adoption root continuity, and lifecycle handoff
 ---
 
 # Source Selection Module (conary-core/src/repository/ + conary-core/src/model/)
@@ -385,6 +385,38 @@ changesets, and the state snapshot. Track and full adoption both preserve
 native package-manager authority until an explicit takeover or
 selected-generation handoff.
 
+Complete, unfiltered `conary system adopt --system --full` additionally scans
+the selected root once, after all native package payload captures succeed. The
+scan uses the same finite publication domains as generation construction:
+`/etc` is config state, `/var` and `/srv` are mutable state, and other retained
+top-level paths are immutable generation input. `/proc`, `/sys`, `/dev`,
+`/run`, `/tmp`, `/home`, `/root`, `/mnt`, and `/media` are the exact
+ephemeral/API/device/user domains and are never captured. Conary's own runtime
+root and database directory are explicit normalized exclusions under both
+their lexical and resolved paths, so path aliases cannot make the CAS or
+database inputs to their own capture. A runtime root resolving to `/` fails
+closed.
+
+Persisted package file anchors and directory claims partition that exact scan.
+Package-owned paths retain their owner and claim graph while their materialized
+node/content authority is reconciled to the one global scan, preserving xattrs
+and hardlinks even when an inode group crosses ownership boundaries. Every
+remaining path belongs to one synthetic `CapturedRoot` trove. That source is a
+generation input but never substitutes for package install, update, remove, or
+native-manager authority. A repeated full adoption recognizes the same exact
+partition without accumulating another captured-root owner. Track-only native
+troves are privately CAS-backed and promoted to `AdoptedFull` in the same
+full-adoption transaction.
+
+Package filters and `--explicit-only` deliberately do not assert whole-root
+continuity: they adopt only their requested native package scope. If any exact
+native query, payload capture, or package persistence fails, full-system
+adoption reports an incomplete outcome and does not classify the missing
+package's paths as unowned captured-root state. Complete capture also fails
+closed if a metadata-only `AdoptedTrack` identity is absent from the current
+native inventory, because retaining that stale non-generation owner would
+silently omit its paths.
+
 ### Install
 
 Install uses the shared effective policy and then layers root-only request
@@ -493,6 +525,13 @@ state requires an explicit scoped install, update, or replatform operation.
   policy construction and canonical package name resolution
 - `apps/conary/src/commands/adopt/packages.rs` for shared single-package
   adoption preview/apply planning and native-authority preservation
+- `apps/conary/src/commands/adopt/system.rs` and
+  `adopt/system/captured_root.rs` for complete system adoption, track-to-full
+  promotion, and exact package-versus-captured-root partitioning
+- `crates/conary-core/src/generation/root_manifest/scan.rs` for finite
+  selected-root capture and normalized runtime exclusions
+- `crates/conary-core/src/generation/builder/runtime_inputs.rs` for installed
+  package and captured-root projection into immutable and mutable manifests
 - `apps/conary/src/commands/update/mod.rs` for update module routing
 - `apps/conary/src/commands/update/package.rs` for single-package update
   execution, delta/full update handling, and lifecycle execution preflight

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -387,15 +387,16 @@ selected-generation handoff.
 
 Complete, unfiltered `conary system adopt --system --full` additionally scans
 the selected root once, after all native package payload captures succeed. The
-scan uses the same finite publication domains as generation construction:
-`/etc` is config state, `/var` and `/srv` are mutable state, and other retained
-top-level paths are immutable generation input. `/proc`, `/sys`, `/dev`,
-`/run`, `/tmp`, `/home`, `/root`, `/mnt`, and `/media` are the exact
-ephemeral/API/device/user domains and are never captured. Conary's own runtime
-root and database directory are explicit normalized exclusions under both
-their lexical and resolved paths, so path aliases cannot make the CAS or
-database inputs to their own capture. A runtime root resolving to `/` fails
-closed.
+scan captures each walked node through a bounded pointwise-stable descriptor
+window, then derives global hardlink topology from the captured snapshots. It
+uses the same finite publication domains as generation construction: `/etc` is
+config state, `/var` and `/srv` are mutable state, and other retained top-level
+paths are immutable generation input. `/proc`, `/sys`, `/dev`, `/run`, `/tmp`,
+`/home`, `/root`, `/mnt`, and `/media` are the exact ephemeral/API/device/user
+domains and are never captured. Conary's own runtime root and database
+directory are explicit normalized exclusions under both their lexical and
+resolved paths, so path aliases cannot make the CAS or database inputs to their
+own capture. A runtime root resolving to `/` fails closed.
 
 Persisted package file anchors and directory claims partition that exact scan.
 Package-owned paths retain their owner and claim graph while their materialized

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -489,10 +489,28 @@ non-ephemeral nodes and escaping or looping aliases fail before mutation.
 Restoration first rebuilds all package bases, then all anchors, then all claims,
 so cross-package and cyclic claim graphs do not depend on insertion order.
 Additive RPM or CCS metadata changes restore the prior materialized node even
-when the pre-existing anchor package itself was not removed. Adoption uses the
-typed `CapturedRoot` source and commits each package's files, directory claims,
-requirements, and provides atomically; package names and partial warning paths
-are not ownership authority.
+when the pre-existing anchor package itself was not removed. Native adoption
+commits each package's files, directory claims, requirements, and provides
+atomically under `AdoptedTrack` or `AdoptedFull`; package names and partial
+warning paths are not ownership authority.
+
+A complete unfiltered full-system adoption also performs one exact global
+selected-root capture after every native package capture succeeds. Existing
+package anchors and claims retain ownership. Only retained paths with no
+package owner are assigned to one typed `CapturedRoot` authority, which
+generation construction consumes alongside other complete payload sources.
+The capture preserves global hardlink topology and exact numeric ownership,
+mode/type, timestamps, symlink targets, CAS content, and xattrs. Its finite
+domain contract retains immutable paths plus `/etc`, `/var`, and `/srv`, while
+excluding `/proc`, `/sys`, `/dev`, `/run`, `/tmp`, `/home`, `/root`, `/mnt`,
+`/media`, and Conary's own normalized runtime/database subtrees. Runtime
+and database exclusions cover both lexical and resolved authority so aliases
+cannot reintroduce self-capture, and a runtime root resolving to `/` fails
+closed. Runtime generation collection therefore has no source-package-manager
+or source-database dependency. `CapturedRoot` is migration-continuity input,
+not package install/update/remove ownership. A complete capture refuses stale
+`AdoptedTrack` identities absent from the current native inventory rather than
+letting metadata-only ownership suppress their paths from the generation.
 
 ## Configuration Transaction Contract
 

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -499,16 +499,19 @@ selected-root capture after every native package capture succeeds. Existing
 package anchors and claims retain ownership. Only retained paths with no
 package owner are assigned to one typed `CapturedRoot` authority, which
 generation construction consumes alongside other complete payload sources.
-The capture preserves global hardlink topology and exact numeric ownership,
-mode/type, timestamps, symlink targets, CAS content, and xattrs. Its finite
-domain contract retains immutable paths plus `/etc`, `/var`, and `/srv`, while
-excluding `/proc`, `/sys`, `/dev`, `/run`, `/tmp`, `/home`, `/root`, `/mnt`,
-`/media`, and Conary's own normalized runtime/database subtrees. Runtime
-and database exclusions cover both lexical and resolved authority so aliases
-cannot reintroduce self-capture, and a runtime root resolving to `/` fails
-closed. Runtime generation collection therefore has no source-package-manager
-or source-database dependency. `CapturedRoot` is migration-continuity input,
-not package install/update/remove ownership. A complete capture refuses stale
+Each node is captured through a bounded, pointwise-stable descriptor window
+while the tree is walked; hardlink topology is derived from those captured
+snapshots rather than from metadata staged before content capture. The capture
+preserves global hardlink topology and exact numeric ownership, mode/type,
+timestamps, symlink targets, CAS content, and xattrs. Its finite domain contract
+retains immutable paths plus `/etc`, `/var`, and `/srv`, while excluding
+`/proc`, `/sys`, `/dev`, `/run`, `/tmp`, `/home`, `/root`, `/mnt`, `/media`,
+and Conary's own normalized runtime/database subtrees. Runtime and database
+exclusions cover both lexical and resolved authority so aliases cannot
+reintroduce self-capture, and a runtime root resolving to `/` fails closed.
+Runtime generation collection therefore has no source-package-manager or
+source-database dependency. `CapturedRoot` is migration-continuity input, not
+package install/update/remove ownership. A complete capture refuses stale
 `AdoptedTrack` identities absent from the current native inventory rather than
 letting metadata-only ownership suppress their paths from the generation.
 


### PR DESCRIPTION
## Primary Issue

Closes #191

Design / Plan / Roadmap:

- `docs/ARCHITECTURE.md`
- `docs/modules/source-selection.md`
- `docs/specs/foreign-package-lifecycle-contracts.md`

## Problem And Outcome

Complete full-system adoption recorded native package files but omitted retained selected-root state with no package owner. Generation construction also excluded the existing `CapturedRoot` source. That dropped lifecycle aliases, service enablement, and local SSH configuration from exported carriers.

After this change, complete unfiltered full adoption captures one exact selected-root snapshot, preserves package ownership, assigns only unowned retained entries to one typed `CapturedRoot` authority, and consumes both package and captured-root state as generation inputs.

## Changes

- Add a focused captured-root partition owner with deterministic replacement/idempotence, global hardlink continuity, exact node/content reconciliation, runtime/database self-exclusions, alias-safe path authority, and stale track-only refusal.
- Promote current `AdoptedTrack` packages to exact CAS-backed `AdoptedFull` authority without changing package ownership.
- Include `CapturedRoot` in the finite generation-input source contract.
- Replace the heuristic no-package-manager fallback with the same exact scanner and partition.
- Bind regular-file metadata, content, and xattrs to one `O_NOFOLLOW` descriptor, retry a changing node up to eight times, and fail closed when one stable capture window cannot be obtained.
- Bound content reads to the observed length plus one byte and derive hardlink topology only from stable per-node snapshots with path-order-stable identities.
- Add mutation and multi-hardlink regressions that prove content/metadata coherence and shared inode identity/materialization.
- Extend TGE05 to assert adopted systemd aliases, wants links, and SSH authorization state in both booted carriers.
- Update architecture, subsystem routing, integration guidance, source-selection truth, and the foreign lifecycle contract.

## Scope

- In scope: full unfiltered system adoption, selected-root capture boundaries, persisted captured-root authority, runtime generation inputs, and TGE05 lifecycle assertions.
- Out of scope: source package-manager execution at generation time, package ownership transfer, filtered adoption claiming whole-root continuity, and fixture-side reconstruction.

## Ownership / Boundary

- Owning subsystem: Adoption, Unadoption, And Native-Authority Handoff (`adopt`).
- Boundary changed or preserved: package anchors and directory claims remain install/update/remove authority; `CapturedRoot` owns only retained paths with no package owner and is generation input only.
- Persisted state or public surface impact: one replaceable `CapturedRoot` trove and exact file rows; no schema compatibility chain; full-adoption and TGE05 behavior/documentation change.
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability.

## Verification

Final integrated local head `199371ad35a65d88cc604d680f3b28f7fb4fb881`:

```text
cargo test -p conary-core --lib
  3194 passed; 0 failed; 2 ignored
cargo test -p conary --lib
  946 passed; 0 failed; 2 ignored
cargo test -p conary-core generation::root_manifest --lib
  13 passed; 0 failed
cargo test -p conary --lib commands::adopt::system
  10 passed; 0 failed
cargo fmt --check
bash scripts/check-doc-truth.sh
git diff --check origin/main...HEAD
  passed
```

- [x] Pre-integration exact head `11c19707054e42be514f3b39a72a6333f426c09f` PR gate `30473185397` — every job passed.
- [x] Prerequisite #189 merge `e735a9d5e6c34da59a6860f676262fd59b684a36` validation `30478124345` — every job passed.
- [x] Final integrated exact head `199371ad35a65d88cc604d680f3b28f7fb4fb881` PR gate `30478350965` — every job passed, including workspace tests and the three-distro lifecycle matrix.
- [x] Targeted TGE05 on combined #137 + #188 + #191 head `96935c3507b527ef269a69dcece3f98da981db6e` — passed in 2,846,622 ms.
  - baseline and capability-enabled qcow2 carriers both booted to SSH
  - both retained `/etc/systemd/system/dbus.service`, sshd and NetworkManager wants links, `/etc/ssh/authorized_keys/root`, and the configured authorized-keys path
  - baseline had no file capability; enabled returned exact `cap_net_bind_service=ep`
  - selected suite summary was `passed 1 / failed 0 / skipped 4`; the wrapper exit was 1 solely because four deliberately disabled sibling tests count as skipped, while TGE05 itself passed

## Review And Merge Notes

- Review focus: ownership partitioning, stable per-node capture, deletion/reanchor behavior for prior captured-root rows, global hardlink topology, runtime/database alias exclusions, and the no-self-capture boundary.
- User or developer impact: full adoption now preserves supported unowned lifecycle state in generations; filtered adoption remains package-scoped.
- Required-check bypass: not used.