### PR TITLE
fix(repository): preserve signed RPM primary file providers

### DIFF
--- a/apps/remi/src/server/handlers/sparse.rs
+++ b/apps/remi/src/server/handlers/sparse.rs
@@ -343,7 +343,7 @@ mod tests {
     use crate::server::native_publish::test_support::seed_native_publication;
     use axum::extract::{Path, Query, State};
     use conary_core::db::models::{
-        CONVERSION_VERSION, ConvertedPackage, Repository, RepositoryRequirement,
+        CONVERSION_VERSION, ConvertedPackage, Repository, RepositoryProvide, RepositoryRequirement,
         RepositoryRequirementGroup as DbRequirementGroup,
     };
     use conary_core::db::schema;
@@ -585,6 +585,15 @@ mod tests {
         let (temp_file, conn) = create_test_db();
         let repo_id = insert_repo(&conn, "fedora-base", "fedora");
         let fetchable_id = insert_package(&conn, repo_id, "fetchable", "1.0-1.fc44", 1024);
+        let mut file_provider = RepositoryProvide::new(
+            fetchable_id,
+            "/usr/bin/fetchable".to_string(),
+            None,
+            "file".to_string(),
+            None,
+            conary_core::repository::versioning::VersionScheme::Rpm,
+        );
+        file_provider.insert(&conn).unwrap();
         conn.execute(
             "UPDATE repository_packages SET metadata = ?1 WHERE id = ?2",
             rusqlite::params![
@@ -617,6 +626,9 @@ mod tests {
             .collect::<Vec<_>>();
         let list = build_package_list(temp_file.path(), "fedora", 1, 100).unwrap();
         let page = build_package_page(temp_file.path(), "fedora", 1, 100).unwrap();
+        let lookup = build_sparse_entry(temp_file.path(), "fedora", "fetchable")
+            .unwrap()
+            .unwrap();
         let page_names = page
             .packages
             .iter()
@@ -632,6 +644,16 @@ mod tests {
             page.packages[0].versions[0].metadata.as_ref().unwrap()["security_advisory"]["id"],
             "FEDORA-2026-0001"
         );
+        assert!(page.packages[0].versions[0].provides.iter().any(|provide| {
+            provide.capability == "/usr/bin/fetchable"
+                && provide.kind == "file"
+                && provide.version.is_none()
+        }));
+        assert!(lookup.versions[0].provides.iter().any(|provide| {
+            provide.capability == "/usr/bin/fetchable"
+                && provide.kind == "file"
+                && provide.version.is_none()
+        }));
         assert_eq!(page.packages[1].versions.len(), 1);
         assert_eq!(page.packages[1].versions[0].version, "1.0-1.fc44");
         assert_eq!(page.packages[1].versions[0].requirement_groups.len(), 2);

--- a/crates/conary-core/src/repository/parsers/fedora.rs
+++ b/crates/conary-core/src/repository/parsers/fedora.rs
@@ -365,6 +365,9 @@ impl FedoraParser {
                                     "RPM primary file records cannot be nested".to_string(),
                                 ));
                             }
+                            // A path's trailing XML whitespace is package
+                            // identity, not inter-element formatting.
+                            reader.config_mut().trim_text_end = false;
                         }
                         "checksum" => {
                             if let Some(ref mut pkg) = current_package {
@@ -670,6 +673,7 @@ impl FedoraParser {
                                 "RPM primary file record ended without starting".to_string(),
                             )
                         })?;
+                        reader.config_mut().trim_text_end = true;
                         let file = validate_primary_file_path(file)?;
                         current_package
                             .as_mut()

--- a/crates/conary-core/src/repository/parsers/fedora.rs
+++ b/crates/conary-core/src/repository/parsers/fedora.rs
@@ -335,6 +335,11 @@ impl FedoraParser {
                 Ok(Event::Start(e)) => {
                     let tag_name = String::from_utf8_lossy(e.name().as_ref()).to_string();
                     let local_tag = Self::local_tag_name(&tag_name);
+                    if current_primary_file.is_some() {
+                        return Err(Error::ParseError(
+                            "RPM primary file record cannot contain nested elements".to_string(),
+                        ));
+                    }
                     current_tag = tag_name.clone();
 
                     match local_tag {
@@ -360,11 +365,7 @@ impl FedoraParser {
                                     "RPM primary file record appears outside a package".to_string(),
                                 ));
                             }
-                            if current_primary_file.replace(String::new()).is_some() {
-                                return Err(Error::ParseError(
-                                    "RPM primary file records cannot be nested".to_string(),
-                                ));
-                            }
+                            current_primary_file = Some(String::new());
                             // A path's trailing XML whitespace is package
                             // identity, not inter-element formatting.
                             reader.config_mut().trim_text_end = false;
@@ -401,6 +402,11 @@ impl FedoraParser {
                 Ok(Event::Empty(e)) => {
                     let tag_name = String::from_utf8_lossy(e.name().as_ref()).to_string();
                     let local_tag = Self::local_tag_name(&tag_name);
+                    if current_primary_file.is_some() {
+                        return Err(Error::ParseError(
+                            "RPM primary file record cannot contain nested elements".to_string(),
+                        ));
+                    }
 
                     match local_tag {
                         "version" => {
@@ -658,6 +664,20 @@ impl FedoraParser {
                                 .to_string()
                         }
                     };
+                    if let Some(file) = current_primary_file.as_mut() {
+                        file.push_str(&text);
+                    } else if let Some(ref mut pkg) = current_package {
+                        append_package_text(pkg, &current_tag, &text);
+                    }
+                }
+                Ok(Event::CData(e)) => {
+                    let text =
+                        e.xml_content(quick_xml::XmlVersion::Implicit1_0)
+                            .map_err(|error| {
+                                Error::ParseError(format!(
+                                    "Failed to decode primary.xml CDATA: {error}"
+                                ))
+                            })?;
                     if let Some(file) = current_primary_file.as_mut() {
                         file.push_str(&text);
                     } else if let Some(ref mut pkg) = current_package {

--- a/crates/conary-core/src/repository/parsers/fedora.rs
+++ b/crates/conary-core/src/repository/parsers/fedora.rs
@@ -4,6 +4,9 @@
 //!
 //! Parses Fedora-style repomd.xml and primary.xml files which contain
 //! RPM package metadata in XML format.
+//! Generator-selected `<file>` records in primary.xml are package-owned file
+//! provides. This follows createrepo_c's pinned primary metadata contract:
+//! <https://github.com/rpm-software-management/createrepo_c/blob/5cf41fe5d703901d78078ed18c67ab667e446c1a/src/xml_dump.c#L175-L225>.
 
 use super::common::{self, MAX_PACKAGE_SIZE};
 use super::{ChecksumType, PackageMetadata, RepositoryParser};
@@ -325,6 +328,7 @@ impl FedoraParser {
         let mut current_tag = String::new();
         let mut in_format = false;
         let mut format_section = None;
+        let mut current_primary_file = None::<String>;
 
         loop {
             match reader.read_event_into(&mut buf) {
@@ -349,6 +353,18 @@ impl FedoraParser {
                         }
                         "obsoletes" if in_format => {
                             format_section = Some(FormatSection::Obsoletes);
+                        }
+                        "file" if in_format => {
+                            if current_package.is_none() {
+                                return Err(Error::ParseError(
+                                    "RPM primary file record appears outside a package".to_string(),
+                                ));
+                            }
+                            if current_primary_file.replace(String::new()).is_some() {
+                                return Err(Error::ParseError(
+                                    "RPM primary file records cannot be nested".to_string(),
+                                ));
+                            }
                         }
                         "checksum" => {
                             if let Some(ref mut pkg) = current_package {
@@ -582,31 +598,38 @@ impl FedoraParser {
                                 }
                             }
                         }
+                        "file" if in_format => {
+                            return Err(Error::ParseError(
+                                "RPM primary file record must contain an absolute path".to_string(),
+                            ));
+                        }
                         _ => {}
                     }
                 }
                 Ok(Event::Text(e)) => {
-                    if let Some(ref mut pkg) = current_package {
-                        let decoded =
-                            e.xml_content(quick_xml::XmlVersion::Implicit1_0)
-                                .map_err(|error| {
-                                    Error::ParseError(format!(
-                                        "Failed to decode primary.xml text: {error}"
-                                    ))
-                                })?;
-                        let text = quick_xml::escape::unescape(&decoded)
+                    let decoded =
+                        e.xml_content(quick_xml::XmlVersion::Implicit1_0)
                             .map_err(|error| {
                                 Error::ParseError(format!(
-                                    "Failed to unescape primary.xml text: {error}"
+                                    "Failed to decode primary.xml text: {error}"
                                 ))
-                            })?
-                            .into_owned();
-                        // Skip inter-element whitespace that quick_xml emits as
-                        // text events -- without this guard, trailing whitespace
-                        // between tags overwrites fields like pkg.name with "".
-                        if text.is_empty() {
-                            continue;
-                        }
+                            })?;
+                    let text = quick_xml::escape::unescape(&decoded)
+                        .map_err(|error| {
+                            Error::ParseError(format!(
+                                "Failed to unescape primary.xml text: {error}"
+                            ))
+                        })?
+                        .into_owned();
+                    // Skip inter-element whitespace that quick_xml emits as
+                    // text events -- without this guard, trailing whitespace
+                    // between tags overwrites fields like pkg.name with "".
+                    if text.is_empty() {
+                        continue;
+                    }
+                    if let Some(file) = current_primary_file.as_mut() {
+                        file.push_str(&text);
+                    } else if let Some(ref mut pkg) = current_package {
                         append_package_text(pkg, &current_tag, &text);
                     }
                 }
@@ -632,14 +655,32 @@ impl FedoraParser {
                                 .to_string()
                         }
                     };
-                    if let Some(ref mut pkg) = current_package {
+                    if let Some(file) = current_primary_file.as_mut() {
+                        file.push_str(&text);
+                    } else if let Some(ref mut pkg) = current_package {
                         append_package_text(pkg, &current_tag, &text);
                     }
                 }
                 Ok(Event::End(e)) => {
                     let tag_name = String::from_utf8_lossy(e.name().as_ref()).to_string();
                     let local_tag = Self::local_tag_name(&tag_name);
-                    if local_tag == "package" {
+                    if local_tag == "file" && in_format {
+                        let file = current_primary_file.take().ok_or_else(|| {
+                            Error::ParseError(
+                                "RPM primary file record ended without starting".to_string(),
+                            )
+                        })?;
+                        let file = validate_primary_file_path(file)?;
+                        current_package
+                            .as_mut()
+                            .ok_or_else(|| {
+                                Error::ParseError(
+                                    "RPM primary file record appears outside a package".to_string(),
+                                )
+                            })?
+                            .primary_files
+                            .push(file);
+                    } else if local_tag == "package" {
                         let builder = current_package.take().ok_or_else(|| {
                             Error::ParseError(
                                 "RPM metadata ended a package that was never started".to_string(),
@@ -708,6 +749,7 @@ struct PackageBuilder {
     url: Option<String>,
     dependencies: Vec<(String, String)>,
     provides: Vec<(String, RpmProvideConstraint)>,
+    primary_files: Vec<String>,
     relations: Vec<(RepositoryRequirementKind, String)>,
 }
 
@@ -834,6 +876,12 @@ impl PackageBuilder {
                 native_text: Some(native_text),
             });
         }
+        structured_provides.extend(
+            self.primary_files
+                .iter()
+                .cloned()
+                .map(RepositoryProvide::file),
+        );
 
         let rpm_provides: Vec<String> = self
             .provides
@@ -879,6 +927,15 @@ impl PackageBuilder {
             provides: structured_provides,
         })
     }
+}
+
+fn validate_primary_file_path(path: String) -> Result<String> {
+    if path.is_empty() || !path.starts_with('/') {
+        return Err(Error::ParseError(
+            "RPM primary file record must contain an absolute path".to_string(),
+        ));
+    }
+    Ok(path)
 }
 
 fn append_package_text(package: &mut PackageBuilder, tag: &str, text: &str) {

--- a/crates/conary-core/src/repository/parsers/fedora/tests.rs
+++ b/crates/conary-core/src/repository/parsers/fedora/tests.rs
@@ -178,6 +178,7 @@ fn primary_xml_projects_every_generator_selected_file_as_a_typed_provide() {
       <file type="ghost">/usr/bin/sh</file>
       <file type="dir">/usr/share/bash-completion</file>
       <file>/opt/provider&amp;selected</file>
+      <file>/usr/bin/trailing-space </file>
 "#,
     );
 
@@ -200,6 +201,7 @@ fn primary_xml_projects_every_generator_selected_file_as_a_typed_provide() {
             "/usr/bin/sh",
             "/usr/share/bash-completion",
             "/opt/provider&selected",
+            "/usr/bin/trailing-space ",
         ]
     );
     assert!(files.iter().all(|provide| provide.version.is_none()

--- a/crates/conary-core/src/repository/parsers/fedora/tests.rs
+++ b/crates/conary-core/src/repository/parsers/fedora/tests.rs
@@ -30,6 +30,28 @@ fn valid_builder() -> PackageBuilder {
     builder
 }
 
+fn primary_package_with_format(format_body: &str) -> String {
+    format!(
+        r#"
+<metadata xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+  <package type="rpm">
+    <name>bash</name>
+    <arch>x86_64</arch>
+    <version epoch="0" ver="5.3.3" rel="2.fc44"/>
+    <checksum type="sha256">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</checksum>
+    <summary>GNU Bourne Again shell</summary>
+    <description>GNU Bourne Again shell</description>
+    <size package="1024"/>
+    <location href="Packages/b/bash-5.3.3-2.fc44.x86_64.rpm"/>
+    <format>
+      {format_body}
+    </format>
+  </package>
+</metadata>
+"#
+    )
+}
+
 #[test]
 fn test_package_builder() {
     let builder = valid_builder();
@@ -140,6 +162,66 @@ fn test_parse_primary_xml_captures_namespaced_requires_and_provides() {
             .all(|clause| !clause.name.starts_with("rpmlib("))
     );
     assert!(metadata.get("rpm_requires").is_none());
+}
+
+#[test]
+fn primary_xml_projects_every_generator_selected_file_as_a_typed_provide() {
+    // Structure derived from createrepo_c 5cf41fe5d703901d78078ed18c67ab667e446c1a
+    // tests/testdata/repodata_snippets/primary_snippet_02.xml. The repository
+    // generator owns selection; the parser must preserve every signed record.
+    let xml = primary_package_with_format(
+        r#"
+      <rpm:provides>
+        <rpm:entry name="bash" flags="EQ" epoch="0" ver="5.3.3" rel="2.fc44"/>
+      </rpm:provides>
+      <file>/usr/bin/bash</file>
+      <file type="ghost">/usr/bin/sh</file>
+      <file type="dir">/usr/share/bash-completion</file>
+      <file>/opt/provider&amp;selected</file>
+"#,
+    );
+
+    let packages = parser()
+        .parse_primary_xml(&xml, "https://example.com")
+        .unwrap();
+    let files = packages[0]
+        .provides
+        .iter()
+        .filter(|provide| provide.kind == RepositoryCapabilityKind::File)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        files
+            .iter()
+            .map(|provide| provide.name.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "/usr/bin/bash",
+            "/usr/bin/sh",
+            "/usr/share/bash-completion",
+            "/opt/provider&selected",
+        ]
+    );
+    assert!(files.iter().all(|provide| provide.version.is_none()
+        && provide.version_relation.is_none()
+        && provide.architecture_qualifier
+            == crate::repository::dependency_model::ProvideArchitectureQualifier::Implicit));
+}
+
+#[test]
+fn primary_xml_rejects_file_records_without_an_absolute_path() {
+    for file_record in ["<file/>", "<file></file>", "<file>usr/bin/bash</file>"] {
+        let xml = primary_package_with_format(file_record);
+        let error = parser()
+            .parse_primary_xml(&xml, "https://example.com")
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("file record must contain an absolute path"),
+            "{file_record}: {error}"
+        );
+    }
 }
 
 #[test]

--- a/crates/conary-core/src/repository/parsers/fedora/tests.rs
+++ b/crates/conary-core/src/repository/parsers/fedora/tests.rs
@@ -178,6 +178,7 @@ fn primary_xml_projects_every_generator_selected_file_as_a_typed_provide() {
       <file type="ghost">/usr/bin/sh</file>
       <file type="dir">/usr/share/bash-completion</file>
       <file>/opt/provider&amp;selected</file>
+      <file>/usr<![CDATA[/local/bin/cdata]]></file>
       <file>/usr/bin/trailing-space </file>
 "#,
     );
@@ -201,6 +202,7 @@ fn primary_xml_projects_every_generator_selected_file_as_a_typed_provide() {
             "/usr/bin/sh",
             "/usr/share/bash-completion",
             "/opt/provider&selected",
+            "/usr/local/bin/cdata",
             "/usr/bin/trailing-space ",
         ]
     );
@@ -208,6 +210,25 @@ fn primary_xml_projects_every_generator_selected_file_as_a_typed_provide() {
         && provide.version_relation.is_none()
         && provide.architecture_qualifier
             == crate::repository::dependency_model::ProvideArchitectureQualifier::Implicit));
+}
+
+#[test]
+fn primary_xml_rejects_ambiguous_file_record_structure() {
+    for file_record in [
+        "<file>/usr<unexpected/>/bin/bash</file>",
+        "<file>/usr<file>/bin/bash</file></file>",
+    ] {
+        let xml = primary_package_with_format(file_record);
+        let error = parser()
+            .parse_primary_xml(&xml, "https://example.com")
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("file record cannot contain nested elements"),
+            "{file_record}: {error}"
+        );
+    }
 }
 
 #[test]

--- a/crates/conary-core/src/repository/sync/tests/native.rs
+++ b/crates/conary-core/src/repository/sync/tests/native.rs
@@ -103,6 +103,74 @@ fn test_persist_native_sync_rows_writes_normalized_capabilities() {
 }
 
 #[test]
+fn native_sync_persists_generator_selected_rpm_file_providers_without_reclassification() {
+    let conn = Connection::open_in_memory().unwrap();
+    ensure_current(&conn).unwrap();
+
+    let mut repo = Repository::new(
+        "fedora-44".to_string(),
+        "https://example.com/fedora".to_string(),
+    );
+    repo.source_profile = Some("fedora-44".to_string());
+    repo.insert(&conn).unwrap();
+    let repo_id = repo.id.unwrap();
+
+    let mut pkg_meta = PackageMetadata::new(
+        "bash".to_string(),
+        "5.3.3-2.fc44".to_string(),
+        "abc123".to_string(),
+        1024,
+        "https://example.com/fedora/bash.rpm".to_string(),
+        RepositoryDependencyFlavor::Rpm,
+        VersionScheme::Rpm,
+    );
+    pkg_meta.architecture = Some("x86_64".to_string());
+    pkg_meta.provides = vec![
+        dep_model::RepositoryProvide::package_name(
+            "bash".to_string(),
+            Some("5.3.3-2.fc44".to_string()),
+        ),
+        dep_model::RepositoryProvide::file("/usr/bin/bash".to_string()),
+    ];
+
+    let provides = normalized_repository_capabilities(&pkg_meta);
+    let synced_packages = vec![SyncedPackageRow {
+        package: {
+            let mut package = RepositoryPackage::new(
+                repo_id,
+                pkg_meta.name,
+                pkg_meta.version,
+                VersionScheme::Rpm,
+                pkg_meta.checksum,
+                pkg_meta.size as i64,
+                pkg_meta.download_url,
+            );
+            package.architecture = pkg_meta.architecture;
+            package.source_profile = Some("fedora-44".to_string());
+            package
+        },
+        provides,
+        requirement_groups: Vec::new(),
+        requirement_group_clauses: Vec::new(),
+    }];
+    persist_native_sync_rows(&conn, &mut repo, synced_packages).unwrap();
+
+    let package = RepositoryPackage::find_by_repository(&conn, repo_id)
+        .unwrap()
+        .pop()
+        .unwrap();
+    let stored = RepositoryProvide::find_by_repository_package(&conn, package.id.unwrap()).unwrap();
+    let file = stored
+        .iter()
+        .find(|provide| provide.capability == "/usr/bin/bash")
+        .expect("persisted file provider");
+    assert_eq!(file.kind, "file");
+    assert_eq!(file.version, None);
+    assert_eq!(file.raw, None);
+    assert_eq!(file.version_scheme, VersionScheme::Rpm);
+}
+
+#[test]
 fn test_remi_sparse_entry_builds_normalized_capabilities() {
     let entry = RemiSparseResolutionVersionEntry {
         version: "6.19.6-200.fc44".to_string(),
@@ -129,6 +197,16 @@ fn test_remi_sparse_entry_builds_normalized_capabilities() {
                 ),
                 kind: "package".to_string(),
                 raw: Some("kernel-core-uname-r = 6.19.6-200.fc44.x86_64".to_string()),
+                version_scheme: VersionScheme::Rpm,
+                architecture_qualifier:
+                    crate::repository::dependency_model::ProvideArchitectureQualifier::Implicit,
+            },
+            RemiProvide {
+                capability: "/usr/bin/kernel-install".to_string(),
+                version: None,
+                version_relation: None,
+                kind: "file".to_string(),
+                raw: None,
                 version_scheme: VersionScheme::Rpm,
                 architecture_qualifier:
                     crate::repository::dependency_model::ProvideArchitectureQualifier::Implicit,
@@ -200,6 +278,12 @@ fn test_remi_sparse_entry_builds_normalized_capabilities() {
         provide.capability == "kernel-core-uname-r"
             && provide.version.as_deref() == Some("6.19.6-200.fc44.x86_64")
             && provide.raw.as_deref() == Some("kernel-core-uname-r = 6.19.6-200.fc44.x86_64")
+    }));
+    assert!(row.provides.iter().any(|provide| {
+        provide.capability == "/usr/bin/kernel-install"
+            && provide.kind == "file"
+            && provide.version.is_none()
+            && provide.raw.is_none()
     }));
     let requirements = row.requirement_group_clauses.concat();
     assert!(requirements.iter().any(|requirement| {

--- a/crates/conary-core/src/resolver/sat/tests.rs
+++ b/crates/conary-core/src/resolver/sat/tests.rs
@@ -433,6 +433,74 @@ fn test_sat_install_uses_repo_native_arch_constraints_via_provider() {
 }
 
 #[test]
+fn rpm_path_requirement_resolves_through_generator_selected_file_provider() {
+    use crate::repository::dependency_model::RepositoryRequirementKind;
+
+    let (_dir, conn) = setup_test_db();
+    let mut repository = Repository::new(
+        "fedora-44".to_string(),
+        "https://example.com/fedora".to_string(),
+    );
+    repository.source_profile = Some("fedora-44".to_string());
+    let repository_id = repository.insert(&conn).unwrap();
+
+    let mut consumer = RepositoryPackage::new(
+        repository_id,
+        "glibc-common".to_string(),
+        "2.43.9000-6.fc44".to_string(),
+        VersionScheme::Rpm,
+        "sha256:glibc-common".to_string(),
+        1,
+        "https://example.com/fedora/glibc-common.rpm".to_string(),
+    );
+    consumer.architecture = Some("x86_64".to_string());
+    let consumer_id = consumer.insert(&conn).unwrap();
+    let requirement = crate::repository::requirement::parse_native_requirement(
+        RepositoryRequirementKind::Depends,
+        VersionScheme::Rpm,
+        "/usr/bin/bash",
+    )
+    .unwrap();
+    insert_typed_repo_requirement_group(&conn, consumer_id, &requirement);
+
+    let mut provider = RepositoryPackage::new(
+        repository_id,
+        "bash".to_string(),
+        "5.3.3-2.fc44".to_string(),
+        VersionScheme::Rpm,
+        "sha256:bash".to_string(),
+        1,
+        "https://example.com/fedora/bash.rpm".to_string(),
+    );
+    provider.architecture = Some("x86_64".to_string());
+    let provider_id = provider.insert(&conn).unwrap();
+    let mut file_provide = RepositoryProvide::new(
+        provider_id,
+        "/usr/bin/bash".to_string(),
+        None,
+        "file".to_string(),
+        None,
+        VersionScheme::Rpm,
+    );
+    file_provide.insert(&conn).unwrap();
+
+    let result = solve_install(
+        &conn,
+        &[("glibc-common".to_string(), VersionConstraint::Any)],
+    )
+    .unwrap();
+
+    assert!(result.conflict_message.is_none(), "{result:?}");
+    let names = result
+        .install_order
+        .iter()
+        .map(|package| package.name.as_str())
+        .collect::<Vec<_>>();
+    assert!(names.contains(&"glibc-common"));
+    assert!(names.contains(&"bash"));
+}
+
+#[test]
 fn debian_multi_arch_qualifiers_reach_sat_without_name_suffix_matching() {
     use crate::repository::dependency_model::{DebianMultiArch, RepositoryRequirementKind};
 

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-07-29
-revision: 12
+revision: 13
 summary: Document Remi source, sparse sync, signing, canonical-map, repository trust, conversion, publication, and serving authority
 ---
 
@@ -99,6 +99,12 @@ as explicitly trusted security advisories. Conversion-cache state, diagnostic
 scriptlet summaries, and content hashes stay on other public projections
 because sync does not consume them.
 `GET /v1/{distro}/metadata` is not a client-sync fallback.
+
+For Fedora, normalized provides include every generator-selected `<file>`
+record from authenticated `primary.xml` as `kind = "file"`. The sparse page and
+per-name lookup project that persisted typed row unchanged; Remi does not
+derive file providers from package names or filter them through its own path
+rules.
 
 Remi opens SQLite once for each HTTP page, selects all visible package/version
 rows for the page together, and batch-loads their normalized provides and

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-07-29
-revision: 20
+revision: 21
 summary: Document exact profile-owned source policy, Remi CCS package authority, canonical map authority, native repository authority, package identity, full-adoption root continuity, and lifecycle handoff
 ---
 
@@ -224,8 +224,9 @@ The supported chains are:
 - RPM: repository metadata and packages have distinct authorities. Either a
   detached OpenPGP signature or an exact HTTPS metalink identity authenticates
   `repomd.xml`; its SHA-256 and size authenticate `primary.xml`; primary
-  metadata authenticates the RPM bytes; and an independently pinned package
-  certificate verifies the RPM's embedded OpenPGP signature.
+  metadata supplies exact package relations and generator-selected file
+  providers and authenticates the RPM bytes; and an independently pinned
+  package certificate verifies the RPM's embedded OpenPGP signature.
 - Arch: one exact keyring source supplies the pinned master certificates,
   their certifications, packager certificates, and the companion
   `<keyring>-revoked` disabled-key list. An explicit threshold says how many
@@ -302,6 +303,16 @@ the same-operator chain and tag-context rules; and constructs repeated `with`
 from the right side as RPM does. The source-pinned Fedora 44 corpus under
 `crates/conary-core/tests/fixtures/rpm/` proves real repository expressions
 without granting those packages exceptional behavior.
+
+RPM primary-file authority is derived from `createrepo_c`
+`5cf41fe5d703901d78078ed18c67ab667e446c1a`: its
+[`cr_xml_dump_files()`](https://github.com/rpm-software-management/createrepo_c/blob/5cf41fe5d703901d78078ed18c67ab667e446c1a/src/xml_dump.c#L175-L225)
+selects and emits package-owned `<file>` records in `primary.xml`, and its
+[`STATE_FILE` parser](https://github.com/rpm-software-management/createrepo_c/blob/5cf41fe5d703901d78078ed18c67ab667e446c1a/src/xml_parser_primary.c#L428-L445)
+reads them independently of `rpm:provides`. Conary preserves every such signed
+record as an unversioned typed file provider on the exact package. It does not
+reimplement createrepo's path-selection rule or infer providers from package
+names, payload guesses, or a curated path list.
 
 The contract was derived against the package managers' and repository
 generators' own documentation:


### PR DESCRIPTION
## Primary Issue

Refs #196

Design / Plan / Roadmap: Refs #137 and #110; owning contract in `docs/modules/source-selection.md`.

## Problem And Outcome

Fedora `primary.xml` is authenticated and already carries generator-selected `<file>` records on exact packages, but Conary discarded those records while preserving only `rpm:provides`. Ordinary Fedora requirements for `/usr/bin/bash`, `/usr/bin/sh`, and `/usr/bin/kernel-install` therefore had no provider during dependency closure.

After this change, every valid signed primary `<file>` record becomes an unversioned typed `file` provider on its exact package, persists through native sync, crosses both Remi sparse projections unchanged, and participates in SAT resolution. Conary does not reimplement createrepo's path-selection rule.

## Changes

- Parse complete primary `<file>` text, entity, and CDATA content within the owning RPM package, preserve XML-significant trailing whitespace exactly, and fail closed on empty, non-absolute, or nested-element records.
- Project each record through `RepositoryProvide::file`, native persistence, Remi page/lookup metadata, and sparse-client ingestion.
- Add parser, persistence, wire, and SAT contract tests, including the exact `/usr/bin/bash` dependency class that blocked #137 TGE02.
- Pin the upstream `createrepo_c` source contract and document the persisted/public Remi behavior.

## Scope

- In scope: authenticated RPM primary-file providers, normalized persistence, sparse wire preservation, resolver proof, and owning docs.
- Out of scope: loading full `filelists.xml`, package/path allowlists, payload-based provider inference, and unrelated transaction-order failures. Production Fedora re-ingest and #137 KVM rerun remain issue-closeout gates after release/deploy.

## Ownership / Boundary

- Owning subsystem: `resolution` — repository metadata, requirements, providers, and SAT.
- Boundary changed or preserved: preserves the existing signed `primary.xml -> PackageMetadata -> repository_provides -> Remi sparse -> SAT` boundary; no new authority is introduced.
- Persisted state or public surface impact: a Fedora re-sync rebuilds disposable repository rows with additional `kind = "file"` providers; existing Remi schemas carry those rows unchanged.
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

Provider implementation full-gate head: `e0767c8c607dce9bd98498cafb94174236fa5361`. Current head `bb40d96b082522f74962afcad8aa891867c25f5c` additionally merges validated `main` at `83fdc2fa84795532fdf2db5fe8aa62594e1638cd` (#199).

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code
- [x] Updated subsystem docs or maps when the "look here first" path changed (no routing path changed; owning module docs updated)
- [x] Ran the broader interaction gate when the feature ownership card required it (the full owning packages subsume every focused interaction command)
- [x] Updated the primary issue with any acceptance criteria left for later PRs (issue retains production re-ingest and KVM gates)

```text
- cargo test -p conary-core primary_xml_projects_every_generator_selected_file_as_a_typed_provide
  # passed; attributes, XML entities, CDATA, and trailing path whitespace preserved
- cargo test -p conary-core primary_xml_rejects_ambiguous_file_record_structure
- cargo test -p conary-core primary_xml_rejects_file_records_without_an_absolute_path
- cargo test -p conary-core native_sync_persists_generator_selected_rpm_file_providers_without_reclassification
- cargo test -p conary-core test_remi_sparse_entry_builds_normalized_capabilities
- cargo test -p conary-core rpm_path_requirement_resolves_through_generator_selected_file_provider
- cargo test -p remi sparse_list_bulk_page_and_lookup_share_one_visibility_contract
- cargo test -p conary-core repository::parsers        # 62 passed
- cargo test -p conary-core repository::sync           # 45 passed
- cargo test -p conary-core resolver                   # 119 passed
- cargo test -p remi sparse                            # 22 passed
- bash scripts/check-doc-truth.sh                      # passed
- cargo test -p conary-core                            # passed; 3,204 unit tests, 2 intentional ignores, integrations and doctests clean
- cargo test -p remi                                   # passed; 586 library, 5 binary, 3 CLI tests, doctests clean
- cargo test -p conary                                 # passed; 953 library tests, 2 intentional ignores, integrations and doctests clean
- cargo clippy --workspace --all-targets -- -D warnings # passed
- cargo fmt --check                                    # passed
- cargo test -p conary --lib commands::try_session:: -- --test-threads=16 # 66 passed at current head, including the former CI failure
- cargo fmt --check                                    # passed at current head
- git diff --check                                     # passed at current head
```

## Review And Merge Notes

- Review focus: XML event ownership, mixed-content rejection/preservation, and exact provider kind across persistence/wire boundaries.
- User or developer impact: ordinary Fedora file dependencies become resolvable after repository metadata is re-ingested.
- Required-check bypass: not used

