### PR TITLE
release(remi): prepare 0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [remi-v0.9.3] - 2026-07-30
+
+### Fixed
+- accept Fedora empty-epoch requirements and valid many-to-many RPM file
+  dependency mappings during on-demand conversion (#173, #203, #205)
+
 ## [remi-v0.9.2] - 2026-07-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4857,7 +4857,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remi"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/apps/remi/Cargo.toml
+++ b/apps/remi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remi"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]


### PR DESCRIPTION
## Primary Issue

Refs #201

Related: #137, #173, #202, #203, #204, #205

Design / Plan / Roadmap: `docs/operations/release-artifact-matrix.md`; release ownership card in `docs/modules/feature-ownership.md`

## Problem And Outcome

Production Remi 0.9.2 predates the Fedora RPM conversion fixes merged through #205. Prepare an immutable Remi 0.9.3 patch release so the exact merged service code can pass release CI, deployment, independent production proof, and the final Fedora boot/export fixture.

After merge, the repository owns Remi version 0.9.3 and an accurate changelog entry. Tagging, deployment, and production/KVM proof remain post-merge gates.

## Changes

- bump the Remi crate and lockfile from 0.9.2 to 0.9.3
- document empty-epoch RPM requirements and valid many-to-many file dependency mappings in the Remi 0.9.3 changelog

## Scope

- In scope: release identity and changelog metadata for the already-merged Remi fixes
- Out of scope: release tag creation, deployment, production verification, and Fedora KVM proof; those occur only after exact-head PR CI and post-merge validation succeed

## Ownership / Boundary

- Owning subsystem: release assembly / Remi packaging
- Boundary changed or preserved: preserves the release workflow as the sole authority for the immutable version/tag/deploy chain
- Persisted state or public surface impact: no schema or runtime behavior change in this PR; the later deployment rebuilds disposable Remi state under the existing hard-cut deployment contract
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed (not applicable: release metadata only)
- [x] Ran affected-package verification directly when touching service or daemon code
- [x] Updated subsystem docs or maps when the "look here first" path changed (not applicable: ownership is unchanged)
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs

```text
- cargo fmt --check
- bash scripts/check-doc-truth.sh
- ./scripts/release.sh remi --dry-run --target remi=0.9.3
- bash scripts/check-release-matrix.sh
- bash scripts/test-release-matrix.sh
- cargo test -p conary-core --example sign_hash
- cargo test -p conary --test release_ccs_manifest
- cargo test -p conary-test container::image
- cargo test -p remi
```

Observed: release-matrix checks and all matrix fixtures passed; `sign_hash` 1/1, CCS manifest 1/1, container image tests 7/7, Remi library 586/586, Remi binary 5/5, CLI help 3/3, and doc tests passed (2 ignored examples).

## Review And Merge Notes

- Review focus: exact version identity, release-note scope, and preservation of the tag-after-post-merge-validation gate
- User or developer impact: enables the fixed Remi service to be released and deployed before final Fedora KVM validation
- Required-check bypass: not used