### PR TITLE
fix: unblock Fedora dependency installation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4997,9 +4997,9 @@ dependencies = [
 
 [[package]]
 name = "resolvo"
-version = "0.10.3"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2985c35f7dd19ed00659031b77ce05d1828a12eb9c6b37104da21b09d218fc24"
+checksum = "e1560db4f7a060680c14a93a927e049677bcc9a5a01fc0a2a57170dbee81e33a"
 dependencies = [
  "ahash",
  "bitvec",

--- a/apps/conary/src/commands/install/batch/execution.rs
+++ b/apps/conary/src/commands/install/batch/execution.rs
@@ -279,9 +279,9 @@ where
                 .stored_files_by_pkg
                 .get(change_index)
                 .context("batch payload has no stored-file input")?;
-            let resolved_files =
-                inner::resolve_stored_install_files(self.selected_root, stored_files)?;
             let semantics = InstallSemantics::native_package(package.format);
+            let resolved_files =
+                inner::resolve_stored_install_files(self.selected_root, stored_files, semantics)?;
             let directory_plan = inner::preflight_resolved_file_ownership(
                 self.tx,
                 self.selected_root,

--- a/apps/conary/src/commands/install/conversion.rs
+++ b/apps/conary/src/commands/install/conversion.rs
@@ -24,7 +24,7 @@ use conary_core::packages::PackageFormat;
 use conary_core::packages::common::PackageMetadata;
 use conary_core::repository;
 use conary_core::repository::versioning::VersionScheme;
-use conary_core::resolver::SatPackage;
+use conary_core::resolver::{SatPackage, SatSource};
 use conary_core::scriptlet::SandboxMode;
 use std::collections::HashMap;
 use std::path::Path;
@@ -65,6 +65,98 @@ impl PendingCcsProvider {
             && self.architecture == selected.architecture
             && self.version_scheme == selected.version_scheme
     }
+}
+
+fn validate_selected_repository_ccs_identity(
+    ccs_pkg: &CcsPackage,
+    selected: &SatPackage,
+    repository_provenance: Option<&RepositoryInstallProvenance>,
+) -> Result<()> {
+    if selected.source != SatSource::Repository {
+        anyhow::bail!(
+            "verified CCS dependency '{}' was not selected from a repository row",
+            selected.name
+        );
+    }
+    let selected_row_id = selected.repo_package_id.with_context(|| {
+        format!(
+            "SAT-selected CCS dependency '{}-{}' has no repository package row",
+            selected.name, selected.version
+        )
+    })?;
+    let selected_repository_id = selected.repository_id.with_context(|| {
+        format!(
+            "SAT-selected CCS dependency '{}-{}' has no repository identity",
+            selected.name, selected.version
+        )
+    })?;
+    let provenance = repository_provenance.with_context(|| {
+        format!(
+            "verified CCS dependency '{}-{}' has no repository provenance",
+            selected.name, selected.version
+        )
+    })?;
+
+    let mut mismatches = Vec::new();
+    if provenance.repository_id != selected_repository_id {
+        mismatches.push(format!(
+            "repository {} != {}",
+            provenance.repository_id, selected_repository_id
+        ));
+    }
+    if ccs_pkg.name() != selected.name {
+        mismatches.push(format!("name '{}' != '{}'", ccs_pkg.name(), selected.name));
+    }
+    if ccs_pkg.version() != selected.version {
+        mismatches.push(format!(
+            "version '{}' != '{}'",
+            ccs_pkg.version(),
+            selected.version
+        ));
+    }
+    if ccs_pkg.architecture() != selected.architecture.as_deref() {
+        mismatches.push(format!(
+            "architecture {:?} != {:?}",
+            ccs_pkg.architecture(),
+            selected.architecture
+        ));
+    }
+    if ccs_pkg.version_scheme() != selected.version_scheme {
+        mismatches.push(format!(
+            "version scheme '{}' != '{}'",
+            ccs_pkg.version_scheme().as_str(),
+            selected.version_scheme.as_str()
+        ));
+    }
+    if provenance.version_scheme != selected.version_scheme {
+        mismatches.push(format!(
+            "provenance version scheme '{}' != '{}'",
+            provenance.version_scheme.as_str(),
+            selected.version_scheme.as_str()
+        ));
+    }
+    // Remi repository rows carry the exact source-native EVR in `version`,
+    // while the signed CCS `release` is the conversion build release. Static
+    // CCS rows that explicitly publish a release must still match it.
+    if let Some(selected_release) = selected.package_release.as_deref()
+        && ccs_pkg.package_release() != Some(selected_release)
+    {
+        mismatches.push(format!(
+            "package release {:?} != {:?}",
+            ccs_pkg.package_release(),
+            selected.package_release
+        ));
+    }
+
+    if !mismatches.is_empty() {
+        anyhow::bail!(
+            "verified CCS dependency identity does not match SAT-selected repository row {}: {}",
+            selected_row_id,
+            mismatches.join(", ")
+        );
+    }
+
+    Ok(())
 }
 
 /// Result of attempting CCS conversion
@@ -285,13 +377,14 @@ pub async fn try_convert_to_ccs(
 ///
 /// The artifact may be Conary-native or converted from another package format.
 pub async fn install_ccs_artifact(opts: CcsArtifactInstallOptions<'_>) -> Result<Option<i64>> {
-    install_ccs_artifact_with_pending(opts, Vec::new(), false).await
+    install_ccs_artifact_with_pending(opts, Vec::new(), false, None).await
 }
 
 async fn install_ccs_artifact_with_pending(
     opts: CcsArtifactInstallOptions<'_>,
     pending_providers: Vec<PendingCcsProvider>,
     defer_generation: bool,
+    expected_repository_package: Option<&SatPackage>,
 ) -> Result<Option<i64>> {
     let CcsArtifactInstallOptions {
         ccs_path,
@@ -318,6 +411,13 @@ async fn install_ccs_artifact_with_pending(
 
     let ccs_pkg = CcsPackage::from_verified_archive(ccs_path, &verified)
         .context("Failed to construct verified CCS package")?;
+    if let Some(expected) = expected_repository_package {
+        validate_selected_repository_ccs_identity(
+            &ccs_pkg,
+            expected,
+            repository_provenance.as_ref(),
+        )?;
+    }
     crate::commands::ccs::validate_ccs_capability_declaration(&ccs_pkg)?;
 
     if !no_deps {
@@ -446,6 +546,15 @@ async fn install_ccs_artifact_with_pending(
                                             "CCS dependency {dep_name} is missing exact repository provenance"
                                         )
                                     })?;
+                                let expected_dependency = dep_plan
+                                    .to_install
+                                    .iter()
+                                    .find(|dependency| dependency.package.name == *dep_name)
+                                    .with_context(|| {
+                                        format!(
+                                            "downloaded CCS dependency {dep_name} has no SAT-selected identity"
+                                        )
+                                    })?;
                                 let install_result = Box::pin(install_ccs_artifact_with_pending(
                                     CcsArtifactInstallOptions {
                                         ccs_path: dep_ccs_path,
@@ -464,6 +573,7 @@ async fn install_ccs_artifact_with_pending(
                                     },
                                     child_pending_providers,
                                     true,
+                                    Some(&expected_dependency.package),
                                 ))
                                 .await;
                                 install_result.with_context(|| {

--- a/apps/conary/src/commands/install/conversion/tests/dependencies.rs
+++ b/apps/conary/src/commands/install/conversion/tests/dependencies.rs
@@ -1,7 +1,120 @@
 // apps/conary/src/commands/install/conversion/tests/dependencies.rs
 
 use super::*;
+
 #[test]
 fn default_dependency_passes_reach_kernel_initramfs_toolchain() {
     assert_eq!(DEFAULT_CCS_DEPENDENCY_PASSES, 2);
+}
+
+fn verified_rpm_ccs(name: &str, version: &str, architecture: &str) -> CcsPackage {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let signing_key = SigningKeyPair::generate().with_key_id("dependency-identity");
+    let mut manifest = CcsManifest::new_minimal(name, version);
+    manifest.package.version_scheme = conary_core::repository::versioning::VersionScheme::Rpm;
+    manifest.package.platform.as_mut().unwrap().arch = Some(architecture.to_string());
+    let package_path =
+        write_runtime_signed_ccs_package(temp_dir.path(), name, manifest, &signing_key);
+    let verified = conary_core::ccs::verify::verify_package(
+        &package_path,
+        &conary_core::ccs::TrustPolicy::strict(vec![signing_key.public_key_base64()]),
+    )
+    .unwrap();
+    CcsPackage::from_verified_archive(package_path.to_str().unwrap(), &verified).unwrap()
+}
+
+fn selected_rpm_dependency() -> SatPackage {
+    SatPackage {
+        name: "dbus-broker".to_string(),
+        version: "37-8.fc44".to_string(),
+        package_release: None,
+        architecture: Some("x86_64".to_string()),
+        version_scheme: conary_core::repository::versioning::VersionScheme::Rpm,
+        repo_package_id: Some(41),
+        repository_id: Some(7),
+        repository_name: Some("supported-host-fedora-44".to_string()),
+        installed_trove_id: None,
+        source: SatSource::Repository,
+    }
+}
+
+fn selected_remi_provenance() -> RepositoryInstallProvenance {
+    RepositoryInstallProvenance {
+        repository_id: 7,
+        source_profile: Some("fedora-44".to_string()),
+        version_scheme: conary_core::repository::versioning::VersionScheme::Rpm,
+        source_kind: RepositorySourceKind::Remi,
+    }
+}
+
+#[test]
+fn verified_remi_ccs_matches_exact_selected_source_identity() {
+    let package = verified_rpm_ccs("dbus-broker", "37-8.fc44", "x86_64");
+    let selected = selected_rpm_dependency();
+
+    validate_selected_repository_ccs_identity(
+        &package,
+        &selected,
+        Some(&selected_remi_provenance()),
+    )
+    .expect("signed CCS identity must match its exact selected Remi row");
+}
+
+#[test]
+fn verified_remi_ccs_rejects_any_selected_identity_drift() {
+    let package = verified_rpm_ccs("dbus-broker", "37-8.fc44", "x86_64");
+    let provenance = selected_remi_provenance();
+
+    let mut mismatches = Vec::new();
+
+    let mut name = selected_rpm_dependency();
+    name.name = "dbus-daemon".to_string();
+    mismatches.push(name);
+
+    let mut version = selected_rpm_dependency();
+    version.version = "37-9.fc44".to_string();
+    mismatches.push(version);
+
+    let mut architecture = selected_rpm_dependency();
+    architecture.architecture = Some("aarch64".to_string());
+    mismatches.push(architecture);
+
+    let mut scheme = selected_rpm_dependency();
+    scheme.version_scheme = conary_core::repository::versioning::VersionScheme::Debian;
+    mismatches.push(scheme);
+
+    let mut repository = selected_rpm_dependency();
+    repository.repository_id = Some(8);
+    mismatches.push(repository);
+
+    for selected in mismatches {
+        let error =
+            validate_selected_repository_ccs_identity(&package, &selected, Some(&provenance))
+                .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("does not match SAT-selected repository row"),
+            "identity drift must fail before mutation: {error:#}"
+        );
+    }
+}
+
+#[test]
+fn explicit_static_ccs_release_must_match_selected_row() {
+    let package = verified_rpm_ccs("dbus-broker", "37-8.fc44", "x86_64");
+    let mut selected = selected_rpm_dependency();
+    selected.package_release = Some("2".to_string());
+
+    let error = validate_selected_repository_ccs_identity(
+        &package,
+        &selected,
+        Some(&selected_remi_provenance()),
+    )
+    .unwrap_err();
+
+    assert!(
+        error.to_string().contains("package release"),
+        "an explicitly selected CCS release must remain exact: {error:#}"
+    );
 }

--- a/apps/conary/src/commands/install/dep_resolution.rs
+++ b/apps/conary/src/commands/install/dep_resolution.rs
@@ -32,6 +32,10 @@ pub struct DepResolutionPlan {
     pub unresolvable: Vec<MissingDependency>,
 }
 
+fn normalized_package_release(release: &str) -> Option<&str> {
+    (!release.is_empty()).then_some(release)
+}
+
 #[cfg(test)]
 pub(super) fn version_satisfies_constraint(
     scheme: VersionScheme,
@@ -104,7 +108,8 @@ pub fn exact_repository_downloads(
             let exact = package.repository_id == repository_id
                 && package.name == expected.name
                 && package.version == expected.version
-                && Some(package.package_release.as_str()) == expected.package_release.as_deref()
+                && normalized_package_release(&package.package_release)
+                    == expected.package_release.as_deref()
                 && package.architecture == expected.architecture
                 && package.version_scheme == expected.version_scheme
                 && expected.repository_name.as_deref() == Some(repository.name.as_str());
@@ -171,7 +176,8 @@ mod tests {
             package: SatPackage {
                 name: package.name.clone(),
                 version: package.version.clone(),
-                package_release: Some(package.package_release.clone()),
+                package_release: normalized_package_release(&package.package_release)
+                    .map(str::to_string),
                 architecture: package.architecture.clone(),
                 version_scheme: package.version_scheme,
                 repo_package_id: package.id,
@@ -202,6 +208,21 @@ mod tests {
         assert_eq!(downloads.len(), 1);
         assert_eq!(downloads[0].1.package.id, package.id);
         assert_eq!(downloads[0].1.package.package_release, "7");
+    }
+
+    #[test]
+    fn exact_repository_download_accepts_normalized_empty_release() {
+        let conn = test_db();
+        let package = add_repository_package(&conn, "glibc", "2.43-2.fc44");
+        let repository = Repository::find_by_name(&conn, "test").unwrap().unwrap();
+        let selected = selected(&package, &repository);
+
+        assert_eq!(selected.package.package_release, None);
+        let downloads = exact_repository_downloads(&conn, &[selected]).unwrap();
+
+        assert_eq!(downloads.len(), 1);
+        assert_eq!(downloads[0].1.package.id, package.id);
+        assert!(downloads[0].1.package.package_release.is_empty());
     }
 
     #[test]

--- a/apps/conary/src/commands/install/inner.rs
+++ b/apps/conary/src/commands/install/inner.rs
@@ -90,7 +90,8 @@ pub fn install_inner(
         stored_files.len(),
         pkg.name()
     );
-    let resolved_files = resolve_stored_install_files(Path::new(ctx.root), &stored_files)?;
+    let resolved_files =
+        resolve_stored_install_files(Path::new(ctx.root), &stored_files, ctx.semantics)?;
     let directory_plan = preflight_resolved_file_ownership(
         tx,
         Path::new(ctx.root),
@@ -178,6 +179,7 @@ pub(super) fn store_extracted_files_in_cas(
 pub(super) fn resolve_stored_install_files(
     root: &Path,
     stored_files: &[StoredInstallFile],
+    semantics: InstallSemantics,
 ) -> Result<Vec<ResolvedInstallFile>> {
     let mut paths = HashSet::with_capacity(stored_files.len());
     for file in stored_files {
@@ -188,6 +190,7 @@ pub(super) fn resolve_stored_install_files(
     let resolved_nodes = super::payload_identity::resolve_payload_nodes(
         root,
         stored_files.iter().map(|file| file.node.clone()),
+        semantics,
     )?;
     Ok(stored_files
         .iter()

--- a/apps/conary/src/commands/install/payload_identity.rs
+++ b/apps/conary/src/commands/install/payload_identity.rs
@@ -8,6 +8,7 @@
 //! only that root's account databases and rejects missing or ambiguous
 //! authority.
 
+use super::{InstallSemantics, PackageFormatType, PreparedSourceKind};
 use anyhow::{Context, Result, bail};
 use conary_core::payload::{PayloadIdentity, PayloadNode, ResolvedPayloadNode};
 use std::collections::{BTreeMap, BTreeSet};
@@ -19,10 +20,11 @@ const MAX_IDENTITY_DATABASE_SIZE: u64 = 16 * 1024 * 1024;
 pub(super) fn resolve_payload_nodes(
     root: &Path,
     nodes: impl IntoIterator<Item = PayloadNode>,
+    semantics: InstallSemantics,
 ) -> Result<Vec<ResolvedPayloadNode>> {
     let nodes = nodes.into_iter().collect::<Vec<_>>();
-    let named_users = named_identities(nodes.iter().map(|node| &node.user));
-    let named_groups = named_identities(nodes.iter().map(|node| &node.group));
+    let named_users = named_identities(nodes.iter().map(|node| &node.user), semantics);
+    let named_groups = named_identities(nodes.iter().map(|node| &node.group), semantics);
 
     let users = if named_users.is_empty() {
         BTreeMap::new()
@@ -42,8 +44,8 @@ pub(super) fn resolve_payload_nodes(
         .into_iter()
         .map(|source| {
             source.validate()?;
-            let uid = resolve_identity(&source.user, &users, "user")?;
-            let gid = resolve_identity(&source.group, &groups, "group")?;
+            let uid = resolve_identity(&source.user, &users, "user", semantics)?;
+            let gid = resolve_identity(&source.group, &groups, "group", semantics)?;
             let resolved = ResolvedPayloadNode { source, uid, gid };
             resolved.validate()?;
             Ok(resolved)
@@ -53,14 +55,39 @@ pub(super) fn resolve_payload_nodes(
 
 fn named_identities<'a>(
     identities: impl IntoIterator<Item = &'a PayloadIdentity>,
+    semantics: InstallSemantics,
 ) -> BTreeSet<&'a str> {
     identities
         .into_iter()
         .filter_map(|identity| match identity {
-            PayloadIdentity::Named { name } => Some(name.as_str()),
+            PayloadIdentity::Named { name }
+                if source_defined_numeric_identity(identity, semantics).is_none() =>
+            {
+                Some(name.as_str())
+            }
             PayloadIdentity::Numeric { .. } => None,
+            PayloadIdentity::Named { .. } => None,
         })
         .collect()
+}
+
+/// RPM's pinned source ABI resolves its distinguished UID-0 user and GID-0
+/// group without consulting account databases. Converted RPM CCS packages
+/// retain `NativePackage { Rpm }` semantics, so this rule survives transport.
+fn source_defined_numeric_identity(
+    identity: &PayloadIdentity,
+    semantics: InstallSemantics,
+) -> Option<u64> {
+    let is_rpm = matches!(
+        semantics.source,
+        PreparedSourceKind::NativePackage {
+            format: PackageFormatType::Rpm
+        }
+    );
+    match identity {
+        PayloadIdentity::Named { name } if is_rpm && name == "root" => Some(0),
+        _ => None,
+    }
 }
 
 fn require_all_names(
@@ -88,7 +115,11 @@ fn resolve_identity(
     identity: &PayloadIdentity,
     names: &BTreeMap<String, u64>,
     kind: &str,
+    semantics: InstallSemantics,
 ) -> Result<u64> {
+    if let Some(id) = source_defined_numeric_identity(identity, semantics) {
+        return Ok(id);
+    }
     match identity {
         PayloadIdentity::Numeric { id } => Ok(*id),
         PayloadIdentity::Named { name } => names
@@ -246,6 +277,7 @@ fn parse_identity_records(text: &str, kind: IdentityDatabaseKind) -> Result<BTre
 mod tests {
     use super::*;
     use conary_core::payload::{PayloadIdentity, PayloadNode};
+    use conary_core::repository::versioning::VersionScheme;
 
     fn named_node(user: &str, group: &str) -> PayloadNode {
         let mut node = PayloadNode::regular(0o755);
@@ -256,6 +288,14 @@ mod tests {
             name: group.to_string(),
         };
         node
+    }
+
+    fn rpm_semantics() -> InstallSemantics {
+        InstallSemantics::native_package(PackageFormatType::Rpm)
+    }
+
+    fn conary_semantics() -> InstallSemantics {
+        InstallSemantics::ccs(VersionScheme::Conary)
     }
 
     #[test]
@@ -273,8 +313,12 @@ mod tests {
         )
         .unwrap();
 
-        let resolved =
-            resolve_payload_nodes(root.path(), [named_node("svc", "svc-group")]).unwrap();
+        let resolved = resolve_payload_nodes(
+            root.path(),
+            [named_node("svc", "svc-group")],
+            rpm_semantics(),
+        )
+        .unwrap();
 
         assert_eq!(resolved[0].uid, 417);
         assert_eq!(resolved[0].gid, 819);
@@ -293,7 +337,7 @@ mod tests {
         node.user = PayloadIdentity::Numeric { id: 123 };
         node.group = PayloadIdentity::Numeric { id: 456 };
 
-        let resolved = resolve_payload_nodes(root.path(), [node]).unwrap();
+        let resolved = resolve_payload_nodes(root.path(), [node], conary_semantics()).unwrap();
 
         assert_eq!(resolved[0].uid, 123);
         assert_eq!(resolved[0].gid, 456);
@@ -314,8 +358,12 @@ mod tests {
         )
         .unwrap();
 
-        let error =
-            resolve_payload_nodes(root.path(), [named_node("missing", "svc-group")]).unwrap_err();
+        let error = resolve_payload_nodes(
+            root.path(),
+            [named_node("missing", "svc-group")],
+            rpm_semantics(),
+        )
+        .unwrap_err();
 
         assert!(error.to_string().contains("does not define payload user"));
     }
@@ -331,8 +379,12 @@ mod tests {
         .unwrap();
         fs::write(root.path().join("etc/group"), "svc-group:x:819:\n").unwrap();
 
-        let error =
-            resolve_payload_nodes(root.path(), [named_node("svc", "svc-group")]).unwrap_err();
+        let error = resolve_payload_nodes(
+            root.path(),
+            [named_node("svc", "svc-group")],
+            rpm_semantics(),
+        )
+        .unwrap_err();
 
         assert!(error.to_string().contains("defined more than once"));
     }
@@ -344,9 +396,67 @@ mod tests {
         std::os::unix::fs::symlink("/etc/passwd", root.path().join("etc/passwd")).unwrap();
         fs::write(root.path().join("etc/group"), "svc-group:x:819:\n").unwrap();
 
-        let error =
-            resolve_payload_nodes(root.path(), [named_node("svc", "svc-group")]).unwrap_err();
+        let error = resolve_payload_nodes(
+            root.path(),
+            [named_node("svc", "svc-group")],
+            rpm_semantics(),
+        )
+        .unwrap_err();
 
         assert!(error.to_string().contains("must not be a symlink"));
+    }
+
+    #[test]
+    fn rpm_distinguished_root_resolves_without_account_databases() {
+        let root = tempfile::tempdir().unwrap();
+
+        let resolved =
+            resolve_payload_nodes(root.path(), [named_node("root", "root")], rpm_semantics())
+                .unwrap();
+
+        assert_eq!(resolved[0].uid, 0);
+        assert_eq!(resolved[0].gid, 0);
+        assert_eq!(
+            resolved[0].source.user,
+            PayloadIdentity::Named {
+                name: "root".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn rpm_non_root_name_still_requires_target_account_database() {
+        let root = tempfile::tempdir().unwrap();
+
+        let error = resolve_payload_nodes(
+            root.path(),
+            [named_node("service", "root")],
+            rpm_semantics(),
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("target root has no /etc directory")
+        );
+    }
+
+    #[test]
+    fn non_rpm_named_root_does_not_inherit_rpm_uid_zero_semantics() {
+        let root = tempfile::tempdir().unwrap();
+
+        let error = resolve_payload_nodes(
+            root.path(),
+            [named_node("root", "root")],
+            conary_semantics(),
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("target root has no /etc directory")
+        );
     }
 }

--- a/apps/conary/src/commands/install/restore/transaction.rs
+++ b/apps/conary/src/commands/install/restore/transaction.rs
@@ -732,8 +732,11 @@ impl NativeGraphPayloadMutation for RestoreInstallPayload<'_, '_> {
             .stored_files
             .get(change_index)
             .context("state-restore install payload has no stored files")?;
-        let resolved_files =
-            inner::resolve_stored_install_files(self.selected_root.selected_root(), stored_files)?;
+        let resolved_files = inner::resolve_stored_install_files(
+            self.selected_root.selected_root(),
+            stored_files,
+            prepared.semantics,
+        )?;
         let directory_plan = inner::preflight_resolved_file_ownership(
             self.tx,
             self.selected_root.selected_root(),

--- a/apps/conary/src/commands/install/transaction/selected_root.rs
+++ b/apps/conary/src/commands/install/transaction/selected_root.rs
@@ -316,6 +316,7 @@ impl NativeGraphPayloadMutation for SelectedRootPayload<'_, '_> {
         let resolved_files = inner::resolve_stored_install_files(
             self.selected_root.selected_root(),
             self.stored_files,
+            self.ctx.semantics,
         )?;
         let directory_plan = inner::preflight_resolved_file_ownership(
             self.tx,

--- a/apps/conary/tests/rpm_named_ownership.rs
+++ b/apps/conary/tests/rpm_named_ownership.rs
@@ -15,6 +15,8 @@ use std::process::{Command, Output};
 
 const PACKAGE_NAME: &str = "named-owner-fixture";
 const PACKAGE_PATH: &str = "/usr/lib/named-owner-fixture/payload";
+const ROOT_PACKAGE_NAME: &str = "root-owner-fixture";
+const ROOT_PACKAGE_PATH: &str = "/usr/lib/root-owner-fixture/payload";
 const USER_NAME: &str = "conary-fixture-user";
 const GROUP_NAME: &str = "conary-fixture-group";
 
@@ -26,9 +28,15 @@ fn output_text(output: &Output) -> String {
     )
 }
 
-fn write_named_owner_rpm(directory: &Path) -> std::path::PathBuf {
+fn write_owned_rpm(
+    directory: &Path,
+    package_name: &str,
+    package_path: &str,
+    user: &str,
+    group: &str,
+) -> std::path::PathBuf {
     let mut builder = rpm::PackageBuilder::new(
-        PACKAGE_NAME,
+        package_name,
         "1.0.0",
         "MIT",
         std::env::consts::ARCH,
@@ -37,14 +45,14 @@ fn write_named_owner_rpm(directory: &Path) -> std::path::PathBuf {
     builder
         .with_file_contents(
             b"named owner payload\n".to_vec(),
-            rpm::FileOptions::new(PACKAGE_PATH)
+            rpm::FileOptions::new(package_path)
                 .permissions(0o640)
-                .user(USER_NAME)
-                .group(GROUP_NAME),
+                .user(user)
+                .group(group),
         )
         .unwrap();
     let package = builder.build().unwrap();
-    let path = directory.join("named-owner-fixture.rpm");
+    let path = directory.join(format!("{package_name}.rpm"));
     package.write_file(&path).unwrap();
     path
 }
@@ -88,7 +96,7 @@ fn regular_entry(
     )
 }
 
-fn seed_selected_root(db_path: &Path, uid: u32, gid: u32) {
+fn seed_selected_root(db_path: &Path, named_account: Option<(u32, u32)>) {
     let runtime_root = ConaryRuntimeRoot::from_db_path(db_path.to_path_buf());
     stage_test_boot_assets(runtime_root.root());
     let conn = conary_core::db::open(db_path).unwrap();
@@ -109,27 +117,29 @@ fn seed_selected_root(db_path: &Path, uid: u32, gid: u32) {
     ] {
         directory_entry(path, base_id).insert(&conn).unwrap();
     }
-    regular_entry(
-        &runtime_root,
-        "/etc/passwd",
-        format!(
-            "root:x:0:0:root:/root:/bin/sh\n{USER_NAME}:x:{uid}:{gid}:fixture:/:/sbin/nologin\n"
+    if let Some((uid, gid)) = named_account {
+        regular_entry(
+            &runtime_root,
+            "/etc/passwd",
+            format!(
+                "root:x:0:0:root:/root:/bin/sh\n{USER_NAME}:x:{uid}:{gid}:fixture:/:/sbin/nologin\n"
+            )
+            .as_bytes(),
+            0o644,
+            base_id,
         )
-        .as_bytes(),
-        0o644,
-        base_id,
-    )
-    .insert(&conn)
-    .unwrap();
-    regular_entry(
-        &runtime_root,
-        "/etc/group",
-        format!("root:x:0:\n{GROUP_NAME}:x:{gid}:\n").as_bytes(),
-        0o644,
-        base_id,
-    )
-    .insert(&conn)
-    .unwrap();
+        .insert(&conn)
+        .unwrap();
+        regular_entry(
+            &runtime_root,
+            "/etc/group",
+            format!("root:x:0:\n{GROUP_NAME}:x:{gid}:\n").as_bytes(),
+            0o644,
+            base_id,
+        )
+        .insert(&conn)
+        .unwrap();
+    }
     regular_entry(
         &runtime_root,
         "/sbin/init",
@@ -190,9 +200,15 @@ fn rpm_install_resolves_named_ownership_from_selected_target_root() {
     let uid = unsafe { libc::geteuid() };
     let gid = unsafe { libc::getegid() };
     conary_core::db::init(&db_path).unwrap();
-    seed_selected_root(&db_path, uid, gid);
+    seed_selected_root(&db_path, Some((uid, gid)));
 
-    let rpm_path = write_named_owner_rpm(temp.path());
+    let rpm_path = write_owned_rpm(
+        temp.path(),
+        PACKAGE_NAME,
+        PACKAGE_PATH,
+        USER_NAME,
+        GROUP_NAME,
+    );
     let output = Command::new(env!("CARGO_BIN_EXE_conary"))
         .env("CONARY_TEST_SKIP_GENERATION_MOUNT", "1")
         .args([
@@ -258,5 +274,46 @@ fn rpm_install_resolves_named_ownership_from_selected_target_root() {
             .retrieve(&content.sha256)
             .unwrap(),
         b"named owner payload\n"
+    );
+}
+
+#[test]
+fn rpm_root_ownership_dry_run_does_not_require_account_databases() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().join("root");
+    let db_path = temp.path().join("conary.db");
+    fs::create_dir_all(&root).unwrap();
+    conary_core::db::init(&db_path).unwrap();
+    seed_selected_root(&db_path, None);
+
+    let rpm_path = write_owned_rpm(
+        temp.path(),
+        ROOT_PACKAGE_NAME,
+        ROOT_PACKAGE_PATH,
+        "root",
+        "root",
+    );
+    let output = Command::new(env!("CARGO_BIN_EXE_conary"))
+        .env("CONARY_TEST_SKIP_GENERATION_MOUNT", "1")
+        .args([
+            "install",
+            rpm_path.to_str().unwrap(),
+            "--db-path",
+            db_path.to_str().unwrap(),
+            "--root",
+            root.to_str().unwrap(),
+            "--no-deps",
+            "--sandbox",
+            "always",
+            "--dry-run",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_text(&output));
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("Dry run complete. No changes made."),
+        "{}",
+        output_text(&output)
     );
 }

--- a/crates/conary-core/Cargo.toml
+++ b/crates/conary-core/Cargo.toml
@@ -70,7 +70,7 @@ xattr = "1.6"
 rayon.workspace = true
 
 # SAT-based dependency resolver
-resolvo = "0.10"
+resolvo = "0.12.0"
 
 # Progress bars for downloads
 indicatif.workspace = true

--- a/crates/conary-core/src/packages/rpm.rs
+++ b/crates/conary-core/src/packages/rpm.rs
@@ -69,63 +69,13 @@ impl RpmPackage {
 
     /// Parse RPM Requires into the formal Boolean requirement grammar.
     fn extract_requirements(pkg: &Package) -> Result<Vec<RepositoryRequirementGroup>> {
-        // RPMSENSE_CONFIG is not disposable annotation. RPM generates paired
-        // config(NAME) requires/provides for packages containing %config files:
-        // https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/build/rpmfc.cc#L1748-L1762
-        // Conary installs those files, so preserve the exact package
-        // capability instead of silently discarding the flag.
         let groups = pkg
             .metadata
             .get_requires()
             .map_err(|error| Error::ParseError(format!("Failed to read RPM requires: {error}")))?
             .into_iter()
             .map(|requirement| {
-                let runtime_feature =
-                    crate::repository::rpm_runtime::RpmRuntimeFeature::parse_capability(
-                        &requirement.name,
-                    )
-                    .map_err(|error| Error::ParseError(error.to_string()))?;
-                if requirement.flags.intersects(DependencyFlags::RPMLIB)
-                    && runtime_feature.is_none()
-                {
-                    return Err(Error::ParseError(format!(
-                        "RPM requirement '{}' carries RPMLIB sense outside the rpmlib(Feature) grammar",
-                        requirement.name
-                    )));
-                }
-                validate_rpm_config_sense(&requirement.name, requirement.flags)?;
-                let native_text = if requirement.name.starts_with('(') {
-                    if !requirement.version.is_empty()
-                        || requirement.flags.intersects(
-                            DependencyFlags::LESS
-                                | DependencyFlags::GREATER
-                                | DependencyFlags::EQUAL,
-                        )
-                    {
-                        return Err(Error::ParseError(format!(
-                            "RPM rich dependency '{}' carries an invalid separate version constraint",
-                            requirement.name
-                        )));
-                    }
-                    requirement.name.to_string()
-                } else {
-                    rpm_relation_text(
-                        &requirement.name,
-                        &requirement.version,
-                        requirement.flags,
-                    )?
-                };
-                let group = crate::repository::requirement::parse_native_requirement(
-                    RepositoryRequirementKind::Depends,
-                    VersionScheme::Rpm,
-                    &native_text,
-                )
-                .map_err(Error::ParseError)?;
-                crate::repository::rpm_runtime::simplify_runtime_requirement_group(
-                    group,
-                    VersionScheme::Rpm,
-                )
-                .map_err(|error| Error::ParseError(error.to_string()))
+                decode_rpm_requirement(&requirement.name, &requirement.version, requirement.flags)
             })
             .collect::<Result<Vec<_>>>()?;
         Ok(groups.into_iter().flatten().collect())
@@ -219,6 +169,62 @@ impl RpmPackage {
         }
         Ok(relations)
     }
+}
+
+/// Decode one aligned RPM Requires header record into Conary's typed model.
+///
+/// Artifact parsing and installed-rpmdb adoption share this boundary so query
+/// formatting cannot create a second dependency grammar. RPM itself accepts an
+/// empty serialized epoch before `:` as epoch zero in `parseEVR()` at pinned
+/// upstream commit a8f0192a; Conary canonicalizes that source spelling to an
+/// omitted epoch while retaining the stricter canonical EVR grammar elsewhere.
+pub(crate) fn decode_rpm_requirement(
+    name: &str,
+    version: &str,
+    flags: DependencyFlags,
+) -> Result<Option<RepositoryRequirementGroup>> {
+    // RPMSENSE_CONFIG is not disposable annotation. RPM generates paired
+    // config(NAME) requires/provides for packages containing %config files:
+    // https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/build/rpmfc.cc#L1748-L1762
+    // Conary installs those files, so preserve the exact package capability.
+    let runtime_feature = crate::repository::rpm_runtime::RpmRuntimeFeature::parse_capability(name)
+        .map_err(|error| Error::ParseError(error.to_string()))?;
+    if flags.intersects(DependencyFlags::RPMLIB) && runtime_feature.is_none() {
+        return Err(Error::ParseError(format!(
+            "RPM requirement '{name}' carries RPMLIB sense outside the rpmlib(Feature) grammar"
+        )));
+    }
+    validate_rpm_config_sense(name, flags)?;
+
+    let native_text = if name.starts_with('(') {
+        if !version.is_empty()
+            || flags.intersects(
+                DependencyFlags::LESS | DependencyFlags::GREATER | DependencyFlags::EQUAL,
+            )
+        {
+            return Err(Error::ParseError(format!(
+                "RPM rich dependency '{name}' carries an invalid separate version constraint"
+            )));
+        }
+        name.to_string()
+    } else {
+        let canonical_version = canonicalize_rpm_evr(version);
+        rpm_relation_text(name, canonical_version, flags)?
+    };
+    let group = crate::repository::requirement::parse_native_requirement(
+        RepositoryRequirementKind::Depends,
+        VersionScheme::Rpm,
+        &native_text,
+    )
+    .map_err(Error::ParseError)?;
+    crate::repository::rpm_runtime::simplify_runtime_requirement_group(group, VersionScheme::Rpm)
+        .map_err(|error| Error::ParseError(error.to_string()))
+}
+
+/// Canonicalize RPM's source-defined empty serialized epoch to omitted epoch
+/// zero without weakening the repository-wide EVR grammar.
+pub(crate) fn canonicalize_rpm_evr(version: &str) -> &str {
+    version.strip_prefix(':').unwrap_or(version)
 }
 
 fn validate_rpm_config_sense(name: &str, flags: DependencyFlags) -> Result<()> {

--- a/crates/conary-core/src/packages/rpm/sysusers.rs
+++ b/crates/conary-core/src/packages/rpm/sysusers.rs
@@ -54,27 +54,53 @@ impl RpmPackage {
         }
 
         let provider_files = rpm_provider_files(&pkg.metadata, provides.len())?;
-        let mut groups = Vec::<RpmSysusersMetadata>::new();
-        for decoded in decoded {
-            let source_path = provider_files
-                .get(decoded.provide_index)
-                .and_then(Clone::clone);
-            let group_index = groups
-                .iter()
-                .position(|group| group.source_path == source_path)
-                .unwrap_or_else(|| {
-                    groups.push(RpmSysusersMetadata {
-                        source_path: source_path.clone(),
-                        lines: Vec::new(),
-                        directives: Vec::new(),
-                    });
-                    groups.len() - 1
-                });
-            groups[group_index].lines.push(decoded.line);
-            groups[group_index].directives.push(decoded.directive);
-        }
-        Ok(groups)
+        group_decoded_sysusers(decoded, &provider_files)
     }
+}
+
+fn group_decoded_sysusers(
+    decoded: Vec<DecodedSysuser>,
+    provider_files: &[Vec<String>],
+) -> Result<Vec<RpmSysusersMetadata>> {
+    let mut groups = Vec::<RpmSysusersMetadata>::new();
+    for decoded in decoded {
+        let source_paths = provider_files.get(decoded.provide_index).ok_or_else(|| {
+            Error::ParseError(format!(
+                "RPM %sysusers provide index {} has no file dependency mapping",
+                decoded.provide_index
+            ))
+        })?;
+        if source_paths.is_empty() {
+            append_decoded_sysuser(&mut groups, None, &decoded);
+        } else {
+            for source_path in source_paths {
+                append_decoded_sysuser(&mut groups, Some(source_path.clone()), &decoded);
+            }
+        }
+    }
+    Ok(groups)
+}
+
+fn append_decoded_sysuser(
+    groups: &mut Vec<RpmSysusersMetadata>,
+    source_path: Option<String>,
+    decoded: &DecodedSysuser,
+) {
+    let group_index = groups
+        .iter()
+        .position(|group| group.source_path == source_path)
+        .unwrap_or_else(|| {
+            groups.push(RpmSysusersMetadata {
+                source_path: source_path.clone(),
+                lines: Vec::new(),
+                directives: Vec::new(),
+            });
+            groups.len() - 1
+        });
+    groups[group_index].lines.push(decoded.line.clone());
+    groups[group_index]
+        .directives
+        .push(decoded.directive.clone());
 }
 
 #[derive(Debug)]
@@ -230,18 +256,34 @@ fn invalid_sysusers_shape(line: &str, expectation: &str) -> Error {
 fn rpm_provider_files(
     metadata: &rpm::PackageMetadata,
     provide_count: usize,
-) -> Result<Vec<Option<String>>> {
+) -> Result<Vec<Vec<String>>> {
     let file_starts = optional_u32_array(metadata, rpm::IndexTag::RPMTAG_FILEDEPENDSX)?;
     let file_counts = optional_u32_array(metadata, rpm::IndexTag::RPMTAG_FILEDEPENDSN)?;
     let dependency_dictionary = optional_u32_array(metadata, rpm::IndexTag::RPMTAG_DEPENDSDICT)?;
     if file_starts.is_empty() && file_counts.is_empty() && dependency_dictionary.is_empty() {
-        return Ok(vec![None; provide_count]);
+        return Ok(vec![Vec::new(); provide_count]);
     }
     let paths = metadata.get_file_paths().map_err(|error| {
         Error::ParseError(format!(
             "Failed to read RPM file paths for %sysusers: {error}"
         ))
     })?;
+    provider_files_from_dependency_arrays(
+        &paths,
+        &file_starts,
+        &file_counts,
+        &dependency_dictionary,
+        provide_count,
+    )
+}
+
+fn provider_files_from_dependency_arrays(
+    paths: &[std::path::PathBuf],
+    file_starts: &[u32],
+    file_counts: &[u32],
+    dependency_dictionary: &[u32],
+    provide_count: usize,
+) -> Result<Vec<Vec<String>>> {
     if file_starts.len() != paths.len() || file_counts.len() != paths.len() {
         return Err(Error::ParseError(format!(
             "RPM file dependency arrays do not match file count: starts={}, counts={}, files={}",
@@ -251,7 +293,7 @@ fn rpm_provider_files(
         )));
     }
 
-    let mut provider_files = vec![None; provide_count];
+    let mut provider_files = vec![Vec::new(); provide_count];
     for (file_index, path) in paths.iter().enumerate() {
         let start = usize::try_from(file_starts[file_index]).map_err(|_| {
             Error::ParseError("RPM file dependency start does not fit usize".to_string())
@@ -280,14 +322,8 @@ fn rpm_provider_files(
                 ))
             })?;
             let normalized = normalize_rpm_header_path(path);
-            match target {
-                Some(existing) if existing != &normalized => {
-                    return Err(Error::ParseError(format!(
-                        "RPM provide index {provide_index} is attached to multiple files"
-                    )));
-                }
-                Some(_) => {}
-                None => *target = Some(normalized),
+            if !target.contains(&normalized) {
+                target.push(normalized);
             }
         }
     }
@@ -318,6 +354,10 @@ fn normalize_rpm_header_path(path: &std::path::Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn packed_provide(index: u32) -> u32 {
+        (FILE_DEPENDENCY_KIND_PROVIDE << 24) | index
+    }
 
     fn identity_user() -> SysuserProvideIdentity {
         SysuserProvideIdentity::User("dnsmasq".to_string())
@@ -366,5 +406,100 @@ mod tests {
 
         let encoded = base64::engine::general_purpose::STANDARD.encode(b"g input\0x");
         assert!(decode_sysusers_line(&encoded, "group(input)").is_err());
+    }
+
+    #[test]
+    fn one_provide_index_preserves_every_attached_file() {
+        let paths = vec![
+            std::path::PathBuf::from("./usr/lib/sysusers.d/first.conf"),
+            std::path::PathBuf::from("./usr/lib/sysusers.d/second.conf"),
+        ];
+        let provider_files = provider_files_from_dependency_arrays(
+            &paths,
+            &[0, 1],
+            &[1, 1],
+            &[packed_provide(0), packed_provide(0)],
+            1,
+        )
+        .unwrap();
+
+        assert_eq!(
+            provider_files,
+            vec![vec![
+                "/usr/lib/sysusers.d/first.conf".to_string(),
+                "/usr/lib/sysusers.d/second.conf".to_string(),
+            ]]
+        );
+    }
+
+    #[test]
+    fn decoded_declaration_is_grouped_under_every_source_file() {
+        let decoded = vec![DecodedSysuser {
+            provide_index: 0,
+            line: "u dnsmasq -".to_string(),
+            directive: RpmSysusersDirective::User {
+                name: "dnsmasq".to_string(),
+                id: None,
+                description: None,
+                home: None,
+                shell: None,
+                locked: false,
+            },
+        }];
+        let groups = group_decoded_sysusers(
+            decoded,
+            &[vec![
+                "/usr/lib/sysusers.d/first.conf".to_string(),
+                "/usr/lib/sysusers.d/second.conf".to_string(),
+            ]],
+        )
+        .unwrap();
+
+        assert_eq!(groups.len(), 2);
+        assert_eq!(
+            groups[0].source_path.as_deref(),
+            Some("/usr/lib/sysusers.d/first.conf")
+        );
+        assert_eq!(
+            groups[1].source_path.as_deref(),
+            Some("/usr/lib/sysusers.d/second.conf")
+        );
+        assert!(groups.iter().all(|group| group.lines == ["u dnsmasq -"]));
+    }
+
+    #[test]
+    fn package_level_declaration_keeps_absent_source_path() {
+        let decoded = vec![DecodedSysuser {
+            provide_index: 0,
+            line: "g dnsmasq -".to_string(),
+            directive: RpmSysusersDirective::Group {
+                name: "dnsmasq".to_string(),
+                id: None,
+            },
+        }];
+
+        let groups = group_decoded_sysusers(decoded, &[Vec::new()]).unwrap();
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].source_path, None);
+        assert_eq!(groups[0].lines, ["g dnsmasq -"]);
+    }
+
+    #[test]
+    fn malformed_file_dependency_index_still_fails_closed() {
+        let error = provider_files_from_dependency_arrays(
+            &[std::path::PathBuf::from("./usr/bin/example")],
+            &[0],
+            &[1],
+            &[packed_provide(1)],
+            1,
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("references missing provide index 1")
+        );
     }
 }

--- a/crates/conary-core/src/packages/rpm/tests.rs
+++ b/crates/conary-core/src/packages/rpm/tests.rs
@@ -81,6 +81,29 @@ fn rpm_artifact_parser_preserves_nonzero_epoch_in_version_identity() {
 }
 
 #[test]
+fn rpm_artifact_requirement_canonicalizes_empty_epoch_at_typed_boundary() {
+    let mut builder = rpm::PackageBuilder::new(
+        "empty-epoch-consumer",
+        "1",
+        "MIT",
+        "x86_64",
+        "RPM empty requirement epoch fixture",
+    );
+    builder.requires(rpm::Dependency {
+        name: "device-mapper-libs".to_string(),
+        flags: DependencyFlags::EQUAL,
+        version: ":1.02.212-2.fc44".to_string(),
+    });
+
+    let requirements = RpmPackage::extract_requirements(&builder.build().unwrap()).unwrap();
+
+    assert_eq!(
+        requirements[0].native_text.as_deref(),
+        Some("device-mapper-libs = 1.02.212-2.fc44")
+    );
+}
+
+#[test]
 fn rpm_header_relations_preserve_conflicts_and_obsoletes_as_typed_authority() {
     let mut builder =
         rpm::PackageBuilder::new("newpkg", "2", "MIT", "x86_64", "package relation fixture");

--- a/crates/conary-core/src/repository/dependencies.rs
+++ b/crates/conary-core/src/repository/dependencies.rs
@@ -13,6 +13,7 @@ use super::download::{
     DownloadOptions, DownloadProgress, download_package_verified_with_progress,
     download_static_package_verified_with_progress,
 };
+use super::remi::RemiClient;
 use super::selector::PackageWithRepo;
 
 /// Download all dependencies to a directory in parallel
@@ -66,18 +67,8 @@ pub async fn download_dependencies(
     for ((dep_name, pkg_with_repo), pb) in dependencies.iter().zip(progress_bars.iter()) {
         info!("Downloading dependency: {}", dep_name);
 
-        let trust = if pkg_with_repo.repository.default_strategy.as_deref() == Some("static") {
-            None
-        } else {
-            Some(DownloadOptions::for_repository(
-                &pkg_with_repo.repository,
-                keyring_dir,
-            )?)
-        };
-
         let result =
-            match download_dependency_package(pkg_with_repo, dest_dir, trust.as_ref(), Some(pb))
-                .await
+            match download_dependency_package(pkg_with_repo, dest_dir, keyring_dir, Some(pb)).await
             {
                 Ok(path) => {
                     DownloadProgress::finish_download(pb, dep_name);
@@ -139,30 +130,226 @@ pub async fn download_dependencies(
 async fn download_dependency_package(
     pkg_with_repo: &PackageWithRepo,
     dest_dir: &Path,
-    native_trust: Option<&DownloadOptions>,
+    keyring_dir: &Path,
     progress_bar: Option<&indicatif::ProgressBar>,
 ) -> Result<PathBuf> {
-    if pkg_with_repo.repository.default_strategy.as_deref() == Some("static") {
-        download_static_package_verified_with_progress(
-            &pkg_with_repo.package,
-            dest_dir,
-            None,
-            progress_bar,
-        )
-        .await
-    } else {
-        let trust = native_trust.ok_or_else(|| {
+    match pkg_with_repo.repository.default_strategy.as_deref() {
+        Some("static") => {
+            download_static_package_verified_with_progress(
+                &pkg_with_repo.package,
+                dest_dir,
+                None,
+                progress_bar,
+            )
+            .await
+        }
+        Some("remi") => download_remi_dependency_package(pkg_with_repo, dest_dir).await,
+        None | Some("binary") => {
+            let trust = DownloadOptions::for_repository(&pkg_with_repo.repository, keyring_dir)?;
+            download_package_verified_with_progress(
+                &pkg_with_repo.package,
+                dest_dir,
+                &trust,
+                progress_bar,
+            )
+            .await
+        }
+        Some(strategy) => Err(Error::ConfigError(format!(
+            "repository '{}' has unsupported dependency download strategy '{}'",
+            pkg_with_repo.repository.name, strategy
+        ))),
+    }
+}
+
+async fn download_remi_dependency_package(
+    pkg_with_repo: &PackageWithRepo,
+    dest_dir: &Path,
+) -> Result<PathBuf> {
+    let repository = &pkg_with_repo.repository;
+    let endpoint = repository
+        .default_strategy_endpoint
+        .as_deref()
+        .filter(|endpoint| !endpoint.trim().is_empty())
+        .ok_or_else(|| {
             Error::ConfigError(format!(
-                "native repository '{}' download has no prepared trust policy",
-                pkg_with_repo.repository.name
+                "Remi repository '{}' has no conversion endpoint",
+                repository.name
             ))
         })?;
-        download_package_verified_with_progress(
-            &pkg_with_repo.package,
+    let source_profile =
+        super::selector::candidate_source_profile(&pkg_with_repo.package, repository)?.ok_or_else(
+            || {
+                Error::ConfigError(format!(
+                    "Remi repository package '{}-{}' has no source profile",
+                    pkg_with_repo.package.name, pkg_with_repo.package.version
+                ))
+            },
+        )?;
+    let profile =
+        super::supported_profiles::profile_for_remi_target(source_profile).ok_or_else(|| {
+            Error::ConfigError(format!(
+                "Remi repository package '{}-{}' has unsupported source profile '{}'",
+                pkg_with_repo.package.name, pkg_with_repo.package.version, source_profile
+            ))
+        })?;
+
+    RemiClient::new(endpoint)?
+        .fetch_package(
+            profile.remi_route_slug(),
+            &pkg_with_repo.package.name,
+            Some(&pkg_with_repo.package.version),
+            pkg_with_repo.package.architecture.as_deref(),
             dest_dir,
-            trust,
-            progress_bar,
         )
         .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::models::{Repository, RepositoryPackage};
+    use crate::repository::versioning::VersionScheme;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    fn package_with_repository(
+        strategy: Option<&str>,
+        endpoint: Option<String>,
+        source_profile: Option<&str>,
+        download_url: String,
+        checksum: String,
+        size: i64,
+    ) -> PackageWithRepo {
+        let mut repository = Repository::new(
+            "dependency-source".to_string(),
+            "https://metadata.example.invalid".to_string(),
+        );
+        repository.default_strategy = strategy.map(str::to_string);
+        repository.default_strategy_endpoint = endpoint;
+        repository.source_profile = source_profile.map(str::to_string);
+
+        let mut package = RepositoryPackage::new(
+            7,
+            "dbus-broker".to_string(),
+            "37-8.fc44".to_string(),
+            VersionScheme::Rpm,
+            checksum,
+            size,
+            download_url,
+        );
+        package.architecture = Some("x86_64".to_string());
+        package.source_profile = source_profile.map(str::to_string);
+
+        PackageWithRepo {
+            package,
+            repository,
+        }
+    }
+
+    #[tokio::test]
+    async fn remi_dependency_uses_exact_profile_route_without_native_trust() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 1024];
+            loop {
+                let read = socket.read(&mut buffer).await.unwrap();
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..read]);
+                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+
+            let mut response = b"HTTP/1.1 200 OK\r\n\
+                                 Content-Disposition: attachment; filename=\"dbus-broker.ccs\"\r\n\
+                                 Content-Length: 2\r\n\
+                                 Connection: close\r\n\
+                                 \r\n"
+                .to_vec();
+            response.extend_from_slice(&[0x1f, 0x8b]);
+            socket.write_all(&response).await.unwrap();
+
+            String::from_utf8(request).unwrap()
+        });
+        let destination = tempfile::tempdir().unwrap();
+        let keyring = tempfile::tempdir().unwrap();
+        let package = package_with_repository(
+            Some("remi"),
+            Some(endpoint),
+            Some("fedora-44"),
+            "https://native.example.invalid/dbus-broker.rpm".to_string(),
+            "sha256:unused-by-remi".to_string(),
+            2,
+        );
+
+        let downloaded =
+            download_dependency_package(&package, destination.path(), keyring.path(), None)
+                .await
+                .expect("Remi dependency must not require ecosystem-native trust");
+        let request = server.await.unwrap();
+
+        assert_eq!(downloaded, destination.path().join("dbus-broker.ccs"));
+        assert_eq!(std::fs::read(downloaded).unwrap(), [0x1f, 0x8b]);
+        assert!(
+            request.starts_with(
+                "GET /v1/fedora/packages/dbus-broker/download?version=37-8.fc44&arch=x86_64 "
+            ),
+            "unexpected exact Remi dependency request: {request}"
+        );
+    }
+
+    #[tokio::test]
+    async fn native_dependency_still_requires_ecosystem_trust() {
+        let destination = tempfile::tempdir().unwrap();
+        let keyring = tempfile::tempdir().unwrap();
+        let package = package_with_repository(
+            Some("binary"),
+            None,
+            Some("fedora-44"),
+            "https://native.example.invalid/dbus-broker.rpm".to_string(),
+            "sha256:unused".to_string(),
+            1,
+        );
+
+        let error = download_dependency_package(&package, destination.path(), keyring.path(), None)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("has no ecosystem-native trust policy"),
+            "native dependency trust must remain mandatory: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn static_dependency_keeps_checksum_verified_local_path() {
+        let source = tempfile::tempdir().unwrap();
+        let destination = tempfile::tempdir().unwrap();
+        let keyring = tempfile::tempdir().unwrap();
+        let source_path = source.path().join("dependency.ccs");
+        let bytes = [0x1f, 0x8b, 0x08, 0x00];
+        std::fs::write(&source_path, bytes).unwrap();
+        let package = package_with_repository(
+            Some("static"),
+            None,
+            None,
+            source_path.to_string_lossy().into_owned(),
+            crate::hash::sha256(&bytes),
+            bytes.len() as i64,
+        );
+
+        let downloaded =
+            download_dependency_package(&package, destination.path(), keyring.path(), None)
+                .await
+                .expect("static dependency path must remain checksum verified");
+
+        assert_eq!(std::fs::read(downloaded).unwrap(), bytes);
     }
 }

--- a/crates/conary-core/src/repository/parsers/fedora.rs
+++ b/crates/conary-core/src/repository/parsers/fedora.rs
@@ -30,8 +30,7 @@ mod metalink;
 mod relation;
 use metalink::parse_metalink_repomd_identity;
 use relation::{
-    RpmProvideConstraint, rpm_constraint_native_text, rpm_provide_constraint,
-    rpm_relation_native_text, rpm_require_to_group,
+    RpmProvideConstraint, rpm_provide_constraint, rpm_relation_native_text, rpm_require_to_group,
 };
 
 /// Fedora/RPM repository parser
@@ -560,14 +559,15 @@ impl FedoraParser {
                                     })?;
                                     match section {
                                         FormatSection::Requires => {
-                                            let constraint = rpm_constraint_native_text(
+                                            if let Some(requirement) = rpm_require_to_group(
                                                 &name,
                                                 dep_flags.as_deref(),
                                                 dep_epoch.as_deref(),
                                                 dep_ver.as_deref(),
                                                 dep_rel.as_deref(),
-                                            )?;
-                                            pkg.dependencies.push((name, constraint));
+                                            )? {
+                                                pkg.dependencies.push(requirement);
+                                            }
                                         }
                                         FormatSection::Provides => {
                                             let provide = rpm_provide_constraint(
@@ -771,7 +771,7 @@ struct PackageBuilder {
     size: Option<String>,
     location: Option<String>,
     url: Option<String>,
-    dependencies: Vec<(String, String)>,
+    dependencies: Vec<RepositoryRequirementGroup>,
     provides: Vec<(String, RpmProvideConstraint)>,
     primary_files: Vec<String>,
     relations: Vec<(RepositoryRequirementKind, String)>,
@@ -839,14 +839,7 @@ impl PackageBuilder {
         };
 
         // Build structured requirements
-        let mut requirements: Vec<RepositoryRequirementGroup> = self
-            .dependencies
-            .iter()
-            .map(|(dep_name, constraint)| rpm_require_to_group(dep_name, constraint))
-            .collect::<Result<Vec<_>>>()?
-            .into_iter()
-            .flatten()
-            .collect();
+        let mut requirements = self.dependencies;
         requirements.extend(
             self.relations
                 .iter()

--- a/crates/conary-core/src/repository/parsers/fedora/relation.rs
+++ b/crates/conary-core/src/repository/parsers/fedora/relation.rs
@@ -12,11 +12,9 @@
 //! <https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/rpmio/rpmver.cc#L59-L106>.
 
 use crate::error::{Error, Result};
-use crate::repository::dependency_model::{
-    ConditionalRequirementBehavior, ProvideVersionRelation, RepositoryRequirementGroup,
-    RepositoryRequirementKind,
-};
+use crate::repository::dependency_model::{ProvideVersionRelation, RepositoryRequirementGroup};
 use crate::repository::versioning::{RepoVersionConstraint, VersionScheme, parse_repo_constraint};
+use rpm::DependencyFlags;
 
 #[derive(Debug)]
 pub(super) struct RpmProvideConstraint {
@@ -34,6 +32,52 @@ fn rpm_flags_to_op(flags: &str) -> Option<&'static str> {
         "LT" => Some("<"),
         "GT" => Some(">"),
         _ => None,
+    }
+}
+
+fn rpm_flags_to_dependency_flags(name: &str, flags: Option<&str>) -> Result<DependencyFlags> {
+    match flags {
+        None => Ok(DependencyFlags::empty()),
+        Some("GE") => Ok(DependencyFlags::GREATER | DependencyFlags::EQUAL),
+        Some("LE") => Ok(DependencyFlags::LESS | DependencyFlags::EQUAL),
+        Some("EQ") => Ok(DependencyFlags::EQUAL),
+        Some("LT") => Ok(DependencyFlags::LESS),
+        Some("GT") => Ok(DependencyFlags::GREATER),
+        Some(flags) => Err(Error::ParseError(format!(
+            "unsupported RPM relation flags '{flags}' for {name}"
+        ))),
+    }
+}
+
+fn rpm_evr_native_text(
+    name: &str,
+    flags: Option<&str>,
+    epoch: Option<&str>,
+    version: Option<&str>,
+    release: Option<&str>,
+) -> Result<String> {
+    match (flags, version) {
+        (None, None) if epoch.is_none() && release.is_none() => Ok(String::new()),
+        (Some(_), Some(version)) => {
+            let mut evr = String::new();
+            if let Some(epoch) = epoch
+                && epoch != "0"
+            {
+                evr.push_str(epoch);
+                evr.push(':');
+            }
+            evr.push_str(version);
+            if let Some(release) = release
+                && !release.is_empty()
+            {
+                evr.push('-');
+                evr.push_str(release);
+            }
+            Ok(evr)
+        }
+        _ => Err(Error::ParseError(format!(
+            "malformed RPM relation entry for {name}: comparison flags and version must appear together"
+        ))),
     }
 }
 
@@ -59,34 +103,19 @@ pub(super) fn rpm_constraint_native_text(
     version: Option<&str>,
     release: Option<&str>,
 ) -> Result<String> {
-    match (flags, version) {
-        (None, None) if epoch.is_none() && release.is_none() => Ok(String::new()),
-        (Some(flags), Some(version)) => {
-            let operator = rpm_flags_to_op(flags).ok_or_else(|| {
-                Error::ParseError(format!(
-                    "unsupported RPM relation flags '{flags}' for {name}"
-                ))
-            })?;
-            let mut evr = String::new();
-            if let Some(epoch) = epoch
-                && epoch != "0"
-            {
-                evr.push_str(epoch);
-                evr.push(':');
-            }
-            evr.push_str(version);
-            if let Some(release) = release
-                && !release.is_empty()
-            {
-                evr.push('-');
-                evr.push_str(release);
-            }
-            Ok(format!("{operator} {evr}"))
-        }
-        _ => Err(Error::ParseError(format!(
-            "malformed RPM relation entry for {name}: comparison flags and version must appear together"
-        ))),
-    }
+    let Some(flags) = flags else {
+        return rpm_evr_native_text(name, None, epoch, version, release);
+    };
+    let operator = rpm_flags_to_op(flags).ok_or_else(|| {
+        Error::ParseError(format!(
+            "unsupported RPM relation flags '{flags}' for {name}"
+        ))
+    })?;
+    let evr = rpm_evr_native_text(name, Some(flags), epoch, version, release)?;
+    Ok(format!(
+        "{operator} {}",
+        crate::packages::rpm::canonicalize_rpm_evr(&evr)
+    ))
 }
 
 pub(super) fn rpm_provide_constraint(
@@ -135,39 +164,14 @@ pub(super) fn rpm_provide_constraint(
 /// Build a typed requirement group from one exact RPM primary-metadata entry.
 pub(super) fn rpm_require_to_group(
     name: &str,
-    constraint: &str,
+    flags: Option<&str>,
+    epoch: Option<&str>,
+    version: Option<&str>,
+    release: Option<&str>,
 ) -> Result<Option<RepositoryRequirementGroup>> {
-    let native_text = if constraint.is_empty() {
-        name.to_string()
-    } else {
-        format!("{name} {constraint}")
-    };
-    let expression = crate::repository::rpm_dependency::parse_rpm_dependency(
-        RepositoryRequirementKind::Depends,
-        &native_text,
-    )
-    .map_err(Error::ParseError)?;
-    let clauses = expression.atoms().into_iter().cloned().collect::<Vec<_>>();
-    let behavior = if expression.is_conditional() {
-        ConditionalRequirementBehavior::Conditional
-    } else {
-        ConditionalRequirementBehavior::Hard
-    };
-    let first = clauses.first().cloned().ok_or_else(|| {
-        Error::ParseError(format!(
-            "RPM dependency produced no atomic requirements: {native_text}"
-        ))
-    })?;
-    let mut group = RepositoryRequirementGroup::simple(RepositoryRequirementKind::Depends, first)
-        .with_behavior(behavior)
-        .with_expression(expression)
-        .with_native_text(native_text);
-    group.alternatives = clauses;
-    crate::repository::rpm_runtime::simplify_runtime_requirement_group(
-        group,
-        crate::repository::versioning::VersionScheme::Rpm,
-    )
-    .map_err(|error| Error::ParseError(error.to_string()))
+    let dependency_flags = rpm_flags_to_dependency_flags(name, flags)?;
+    let evr = rpm_evr_native_text(name, flags, epoch, version, release)?;
+    crate::packages::rpm::decode_rpm_requirement(name, &evr, dependency_flags)
 }
 
 #[cfg(test)]
@@ -187,6 +191,44 @@ mod tests {
             .unwrap(),
             ">= 2:3.2.0-4.fc44"
         );
+    }
+
+    #[test]
+    fn requirement_canonicalizes_zero_epochs_through_shared_rpm_decoder() {
+        for epoch in ["", "0"] {
+            let requirement = rpm_require_to_group(
+                "device-mapper-libs",
+                Some("EQ"),
+                Some(epoch),
+                Some("1.02.212"),
+                Some("2.fc44"),
+            )
+            .unwrap()
+            .unwrap();
+
+            assert_eq!(
+                requirement.alternatives[0].version_constraint.as_deref(),
+                Some("= 1.02.212-2.fc44")
+            );
+            assert_eq!(
+                requirement.native_text.as_deref(),
+                Some("device-mapper-libs = 1.02.212-2.fc44")
+            );
+        }
+    }
+
+    #[test]
+    fn requirement_rejects_non_decimal_epoch_through_shared_rpm_decoder() {
+        let error = rpm_require_to_group(
+            "device-mapper-libs",
+            Some("EQ"),
+            Some("invalid"),
+            Some("1.02.212"),
+            Some("2.fc44"),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("epoch"));
     }
 
     #[test]

--- a/crates/conary-core/src/repository/parsers/fedora/tests.rs
+++ b/crates/conary-core/src/repository/parsers/fedora/tests.rs
@@ -165,6 +165,31 @@ fn test_parse_primary_xml_captures_namespaced_requires_and_provides() {
 }
 
 #[test]
+fn primary_xml_canonicalizes_empty_requirement_epoch_through_rpm_decoder() {
+    let xml = primary_package_with_format(
+        r#"
+      <rpm:requires>
+        <rpm:entry name="device-mapper-libs" flags="EQ" epoch="" ver="1.02.212" rel="2.fc44"/>
+      </rpm:requires>
+"#,
+    );
+
+    let packages = parser()
+        .parse_primary_xml(&xml, "https://example.com")
+        .unwrap();
+    let requirement = packages[0].requirements.first().unwrap();
+
+    assert_eq!(
+        requirement.native_text.as_deref(),
+        Some("device-mapper-libs = 1.02.212-2.fc44")
+    );
+    assert_eq!(
+        requirement.alternatives[0].version_constraint.as_deref(),
+        Some("= 1.02.212-2.fc44")
+    );
+}
+
+#[test]
 fn primary_xml_projects_every_generator_selected_file_as_a_typed_provide() {
     // Structure derived from createrepo_c 5cf41fe5d703901d78078ed18c67ab667e446c1a
     // tests/testdata/repodata_snippets/primary_snippet_02.xml. The repository

--- a/crates/conary-core/src/resolver/provider/expression.rs
+++ b/crates/conary-core/src/resolver/provider/expression.rs
@@ -136,7 +136,7 @@ impl ConaryProvider<'_> {
     fn version_set_id(&self, atom: &SolverAtom) -> Option<VersionSetId> {
         let name = self.name_to_id.get(&atom.name)?;
         self.version_set_cache
-            .get(&(name.0, atom.constraint.clone()))
+            .get(&(name.into_raw(), atom.constraint.clone()))
             .copied()
     }
 

--- a/crates/conary-core/src/resolver/provider/mod.rs
+++ b/crates/conary-core/src/resolver/provider/mod.rs
@@ -24,7 +24,7 @@ use crate::repository::versioning::{VersionScheme, validate_repo_version};
 use crate::resolver::identity::PackageIdentity;
 use crate::resolver::provides_index::ProvidesIndex;
 use resolvo::{
-    Condition, ConditionalRequirement, NameId, SolvableId, StringId, VersionSetId,
+    Condition, ConditionalRequirement, DenseIndex, NameId, SolvableId, StringId, VersionSetId,
     VersionSetUnionId,
 };
 
@@ -198,7 +198,7 @@ impl<'db> ConaryProvider<'db> {
         if let Some(&id) = self.name_to_id.get(name) {
             return Ok(id);
         }
-        let id = NameId(Self::pool_u32(self.names.len(), "name")?);
+        let id = NameId::from_raw(Self::pool_u32(self.names.len(), "name")?);
         let owned = name.to_string();
         self.names.push(owned.clone());
         self.name_to_id.insert(owned, id);
@@ -225,18 +225,18 @@ impl<'db> ConaryProvider<'db> {
                 "RPM runtime capability reached package version-set interning".to_string(),
             ));
         }
-        if name_id.0 as usize >= self.names.len() {
+        if name_id.to_index() >= self.names.len() {
             return Err(Error::ResolutionError(format!(
                 "cannot intern a version set for unknown resolver name ID {}",
-                name_id.0
+                name_id.into_raw()
             )));
         }
-        let cache_key = (name_id.0, constraint.clone());
+        let cache_key = (name_id.into_raw(), constraint.clone());
         if let Some(&existing) = self.version_set_cache.get(&cache_key) {
             return Ok(existing);
         }
         if matches!(constraint, ConaryConstraint::ProviderExpression { .. }) {
-            self.provider_expression_name_ids.insert(name_id.0);
+            self.provider_expression_name_ids.insert(name_id.into_raw());
         }
         let id = VersionSetId(Self::pool_u32(self.version_sets.len(), "version_set")?);
         self.version_sets.push((name_id, constraint));
@@ -268,7 +268,7 @@ impl<'db> ConaryProvider<'db> {
         sets: Vec<VersionSetId>,
     ) -> Result<VersionSetUnionId> {
         for set in &sets {
-            if set.0 as usize >= self.version_sets.len() {
+            if set.to_index() >= self.version_sets.len() {
                 return Err(Error::ResolutionError(format!(
                     "cannot intern a version-set union containing unknown version-set ID {}",
                     set.0
@@ -317,7 +317,7 @@ impl<'db> ConaryProvider<'db> {
             }
         }
         let idx = self.solvables.len();
-        let id = SolvableId(Self::pool_u32(idx, "solvable")?);
+        let id = SolvableId::from_raw(Self::pool_u32(idx, "solvable")?);
         // Update name-to-solvable index for O(1) lookup by name.
         self.name_to_solvable_ids
             .entry(pkg.name.clone())
@@ -329,8 +329,8 @@ impl<'db> ConaryProvider<'db> {
         }
         self.solvables.push(pkg);
         self.solvable_ids.push(id);
-        self.dependencies.insert(id.0, Vec::new());
-        self.relations.insert(id.0, Vec::new());
+        self.dependencies.insert(id.into_raw(), Vec::new());
+        self.relations.insert(id.into_raw(), Vec::new());
         Ok(id)
     }
 
@@ -358,8 +358,8 @@ impl<'db> ConaryProvider<'db> {
                         .map(relation_to_solver_dep)
                         .collect::<Result<Vec<_>>>()?,
                 );
-                self.dependencies.insert(solvable_id.0, dep_list);
-                self.relations.insert(solvable_id.0, relations);
+                self.dependencies.insert(solvable_id.into_raw(), dep_list);
+                self.relations.insert(solvable_id.into_raw(), relations);
             }
         }
         Ok(())
@@ -384,7 +384,7 @@ impl<'db> ConaryProvider<'db> {
                     .get(name.as_str())
                     .is_some_and(|ids| {
                         ids.iter()
-                            .any(|id| self.solvables[id.0 as usize].repo_package_id.is_some())
+                            .any(|id| self.solvables[id.to_index()].repo_package_id.is_some())
                     });
             if already_has_repo {
                 continue;
@@ -492,8 +492,8 @@ impl<'db> ConaryProvider<'db> {
                         .map(relation_to_solver_dep)
                         .collect::<Result<Vec<_>>>()?,
                 );
-                self.dependencies.insert(solvable_id.0, sub_deps);
-                self.relations.insert(solvable_id.0, relations);
+                self.dependencies.insert(solvable_id.into_raw(), sub_deps);
+                self.relations.insert(solvable_id.into_raw(), relations);
             }
         }
 
@@ -589,7 +589,7 @@ impl<'db> ConaryProvider<'db> {
 
     /// Get the solvable package at a given index.
     pub fn get_solvable(&self, id: SolvableId) -> &PackageIdentity {
-        &self.solvables[id.0 as usize]
+        &self.solvables[id.to_index()]
     }
 
     /// Get the total number of solvables.
@@ -604,16 +604,19 @@ impl<'db> ConaryProvider<'db> {
 
     /// Get the dependency list for a solvable (if loaded).
     pub fn get_dependency_list(&self, id: SolvableId) -> Option<&[SolverDep]> {
-        self.dependencies.get(&id.0).map(Vec::as_slice)
+        self.dependencies.get(&id.into_raw()).map(Vec::as_slice)
     }
 
     pub fn get_relation_list(&self, id: SolvableId) -> Result<&[SolverRelation]> {
-        self.relations.get(&id.0).map(Vec::as_slice).ok_or_else(|| {
-            Error::ResolutionError(format!(
-                "solver candidate {} has no registered relation authority",
-                id.0
-            ))
-        })
+        self.relations
+            .get(&id.into_raw())
+            .map(Vec::as_slice)
+            .ok_or_else(|| {
+                Error::ResolutionError(format!(
+                    "solver candidate {} has no registered relation authority",
+                    id.into_raw()
+                ))
+            })
     }
 
     /// Collect all unique dependency names from loaded packages.
@@ -663,47 +666,54 @@ impl<'db> ConaryProvider<'db> {
 
         for (index, (package, id)) in self.solvables.iter().zip(&self.solvable_ids).enumerate() {
             let expected = Self::pool_u32(index, "solvable")?;
-            if id.0 != expected {
+            if id.into_raw() != expected {
                 return Err(Error::ResolutionError(format!(
                     "resolver candidate '{}' has ID {} at pool position {expected}",
-                    package.name, id.0
+                    package.name,
+                    id.into_raw()
                 )));
             }
-            if !self.dependencies.contains_key(&id.0)
-                || !self.relations.contains_key(&id.0)
-                || !self.compiled_dependencies.contains_key(&id.0)
+            if !self.dependencies.contains_key(&id.into_raw())
+                || !self.relations.contains_key(&id.into_raw())
+                || !self.compiled_dependencies.contains_key(&id.into_raw())
             {
                 return Err(Error::ResolutionError(format!(
                     "resolver candidate '{}' ({}) is missing registered dependency, relation, or compiled authority",
-                    package.name, id.0
+                    package.name,
+                    id.into_raw()
                 )));
             }
             let Some(ids) = self.name_to_solvable_ids.get(&package.name) else {
                 return Err(Error::ResolutionError(format!(
                     "resolver candidate '{}' ({}) is absent from the name index",
-                    package.name, id.0
+                    package.name,
+                    id.into_raw()
                 )));
             };
             if !ids.contains(id) {
                 return Err(Error::ResolutionError(format!(
                     "resolver candidate '{}' ({}) is absent from its name index entry",
-                    package.name, id.0
+                    package.name,
+                    id.into_raw()
                 )));
             }
         }
 
         for (name, ids) in &self.name_to_solvable_ids {
             for id in ids {
-                let Some(package) = self.solvables.get(id.0 as usize) else {
+                let Some(package) = self.solvables.get(id.to_index()) else {
                     return Err(Error::ResolutionError(format!(
                         "resolver name index '{}' references unknown candidate ID {}",
-                        name, id.0
+                        name,
+                        id.into_raw()
                     )));
                 };
                 if package.name != *name {
                     return Err(Error::ResolutionError(format!(
                         "resolver name index '{}' references candidate '{}' ({})",
-                        name, package.name, id.0
+                        name,
+                        package.name,
+                        id.into_raw()
                     )));
                 }
             }
@@ -717,7 +727,7 @@ impl<'db> ConaryProvider<'db> {
                 )));
             }
             for set in sets {
-                if set.0 as usize >= self.version_sets.len() {
+                if set.to_index() >= self.version_sets.len() {
                     return Err(Error::ResolutionError(format!(
                         "resolver version-set union {index} references unknown version-set ID {}",
                         set.0
@@ -758,7 +768,7 @@ impl<'db> ConaryProvider<'db> {
 
     /// Find all solvables that match a given package name.
     pub(super) fn solvables_for_name(&self, name_id: NameId) -> Vec<SolvableId> {
-        let name = &self.names[name_id.0 as usize];
+        let name = &self.names[name_id.to_index()];
         self.name_to_solvable_ids
             .get(name)
             .cloned()
@@ -781,10 +791,10 @@ impl<'db> ConaryProvider<'db> {
 
     /// Find the installed solvable for a name, if any.
     pub(super) fn installed_solvable_for_name(&self, name_id: NameId) -> Option<SolvableId> {
-        let name = &self.names[name_id.0 as usize];
+        let name = &self.names[name_id.to_index()];
         self.name_to_solvable_ids.get(name).and_then(|ids| {
             ids.iter()
-                .find(|id| self.solvables[id.0 as usize].installed_trove_id.is_some())
+                .find(|id| self.solvables[id.to_index()].installed_trove_id.is_some())
                 .copied()
         })
     }
@@ -827,7 +837,7 @@ impl<'db> ConaryProvider<'db> {
             let dep_list =
                 load_installed_dependency_requests(self.conn, tid, package_architecture)?;
 
-            self.removal_deps.insert(sid.0, dep_list);
+            self.removal_deps.insert(sid.into_raw(), dep_list);
         }
 
         Ok(())
@@ -870,7 +880,7 @@ impl<'db> ConaryProvider<'db> {
     /// Unlike `get_dependency_list()` this includes virtual provides such as
     /// soname deps, perl modules, etc. that the regular list strips out.
     pub fn get_removal_dependency_list(&self, id: SolvableId) -> Option<&[SolverDep]> {
-        self.removal_deps.get(&id.0).map(Vec::as_slice)
+        self.removal_deps.get(&id.into_raw()).map(Vec::as_slice)
     }
 
     /// Load canonical equivalents from the local DB.

--- a/crates/conary-core/src/resolver/provider/tests.rs
+++ b/crates/conary-core/src/resolver/provider/tests.rs
@@ -13,7 +13,7 @@ use crate::repository::versioning::RepoVersionConstraint;
 use crate::resolver::identity::ProvidedCapability;
 use crate::version::VersionConstraint;
 use futures::executor::block_on;
-use resolvo::{DependencyProvider, SolverCache};
+use resolvo::{DenseIndex, DependencyProvider, SolverCache};
 
 fn setup_test_db() -> (tempfile::TempDir, rusqlite::Connection) {
     let temp_dir = tempfile::tempdir().unwrap();
@@ -167,6 +167,7 @@ fn resolver_uses_loaded_pin_authority_and_excludes_uncompiled_candidates() {
 
     let candidates = block_on(provider.get_candidates(name)).unwrap();
     assert_eq!(candidates.locked, Some(installed_id));
+    assert!(!candidates.allow_multiple);
     assert!(matches!(
         block_on(provider.get_dependencies(installed_id)),
         resolvo::Dependencies::Unknown(_)
@@ -376,8 +377,8 @@ fn test_intern_name_roundtrip() {
 
     assert_eq!(id1, id2);
     assert_ne!(id1, id3);
-    assert_eq!(provider.names[id1.0 as usize], "nginx");
-    assert_eq!(provider.names[id3.0 as usize], "curl");
+    assert_eq!(provider.names[id1.to_index()], "nginx");
+    assert_eq!(provider.names[id3.to_index()], "curl");
 }
 
 #[test]
@@ -403,12 +404,12 @@ fn test_version_set_filtering() {
     let candidates = [s1, s2, s3];
 
     // Test the filtering logic directly
-    let (_, ref constraint) = provider.version_sets[vs_id.0 as usize];
+    let (_, ref constraint) = provider.version_sets[vs_id.to_index()];
     let matching: Vec<SolvableId> = candidates
         .iter()
         .copied()
         .filter(|&sid| {
-            let pkg = &provider.solvables[sid.0 as usize];
+            let pkg = &provider.solvables[sid.to_index()];
             constraint_matches_package(constraint, &pkg.version, pkg.version_scheme)
                 .expect("valid test versions")
         })
@@ -462,7 +463,7 @@ fn test_unknown_version_set_ids_are_rejected_before_solver_callbacks() {
 
     let err = provider
         .intern_version_set(
-            NameId(u32::MAX),
+            NameId::from_raw(u32::MAX),
             VersionConstraint::parse("*").expect("valid test constraint"),
         )
         .expect_err("unknown name IDs must be rejected");
@@ -490,7 +491,7 @@ fn test_corrupt_solvable_name_index_is_a_typed_invariant_error() {
         .name_to_solvable_ids
         .get_mut("pkg")
         .unwrap()
-        .push(SolvableId(99));
+        .push(SolvableId::from_raw(99));
 
     let err = provider
         .intern_all_dependency_version_sets()
@@ -637,12 +638,12 @@ fn filter_candidates_uses_provide_version_for_virtual_capabilities() {
     }];
     let candidate = provider.add_solvable(identity).unwrap();
 
-    let requested_name = &provider.names[capability_name.0 as usize];
-    let (_, constraint) = &provider.version_sets[version_set.0 as usize];
+    let requested_name = &provider.names[capability_name.to_index()];
+    let (_, constraint) = &provider.version_sets[version_set.to_index()];
     let matching: Vec<SolvableId> = [candidate]
         .into_iter()
         .filter(|sid| {
-            let pkg = &provider.solvables[sid.0 as usize];
+            let pkg = &provider.solvables[sid.to_index()];
             let provided = pkg
                 .provided_capabilities
                 .iter()

--- a/crates/conary-core/src/resolver/provider/traits.rs
+++ b/crates/conary-core/src/resolver/provider/traits.rs
@@ -9,7 +9,7 @@
 use std::fmt;
 
 use resolvo::{
-    Candidates, Condition, ConditionId, Dependencies, DependencyProvider,
+    Candidates, Condition, ConditionId, DenseIndex, Dependencies, DependencyProvider,
     HintDependenciesAvailable, Interner, KnownDependencies, NameId, SolvableId, SolverCache,
     StringId, VersionSetId, VersionSetUnionId,
 };
@@ -57,8 +57,11 @@ impl fmt::Display for DisplayString<'_> {
 // --- Interner implementation ---
 
 impl Interner for ConaryProvider<'_> {
+    type NameId = NameId;
+    type SolvableId = SolvableId;
+
     fn display_solvable(&self, solvable: SolvableId) -> impl fmt::Display + '_ {
-        let pkg = &self.solvables[solvable.0 as usize];
+        let pkg = &self.solvables[solvable.to_index()];
         DisplaySolvable {
             name: &pkg.name,
             version: &pkg.version,
@@ -66,23 +69,23 @@ impl Interner for ConaryProvider<'_> {
     }
 
     fn display_name(&self, name: NameId) -> impl fmt::Display + '_ {
-        DisplayName(&self.names[name.0 as usize])
+        DisplayName(&self.names[name.to_index()])
     }
 
     fn display_version_set(&self, version_set: VersionSetId) -> impl fmt::Display + '_ {
-        DisplayVersionSet(&self.version_sets[version_set.0 as usize].1)
+        DisplayVersionSet(&self.version_sets[version_set.to_index()].1)
     }
 
     fn display_string(&self, string_id: StringId) -> impl fmt::Display + '_ {
-        DisplayString(&self.strings[string_id.0 as usize])
+        DisplayString(&self.strings[string_id.to_index()])
     }
 
     fn version_set_name(&self, version_set: VersionSetId) -> NameId {
-        self.version_sets[version_set.0 as usize].0
+        self.version_sets[version_set.to_index()].0
     }
 
     fn solvable_name(&self, solvable: SolvableId) -> NameId {
-        let pkg = &self.solvables[solvable.0 as usize];
+        let pkg = &self.solvables[solvable.to_index()];
         self.name_to_id[&pkg.name]
     }
 
@@ -91,7 +94,7 @@ impl Interner for ConaryProvider<'_> {
         version_set_union: VersionSetUnionId,
     ) -> impl Iterator<Item = VersionSetId> {
         self.version_set_unions
-            .get(version_set_union.0 as usize)
+            .get(version_set_union.to_index())
             .expect("resolvo requested a version-set union minted by this provider")
             .clone()
             .into_iter()
@@ -111,8 +114,8 @@ impl DependencyProvider for ConaryProvider<'_> {
         version_set: VersionSetId,
         inverse: bool,
     ) -> Vec<SolvableId> {
-        let (name_id, ref constraint) = self.version_sets[version_set.0 as usize];
-        let requested_name = &self.names[name_id.0 as usize];
+        let (name_id, ref constraint) = self.version_sets[version_set.to_index()];
+        let requested_name = &self.names[name_id.to_index()];
         let requested_kind = match constraint {
             ConaryConstraint::Repository {
                 capability_kind, ..
@@ -125,7 +128,7 @@ impl DependencyProvider for ConaryProvider<'_> {
             .iter()
             .copied()
             .filter(|&sid| {
-                let pkg = &self.solvables[sid.0 as usize];
+                let pkg = &self.solvables[sid.to_index()];
                 let matches = match constraint {
                     ConaryConstraint::RpmRuntime(_) => false,
                     ConaryConstraint::ProviderExpression { expression } => {
@@ -190,11 +193,11 @@ impl DependencyProvider for ConaryProvider<'_> {
     }
 
     async fn get_candidates(&self, name: NameId) -> Option<Candidates> {
-        let name_str = &self.names[name.0 as usize];
+        let name_str = &self.names[name.to_index()];
         if name_str == "\0conary:false" {
             return None;
         }
-        if self.provider_expression_name_ids.contains(&name.0) {
+        if self.provider_expression_name_ids.contains(&name.into_raw()) {
             let candidates = self.solvable_ids.clone();
             return (!candidates.is_empty()).then_some(Candidates {
                 candidates,
@@ -202,6 +205,7 @@ impl DependencyProvider for ConaryProvider<'_> {
                 locked: None,
                 hint_dependencies_available: HintDependenciesAvailable::All,
                 excluded: Vec::new(),
+                allow_multiple: false,
             });
         }
         let mut candidates = self.solvables_for_name(name);
@@ -241,7 +245,7 @@ impl DependencyProvider for ConaryProvider<'_> {
         let locked = candidates
             .iter()
             .find(|&&sid| {
-                let pkg = &self.solvables[sid.0 as usize];
+                let pkg = &self.solvables[sid.to_index()];
                 pkg.name == *name_str && pkg.installed_pinned
             })
             .copied();
@@ -252,6 +256,7 @@ impl DependencyProvider for ConaryProvider<'_> {
             locked,
             hint_dependencies_available: HintDependenciesAvailable::All,
             excluded: Vec::new(),
+            allow_multiple: false,
         })
     }
 
@@ -261,11 +266,11 @@ impl DependencyProvider for ConaryProvider<'_> {
         // should sort after exact-name candidates.
         let primary_name = solvables
             .first()
-            .map(|s| self.solvables[s.0 as usize].name.as_str());
+            .map(|s| self.solvables[s.to_index()].name.as_str());
 
         solvables.sort_by(|a, b| {
-            let pkg_a = &self.solvables[a.0 as usize];
-            let pkg_b = &self.solvables[b.0 as usize];
+            let pkg_a = &self.solvables[a.to_index()];
+            let pkg_b = &self.solvables[b.to_index()];
 
             // Exact-name candidates sort before canonical fallbacks
             if let Some(primary) = primary_name {
@@ -308,7 +313,7 @@ impl DependencyProvider for ConaryProvider<'_> {
     }
 
     async fn get_dependencies(&self, solvable: SolvableId) -> Dependencies {
-        match self.compiled_dependencies.get(&solvable.0) {
+        match self.compiled_dependencies.get(&solvable.into_raw()) {
             Some(requirements) => Dependencies::Known(KnownDependencies {
                 requirements: requirements.clone(),
                 constrains: Vec::new(),

--- a/crates/conary-core/src/resolver/sat/tests/root_requirements.rs
+++ b/crates/conary-core/src/resolver/sat/tests/root_requirements.rs
@@ -107,6 +107,22 @@ fn root_if_else_preserves_boolean_semantics() {
 }
 
 #[test]
+fn root_if_missing_required_returns_conflict_without_panic() {
+    let (_temp, conn) = setup_test_db();
+    let repository_id = repository(&conn);
+    package(&conn, repository_id, "condition", &[]);
+
+    let result = solve_rpm_roots(&conn, &["(required if condition)", "condition"]);
+    let conflict = result
+        .conflict_message
+        .as_ref()
+        .expect("triggered conditional with no required provider must be unsatisfiable");
+
+    assert!(!conflict.trim().is_empty());
+    assert!(result.install_order.is_empty(), "{result:?}");
+}
+
+#[test]
 fn root_with_and_without_require_same_provider_facts() {
     let (_temp, conn) = setup_test_db();
     let repository_id = repository(&conn);

--- a/crates/conary-core/tests/native_abi.rs
+++ b/crates/conary-core/tests/native_abi.rs
@@ -411,6 +411,34 @@ fn pinned_fedora_filesystem_root_anchor_parses_and_converts() {
     assert_conversion_preserves_native_entries(&package, &path, "rpm", "fedora-44");
 }
 
+/// Live source artifact for issue #203:
+/// https://kojipkgs.fedoraproject.org/packages/setup/2.15.0/28.fc44/noarch/setup-2.15.0-28.fc44.noarch.rpm
+///
+/// This package carries a valid many-to-many file dependency mapping. Keep the
+/// proof opt-in so ordinary tests remain hermetic while retaining the exact
+/// public artifact and digest that exposed the parser defect.
+#[test]
+#[ignore = "requires CONARY_RPM_SETUP_FIXTURE pointing to the pinned Fedora 44 setup RPM"]
+fn pinned_fedora_setup_many_file_provides_parse_and_convert() {
+    let path = PathBuf::from(
+        std::env::var("CONARY_RPM_SETUP_FIXTURE")
+            .expect("set CONARY_RPM_SETUP_FIXTURE to the pinned Fedora setup RPM"),
+    );
+    let bytes = fs::read(&path).expect("read pinned Fedora setup RPM");
+    assert_eq!(bytes.len(), 154_691);
+    assert_eq!(
+        conary_core::hash::sha256(&bytes),
+        "7a850ffbba5b3e8ca93fbfef25f7597bbfa87c8dfc8bc699f869cda85ee7440d"
+    );
+
+    let package = RpmPackage::parse(path.to_str().expect("UTF-8 fixture path"))
+        .expect("parse pinned Fedora setup RPM");
+
+    assert_eq!(package.name(), "setup");
+    assert_eq!(package.version(), "2.15.0-28.fc44");
+    assert_conversion_preserves_native_entries(&package, &path, "rpm", "fedora-44");
+}
+
 fn native_slots(package: &impl PackageFormat) -> BTreeSet<&str> {
     package
         .native_scriptlet_abi()

--- a/docs/modules/ccs.md
+++ b/docs/modules/ccs.md
@@ -157,12 +157,17 @@ consumers must not recover node kind from mode bits, path spelling, content
 length, or the presence of an unrelated field.
 
 RPM header arrays own installed metadata while the paired CPIO member owns
-bytes. RPM `FILEUSERNAME` and `FILEGROUPNAME` remain named source identities
-and are resolved from the selected target root's exact passwd and group
-records immediately before apply. Debian and Arch payloads retain the numeric
-uid and gid declared by their accepted tar grammars. Installed rows preserve
-both source identity and resolved numeric identity so later generation,
-rollback, query, and verification paths do not repeat or guess resolution.
+bytes. RPM `FILEUSERNAME` and `FILEGROUPNAME` remain source identities.
+Matching pinned RPM
+[`rpmugUid()` and `rpmugGid()`](https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/lib/rpmug.cc#L164-L220),
+the distinguished RPM `root` user and group resolve directly to numeric zero
+before any account database exists. Every other named RPM identity is resolved
+exactly once from the selected target root's passwd or group records
+immediately before apply; author-native CCS does not inherit RPM's root rule.
+Debian and Arch payloads retain the numeric uid and gid declared by their
+accepted tar grammars. Installed rows preserve both source identity and
+resolved numeric identity so later generation, rollback, query, and
+verification paths do not repeat or guess resolution.
 Unknown names, conflicting header/payload facts, unsupported archive records,
 and missing content authority reject the package before filesystem mutation.
 For an RPM symlink, `FILELINKTOS` owns the target and the CPIO member must carry

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -431,6 +431,21 @@ plan and report lifecycle without executing it because it performs no mutation;
 an applied transaction must execute the complete typed graph or fail before its
 first mutation.
 
+### Source Payload Identity
+
+RPM `FILEUSERNAME` and `FILEGROUPNAME` are source-format ownership authority.
+Before consulting the selected root's account databases, Conary applies pinned
+RPM's
+[`rpmugUid()` and `rpmugGid()`](https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/lib/rpmug.cc#L164-L220)
+contract: the distinguished RPM `root` user and group resolve directly to
+numeric zero. Every other named RPM identity must resolve exactly once from
+that root's exact passwd or group records before mutation. Converted CCS
+retains this rule through its signed native RPM source semantics; author-native
+CCS and other source formats cannot acquire it from a matching name. Installed
+payload state records both the source identity and resolved numeric identity,
+so later generation, rollback, query, and verification paths never repeat or
+guess the resolution.
+
 ### Source Root Ownership Anchors
 
 The selected root is the transaction container and cannot also be a package


### PR DESCRIPTION
## Primary Issue

Refs #201

Design / Plan / Roadmap: #137; related defects #173, #202, #203, and #204.

## Problem And Outcome

The Fedora 44 supported-host gate exposed a sequence of independent ordinary-package failures after repository sync: a Resolvo conflict-graph panic, false empty-release identity drift, Remi dependencies entering native trust authority, valid RPM many-to-many file dependency mappings being rejected, empty RPM epochs bypassing the shared typed decoder, and RPM's distinguished root ownership requiring account databases before they exist.

After this change, the unchanged Fedora package graph resolves without panic or identity drift, each dependency follows its repository's typed acquisition strategy, valid Fedora RPMs convert through one RPM requirement boundary, and root-owned RPM payloads can bootstrap an empty selected root without weakening any other named-identity lookup.

The post-merge Remi deployment and exact #137 TGE02/TISO01 gates remain required before the linked issues close.

## Changes

- Upgrade Resolvo to 0.12 with explicit dense `NameId`/`SolvableId` mappings and `allow_multiple = false`.
- Normalize empty persisted package releases at the SAT-to-download identity boundary.
- Route exact Remi dependency selections through signed CCS acquisition while preserving static and native trust branches.
- Preserve ordered many-to-many RPM file dependency mappings and every sysusers source-file association.
- Route RPM artifacts and Fedora `primary.xml` requirements through the shared typed RPM decoder; canonicalize empty/zero epochs only at the RPM source boundary.
- Resolve RPM's distinguished `root` user/group to UID/GID 0 before account-database lookup, while keeping all other RPM names and all non-RPM named identities fail-closed.
- Add unit, integration, and command-level regressions plus canonical payload-authority documentation.

## Scope

- In scope: the exact Fedora TGE02 resolver, acquisition, RPM conversion, dependency metadata, and payload-identity blockers recorded in #201, #202, #203, #173, and #204.
- Out of scope: package-name heuristics, trust bypasses, native package-manager fallback, fixture account seeding, install retries, compatibility paths, release/deploy changes, and unrelated #151 fixture work.

## Ownership / Boundary

- Owning subsystems: repository resolution/acquisition and CCS/RPM payload authority.
- Boundary changed or preserved: source-format semantics remain authoritative; repository strategy selects acquisition; signed converted CCS retains native RPM semantics; generic account lookup remains strict.
- Persisted state or public surface impact: no schema change. Remi conversion accepts valid RPM many-to-many mappings and empty-epoch requirements that were previously rejected.
- [x] Checked `docs/modules/feature-ownership.md` through `scripts/agent-context.sh` for the resolution and CCS paths.

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service code
- [x] Updated the owning CCS module and foreign lifecycle contract
- [x] Ran the resolution and conversion interaction gates
- [x] Kept the primary issue open for post-merge deployment and KVM proof

```text
cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test -p conary-core
cargo test -p conary
cargo test -p remi
bash scripts/check-doc-truth.sh
```

Observed results:

- `conary-core`: 3,216 unit tests passed, 0 failed, 2 fixture-gated tests ignored; integration and doc tests passed.
- `conary`: all library, binary, integration, and doc tests passed with 0 failures; the new RPM ownership command tests passed 2/2.
- `remi`: 586 library, 5 binary, and 3 CLI integration tests passed; 0 failures.
- Strict workspace Clippy, formatting, and documentation truth passed.
- Unchanged public Fedora 44 `dbus-broker` dry-run completed: 34 dependencies, no panic, no identity drift.
- Pinned `setup-2.15.0-28.fc44.noarch.rpm` (`sha256:7a850ffbba5b3e8ca93fbfef25f7597bbfa87c8dfc8bc699f869cda85ee7440d`) converted and completed dry-run: 43 payload files, 2 dependencies.
- Public Fedora 44 `systemd-boot-unsigned` completed dry-run against an empty selected root without passwd/group databases: 7 payload files.

Still required after merge/deploy:

- Remi patch release and independent production health/conversion proof.
- Exact #137 Group O TGE02 and Group P TISO01 KVM gates from the deployed fix.

## Review And Merge Notes

- Review focus: typed boundary preservation across SAT identity, repository strategy dispatch, RPM header/primary-metadata parity, and source-specific root identity resolution.
- User or developer impact: ordinary Fedora dependency installs advance through resolution, acquisition, conversion, and pre-mutation payload identity planning.
- Required-check bypass: not used.