### PR TITLE
release(remi): prepare 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [remi-v0.9.2] - 2026-07-30
+
+### Fixed
+- preserve signed RPM primary file providers across Fedora ingest and sparse
+  serving (#196, #197)
+- accept signed CCS file-capability authority during Remi publication (#187)
+
 ## [remi-v0.9.1] - 2026-07-29
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4857,7 +4857,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remi"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/apps/remi/Cargo.toml
+++ b/apps/remi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remi"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]


### PR DESCRIPTION
## Primary Issue

Refs #196

Design / Plan / Roadmap: `docs/operations/release-artifact-matrix.md`; `docs/modules/source-selection.md`; `docs/modules/remi.md`

## Problem And Outcome

Production Remi 0.9.1 predates the reviewed Fedora primary-file-provider fix merged in #197. Without a new immutable Remi release and Fedora re-ingest, ordinary signed path requirements such as `/usr/bin/bash`, `/usr/bin/sh`, and `/usr/bin/kernel-install` remain absent from the public sparse index and #196 cannot satisfy its production or supported-host acceptance gates.

This PR prepares the smallest reviewed Remi 0.9.2 release packet. After merge, its exact merge commit can be tagged, built, deployed, force-refreshed, and independently verified before #196 is closed.

## Changes

- bump the Remi crate and lockfile version from 0.9.1 to 0.9.2
- add a dated Remi 0.9.2 changelog entry for Fedora primary-file-provider serving (#196/#197)
- record the already-merged signed CCS file-capability publication behavior from #187
- leave tag creation, release publication, deployment, source refresh, and live acceptance proof outside this PR until exact-head CI and review complete

## Scope

- In scope: Remi version metadata and accurate release notes for 0.9.2
- Out of scope: new runtime behavior, compatibility paths, tag creation, deployment, production refresh, and #137 KVM execution

## Ownership / Boundary

- Owning subsystem: release assembly and Remi service packaging
- Boundary changed or preserved: preserves the already-reviewed signed repository and CCS authority boundaries; only release identity and notes change
- Persisted state or public surface impact: no persisted-state change in this PR; the later immutable tag and deployment will publish Remi 0.9.2, after which a forced Fedora refresh rebuilds disposable repository rows with typed file providers
- [x] Checked `docs/modules/feature-ownership.md` through `scripts/agent-context.sh --feature release`

## Verification

- [x] Listed the exact verification commands run below
- [x] Existing behavior regression coverage was added and reviewed in #197 and #187; this PR changes release metadata only
- [x] Ran affected-package verification directly with `cargo test -p remi`
- [x] No subsystem routing path changed
- [x] Ran the release card's focused proof; workflow interaction gates are unchanged
- [x] Issue #196 remains open for tag, deploy, forced Fedora re-ingest, live sparse-provider proof, and #137 KVM gates

```text
bash scripts/check-release-matrix.sh
bash scripts/test-release-matrix.sh
cargo test -p conary-core --example sign_hash
cargo test -p conary --test release_ccs_manifest
cargo test -p conary-test container::image
cargo test -p remi
bash scripts/check-doc-truth.sh
cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
git diff --cached --check
```

Observed locally on `f2c1a9f6`: release policy and self-tests passed; exact signer-authority and shipping-manifest tests passed; all 7 container image contract tests passed; Remi completed 586 library tests, 5 binary tests, 3 CLI tests, and doctests with no failures (2 documented doctests ignored); documentation truth, formatting, warning-denied workspace Clippy, and diff checks passed.

## Review And Merge Notes

- Review focus: exact 0.9.2 version alignment and changelog scope against Remi-shipped behavior
- User or developer impact: enables immutable Remi 0.9.2 publication and production acceptance proof after merge
- Required-check bypass: not used