### PR TITLE
fix(generation): retain deferred IMA signatures

### DIFF
--- a/apps/conary/src/commands/generation/selected_root.rs
+++ b/apps/conary/src/commands/generation/selected_root.rs
@@ -2,6 +2,8 @@
 
 //! Rollback-safe writable roots for generation-aware transaction execution.
 
+mod deferred_ima;
+
 use crate::commands::{LiveRootFile, LiveRootStats, LiveRootTransaction};
 use anyhow::{Context, Result, bail};
 use conary_core::db::models::GenerationPublication;
@@ -15,6 +17,8 @@ use conary_core::transaction::{TransactionConfig, TransactionEngine};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use deferred_ima::DeferredImaAuthority;
+
 /// One isolated selected-root view backed by a single filesystem journal.
 ///
 /// The caller retains its SQLite transaction. This session never changes the
@@ -25,6 +29,7 @@ pub(crate) struct SelectedRootSession {
     selected_root: PathBuf,
     transaction: Option<LiveRootTransaction>,
     transaction_engine: TransactionEngine,
+    deferred_ima: DeferredImaAuthority,
 }
 
 impl SelectedRootSession {
@@ -88,10 +93,20 @@ impl SelectedRootSession {
                 selected_root.display()
             )
         })?;
-        if let Err(error) = materialize_current_root(conn, runtime_root, &selected_root) {
-            let _ = fs::remove_dir_all(&session_dir);
-            return Err(error);
-        }
+        let materialized = match materialize_current_root(conn, runtime_root, &selected_root) {
+            Ok(materialized) => materialized,
+            Err(error) => {
+                let _ = fs::remove_dir_all(&session_dir);
+                return Err(error);
+            }
+        };
+        let deferred_ima = match DeferredImaAuthority::from_captured(&materialized) {
+            Ok(authority) => authority,
+            Err(error) => {
+                let _ = fs::remove_dir_all(&session_dir);
+                return Err(error);
+            }
+        };
         let transaction =
             LiveRootTransaction::begin(runtime_root.root(), &selected_root, session_id, operation)?;
         Ok(Self {
@@ -99,6 +114,7 @@ impl SelectedRootSession {
             selected_root,
             transaction: Some(transaction),
             transaction_engine,
+            deferred_ima,
         })
     }
 
@@ -115,16 +131,21 @@ impl SelectedRootSession {
     /// Rollback persists this manifest with the changeset. Rebuilding from package
     /// rows alone would lose exact parent-directory and lifecycle-created state.
     pub(crate) fn capture_rollback_authority(&self) -> Result<CapturedSelectedRoot> {
-        scan_selected_root(&self.selected_root, self.transaction_engine.cas()).map_err(Into::into)
+        let mut captured = scan_selected_root(&self.selected_root, self.transaction_engine.cas())?;
+        self.deferred_ima.restore_into(&mut captured)?;
+        Ok(captured)
     }
 
     pub(crate) fn apply_install_files(&mut self, files: &[LiveRootFile]) -> Result<()> {
         self.transaction_mut()?.apply_install_files(files)?;
+        self.deferred_ima.record_overlay(files)?;
         Ok(())
     }
 
     pub(crate) fn apply_remove_paths(&mut self, paths: &[String]) -> Result<LiveRootStats> {
-        self.transaction_mut()?.apply_remove_paths(paths)
+        let stats = self.transaction_mut()?.apply_remove_paths(paths)?;
+        self.deferred_ima.remove_paths(paths);
+        Ok(stats)
     }
 
     /// Commit and capture the exact selected root while retaining its writable
@@ -138,7 +159,8 @@ impl SelectedRootSession {
             .context("selected-root transaction already completed")?
             .commit()?;
         let cas = CasStore::new(runtime_root.objects_dir())?;
-        let captured = scan_selected_root(&self.selected_root, &cas)?;
+        let mut captured = scan_selected_root(&self.selected_root, &cas)?;
+        self.deferred_ima.restore_into(&mut captured)?;
         Ok((self.selected_root.clone(), captured))
     }
 
@@ -158,7 +180,8 @@ impl SelectedRootSession {
                 .context("selected-root transaction already completed")?
                 .commit()?;
             let cas = CasStore::new(runtime_root.objects_dir())?;
-            let captured = scan_selected_root(&self.selected_root, &cas)?;
+            let mut captured = scan_selected_root(&self.selected_root, &cas)?;
+            self.deferred_ima.restore_into(&mut captured)?;
             persist_publication_candidate(runtime_root, debt, &self.session_dir, &captured)?;
             Ok(captured)
         })();
