### PR TITLE
fix(generation): preserve ambient SELinux labels

### DIFF
--- a/crates/conary-core/src/generation/root_manifest/materialize.rs
+++ b/crates/conary-core/src/generation/root_manifest/materialize.rs
@@ -382,11 +382,13 @@ fn create_fifo(path: &Path) -> crate::Result<()> {
     }
 }
 
-/// Restore the complete metadata authority of one already-created payload node.
+/// Restore the complete payload-owned metadata of one already-created node.
 ///
 /// This is shared by immutable generation reconstruction and journaled
 /// mutable-root application so the two paths cannot drift on ownership,
-/// permissions, timestamps, or xattrs.
+/// permissions, timestamps, or xattrs. An undeclared `security.selinux`
+/// attribute is target LSM authority assigned at node creation and is
+/// preserved; a declared value remains exact payload authority.
 pub fn apply_resolved_payload_metadata(
     path: &Path,
     node: &ResolvedPayloadNode,
@@ -448,7 +450,7 @@ fn replace_xattrs(
     let expected_names = expected.keys().map(String::as_str).collect::<BTreeSet<_>>();
     for name in existing
         .iter()
-        .filter(|name| !expected_names.contains(name.as_str()))
+        .filter(|name| existing_xattr_requires_removal(name, &expected_names))
     {
         let c_name = CString::new(name.as_bytes()).expect("validated xattr name");
         let result = unsafe { libc::lremovexattr(c_path.as_ptr(), c_name.as_ptr()) };
@@ -490,6 +492,11 @@ fn replace_xattrs(
 }
 
 const SECURITY_IMA_XATTR: &str = "security.ima";
+const SECURITY_SELINUX_XATTR: &str = "security.selinux";
+
+fn existing_xattr_requires_removal(name: &str, expected_names: &BTreeSet<&str>) -> bool {
+    !expected_names.contains(name) && name != SECURITY_SELINUX_XATTR
+}
 
 fn ima_staging_error_is_non_fatal(
     name: &str,
@@ -612,7 +619,11 @@ fn xattr_error(operation: &str, path: &Path, error: io::Error) -> crate::Error {
 
 #[cfg(test)]
 mod tests {
-    use super::{SECURITY_IMA_XATTR, ima_staging_error_is_non_fatal};
+    use super::{
+        SECURITY_IMA_XATTR, SECURITY_SELINUX_XATTR, existing_xattr_requires_removal,
+        ima_staging_error_is_non_fatal, replace_xattrs,
+    };
+    use std::collections::{BTreeMap, BTreeSet};
 
     #[test]
     fn ima_staging_error_policy_matches_pinned_rpm_contract() {
@@ -634,5 +645,48 @@ mod tests {
             );
         }
         assert!(!ima_staging_error_is_non_fatal(SECURITY_IMA_XATTR, None, 0));
+    }
+
+    #[test]
+    fn undeclared_selinux_label_is_ambient_target_authority() {
+        let no_declared_xattrs = BTreeSet::new();
+        assert!(!existing_xattr_requires_removal(
+            SECURITY_SELINUX_XATTR,
+            &no_declared_xattrs
+        ));
+
+        let declared_xattrs = BTreeSet::from([SECURITY_SELINUX_XATTR]);
+        assert!(!existing_xattr_requires_removal(
+            SECURITY_SELINUX_XATTR,
+            &declared_xattrs
+        ));
+
+        for name in ["security.capability", SECURITY_IMA_XATTR, "user.demo"] {
+            assert!(
+                existing_xattr_requires_removal(name, &no_declared_xattrs),
+                "{name} must not gain the SELinux ambient-authority exception"
+            );
+        }
+    }
+
+    #[test]
+    fn replacement_removes_other_undeclared_xattrs_and_sets_declared_values() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let path = temp.path().join("payload");
+        std::fs::write(&path, b"payload").expect("create payload");
+        xattr::set(&path, "user.remove-me", b"stale").expect("set stale xattr");
+        xattr::set(&path, "user.keep-me", b"old").expect("set declared xattr");
+
+        let expected = BTreeMap::from([("user.keep-me".to_string(), b"exact".to_vec())]);
+        replace_xattrs(&path, &expected).expect("replace xattrs");
+
+        assert_eq!(
+            xattr::get(&path, "user.remove-me").expect("read stale xattr"),
+            None
+        );
+        assert_eq!(
+            xattr::get(&path, "user.keep-me").expect("read declared xattr"),
+            Some(b"exact".to_vec())
+        );
     }
 }

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -396,6 +396,13 @@ filesystem that cannot apply the signature does not erase it: capture restores
 the deferred value only while the regular-file SHA-256 and size are unchanged,
 so a lifecycle content mutation invalidates the signature before generation
 serialization.
+Payload metadata application also distinguishes package-declared xattrs from
+the target LSM label assigned when a staging node is created. An undeclared
+`security.selinux` value is preserved as ambient target authority and becomes
+part of selected-root capture; when the payload declares `security.selinux`,
+that exact opaque value is applied instead. This is not a general
+`security.*` exception: every other undeclared xattr is removed, and a removal
+failure remains fatal.
 Generation-local config projection removes exactly one `/etc` prefix when it
 materializes the overlay upper; `/var` and `/srv` entries cannot enter that
 upper. Boot-carrier export copies both manifests, reconstructs `/var` and


### PR DESCRIPTION
## Primary Issue

Closes #210

Design / Plan / Roadmap: Unblocks #137 and PR #151.

## Problem And Outcome

On an SELinux-enforcing target, newly created staging nodes receive an ambient `security.selinux` xattr. The shared metadata replacement path treated that target-owned label as stale package metadata and tried to remove it; SELinux returned `EACCES`, collapsing ordinary package installation and the supported-host generation fixture.

After merge, an undeclared `security.selinux` label remains target/LSM authority. A payload that explicitly declares the label still replaces it exactly, while every other undeclared xattr retains the existing remove-or-fail behavior.

## Changes

- preserve only an undeclared `security.selinux` xattr during shared payload metadata replacement
- add contract coverage for the SELinux boundary and for exact replacement/removal of all other xattrs
- document the package-vs-target xattr authority boundary in the lifecycle specification

## Scope

- In scope: shared generation/live-root payload metadata application and its durable xattr contract
- Out of scope: SELinux policy synthesis, restorecon heuristics, general `security.*` exceptions, and the separate container-build diagnostics issue #209

## Ownership / Boundary

- Owning subsystem: Generation Build, Switch, Recovery, And Export
- Boundary changed or preserved: preserves the one shared metadata application owner while separating typed payload authority from the target LSM label assigned at node creation
- Persisted state or public surface impact: no schema or artifact-format change; selected-root capture records the preserved target label as existing typed xattr authority
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code (not applicable; neither service nor daemon changed)
- [x] Updated subsystem docs or maps when the "look here first" path changed (not applicable; routing did not change)
- [ ] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs

```text
- cargo fmt --check
- cargo test -p conary-core generation::root_manifest::materialize::tests
- cargo test -p conary-core --lib generation::root_manifest
- cargo test -p conary-core generation::export
- cargo test -p conary-core generation::builder
- cargo test -p conary-core --lib ccs::hooks::capabilities
- cargo clippy -p conary-core --all-targets -- -D warnings
- bash scripts/check-doc-truth.sh

Pending exact-head interaction proof:
- CONARY_HOST_BIN=<exact static branch binary> cargo run -p conary-test -- run --suite <TGE02-only manifest> --distro fedora44 --phase 3
- cargo run -p conary-test -- run --suite phase3-group-o-generation-export --distro fedora44 --phase 3
- cargo run -p conary-test -- run --suite phase3-group-p-iso-export --distro fedora44 --phase 3
```

## Review And Merge Notes

- Review focus: the exception is exact to undeclared `security.selinux`; explicit labels and all other unexpected xattrs remain authoritative/fatal as before
- User or developer impact: ordinary converted package installation can stage onto SELinux-enforcing target filesystems
- Required-check bypass: not used