### PR TITLE
fix(test): serialize mount-skip environment

### DIFF
--- a/apps/conary/src/commands/composefs_ops.rs
+++ b/apps/conary/src/commands/composefs_ops.rs
@@ -301,10 +301,16 @@ fn forced_generation_rebuild_failure() -> Option<anyhow::Error> {
 #[cfg(test)]
 pub(crate) struct TestMountSkipGuard {
     _guard: std::sync::MutexGuard<'static, ()>,
+    previous: Option<std::ffi::OsString>,
 }
 
 #[cfg(test)]
 static TEST_MOUNT_SKIP_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+// This variable controls behavior across the whole unit-test process. Every
+// mutation must stay behind TEST_MOUNT_SKIP_LOCK.
+#[cfg(test)]
+pub(crate) const TEST_MOUNT_SKIP_ENV: &str = "CONARY_TEST_SKIP_GENERATION_MOUNT";
 
 #[cfg(test)]
 fn lock_test_mount_skip() -> std::sync::MutexGuard<'static, ()> {
@@ -314,52 +320,42 @@ fn lock_test_mount_skip() -> std::sync::MutexGuard<'static, ()> {
 }
 
 #[cfg(test)]
-pub(crate) struct TestMountSkipClearGuard {
-    _guard: std::sync::MutexGuard<'static, ()>,
-    previous: Option<std::ffi::OsString>,
+fn replace_test_mount_skip(value: Option<&std::ffi::OsStr>) -> Option<std::ffi::OsString> {
+    let previous = std::env::var_os(TEST_MOUNT_SKIP_ENV);
+    unsafe {
+        if let Some(value) = value {
+            std::env::set_var(TEST_MOUNT_SKIP_ENV, value);
+        } else {
+            std::env::remove_var(TEST_MOUNT_SKIP_ENV);
+        }
+    }
+    previous
 }
 
 #[cfg(test)]
-pub(crate) fn test_mount_skip_guard() -> TestMountSkipGuard {
+fn test_mount_skip_guard_for(value: Option<&std::ffi::OsStr>) -> TestMountSkipGuard {
     let guard = lock_test_mount_skip();
-    unsafe {
-        std::env::set_var("CONARY_TEST_SKIP_GENERATION_MOUNT", "1");
-    }
-    TestMountSkipGuard { _guard: guard }
-}
-
-#[cfg(test)]
-pub(crate) fn test_mount_skip_clear_guard() -> TestMountSkipClearGuard {
-    let guard = lock_test_mount_skip();
-    let previous = std::env::var_os("CONARY_TEST_SKIP_GENERATION_MOUNT");
-    unsafe {
-        std::env::remove_var("CONARY_TEST_SKIP_GENERATION_MOUNT");
-    }
-    TestMountSkipClearGuard {
+    let previous = replace_test_mount_skip(value);
+    TestMountSkipGuard {
         _guard: guard,
         previous,
     }
 }
 
 #[cfg(test)]
-impl Drop for TestMountSkipGuard {
-    fn drop(&mut self) {
-        unsafe {
-            std::env::remove_var("CONARY_TEST_SKIP_GENERATION_MOUNT");
-        }
-    }
+pub(crate) fn test_mount_skip_guard() -> TestMountSkipGuard {
+    test_mount_skip_guard_for(Some(std::ffi::OsStr::new("1")))
 }
 
 #[cfg(test)]
-impl Drop for TestMountSkipClearGuard {
+pub(crate) fn test_mount_skip_clear_guard() -> TestMountSkipGuard {
+    test_mount_skip_guard_for(None)
+}
+
+#[cfg(test)]
+impl Drop for TestMountSkipGuard {
     fn drop(&mut self) {
-        unsafe {
-            if let Some(previous) = &self.previous {
-                std::env::set_var("CONARY_TEST_SKIP_GENERATION_MOUNT", previous);
-            } else {
-                std::env::remove_var("CONARY_TEST_SKIP_GENERATION_MOUNT");
-            }
-        }
+        replace_test_mount_skip(self.previous.as_deref());
     }
 }
 
@@ -395,6 +391,22 @@ impl Drop for TestGenerationRebuildFailureGuard {
 mod tests {
     use super::*;
     use std::path::Path;
+
+    struct MountSkipEnvReset(Option<std::ffi::OsString>);
+
+    impl MountSkipEnvReset {
+        fn replace_with(value: Option<&std::ffi::OsStr>) -> Self {
+            let _guard = lock_test_mount_skip();
+            Self(replace_test_mount_skip(value))
+        }
+    }
+
+    impl Drop for MountSkipEnvReset {
+        fn drop(&mut self) {
+            let _guard = lock_test_mount_skip();
+            replace_test_mount_skip(self.0.as_deref());
+        }
+    }
 
     #[test]
     fn forced_generation_rebuild_failure_reads_test_env_message() {
@@ -457,5 +469,72 @@ mod tests {
             boot_root_for_generation_build(&runtime_root),
             temp.path().join("boot")
         );
+    }
+
+    #[test]
+    fn mount_skip_guards_restore_exact_prior_state() {
+        let reset = MountSkipEnvReset::replace_with(Some(std::ffi::OsStr::new("prior-test-value")));
+
+        {
+            let _guard = test_mount_skip_guard();
+            assert_eq!(
+                std::env::var_os(TEST_MOUNT_SKIP_ENV),
+                Some(std::ffi::OsString::from("1"))
+            );
+        }
+        {
+            let _guard = lock_test_mount_skip();
+            assert_eq!(
+                std::env::var_os(TEST_MOUNT_SKIP_ENV),
+                Some(std::ffi::OsString::from("prior-test-value"))
+            );
+        }
+
+        {
+            let _guard = test_mount_skip_clear_guard();
+            assert_eq!(std::env::var_os(TEST_MOUNT_SKIP_ENV), None);
+        }
+        {
+            let _guard = lock_test_mount_skip();
+            assert_eq!(
+                std::env::var_os(TEST_MOUNT_SKIP_ENV),
+                Some(std::ffi::OsString::from("prior-test-value"))
+            );
+        }
+
+        drop(reset);
+    }
+
+    #[test]
+    fn mount_skip_guards_serialize_competing_mutations() {
+        let first = test_mount_skip_guard();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            let _second = test_mount_skip_clear_guard();
+            acquired_tx
+                .send(std::env::var_os(TEST_MOUNT_SKIP_ENV))
+                .unwrap();
+        });
+
+        started_rx.recv().unwrap();
+        assert!(matches!(
+            TEST_MOUNT_SKIP_LOCK.try_lock(),
+            Err(std::sync::TryLockError::WouldBlock)
+        ));
+        assert!(matches!(
+            acquired_rx.recv_timeout(std::time::Duration::from_millis(100)),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        ));
+
+        drop(first);
+        assert_eq!(
+            acquired_rx
+                .recv_timeout(std::time::Duration::from_secs(5))
+                .unwrap(),
+            None
+        );
+        worker.join().unwrap();
     }
 }

--- a/apps/conary/src/commands/try_session/mod.rs
+++ b/apps/conary/src/commands/try_session/mod.rs
@@ -484,6 +484,11 @@ pub(super) mod test_support {
 
     impl EnvVarGuard {
         pub(super) fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            assert_ne!(
+                key,
+                crate::commands::composefs_ops::TEST_MOUNT_SKIP_ENV,
+                "use composefs_ops::test_mount_skip_guard for the shared mount-skip environment"
+            );
             let previous = std::env::var_os(key);
             unsafe {
                 std::env::set_var(key, value);
@@ -593,6 +598,14 @@ mod tests {
 
     use super::install::{build_try_install_plan, build_try_transaction_config};
     use super::test_support::*;
+
+    #[test]
+    #[should_panic(
+        expected = "use composefs_ops::test_mount_skip_guard for the shared mount-skip environment"
+    )]
+    fn generic_env_guard_rejects_mount_skip_mutation_authority() {
+        let _guard = EnvVarGuard::set("CONARY_TEST_SKIP_GENERATION_MOUNT", "1");
+    }
 
     #[test]
     fn try_transaction_config_override_keeps_live_runtime_paths_for_copied_db() {

--- a/apps/conary/src/commands/try_session/namespace/tests.rs
+++ b/apps/conary/src/commands/try_session/namespace/tests.rs
@@ -322,7 +322,7 @@ fn switch_stable_namespace_root_restores_previous_on_forced_failure() -> anyhow:
     std::fs::write(staged.join("marker"), "new")?;
     recreate_path_symlink(&previous, &stable)?;
 
-    let _mount_guard = EnvVarGuard::set("CONARY_TEST_SKIP_GENERATION_MOUNT", "1");
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
     let _fail_guard = EnvVarGuard::set("CONARY_TEST_TRY_REFRESH_FAIL_NAMESPACE_SWITCH", "1");
     let exposure = StagedNamespaceExposure {
         generation_id: 2,
@@ -391,7 +391,7 @@ fn namespace_switch_commit_removes_superseded_generation_paths() -> anyhow::Resu
         std::fs::create_dir_all(temp.path().join(name))?;
     }
 
-    let _mount_guard = EnvVarGuard::set("CONARY_TEST_SKIP_GENERATION_MOUNT", "1");
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
     let exposure = StagedNamespaceExposure {
         generation_id: 2,
         next_namespace_root: staged,


### PR DESCRIPTION
## Primary Issue

Closes #198

Design / Plan / Roadmap: N/A; test-harness defect with no durable product-contract change.

## Problem And Outcome

Parallel Conary unit tests could clear `CONARY_TEST_SKIP_GENERATION_MOUNT` while another test still depended on it because two unrelated mutexes owned the same process-global variable. That changed the generation boot root mid-build and produced the kernel-identity failure seen in PR #197's exact-head gate.

After merge, every in-process mutation of the mount-skip variable goes through one state-preserving guard and lock. Competing tests cannot change it during a guarded operation, and both set and clear guards restore the exact prior value.

## Changes

- Route the two try-namespace tests that bypassed the shared guard through `test_mount_skip_guard()`.
- Unify set/clear guard state management under one locked implementation that restores the exact previous environment state.
- Reject use of the generic try-session environment guard for the reserved mount-skip variable.
- Add focused contract tests for exact restoration, competing-mutation serialization, and the single-owner boundary.

## Scope

- In scope: Conary in-process test environment ownership for generation mount skipping.
- Out of scope: production generation behavior, RPM repository-provider parsing in #197, and unrelated test environment variables.

## Ownership / Boundary

- Owning subsystem: Conary generation publication and try-session test support.
- Boundary changed or preserved: changed test mutation ownership from two authorities to the existing composefs guard as the single owner.
- Persisted state or public surface impact: none; all changed guard code is compiled only under `cfg(test)`.
- [x] Checked `docs/modules/feature-ownership.md`; no user-visible capability or routing path changed.

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly
- [x] No subsystem docs or maps changed because the look-here-first path is unchanged
- [x] No broader ownership-card interaction gate matched this path
- [x] Issue #198 contains the acceptance criteria and original CI evidence

```text
- cargo test -p conary --lib commands::composefs_ops::tests:: -- --test-threads=8
  - 7 passed
- cargo test -p conary --lib commands::try_session:: -- --test-threads=8
  - 66 passed, including activated_keep_holds_runtime_lock_while_marking_kept
- for run in 1 2 3 4 5 6 7 8 9 10; do cargo test -p conary --lib commands::try_session:: -- --test-threads=16 --quiet || exit 1; done
  - 10/10 runs passed; 660/660 tests
- cargo test -p conary --lib
  - 956 passed, 2 ignored
- cargo test -p conary
  - package unit, integration, and doctest suites passed
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --check
- git diff --check
```

## Review And Merge Notes

- Review focus: single mutation authority, lock lifetime, exact prior-state restoration, and absence of another in-process setter.
- User or developer impact: removes nondeterministic CI failures; no runtime behavior change.
- Required-check bypass: not used