@@ -194,11 +217,11 @@ fn materialize_current_root(
     conn: &rusqlite::Connection,
     runtime_root: &ConaryRuntimeRoot,
     selected_root: &Path,
-) -> Result<()> {
+) -> Result<CapturedSelectedRoot> {
     let cas = CasStore::new(runtime_root.objects_dir())?;
     if let Some(candidate) = latest_selected_root_candidate(conn, runtime_root)? {
-        return materialize_captured_selected_root(&candidate, &cas, selected_root)
-            .map_err(Into::into);
+        materialize_captured_selected_root(&candidate, &cas, selected_root)?;
+        return Ok(candidate);
     }
 
     if let Some(generation) =
@@ -207,18 +230,15 @@ fn materialize_current_root(
         let artifact = conary_core::generation::artifact::load_generation_artifact(
             &runtime_root.generation_path(generation),
         )?;
-        return materialize_captured_selected_root(
-            &CapturedSelectedRoot {
-                generation: artifact.generation_root,
-                state: artifact.mutable_state,
-            },
-            &cas,
-            selected_root,
-        )
-        .map_err(Into::into);
+        let captured = CapturedSelectedRoot {
+            generation: artifact.generation_root,
+            state: artifact.mutable_state,
+        };
+        materialize_captured_selected_root(&captured, &cas, selected_root)?;
+        return Ok(captured);
     }
 
-    conary_core::generation::builder::materialize_selected_root_from_db(
+    conary_core::generation::builder::materialize_selected_root_from_db_with_authority(
         conn,
         &runtime_root.objects_dir(),
         selected_root,

--- a/apps/conary/src/commands/generation/selected_root/deferred_ima.rs
+++ b/apps/conary/src/commands/generation/selected_root/deferred_ima.rs
@@ -1,0 +1,365 @@
+// apps/conary/src/commands/generation/selected_root/deferred_ima.rs
+
+//! Typed carry-through for IMA signatures unavailable on staging filesystems.
+
+use crate::commands::LiveRootFile;
+use anyhow::{Context, Result, bail};
+use conary_core::generation::root_manifest::{CapturedSelectedRoot, GenerationRootEntry};
+use conary_core::payload::{PayloadContentAuthority, PayloadNodeKind};
+use std::collections::BTreeMap;
+
+const SECURITY_IMA_XATTR: &str = "security.ima";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DeferredImaSignature {
+    value: Vec<u8>,
+    content: PayloadContentAuthority,
+}
+
+/// IMA signatures remain typed package and generation authority when an
+/// intermediate selected-root filesystem cannot apply `security.ima`.
+///
+/// The signature is restored into a captured manifest only when the selected
+/// root still has the exact signed content digest and size. Lifecycle writes
+/// therefore invalidate deferred signatures without relying on path or
+/// package-name heuristics.
+#[derive(Debug, Default)]
+pub(super) struct DeferredImaAuthority {
+    signatures: BTreeMap<String, DeferredImaSignature>,
+    content_by_path: BTreeMap<String, PayloadContentAuthority>,
+}
+
+impl DeferredImaAuthority {
+    pub(super) fn from_captured(captured: &CapturedSelectedRoot) -> Result<Self> {
+        captured.generation.validate()?;
+        captured.state.validate()?;
+        let entries = captured
+            .generation
+            .entries
+            .iter()
+            .chain(&captured.state.entries)
+            .collect::<Vec<_>>();
+        let mut authority = Self::default();
+        authority.record_entries(entries)?;
+        Ok(authority)
+    }
+
+    pub(super) fn record_overlay(&mut self, files: &[LiveRootFile]) -> Result<()> {
+        let entries = files
+            .iter()
+            .map(|file| GenerationRootEntry {
+                path: file.path.clone(),
+                node: file.node.clone(),
+                content: file.content.authority().cloned(),
+            })
+            .collect::<Vec<_>>();
+        self.record_entries(entries.iter().collect())
+    }
+
+    pub(super) fn remove_paths(&mut self, paths: &[String]) {
+        for path in paths {
+            remove_path_and_descendants(&mut self.signatures, path);
+            remove_path_and_descendants(&mut self.content_by_path, path);
+        }
+    }
+
+    pub(super) fn restore_into(&self, captured: &mut CapturedSelectedRoot) -> Result<usize> {
+        captured.generation.validate()?;
+        captured.state.validate()?;
+        let actual_content = content_by_path(
+            captured
+                .generation
+                .entries
+                .iter()
+                .chain(&captured.state.entries),
+        )?;
+        let mut restored = 0;
+        for entry in captured
+            .generation
+            .entries
+            .iter_mut()
+            .chain(&mut captured.state.entries)
+        {
+            let Some(signature) = self.signatures.get(&entry.path) else {
+                continue;
+            };
+            if actual_content.get(&entry.path) != Some(&signature.content)
+                || entry.node.source.xattrs.contains_key(SECURITY_IMA_XATTR)
+            {
+                continue;
+            }
+            entry
+                .node
+                .source
+                .xattrs
+                .insert(SECURITY_IMA_XATTR.to_string(), signature.value.clone());
+            restored += 1;
+        }
+        captured.generation.validate()?;
+        captured.state.validate()?;
+        Ok(restored)
+    }
+
+    fn record_entries(&mut self, entries: Vec<&GenerationRootEntry>) -> Result<()> {
+        for entry in &entries {
+            self.signatures.remove(&entry.path);
+            self.content_by_path.remove(&entry.path);
+        }
+
+        for entry in &entries {
+            if matches!(entry.node.source.kind, PayloadNodeKind::Regular { .. }) {
+                let content = entry.content.clone().with_context(|| {
+                    format!(
+                        "deferred IMA regular path {} has no content authority",
+                        entry.path
+                    )
+                })?;
+                self.content_by_path.insert(entry.path.clone(), content);
+            }
+        }
+        for entry in &entries {
+            if let PayloadNodeKind::Hardlink { target, .. } = &entry.node.source.kind {
+                let content = self.content_by_path.get(target).cloned().with_context(|| {
+                    format!(
+                        "deferred IMA hardlink {} targets unavailable content {target}",
+                        entry.path
+                    )
+                })?;
+                self.content_by_path.insert(entry.path.clone(), content);
+            }
+        }
+
+        for entry in entries {
+            let Some(value) = entry.node.source.xattrs.get(SECURITY_IMA_XATTR) else {
+                continue;
+            };
+            let content = self
+                .content_by_path
+                .get(&entry.path)
+                .cloned()
+                .with_context(|| {
+                    format!(
+                        "security.ima authority at {} is not attached to regular content",
+                        entry.path
+                    )
+                })?;
+            if value.is_empty() {
+                bail!("security.ima authority at {} is empty", entry.path);
+            }
+            self.signatures.insert(
+                entry.path.clone(),
+                DeferredImaSignature {
+                    value: value.clone(),
+                    content,
+                },
+            );
+        }
+        Ok(())
+    }
+}
+
+fn content_by_path<'a>(
+    entries: impl Iterator<Item = &'a GenerationRootEntry>,
+) -> Result<BTreeMap<String, PayloadContentAuthority>> {
+    let entries = entries.collect::<Vec<_>>();
+    let mut content = BTreeMap::new();
+    for entry in &entries {
+        if matches!(entry.node.source.kind, PayloadNodeKind::Regular { .. }) {
+            content.insert(
+                entry.path.clone(),
+                entry.content.clone().with_context(|| {
+                    format!(
+                        "captured regular path {} has no content authority",
+                        entry.path
+                    )
+                })?,
+            );
+        }
+    }
+    for entry in entries {
+        if let PayloadNodeKind::Hardlink { target, .. } = &entry.node.source.kind {
+            let target_content = content.get(target).cloned().with_context(|| {
+                format!(
+                    "captured hardlink {} targets unavailable content {target}",
+                    entry.path
+                )
+            })?;
+            content.insert(entry.path.clone(), target_content);
+        }
+    }
+    Ok(content)
+}
+
+fn remove_path_and_descendants<T>(map: &mut BTreeMap<String, T>, path: &str) {
+    let descendant_prefix = format!("{}/", path.trim_end_matches('/'));
+    map.retain(|candidate, _| candidate != path && !candidate.starts_with(&descendant_prefix));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use conary_core::generation::root_manifest::{
+        GENERATION_ROOT_MANIFEST_VERSION, GenerationRootManifest, MutableStateManifest,
+    };
+    use conary_core::hash::sha256;
+    use conary_core::payload::{PayloadIdentity, PayloadNode, ResolvedPayloadNode};
+
+    #[test]
+    fn exact_content_restores_deferred_ima_into_captured_authority() {
+        let source = signed_root(b"signed");
+        let authority = DeferredImaAuthority::from_captured(&source).unwrap();
+        let mut captured = source.clone();
+        file_mut(&mut captured)
+            .node
+            .source
+            .xattrs
+            .remove(SECURITY_IMA_XATTR);
+
+        assert_eq!(authority.restore_into(&mut captured).unwrap(), 1);
+        assert_eq!(captured, source);
+    }
+
+    #[test]
+    fn changed_content_invalidates_deferred_ima() {
+        let source = signed_root(b"signed");
+        let authority = DeferredImaAuthority::from_captured(&source).unwrap();
+        let mut captured = source.clone();
+        let file = file_mut(&mut captured);
+        file.node.source.xattrs.remove(SECURITY_IMA_XATTR);
+        file.content = Some(content(b"changed"));
+
+        assert_eq!(authority.restore_into(&mut captured).unwrap(), 0);
+        assert!(
+            !file_ref(&captured)
+                .node
+                .source
+                .xattrs
+                .contains_key(SECURITY_IMA_XATTR)
+        );
+    }
+
+    #[test]
+    fn unsigned_overlay_replaces_prior_signature_authority() {
+        let source = signed_root(b"signed");
+        let mut authority = DeferredImaAuthority::from_captured(&source).unwrap();
+        let unsigned = LiveRootFile {
+            path: "/usr/bin/tool".to_string(),
+            content: crate::commands::LiveRootContent::from_in_memory_bytes(b"signed"),
+            node: regular_node(BTreeMap::new()),
+        };
+        authority.record_overlay(&[unsigned]).unwrap();
+        let mut captured = source;
+        file_mut(&mut captured)
+            .node
+            .source
+            .xattrs
+            .remove(SECURITY_IMA_XATTR);
+
+        assert_eq!(authority.restore_into(&mut captured).unwrap(), 0);
+    }
+
+    #[test]
+    fn hardlink_group_restores_one_signed_content_authority() {
+        let mut source = signed_root(b"signed");
+        let primary = file_mut(&mut source);
+        primary.node.source.kind = PayloadNodeKind::Regular {
+            hardlink_identity: Some("signed-inode".to_string()),
+        };
+        let mut linked_node = primary.node.clone();
+        linked_node.source.kind = PayloadNodeKind::Hardlink {
+            target: "/usr/bin/tool".to_string(),
+            identity: "signed-inode".to_string(),
+        };
+        source.generation.entries.push(GenerationRootEntry {
+            path: "/usr/bin/tool-link".to_string(),
+            node: linked_node,
+            content: None,
+        });
+        source.generation.validate().unwrap();
+
+        let authority = DeferredImaAuthority::from_captured(&source).unwrap();
+        let mut captured = source.clone();
+        for entry in captured
+            .generation
+            .entries
+            .iter_mut()
+            .filter(|entry| entry.path.starts_with("/usr/bin/tool"))
+        {
+            entry.node.source.xattrs.remove(SECURITY_IMA_XATTR);
+        }
+
+        assert_eq!(authority.restore_into(&mut captured).unwrap(), 2);
+        assert_eq!(captured, source);
+    }
+
+    fn signed_root(bytes: &[u8]) -> CapturedSelectedRoot {
+        let mut xattrs = BTreeMap::new();
+        xattrs.insert(SECURITY_IMA_XATTR.to_string(), b"signature".to_vec());
+        CapturedSelectedRoot {
+            generation: GenerationRootManifest {
+                version: GENERATION_ROOT_MANIFEST_VERSION,
+                root: directory_node(),
+                entries: vec![
+                    directory_entry("/usr"),
+                    directory_entry("/usr/bin"),
+                    GenerationRootEntry {
+                        path: "/usr/bin/tool".to_string(),
+                        node: regular_node(xattrs),
+                        content: Some(content(bytes)),
+                    },
+                ],
+            },
+            state: MutableStateManifest::empty(),
+        }
+    }
+
+    fn file_ref(captured: &CapturedSelectedRoot) -> &GenerationRootEntry {
+        captured
+            .generation
+            .entries
+            .iter()
+            .find(|entry| entry.path == "/usr/bin/tool")
+            .unwrap()
+    }
+
+    fn file_mut(captured: &mut CapturedSelectedRoot) -> &mut GenerationRootEntry {
+        captured
+            .generation
+            .entries
+            .iter_mut()
+            .find(|entry| entry.path == "/usr/bin/tool")
+            .unwrap()
+    }
+
+    fn directory_entry(path: &str) -> GenerationRootEntry {
+        GenerationRootEntry {
+            path: path.to_string(),
+            node: directory_node(),
+            content: None,
+        }
+    }
+
+    fn directory_node() -> conary_core::payload::ResolvedPayloadNode {
+        let mut node = PayloadNode::regular(0o755);
+        node.kind = PayloadNodeKind::Directory;
+        node.mode = libc::S_IFDIR | 0o755;
+        ResolvedPayloadNode::from_numeric_source(node).unwrap()
+    }
+
+    fn regular_node(
+        xattrs: BTreeMap<String, Vec<u8>>,
+    ) -> conary_core::payload::ResolvedPayloadNode {
+        let mut node = PayloadNode::regular(0o755);
+        node.user = PayloadIdentity::Numeric { id: 0 };
+        node.group = PayloadIdentity::Numeric { id: 0 };
+        node.xattrs = xattrs;
+        ResolvedPayloadNode::from_numeric_source(node).unwrap()
+    }
+
+    fn content(bytes: &[u8]) -> PayloadContentAuthority {
+        PayloadContentAuthority {
+            sha256: sha256(bytes),
+            size: bytes.len() as u64,
+        }
+    }
+}

--- a/crates/conary-core/src/generation/builder.rs
+++ b/crates/conary-core/src/generation/builder.rs
@@ -26,6 +26,7 @@ pub use create::{
     build_generation_from_captured_root_with_boot_root_and_activation, build_generation_from_db,
     build_generation_from_db_with_activation, build_generation_from_db_with_boot_root,
     build_generation_from_db_with_boot_root_and_activation, materialize_selected_root_from_db,
+    materialize_selected_root_from_db_with_authority,
 };
 pub(crate) use rebuild::rebuild_generation_image;
 

--- a/crates/conary-core/src/generation/builder/create.rs
+++ b/crates/conary-core/src/generation/builder/create.rs
@@ -40,19 +40,31 @@ pub fn materialize_selected_root_from_db(
     objects_dir: &Path,
     selected_root: &Path,
 ) -> crate::Result<()> {
+    materialize_selected_root_from_db_with_authority(conn, objects_dir, selected_root).map(drop)
+}
+
+/// Bootstrap a writable selected root and return the exact typed authority
+/// used for materialization.
+///
+/// The returned manifests let staging callers retain metadata that the
+/// selected-root filesystem cannot represent without making package rows a
+/// second publication authority.
+pub fn materialize_selected_root_from_db_with_authority(
+    conn: &rusqlite::Connection,
+    objects_dir: &Path,
+    selected_root: &Path,
+) -> crate::Result<CapturedSelectedRoot> {
     let troves = Trove::list_all(conn)?;
     let all_files = FileEntry::find_all_ordered(conn)?;
     let runtime_inputs =
         runtime_inputs::collect_runtime_generation_inputs(conn, &troves, all_files, selected_root)?;
     let cas = CasStore::new(objects_dir)?;
-    materialize_captured_selected_root(
-        &CapturedSelectedRoot {
-            generation: runtime_inputs.generation,
-            state: runtime_inputs.state,
-        },
-        &cas,
-        selected_root,
-    )
+    let captured = CapturedSelectedRoot {
+        generation: runtime_inputs.generation,
+        state: runtime_inputs.state,
+    };
+    materialize_captured_selected_root(&captured, &cas, selected_root)?;
+    Ok(captured)
 }
 
 /// Build a complete generation from the current database state.

--- a/crates/conary-core/src/generation/root_manifest/materialize.rs
+++ b/crates/conary-core/src/generation/root_manifest/materialize.rs
@@ -11,7 +11,7 @@ use crate::payload::{PayloadNodeKind, ResolvedPayloadNode};
 use std::collections::BTreeSet;
 use std::ffi::CString;
 use std::fs::{self, OpenOptions};
-use std::io::Write;
+use std::io::{self, Write};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::os::unix::net::UnixListener;
@@ -453,7 +453,11 @@ fn replace_xattrs(
         let c_name = CString::new(name.as_bytes()).expect("validated xattr name");
         let result = unsafe { libc::lremovexattr(c_path.as_ptr(), c_name.as_ptr()) };
         if result != 0 {
-            return Err(xattr_error(&format!("remove {name}"), path));
+            return Err(xattr_error(
+                &format!("remove {name}"),
+                path,
+                io::Error::last_os_error(),
+            ));
         }
     }
     for (name, value) in expected {
@@ -470,16 +474,37 @@ fn replace_xattrs(
             )
         };
         if result != 0 {
-            return Err(xattr_error(&format!("set {name}"), path));
+            let error = io::Error::last_os_error();
+            // Pinned RPM treats these two IMA application outcomes as a
+            // staging limitation, not a package failure. The typed payload
+            // node remains authority; selected-root capture carries the
+            // signature forward only while its content digest is unchanged.
+            let real_uid = unsafe { libc::getuid() };
+            if ima_staging_error_is_non_fatal(name, error.raw_os_error(), real_uid) {
+                continue;
+            }
+            return Err(xattr_error(&format!("set {name}"), path, error));
         }
     }
     Ok(())
 }
 
