### PR TITLE
fix(rpm): execute sysusers through target interface

### DIFF
--- a/apps/conary/src/commands/install/native_events.rs
+++ b/apps/conary/src/commands/install/native_events.rs
@@ -172,10 +172,6 @@ impl PreparedNativeTransaction {
             .iter()
             .any(|input| input.version_scheme == VersionScheme::Arch)
             || relation_removal_has_arch;
-        let host_capabilities = arch_transaction
-            .then(|| conary_core::ccs::HostCapabilityInventory::load_required(conn))
-            .transpose()
-            .context("Arch transaction host capability preflight failed")?;
         let input_old_trove_ids = inputs
             .iter()
             .map(|input| {
@@ -532,6 +528,7 @@ impl PreparedNativeTransaction {
             deb_change_indices,
         };
         let plan = plan_native_transaction(&views, &changes, &transaction_state)?;
+        let host_capabilities = host_capabilities_for_plan(conn, arch_transaction, &plan)?;
         let path_projection =
             NativePathProjection::from_transaction(&plan, &changes, &installed_paths_after)?;
         Ok(Self {
@@ -661,11 +658,6 @@ impl PreparedNativeTransaction {
             });
         }
 
-        let host_capabilities = arch_transaction
-            .then(|| conary_core::ccs::HostCapabilityInventory::load_required(conn))
-            .transpose()
-            .context("Arch removal host capability preflight failed")?;
-
         let mut owners = Vec::new();
         let installed_bundles = InstalledNativeLifecycleBundle::find_all(conn)?;
         for installed in installed_bundles {
@@ -719,6 +711,7 @@ impl PreparedNativeTransaction {
             deb_change_indices,
         };
         let plan = plan_native_transaction(&views, &changes, &transaction_state)?;
+        let host_capabilities = host_capabilities_for_plan(conn, arch_transaction, &plan)?;
         let path_projection =
             NativePathProjection::from_transaction(&plan, &changes, &installed_paths_after)?;
         Ok(Self {
@@ -740,6 +733,25 @@ impl PreparedNativeTransaction {
     pub(crate) fn requires_upgrade_payload_boundary(&self) -> bool {
         self.requires_upgrade_payload_boundary
     }
+
+    pub(super) fn rpm_sysusers_interface(&self) -> Result<&conary_core::ccs::ExecutableInterface> {
+        self.host_capabilities
+            .as_ref()
+            .context("RPM sysusers event lost its required typed host capability inventory")?
+            .sysusers_interface()
+            .map_err(anyhow::Error::from)
+    }
+}
+
+fn host_capabilities_for_plan(
+    conn: &rusqlite::Connection,
+    arch_transaction: bool,
+    plan: &NativeTransactionPlan,
+) -> Result<Option<conary_core::ccs::HostCapabilityInventory>> {
+    (arch_transaction || plan.requires_sysusers_interface())
+        .then(|| conary_core::ccs::HostCapabilityInventory::load_required(conn))
+        .transpose()
+        .context("native transaction typed host capability preflight failed")
 }
 
 fn debian_relation_removal_operation(

--- a/apps/conary/src/commands/install/native_events/execution.rs
+++ b/apps/conary/src/commands/install/native_events/execution.rs
@@ -62,12 +62,20 @@ impl PreparedNativeTransaction {
             NativeEventProgram::Command { argv } => executor
                 .execute_native_command("native-transaction-hook", argv, &event.stdin)
                 .map_err(anyhow::Error::from),
+            NativeEventProgram::RpmSysusers { source_path } => executor
+                .execute_rpm_sysusers(
+                    self.rpm_sysusers_interface()?,
+                    source_path.as_deref(),
+                    &event.stdin,
+                )
+                .map_err(anyhow::Error::from),
         };
         let captured = executor.take_activation_invocations();
         if result.is_ok() {
             let source_entry = match &event.program {
                 NativeEventProgram::BundleEntry { entry_id } => entry_id.clone(),
                 NativeEventProgram::Command { .. } => event.order_key.clone(),
+                NativeEventProgram::RpmSysusers { .. } => event.order_key.clone(),
             };
             self.activation_invocations
                 .borrow_mut()

--- a/apps/conary/src/commands/install/native_events/preflight.rs
+++ b/apps/conary/src/commands/install/native_events/preflight.rs
@@ -153,6 +153,9 @@ impl PreparedNativeTransaction {
             NativeEventProgram::Command { argv } => executor
                 .preflight_native_command(argv)
                 .map_err(anyhow::Error::from),
+            NativeEventProgram::RpmSysusers { source_path } => executor
+                .preflight_rpm_sysusers(self.rpm_sysusers_interface()?, source_path.as_deref())
+                .map_err(anyhow::Error::from),
         }
     }
 

--- a/apps/conary/src/commands/install/native_events/tests.rs
+++ b/apps/conary/src/commands/install/native_events/tests.rs
@@ -21,7 +21,7 @@ use conary_core::repository::dependency_model::{
 use conary_core::scriptlet::ExecutionMode;
 use conary_core::transaction::{PackageRelationIncomingIdentity, PackageRelationRemoval};
 use std::collections::BTreeSet;
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{PermissionsExt, symlink};
 
 #[path = "tests/arch.rs"]
 mod arch;
@@ -134,6 +134,48 @@ fn prepared_with_projected_event(
         path_projection,
         ..PreparedNativeTransaction::default()
     }
+}
+
+fn rpm_sysusers_event(bundle: &NativeLifecycleBundle) -> NativeTransactionEvent {
+    NativeTransactionEvent {
+        owner_package: bundle.source_package.clone(),
+        owner_version: bundle.source_version.clone(),
+        owner_arch: bundle.source_arch.clone(),
+        source_format: "rpm".to_string(),
+        stage: NativeEventStage::RpmSysusers,
+        program: NativeEventProgram::RpmSysusers {
+            source_path: Some("/usr/lib/sysusers.d/owner.conf".to_string()),
+        },
+        args: Vec::new(),
+        stdin: b"u owner -\n".to_vec(),
+        matched_targets: vec!["/usr/lib/sysusers.d/owner.conf".to_string()],
+        rpm_trigger_owner: None,
+        deb_package_refcount: None,
+        order_key: "rpm:sysusers:owner".to_string(),
+        placement: NativeEventPlacement::TransactionElement {
+            transaction_index: 0,
+        },
+    }
+}
+
+#[cfg(unix)]
+fn persisted_sysusers_inventory() -> (tempfile::TempDir, conary_core::ccs::HostCapabilityInventory)
+{
+    let interface_dir = tempfile::tempdir().unwrap();
+    let executable = interface_dir.path().join("systemd-sysusers");
+    let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../crates/conary-core/tests/fixtures/host-tools/systemd")
+        .canonicalize()
+        .unwrap();
+    symlink(fixture, &executable).unwrap();
+    let interface = conary_core::ccs::ExecutableInterface::probe_sysusers(executable).unwrap();
+    (
+        interface_dir,
+        conary_core::ccs::HostCapabilityInventory {
+            sysusers: Some(interface),
+            ..conary_core::ccs::HostCapabilityInventory::default()
+        },
+    )
 }
 
 fn deb_entry(
@@ -601,6 +643,86 @@ fn transaction_preflight_walks_exact_command_events() {
     assert!(
         error.to_string().contains("native transaction preflight"),
         "unexpected error: {error:#}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn rpm_sysusers_event_uses_the_persisted_interface_for_an_empty_root() {
+    let bundle = pre_remove_bundle("sysusers-owner", "1");
+    let event = rpm_sysusers_event(&bundle);
+    let mut prepared = prepared_with_projected_event(
+        bundle,
+        event.clone(),
+        NativeEventPathProjection::CurrentRoot,
+    );
+    let (_interface_dir, inventory) = persisted_sysusers_inventory();
+    prepared.host_capabilities = Some(inventory);
+    let target_root = tempfile::tempdir().unwrap();
+
+    assert!(!target_root.path().join("usr/bin/systemd-sysusers").exists());
+    prepared
+        .preflight(target_root.path(), &ExecutionMode::Install)
+        .unwrap();
+    prepared
+        .execute_event(&event, target_root.path(), &ExecutionMode::Install, None)
+        .unwrap();
+
+    assert_eq!(
+        std::fs::read(
+            target_root
+                .path()
+                .join("var/lib/conary-test/systemd-sysusers-stdin")
+        )
+        .unwrap(),
+        b"u owner -\n"
+    );
+}
+
+#[test]
+fn rpm_sysusers_event_rejects_a_missing_persisted_interface() {
+    let bundle = pre_remove_bundle("sysusers-owner", "1");
+    let event = rpm_sysusers_event(&bundle);
+    let mut prepared =
+        prepared_with_projected_event(bundle, event, NativeEventPathProjection::CurrentRoot);
+    prepared.host_capabilities = Some(conary_core::ccs::HostCapabilityInventory::default());
+    let target_root = tempfile::tempdir().unwrap();
+
+    let error = prepared
+        .preflight(target_root.path(), &ExecutionMode::Install)
+        .unwrap_err();
+    assert!(
+        format!("{error:#}").contains("systemd-sysusers target interface"),
+        "unexpected error: {error:#}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn typed_sysusers_plan_loads_host_capabilities_without_an_arch_selector() {
+    let temp = tempfile::tempdir().unwrap();
+    let db_path = temp.path().join("conary.db");
+    conary_core::db::init(&db_path).unwrap();
+    let conn = conary_core::db::open(&db_path).unwrap();
+    let bundle = pre_remove_bundle("sysusers-owner", "1");
+    let plan = NativeTransactionPlan {
+        events: vec![rpm_sysusers_event(&bundle)],
+        graph: NativeTransactionGraph::default(),
+        deb: Default::default(),
+    };
+
+    let missing = host_capabilities_for_plan(&conn, false, &plan).unwrap_err();
+    assert!(
+        format!("{missing:#}").contains("host capability inventory is not initialized"),
+        "unexpected error: {missing:#}"
+    );
+
+    let (_interface_dir, inventory) = persisted_sysusers_inventory();
+    inventory.persist(&conn).unwrap();
+    assert!(
+        host_capabilities_for_plan(&conn, false, &plan)
+            .unwrap()
+            .is_some()
     );
 }
 

--- a/crates/conary-core/src/ccs/hooks/capabilities.rs
+++ b/crates/conary-core/src/ccs/hooks/capabilities.rs
@@ -336,6 +336,24 @@ impl HostCapabilityInventory {
             .map(|interface| interface.command.executable.as_path())
     }
 
+    /// Return the exact persisted sysusers target interface after repeating
+    /// its implementation handshake and executable identity check.
+    pub fn sysusers_interface(&self) -> Result<&ExecutableInterface, HostCapabilityPreflightError> {
+        let Some(interface) = self.sysusers.as_ref() else {
+            return Err(HostCapabilityPreflightError::MissingCapability {
+                requirement: HostCapabilityRequirement::Sysusers,
+                hook: "RPM sysusers native event",
+            });
+        };
+        if !interface.is_available() {
+            return Err(HostCapabilityPreflightError::InterfaceDrift {
+                requirement: HostCapabilityRequirement::Sysusers,
+                executable: interface.executable.clone(),
+            });
+        }
+        Ok(interface)
+    }
+
     /// Return the exact ldconfig program path inside `root` only when libalpm's
     /// two structural guards hold: `/etc/ld.so.conf` exists and the configured
     /// target-root program is executable.
@@ -527,6 +545,7 @@ pub enum HostCapabilityRequirement {
     SystemdManager,
     Systemd,
     SystemdOperation(SystemdOperation),
+    Sysusers,
     Tmpfiles,
     Sysctl,
     Ldconfig,
@@ -540,6 +559,7 @@ impl std::fmt::Display for HostCapabilityRequirement {
             Self::SystemdOperation(operation) => {
                 write!(formatter, "systemctl {operation:?} operation")
             }
+            Self::Sysusers => formatter.write_str("systemd-sysusers target interface"),
             Self::Tmpfiles => formatter.write_str("systemd-tmpfiles command interface"),
             Self::Sysctl => formatter.write_str("sysctl command interface"),
             Self::Ldconfig => formatter.write_str("target-root ldconfig command interface"),
@@ -644,6 +664,43 @@ mod tests {
         assert!(!encoded.contains("distro"));
         assert!(!encoded.contains("profile"));
         assert!(encoded.contains("\"tmpfiles\":{\"command\":{\"executable\":"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sysusers_path_requires_the_exact_persisted_interface() {
+        let missing = HostCapabilityInventory::default()
+            .sysusers_interface()
+            .unwrap_err();
+        assert!(matches!(
+            missing,
+            HostCapabilityPreflightError::MissingCapability {
+                requirement: HostCapabilityRequirement::Sysusers,
+                ..
+            }
+        ));
+
+        let root = tempfile::tempdir().unwrap();
+        let executable = fake_interface(root.path(), "systemd-sysusers");
+        let inventory = HostCapabilityInventory {
+            sysusers: Some(ExecutableInterface::probe_sysusers(executable.clone()).unwrap()),
+            ..HostCapabilityInventory::default()
+        };
+        assert_eq!(
+            inventory.sysusers_interface().unwrap().executable,
+            executable
+        );
+
+        fs::remove_file(&executable).unwrap();
+        link_host_tool(&executable, HostToolFixture::ExitSuccess);
+        let drift = inventory.sysusers_interface().unwrap_err();
+        assert!(matches!(
+            drift,
+            HostCapabilityPreflightError::InterfaceDrift {
+                requirement: HostCapabilityRequirement::Sysusers,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/conary-core/src/ccs/hooks/capabilities/interface_contract.rs
+++ b/crates/conary-core/src/ccs/hooks/capabilities/interface_contract.rs
@@ -83,7 +83,7 @@ impl ExecutableInterface {
         )
     }
 
-    pub(super) fn is_available(&self) -> bool {
+    pub(crate) fn is_available(&self) -> bool {
         self.verify_at(&self.executable)
     }
 
@@ -235,11 +235,7 @@ fn functional_handshake(executable: &Path, contract: HostExecutableContract) -> 
             &["--root=/", "--no-pager", "--no-legend", "list-unit-files"],
             None,
         ),
-        HostExecutableContract::SystemdSysusers => command_succeeds(
-            executable,
-            &["--dry-run", "-"],
-            Some(b"u conary-interface-probe -\n"),
-        ),
+        HostExecutableContract::SystemdSysusers => sysusers_functional_handshake(executable),
         HostExecutableContract::SystemdTmpfiles => command_succeeds(
             executable,
             &["--dry-run", "--create", "-"],
@@ -250,6 +246,27 @@ fn functional_handshake(executable: &Path, contract: HostExecutableContract) -> 
         }
         HostExecutableContract::GlibcLdconfig => command_succeeds(executable, &["-p"], None),
     }
+}
+
+fn sysusers_functional_handshake(executable: &Path) -> bool {
+    let Ok(root) = tempfile::tempdir() else {
+        return false;
+    };
+    let Some(root) = root.path().to_str() else {
+        return false;
+    };
+    let root_argument = format!("--root={root}");
+    command_succeeds(
+        executable,
+        &[
+            "--dry-run",
+            &root_argument,
+            "--replace",
+            "/usr/lib/sysusers.d/conary-interface-probe.conf",
+            "-",
+        ],
+        Some(b"u conary-interface-probe -\n"),
+    ) && std::fs::read_dir(root).is_ok_and(|mut entries| entries.next().is_none())
 }
 
 fn command_succeeds(executable: &Path, args: &[&str], stdin: Option<&[u8]>) -> bool {

--- a/crates/conary-core/src/ccs/native_transaction.rs
+++ b/crates/conary-core/src/ccs/native_transaction.rs
@@ -292,8 +292,17 @@ pub enum NativeEventStage {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NativeEventProgram {
-    BundleEntry { entry_id: String },
-    Command { argv: Vec<String> },
+    BundleEntry {
+        entry_id: String,
+    },
+    Command {
+        argv: Vec<String>,
+    },
+    /// RPM's pre-payload sysusers semantic, executed through the persisted
+    /// target interface rather than a program projected inside the payload.
+    RpmSysusers {
+        source_path: Option<String>,
+    },
 }
 
 /// Which RPM package set supplied a trigger owner.
@@ -354,6 +363,15 @@ impl NativeTransactionPlan {
         stage: NativeEventStage,
     ) -> impl Iterator<Item = &NativeTransactionEvent> {
         self.events.iter().filter(move |event| event.stage == stage)
+    }
+
+    /// Whether this exact plan requires the persisted target sysusers
+    /// interface. This is derived from the typed event graph, never a source
+    /// distro or package-name selector.
+    pub fn requires_sysusers_interface(&self) -> bool {
+        self.events
+            .iter()
+            .any(|event| matches!(event.program, NativeEventProgram::RpmSysusers { .. }))
     }
 }
 

--- a/crates/conary-core/src/ccs/native_transaction/rpm.rs
+++ b/crates/conary-core/src/ccs/native_transaction/rpm.rs
@@ -54,11 +54,6 @@ pub(super) fn plan(
                         entry.id
                     );
                 }
-                let mut argv = vec![entry.interpreter.clone()];
-                if let Some(path) = &sysusers.source_path {
-                    argv.extend(["--replace".to_string(), path.clone()]);
-                }
-                argv.push("-".to_string());
                 let transaction_index = owner_change(view, changes)
                     .map(|change| change.transaction_index)
                     .unwrap_or(usize::MAX);
@@ -68,7 +63,9 @@ pub(super) fn plan(
                     owner_arch: view.bundle.source_arch.clone(),
                     source_format: view.bundle.source_format.as_str().to_string(),
                     stage: NativeEventStage::RpmSysusers,
-                    program: NativeEventProgram::Command { argv },
+                    program: NativeEventProgram::RpmSysusers {
+                        source_path: sysusers.source_path.clone(),
+                    },
                     args: Vec::new(),
                     stdin: lines_stdin(&sysusers.lines),
                     matched_targets: sysusers.source_path.iter().cloned().collect(),

--- a/crates/conary-core/src/ccs/native_transaction/rpm_tests.rs
+++ b/crates/conary-core/src/ccs/native_transaction/rpm_tests.rs
@@ -202,7 +202,7 @@ fn rpm_regular_events_do_not_delegate_transaction_failure_policy() {
 }
 
 #[test]
-fn rpm_sysusers_is_an_exact_pre_payload_compatibility_command() {
+fn rpm_sysusers_is_an_exact_pre_payload_target_interface_event() {
     let mut sysusers = entry(
         "rpm:%sysusers:0",
         LifecyclePath::RpmSysusers,
@@ -234,15 +234,11 @@ fn rpm_sysusers_is_an_exact_pre_payload_compatibility_command() {
     assert_eq!(event.stage, NativeEventStage::RpmSysusers);
     assert_eq!(
         event.program,
-        NativeEventProgram::Command {
-            argv: vec![
-                "/usr/bin/systemd-sysusers".to_string(),
-                "--replace".to_string(),
-                "/usr/lib/sysusers.d/owner.conf".to_string(),
-                "-".to_string(),
-            ]
+        NativeEventProgram::RpmSysusers {
+            source_path: Some("/usr/lib/sysusers.d/owner.conf".to_string()),
         }
     );
+    assert!(plan.requires_sysusers_interface());
     assert_eq!(
         event.stdin,
         b"u! owner - \"Owner service\" /var/lib/owner\n"

--- a/crates/conary-core/src/scriptlet/mod.rs
+++ b/crates/conary-core/src/scriptlet/mod.rs
@@ -38,6 +38,7 @@ mod process;
 mod rpm_runtime;
 mod runtime;
 mod sandbox;
+mod sysusers;
 #[cfg(test)]
 mod test_support;
 mod types;

--- a/crates/conary-core/src/scriptlet/native_command.rs
+++ b/crates/conary-core/src/scriptlet/native_command.rs
@@ -369,6 +369,20 @@ mod tests {
     }
 
     #[test]
+    fn generic_native_command_cannot_use_a_host_program() {
+        let root = tempfile::tempdir().unwrap();
+        let executor = executor(root.path());
+        let error = executor
+            .preflight_native_command(&["/bin/sh".to_string()])
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("missing from target root"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
     fn transaction_command_preflight_rejects_the_host_root() {
         let executor = executor(Path::new("/"));
         let error = executor

--- a/crates/conary-core/src/scriptlet/sysusers.rs
+++ b/crates/conary-core/src/scriptlet/sysusers.rs
@@ -1,0 +1,249 @@
+// conary-core/src/scriptlet/sysusers.rs
+
+//! Typed execution of RPM's pre-payload sysusers target interface.
+
+use super::ScriptletExecutor;
+use super::runtime::{apply_sanitized_command_env, wait_and_capture};
+use crate::ccs::{ExecutableInterface, HostExecutableContract};
+use crate::error::{Error, Result, ScriptletFailureKind};
+use std::ffi::OsString;
+use std::io::{Seek, SeekFrom, Write};
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::CommandExt as _;
+use std::path::{Component, Path};
+use std::process::{Command, Stdio};
+
+impl ScriptletExecutor {
+    /// Validate the fixed RPM sysusers invocation before transaction mutation.
+    pub fn preflight_rpm_sysusers(
+        &self,
+        interface: &ExecutableInterface,
+        source_path: Option<&str>,
+    ) -> Result<()> {
+        self.require_target_root()?;
+        if !self.root.is_dir() {
+            return Err(Error::scriptlet(
+                ScriptletFailureKind::ContractViolation,
+                format!(
+                    "RPM sysusers selected root is not a directory: {}",
+                    self.root.display()
+                ),
+            ));
+        }
+        let executable = &interface.executable;
+        if interface.contract != HostExecutableContract::SystemdSysusers {
+            return Err(Error::scriptlet(
+                ScriptletFailureKind::ContractViolation,
+                format!(
+                    "RPM sysusers executor received the wrong target interface contract: {:?}",
+                    interface.contract
+                ),
+            ));
+        }
+        if !interface.is_available()
+            || !executable.is_absolute()
+            || !executable.metadata().is_ok_and(|metadata| {
+                metadata.is_file() && metadata.permissions().mode() & 0o111 != 0
+            })
+        {
+            return Err(Error::scriptlet(
+                ScriptletFailureKind::ProgramUnavailable,
+                format!(
+                    "persisted RPM sysusers target interface is unavailable: {}",
+                    executable.display()
+                ),
+            ));
+        }
+        if let Some(source_path) = source_path {
+            validate_source_path(source_path)?;
+        }
+        Ok(())
+    }
+
+    /// Execute RPM sysusers through the exact persisted target interface.
+    ///
+    /// The executable remains outside the selected root because RPM schedules
+    /// this event before payload visibility. The fixed `--root` grammar keeps
+    /// all account mutation inside that selected root.
+    pub fn execute_rpm_sysusers(
+        &self,
+        interface: &ExecutableInterface,
+        source_path: Option<&str>,
+        stdin: &[u8],
+    ) -> Result<()> {
+        self.preflight_rpm_sysusers(interface, source_path)?;
+        let executable = &interface.executable;
+
+        let mut root_argument = OsString::from("--root=");
+        root_argument.push(&self.root);
+        let mut stdin_file = tempfile::tempfile()?;
+        stdin_file.write_all(stdin)?;
+        stdin_file.seek(SeekFrom::Start(0))?;
+
+        let mut command = Command::new(executable);
+        command
+            .arg(root_argument)
+            .stdin(Stdio::from(stdin_file))
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        if let Some(source_path) = source_path {
+            command.args(["--replace", source_path]);
+        }
+        command.arg("-");
+        apply_sanitized_command_env(
+            &mut command,
+            &[
+                ("CONARY_PACKAGE_NAME", self.package_name.as_str()),
+                ("CONARY_PACKAGE_VERSION", self.package_version.as_str()),
+            ],
+        );
+        // The timeout helper kills process groups. Establish the typed target
+        // interface as its own group so descendants cannot escape the event.
+        unsafe {
+            command.pre_exec(|| {
+                if nix::libc::setpgid(0, 0) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+
+        let mut child = command.spawn().map_err(|error| {
+            Error::scriptlet(
+                ScriptletFailureKind::ProcessSetupFailed,
+                format!(
+                    "failed to spawn persisted RPM sysusers target interface {}: {error}",
+                    executable.display()
+                ),
+            )
+        })?;
+        let context = format!(" (offline root: {})", self.root.display());
+        wait_and_capture(&mut child, self.timeout, "rpm-sysusers", &context)
+    }
+}
+
+fn validate_source_path(source_path: &str) -> Result<()> {
+    if source_path.contains('\0') || !Path::new(source_path).is_absolute() {
+        return Err(Error::scriptlet(
+            ScriptletFailureKind::ContractViolation,
+            format!("RPM sysusers replacement path is not an absolute guest path: {source_path:?}"),
+        ));
+    }
+    let mut has_name = false;
+    for component in Path::new(source_path).components() {
+        match component {
+            Component::RootDir => {}
+            Component::Normal(_) => has_name = true,
+            Component::CurDir | Component::ParentDir | Component::Prefix(_) => {
+                return Err(Error::scriptlet(
+                    ScriptletFailureKind::ContractViolation,
+                    format!(
+                        "RPM sysusers replacement path escapes its guest root: {source_path:?}"
+                    ),
+                ));
+            }
+        }
+    }
+    if !has_name {
+        return Err(Error::scriptlet(
+            ScriptletFailureKind::ContractViolation,
+            "RPM sysusers replacement path does not name a configuration file",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scriptlet::PackageFormat;
+    use crate::test_support::{HostToolFixture, link_host_tool};
+
+    #[cfg(unix)]
+    #[test]
+    fn persisted_interface_mutates_only_the_empty_selected_root() {
+        let interface_dir = tempfile::tempdir().unwrap();
+        let executable = interface_dir.path().join("systemd-sysusers");
+        link_host_tool(&executable, HostToolFixture::Systemd);
+        let interface = ExecutableInterface::probe_sysusers(executable).unwrap();
+        let selected_root = tempfile::tempdir().unwrap();
+        let executor = ScriptletExecutor::new(
+            selected_root.path(),
+            "shadow-utils",
+            "1",
+            PackageFormat::Rpm,
+        );
+
+        assert!(
+            !selected_root
+                .path()
+                .join("usr/bin/systemd-sysusers")
+                .exists()
+        );
+        executor
+            .execute_rpm_sysusers(
+                &interface,
+                Some("/usr/lib/sysusers.d/shadow.conf"),
+                b"u shadow -\n",
+            )
+            .unwrap();
+
+        let capture = selected_root
+            .path()
+            .join("var/lib/conary-test/systemd-sysusers-stdin");
+        assert_eq!(std::fs::read(capture).unwrap(), b"u shadow -\n");
+        let argv = std::fs::read_to_string(
+            selected_root
+                .path()
+                .join("var/lib/conary-test/systemd-sysusers-argv"),
+        )
+        .unwrap();
+        assert_eq!(
+            argv,
+            format!(
+                "--root={} --replace /usr/lib/sysusers.d/shadow.conf -\n",
+                selected_root.path().display()
+            )
+        );
+    }
+
+    #[test]
+    fn replacement_path_must_be_confined_to_the_guest_root() {
+        for source_path in ["relative.conf", "/../../host.conf", "/"] {
+            let error = validate_source_path(source_path).unwrap_err();
+            assert!(
+                matches!(
+                    &error,
+                    Error::ScriptletExecution {
+                        kind: ScriptletFailureKind::ContractViolation,
+                        ..
+                    }
+                ),
+                "unexpected error: {error}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wrong_target_interface_contract_is_rejected() {
+        let interface_dir = tempfile::tempdir().unwrap();
+        let executable = interface_dir.path().join("systemd-tool");
+        link_host_tool(&executable, HostToolFixture::Systemd);
+        let wrong_interface = ExecutableInterface::probe_tmpfiles(executable).unwrap();
+        let selected_root = tempfile::tempdir().unwrap();
+        let executor =
+            ScriptletExecutor::new(selected_root.path(), "fixture", "1", PackageFormat::Rpm);
+
+        let error = executor
+            .preflight_rpm_sysusers(&wrong_interface, None)
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            Error::ScriptletExecution {
+                kind: ScriptletFailureKind::ContractViolation,
+                ..
+            }
+        ));
+    }
+}

--- a/crates/conary-core/tests/fixtures/host-tools/systemd
+++ b/crates/conary-core/tests/fixtures/host-tools/systemd
@@ -11,8 +11,13 @@ case "${1-}" in
         exit 0
         ;;
     --dry-run)
-        cat >/dev/null
-        exit 0
+        case "${2-}" in
+            --root=*|--create)
+                cat >/dev/null
+                exit 0
+                ;;
+        esac
+        exit 2
         ;;
     --root=*)
         root=${1#--root=}
@@ -24,6 +29,9 @@ case "${1-}" in
         mkdir -p "$capture_dir"
         if [ "${2-}" = "--create" ]; then
             cp "$root$3" "$capture_dir/systemd-tmpfiles-captured.conf"
+        elif [ "${2-}" = "--replace" ] || [ "${2-}" = "-" ]; then
+            printf '%s\n' "$*" > "$capture_dir/systemd-sysusers-argv"
+            cat > "$capture_dir/systemd-sysusers-stdin"
         else
             printf '%s\n' "$*" >> "$capture_dir/systemctl-calls"
         fi

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -85,8 +85,12 @@ commands.
   environment, administrative state, trigger/config capture, and
   update-alternatives projection start in
   `apps/conary/src/commands/install/native_events/debian_runtime.rs` and
-  `apps/conary/src/commands/install/native_events/debian_runtime/`. Exact
-  source-independent payload nodes start in `crates/conary-core/src/payload.rs`.
+  `apps/conary/src/commands/install/native_events/debian_runtime/`. Exact RPM
+  pre-payload sysusers target-interface execution starts in
+  `crates/conary-core/src/scriptlet/sysusers.rs`; generic native argv remains
+  selected-root confined in
+  `crates/conary-core/src/scriptlet/native_command.rs`. Exact source-independent
+  payload nodes start in `crates/conary-core/src/payload.rs`.
   `apps/conary/src/commands/live_root/recovery.rs` is confined to the
   selected-root session journal implementation.
 - Declarative models, source selection, and replatforming:

--- a/docs/modules/ccs.md
+++ b/docs/modules/ccs.md
@@ -528,7 +528,11 @@ Core event planning lives in `crates/conary-core/src/ccs/native_transaction.rs`.
 `apps/conary/src/commands/install/native_events.rs` binds that plan to the
 shared install/remove executor. Command, batch, CCS, restore, remove, and
 autoremove paths call the same stage groups instead of maintaining
-format-specific copies.
+format-specific copies. RPM's pre-payload sysusers event is executed through
+the persisted target interface in
+`crates/conary-core/src/scriptlet/sysusers.rs`; generic native commands remain
+owned by `crates/conary-core/src/scriptlet/native_command.rs` inside the
+selected root.
 
 Applied package transactions cannot suppress lifecycle execution. Install,
 update, remove, restore, batch, autoremove, CCS install, automation, and daemon

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -236,7 +236,7 @@ mutation flows for local package operations.
 `cargo test -p conary-core --lib filesystem::selected_root`;
 `cargo test -p conary-core --lib config_transaction`;
 `cargo test -p conary --lib commands::generation::config_transaction`;
-`cargo test -p conary --lib commands::install::transaction::upgrade_rollback`;
+`cargo test -p conary --lib commands::install::rollback_snapshot`;
 `cargo test -p conary-core native_transaction`;
 `cargo test -p conary --test live_host_mutation_safety`;
 `cargo test -p conary-core native_lifecycle`.

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -186,6 +186,7 @@ mutation flows for local package operations.
 `crates/conary-core/src/scriptlet/sandbox.rs`;
 `crates/conary-core/src/scriptlet/process.rs`;
 `crates/conary-core/src/scriptlet/boundary.rs`;
+`crates/conary-core/src/scriptlet/sysusers.rs`;
 `crates/conary-core/src/scriptlet/native_lifecycle.rs`;
 `crates/conary-core/src/scriptlet/native_lifecycle/contracts.rs`;
 `crates/conary-core/src/db/models/installed_ccs_remove_hook.rs`;

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -89,6 +89,17 @@ value or derive one from a distro, path, policy name, source package manager, or
 pairwise compatibility selector. A version-3 inventory must be replaced by
 rerunning `conary system init`.
 
+RPM sysusers planning emits a dedicated typed native event rather than a
+generic command. Because RPM schedules it before the incoming payload is
+visible, install preflight revalidates the persisted `SystemdSysusers`
+descriptor and execution invokes that exact host-side interface with
+`--root=<selected-root>`, optional `--replace <guest-path>`, and the decoded
+declarations on stdin. The fixed grammar gives the target implementation
+semantic authority without reading or mutating host account state. Missing,
+wrong-contract, or drifted descriptors fail before package mutation. Generic
+native commands remain confined to the selected-root execution boundary and
+cannot acquire this target-interface path from argv text or lifecycle stage.
+
 The typed tmpfiles contract preserves type, path, mode, user, group, age, and
 argument as seven required strings. Conary parses only the documented type
 envelope—one ASCII letter plus tmpfiles modifiers—and the field boundaries
@@ -849,7 +860,8 @@ transaction packages. Conary's typed stages preserve this order:
 1. `%pretrans` of `new`.
 2. `%preuntrans` of `old`.
 3. `%transfiletriggerun` of `any`, selected by paths removed with `old`.
-4. RPM's implicit sysusers operation for `new`.
+4. RPM's implicit sysusers operation for `new`, through the exact persisted
+   target sysusers interface with the selected root supplied explicitly.
 5. `%triggerprein` passes between `rpmdb`, `new`, and the installing change.
 6. `%pre` of `new`.
 7. Unpack `new` and make its payload visible.


### PR DESCRIPTION
## Primary Issue

Closes #212

Design / Plan / Roadmap: `docs/specs/foreign-package-lifecycle-contracts.md`

## Problem And Outcome

RPM schedules its implicit sysusers operation before the incoming payload is visible. Conary lowered that semantic to a generic command inside the selected-root chroot, so a fresh root failed because `/usr/bin/systemd-sysusers` had not yet been installed.

After this change, the RPM planner emits a typed sysusers target-interface event. Transaction preflight loads and revalidates the exact persisted `SystemdSysusers` descriptor, and execution supplies the selected root explicitly without making generic commands host-visible.

## Changes

- add `NativeEventProgram::RpmSysusers` and derive host-capability requirements from the typed plan
- strengthen the sysusers interface handshake with dry-run `--root` and `--replace` proof
- execute the exact descriptor with fixed argv, sanitized environment, stdin, timeout, and process-group cleanup
- preserve selected-root confinement for generic native commands
- add planner, capability, preflight, execution, drift/contract, and confinement tests
- update lifecycle authority and assistant routing docs

## Scope

- In scope: RPM implicit sysusers planning, preflight, target-interface execution, and contract proof
- Out of scope: declarative CCS user/group hooks, tmpfiles behavior, and unrelated dependency ordering

## Ownership / Boundary

- Owning subsystem: `install`, neighboring `ccs` native transaction/scriptlet runtime
- Boundary changed or preserved: adds one typed pre-payload target interface; generic argv remains selected-root confined
- Persisted state or public surface impact: no schema change; existing version-4 host inventory is consumed through its exact sysusers descriptor
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code (not applicable)
- [x] Updated subsystem docs or maps when the "look here first" path changed
- [ ] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs

```text
- cargo fmt --check
- git diff --check
- bash scripts/check-doc-truth.sh
- cargo test -p conary-core --lib ccs::hooks::capabilities
- cargo test -p conary-core --lib scriptlet::sysusers
- cargo test -p conary-core --lib ccs::native_transaction::rpm_tests::rpm_sysusers_is_an_exact_pre_payload_target_interface_event
- cargo test -p conary-core --lib scriptlet::native_command::tests::generic_native_command_cannot_use_a_host_program
- cargo test -p conary --lib sysusers
- cargo clippy -p conary-core --all-targets -- -D warnings
- cargo clippy -p conary --all-targets -- -D warnings
```

Pending before ready-for-review:

- install feature-card focused suite
- conversion/query interaction gate
- exact-head CI
- combined #151 + #211 + this PR TGE02 supported-host proof

## Review And Merge Notes

- Review focus: typed event authority, descriptor revalidation, and host/selected-root mutation boundary
- User or developer impact: fresh RPM installs can run pre-payload sysusers semantics without requiring the incoming program inside the empty selected root
- Required-check bypass: not used