+const SECURITY_IMA_XATTR: &str = "security.ima";
+
+fn ima_staging_error_is_non_fatal(
+    name: &str,
+    raw_os_error: Option<i32>,
+    real_uid: libc::uid_t,
+) -> bool {
+    name == SECURITY_IMA_XATTR
+        && (raw_os_error == Some(libc::EOPNOTSUPP)
+            || (raw_os_error == Some(libc::EPERM) && real_uid == 0))
+}
+
 fn list_xattr_names(c_path: &CString, path: &Path) -> crate::Result<Vec<String>> {
     let length = unsafe { libc::llistxattr(c_path.as_ptr(), std::ptr::null_mut(), 0) };
     if length < 0 {
-        return Err(xattr_error("list", path));
+        return Err(xattr_error("list", path, io::Error::last_os_error()));
     }
     let length = usize::try_from(length).map_err(|_| {
         crate::Error::InvalidPath(format!(
@@ -497,7 +522,7 @@ fn list_xattr_names(c_path: &CString, path: &Path) -> crate::Result<Vec<String>>
             )
         };
         if actual < 0 {
-            return Err(xattr_error("list", path));
+            return Err(xattr_error("list", path, io::Error::last_os_error()));
         }
         bytes.truncate(usize::try_from(actual).map_err(|_| {
             crate::Error::InvalidPath(format!(
@@ -577,10 +602,37 @@ fn sync_directory(path: &Path) -> crate::Result<()> {
     Ok(())
 }
 
-fn xattr_error(operation: &str, path: &Path) -> crate::Error {
+fn xattr_error(operation: &str, path: &Path, error: io::Error) -> crate::Error {
     crate::Error::IoError(format!(
         "failed to {operation} xattrs for {}: {}",
         path.display(),
-        std::io::Error::last_os_error()
+        error
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SECURITY_IMA_XATTR, ima_staging_error_is_non_fatal};
+
+    #[test]
+    fn ima_staging_error_policy_matches_pinned_rpm_contract() {
+        let cases = [
+            (SECURITY_IMA_XATTR, libc::EOPNOTSUPP, 0, true),
+            (SECURITY_IMA_XATTR, libc::EOPNOTSUPP, 1000, true),
+            (SECURITY_IMA_XATTR, libc::EPERM, 0, true),
+            (SECURITY_IMA_XATTR, libc::EPERM, 1000, false),
+            (SECURITY_IMA_XATTR, libc::EACCES, 0, false),
+            ("security.capability", libc::EOPNOTSUPP, 0, false),
+            ("security.capability", libc::EPERM, 0, false),
+        ];
+
+        for (name, errno, real_uid, expected) in cases {
+            assert_eq!(
+                ima_staging_error_is_non_fatal(name, Some(errno), real_uid),
+                expected,
+                "name={name} errno={errno} real_uid={real_uid}"
+            );
+        }
+        assert!(!ima_staging_error_is_non_fatal(SECURITY_IMA_XATTR, None, 0));
+    }
 }

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -387,6 +387,15 @@ regular-file content authority all survive. Immutable content and mutable
 state reference the same SHA-256 CAS used by package payloads. Generation,
 retry, bootstrap EROFS, and try-session materialization consume those typed
 manifests rather than reconstructing lifecycle effects from package rows.
+RPM IMA signatures remain typed `security.ima` payload authority across that
+staging boundary. Matching pinned RPM
+[`plugins/ima.c`](https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/plugins/ima.c#L60-L76),
+`EOPNOTSUPP`, or `EPERM` for real UID zero, is non-fatal only when applying
+that exact xattr; every other xattr/error pair remains fatal. A selected-root
+filesystem that cannot apply the signature does not erase it: capture restores
+the deferred value only while the regular-file SHA-256 and size are unchanged,
+so a lifecycle content mutation invalidates the signature before generation
+serialization.
 Generation-local config projection removes exactly one `/etc` prefix when it
 materializes the overlay upper; `/var` and `/srv` entries cannot enter that
 upper. Boot-carrier export copies both manifests, reconstructs `/var` and


### PR DESCRIPTION
## Primary Issue

Refs #207

Design / Plan / Roadmap: [Foreign package lifecycle contracts](https://github.com/ConaryLabs/Conary/blob/main/docs/specs/foreign-package-lifecycle-contracts.md)

## Problem And Outcome

Fedora's signed `systemd-boot-unsigned` payload reaches selected-root staging with valid `security.ima` authority, but Linux returns `EPERM` when mapped root tries to apply the xattr. Conary treated that expected pinned-RPM outcome as fatal. Simply ignoring the syscall would also lose the signature when the selected root was scanned for generation publication.

After this PR, the syscall boundary matches pinned RPM: `EOPNOTSUPP`, plus `EPERM` for real UID zero, is non-fatal only for `security.ima`. The signature remains typed authority across selected-root capture only while the exact regular-file SHA-256 and size remain unchanged; lifecycle content mutations invalidate it.

## Changes

- Encode the complete pinned-RPM IMA staging error decision table.
- Carry unavailable IMA signatures across selected-root materialization, rollback capture, try capture, and publication capture.
- Reconcile hardlink signatures through their single exact content authority.
- Return initial database-projected typed authority without making package rows a second publication owner.
- Document the durable staging and invalidation contract.

## Scope

- In scope: `security.ima` staging outcomes and typed selected-root carry-through.
- Out of scope: other xattrs, non-root `EPERM`, and unrelated source-format lifecycle behavior.

## Ownership / Boundary

- Owning subsystem: Generation Build, Switch, Recovery, And Export
- Boundary changed or preserved: preserves selected-root manifests as publication authority when the staging filesystem cannot represent one exact xattr.
- Persisted state or public surface impact: no schema or manifest-version change; existing typed xattr fields retain their authority. The owning lifecycle contract is updated.
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code
- [x] Updated subsystem docs or maps when the "look here first" path changed
- [ ] Ran the broader interaction gate when the feature ownership card required it — exact TGE02 is intentionally run after this fix is merged into PR #151
- [x] Updated the primary issue with any acceptance criteria left for later PRs

```text
- cargo fmt --all -- --check
- cargo clippy -p conary-core -p conary --all-targets -- -D warnings
- cargo test -p conary-core generation::root_manifest
- cargo test -p conary --lib commands::generation::selected_root
- bash scripts/agent-context.sh --feature generation --run focused
  - all 17 focused commands passed
- cargo test -p conary-core --quiet
  - 3,217 passed; 2 ignored
- bash scripts/check-doc-truth.sh
- mapped-root install of the signed Fedora 44 systemd-boot-unsigned CCS
  - install committed all 7 package entries
  - publication candidate retained 6 signed regular-file security.ima values
  - generation publication then stopped at the expected independent scratch-root /sbin/init guard
- cargo test -p conary --quiet
  - not completed locally: compiling all integration-test binaries exhausted the shared Cargo incremental cache
  - the recoverable incremental cache was removed; exact PR CI remains required
```

## Review And Merge Notes

- Review focus: content-identity invalidation, hardlink handling, and the exact RPM errno/real-UID boundary.
- User or developer impact: Fedora packages carrying IMA signatures no longer fail selected-root staging under mapped root, without weakening other metadata errors.
- Required-check bypass: not used
