### PR TITLE
fix(remi): bind conversions to repository metadata

### DIFF
--- a/apps/conary/src/commands/installed_authority_snapshot/capture.rs
+++ b/apps/conary/src/commands/installed_authority_snapshot/capture.rs
@@ -641,6 +641,7 @@ fn capture_installed_conversions(
             trove_id: Some(trove_id),
             original_format: snapshot.original_format.clone(),
             original_checksum: snapshot.original_checksum.clone(),
+            repository_provides_digest: None,
             conversion_version: snapshot.conversion_version,
             converted_at: Some(snapshot.converted_at.clone()),
             enhancement_version: snapshot.enhancement_version,

--- a/apps/conary/src/commands/system/rollback_restore.rs
+++ b/apps/conary/src/commands/system/rollback_restore.rs
@@ -811,6 +811,7 @@ fn validate_conversion_snapshot(
         trove_id: Some(trove_id),
         original_format: snapshot.original_format.clone(),
         original_checksum: snapshot.original_checksum.clone(),
+        repository_provides_digest: None,
         conversion_version: snapshot.conversion_version,
         converted_at: Some(snapshot.converted_at.clone()),
         enhancement_version: snapshot.enhancement_version,

--- a/apps/remi/src/server/chunk_gc.rs
+++ b/apps/remi/src/server/chunk_gc.rs
@@ -462,6 +462,7 @@ mod tests {
             3,
             "sha256:first".to_string(),
             "/tmp/first.ccs".to_string(),
+            conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
         );
         first.insert(&conn).unwrap();
 
@@ -476,6 +477,7 @@ mod tests {
             2,
             "sha256:second".to_string(),
             "/tmp/second.ccs".to_string(),
+            conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
         );
         second.insert(&conn).unwrap();
 
@@ -547,6 +549,7 @@ mod tests {
             1,
             "sha256:content".to_string(),
             "/tmp/broken.ccs".to_string(),
+            conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
         );
         let id = converted.insert(&conn).unwrap();
         conn.execute_batch("PRAGMA ignore_check_constraints = ON;")

--- a/apps/remi/src/server/conversion.rs
+++ b/apps/remi/src/server/conversion.rs
@@ -11,7 +11,7 @@ mod persistence;
 mod recipe;
 mod storage;
 #[cfg(test)]
-mod test_support;
+pub(crate) mod test_support;
 mod types;
 mod workflow;
 

--- a/apps/remi/src/server/conversion/lookup.rs
+++ b/apps/remi/src/server/conversion/lookup.rs
@@ -92,6 +92,7 @@ impl ConversionService {
                      FROM repository_packages rp
                      JOIN repositories r ON rp.repository_id = r.id
                      WHERE rp.name = ?1
+                     AND r.enabled = 1
                      AND r.source_profile = ?2
                      AND rp.version = ?3
                      AND rp.architecture = ?4
@@ -123,6 +124,7 @@ impl ConversionService {
                  FROM repository_packages rp
                  JOIN repositories r ON rp.repository_id = r.id
                  WHERE rp.name = ?1
+                 AND r.enabled = 1
                  AND r.source_profile = ?2
                  AND rp.version = ?3
                  AND rp.size > 0
@@ -154,6 +156,7 @@ impl ConversionService {
              FROM repository_packages rp
              JOIN repositories r ON rp.repository_id = r.id
              WHERE rp.name = ?1
+             AND r.enabled = 1
              AND r.source_profile = ?2
              AND (?3 IS NULL OR rp.architecture = ?3)
              AND rp.size > 0",
@@ -368,6 +371,37 @@ mod tests {
         let err_msg = result.unwrap_err().to_string();
         assert!(err_msg.contains("not found"));
         assert!(err_msg.contains("repository sync"));
+    }
+
+    #[test]
+    fn conversion_lookup_never_selects_a_disabled_repository() {
+        let (temp_file, conn) = create_test_db();
+        let repo_id = insert_repo(&conn, "fedora-base", "fedora-44");
+        insert_package(&conn, repo_id, "nginx", "1.24.0", 1024);
+        conn.execute(
+            "UPDATE repositories SET enabled = 0 WHERE id = ?1",
+            [repo_id],
+        )
+        .unwrap();
+
+        let service = ConversionService::new(
+            PathBuf::from("/tmp/chunks"),
+            PathBuf::from("/tmp/cache"),
+            temp_file.path().to_path_buf(),
+            None,
+        );
+
+        for (version, architecture) in [
+            (None, None),
+            (Some("1.24.0"), None),
+            (Some("1.24.0"), Some("x86_64")),
+        ] {
+            assert!(
+                service
+                    .find_package(&conn, "fedora-44", "nginx", version, architecture)
+                    .is_err()
+            );
+        }
     }
 
     #[test]

--- a/apps/remi/src/server/conversion/metadata.rs
+++ b/apps/remi/src/server/conversion/metadata.rs
@@ -2,7 +2,7 @@
 //! Package metadata extraction, safe CCS filenames, and native provide merging.
 
 use super::ConversionService;
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow, ensure};
 use conary_core::db::models::{RepositoryPackage, RepositoryProvide};
 use conary_core::filesystem::path::sanitize_filename;
 use conary_core::packages::arch::ArchPackage;
@@ -29,6 +29,12 @@ type ProvideIdentity = (
     RepositoryVersionScheme,
     ProvideArchitectureQualifier,
 );
+
+#[derive(Debug, Clone)]
+pub(super) struct RepositoryConversionMetadata {
+    pub(super) provides: Vec<ProvidedCapability>,
+    pub(super) digest: String,
+}
 
 impl ConversionService {
     /// Create a safe CCS filename from package name and version
@@ -110,18 +116,38 @@ impl ConversionService {
         }
     }
 
-    pub(super) fn merge_repository_provides(
-        conn: &rusqlite::Connection,
+    pub(super) async fn load_repository_conversion_metadata_async(
+        &self,
         repo_pkg: &RepositoryPackage,
+    ) -> Result<RepositoryConversionMetadata> {
+        let db_path = self.db_path.clone();
+        let expected_package = repo_pkg.clone();
+        let repository_package_id = repo_pkg
+            .id
+            .ok_or_else(|| anyhow!("repository conversion package has no persisted identity"))?;
+        tokio::task::spawn_blocking(move || {
+            let mut conn = conary_core::db::open(&db_path)?;
+            let tx = conn.transaction()?;
+            let current_package = RepositoryPackage::find_by_id(&tx, repository_package_id)?
+                .context("repository package metadata changed before conversion")?;
+            ensure!(
+                repository_package_conversion_inputs_match(&expected_package, &current_package),
+                "repository package identity changed before conversion"
+            );
+            let (provides, digest) =
+                RepositoryProvide::conversion_capabilities_with_digest(&tx, repository_package_id)?;
+            tx.commit()?;
+            Ok(RepositoryConversionMetadata { provides, digest })
+        })
+        .await
+        .map_err(|error| anyhow!("repository conversion metadata task panicked: {error}"))?
+    }
+
+    pub(super) fn merge_repository_provides(
+        repository_metadata: &RepositoryConversionMetadata,
         metadata: &mut PackageMetadata,
     ) -> Result<()> {
-        let Some(repository_package_id) = repo_pkg.id else {
-            return Ok(());
-        };
-
-        let repo_provides =
-            RepositoryProvide::find_by_repository_package(conn, repository_package_id)?;
-        if repo_provides.is_empty() {
+        if repository_metadata.provides.is_empty() {
             return Ok(());
         }
 
@@ -140,19 +166,7 @@ impl ConversionService {
             })
             .collect();
 
-        for provide in repo_provides {
-            let kind = repository_capability_kind(&provide.kind)?;
-            let exact = ProvidedCapability {
-                kind,
-                name: provide.capability,
-                version: provide.version,
-                version_relation: provide.version_relation,
-                version_scheme: provide.version_scheme,
-                architecture_qualifier: provide.architecture_qualifier,
-            };
-            exact
-                .validate()
-                .map_err(|error| anyhow!("invalid normalized repository provide: {error}"))?;
+        for exact in &repository_metadata.provides {
             if !seen.insert((
                 exact.kind,
                 exact.name.clone(),
@@ -163,7 +177,7 @@ impl ConversionService {
             )) {
                 continue;
             }
-            metadata.provides.push(exact);
+            metadata.provides.push(exact.clone());
         }
 
         Ok(())
@@ -190,20 +204,24 @@ impl ConversionService {
     }
 }
 
-fn repository_capability_kind(value: &str) -> Result<RepositoryCapabilityKind> {
-    match value {
-        "package" => Ok(RepositoryCapabilityKind::PackageName),
-        "virtual" => Ok(RepositoryCapabilityKind::Virtual),
-        "soname" => Ok(RepositoryCapabilityKind::Soname),
-        "file" => Ok(RepositoryCapabilityKind::File),
-        "path" => Ok(RepositoryCapabilityKind::Path),
-        "binary" => Ok(RepositoryCapabilityKind::Binary),
-        "pkgconfig" => Ok(RepositoryCapabilityKind::PkgConfig),
-        "generic" => Ok(RepositoryCapabilityKind::Generic),
-        other => Err(anyhow!(
-            "unsupported normalized repository provide kind '{other}'"
-        )),
-    }
+pub(super) fn repository_package_conversion_inputs_match(
+    expected: &RepositoryPackage,
+    current: &RepositoryPackage,
+) -> bool {
+    expected.id == current.id
+        && expected.repository_id == current.repository_id
+        && expected.name == current.name
+        && expected.version == current.version
+        && expected.package_release == current.package_release
+        && expected.architecture == current.architecture
+        && expected.debian_multi_arch == current.debian_multi_arch
+        && bare_sha256(&expected.checksum) == bare_sha256(&current.checksum)
+        && expected.source_profile == current.source_profile
+        && expected.version_scheme == current.version_scheme
+}
+
+fn bare_sha256(value: &str) -> &str {
+    value.strip_prefix("sha256:").unwrap_or(value)
 }
 
 #[cfg(test)]
@@ -334,7 +352,10 @@ mod tests {
             VersionScheme::Rpm,
         );
 
-        ConversionService::merge_repository_provides(&conn, &repo_pkg, &mut metadata).unwrap();
+        let (provides, digest) =
+            RepositoryProvide::conversion_capabilities_with_digest(&conn, repo_pkg_id).unwrap();
+        let repository_metadata = RepositoryConversionMetadata { provides, digest };
+        ConversionService::merge_repository_provides(&repository_metadata, &mut metadata).unwrap();
 
         assert!(metadata.provides.iter().any(|provide| {
             provide.name == "kernel-uname-r"
@@ -344,5 +365,9 @@ mod tests {
                         conary_core::repository::dependency_model::ProvideVersionRelation::Equal,
                     )
         }));
+        assert_eq!(
+            repository_metadata.digest,
+            RepositoryProvide::conversion_capabilities_digest(&conn, repo_pkg_id).unwrap()
+        );
     }
 }

--- a/apps/remi/src/server/conversion/persistence.rs
+++ b/apps/remi/src/server/conversion/persistence.rs
@@ -1,11 +1,13 @@
 // apps/remi/src/server/conversion/persistence.rs
 //! Converted-package persistence and cache-hit reconstruction.
 
+use super::metadata::repository_package_conversion_inputs_match;
 use super::{ConversionService, ScriptletPackageMetadata, ServerConversionResult};
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow, ensure};
 use conary_core::ccs::convert::ConversionResult;
-use conary_core::db::models::{ConvertedPackage, RepositoryPackage};
+use conary_core::db::models::{ConvertedPackage, RepositoryPackage, RepositoryProvide};
 use conary_core::packages::common::PackageMetadata;
+use rusqlite::TransactionBehavior;
 use std::path::PathBuf;
 use tracing::info;
 
@@ -16,6 +18,7 @@ pub(super) struct PersistConversionInput {
     pub(super) original_checksum: String,
     pub(super) conversion_result: ConversionResult,
     pub(super) repo_pkg: RepositoryPackage,
+    pub(super) repository_provides_digest: String,
     pub(super) chunk_hashes: Vec<String>,
 }
 
@@ -25,47 +28,75 @@ impl ConversionService {
         source_profile: &str,
         repo_pkg: &RepositoryPackage,
         original_checksum: &str,
+        repository_provides_digest: &str,
     ) -> Result<Option<ServerConversionResult>> {
         let service = self.clone();
         let source_profile = source_profile.to_string();
         let repo_pkg = repo_pkg.clone();
         let original_checksum = original_checksum.to_string();
+        let repository_provides_digest = repository_provides_digest.to_string();
 
         tokio::task::spawn_blocking(move || {
-            let conn = conary_core::db::open(&service.db_path)?;
+            let mut conn = conary_core::db::open(&service.db_path)?;
+            let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let repository_package_id = repo_pkg
+                .id
+                .context("repository conversion package has no persisted identity")?;
+            let current_package = RepositoryPackage::find_by_id(&tx, repository_package_id)?
+                .context("repository package metadata changed during conversion cache lookup")?;
+            ensure!(
+                repository_package_conversion_inputs_match(&repo_pkg, &current_package),
+                "repository package identity changed during conversion cache lookup"
+            );
             let Some(existing) = ConvertedPackage::find_repository_by_checksum(
-                &conn,
+                &tx,
                 &source_profile,
                 &original_checksum,
             )?
             else {
+                tx.commit()?;
                 return Ok(None);
             };
 
-            let ccs_filename = Self::safe_ccs_filename_with_arch(
-                &repo_pkg.name,
-                &repo_pkg.version,
-                repo_pkg.architecture.as_deref(),
-            )?;
-            let ccs_path = service.cache_dir.join("packages").join(&ccs_filename);
-            if !existing.needs_reconversion() && ccs_path.exists() {
+            let artifact = existing.repository_artifact()?;
+            let expected_architecture = repo_pkg
+                .architecture
+                .as_deref()
+                .context("repository conversion package has no exact architecture")?;
+            let artifact_matches_package = artifact.source_profile == source_profile
+                && artifact.package_name == repo_pkg.name
+                && artifact.package_version == repo_pkg.version
+                && artifact.package_architecture == expected_architecture;
+            let metadata_is_current = existing.repository_metadata_is_current(&tx)?;
+            let ccs_path = PathBuf::from(artifact.ccs_path);
+            if metadata_is_current {
+                ensure!(
+                    artifact_matches_package,
+                    "current conversion checksum maps to a conflicting repository package identity"
+                );
+            }
+            if metadata_is_current
+                && artifact.repository_provides_digest == repository_provides_digest
+                && ccs_path.exists()
+            {
                 info!(
                     "Package already converted (checksum: {})",
                     original_checksum
                 );
-                return service
-                    .build_result_from_existing(&existing, &repo_pkg)
-                    .map(Some);
+                let result = service.build_result_from_existing(&existing)?;
+                tx.commit()?;
+                return Ok(Some(result));
             }
 
             info!(
-                "Stale conversion record (CCS file missing or needs reconversion), re-converting"
+                "Stale conversion record (CCS file missing or conversion input changed), re-converting"
             );
             ConvertedPackage::delete_repository_by_checksum(
-                &conn,
+                &tx,
                 &source_profile,
                 &original_checksum,
             )?;
+            tx.commit()?;
             Ok(None)
         })
         .await
@@ -83,34 +114,51 @@ impl ConversionService {
             original_checksum,
             conversion_result,
             repo_pkg,
+            repository_provides_digest,
             chunk_hashes,
         } = input;
 
-        let conn = conary_core::db::open(&self.db_path)?;
         let ccs_path = conversion_result
             .package_path
             .as_ref()
             .ok_or_else(|| anyhow!("No CCS package path"))?;
 
-        let content_hash = Self::calculate_sha256(ccs_path)?.to_prefixed_string();
+        let content_hash = Self::calculate_sha256(ccs_path)?;
+        let content_hash_text = content_hash.to_prefixed_string();
         let total_size = std::fs::metadata(ccs_path)?.len();
+        let persisted_total_size =
+            i64::try_from(total_size).context("converted CCS size exceeds SQLite INTEGER range")?;
 
         let package_architecture = repo_pkg
             .architecture
             .clone()
             .or_else(|| metadata.architecture.clone())
             .ok_or_else(|| anyhow!("converted package has no exact architecture identity"))?;
-        let ccs_filename = Self::safe_ccs_filename_with_arch(
-            &metadata.name,
-            &metadata.version,
-            Some(&package_architecture),
-        )?;
+        let ccs_filename = format!("{}.ccs", content_hash.as_str());
         let final_ccs_path = self.cache_dir.join("packages").join(&ccs_filename);
 
         if let Some(parent) = final_ccs_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
         std::fs::copy(ccs_path, &final_ccs_path)?;
+
+        let mut conn = conary_core::db::open(&self.db_path)?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let repository_package_id = repo_pkg
+            .id
+            .context("converted repository package has no persisted identity")?;
+        let current_package = RepositoryPackage::find_by_id(&tx, repository_package_id)?
+            .context("repository package metadata changed while conversion was running")?;
+        ensure!(
+            repository_package_conversion_inputs_match(&repo_pkg, &current_package),
+            "repository package identity changed while conversion was running"
+        );
+        let current_repository_provides_digest =
+            RepositoryProvide::conversion_capabilities_digest(&tx, repository_package_id)?;
+        ensure!(
+            current_repository_provides_digest == repository_provides_digest,
+            "repository provide authority changed while conversion was running"
+        );
 
         let mut converted = ConvertedPackage::new_repository(
             source_profile.clone(),
@@ -120,12 +168,18 @@ impl ConversionService {
             format.to_string(),
             original_checksum,
             &chunk_hashes,
-            total_size as i64,
-            content_hash.clone(),
+            persisted_total_size,
+            content_hash_text.clone(),
             final_ccs_path.to_string_lossy().to_string(),
+            repository_provides_digest,
         );
         converted.set_scriptlet_metadata(&conversion_result.scriptlet_metadata)?;
-        converted.insert(&conn)?;
+        ensure!(
+            converted.repository_metadata_is_current(&tx)?,
+            "repository source metadata changed while conversion was running"
+        );
+        converted.insert(&tx)?;
+        tx.commit()?;
 
         info!(
             "Recorded conversion in database (source_profile={}, name={}, version={})",
@@ -139,7 +193,7 @@ impl ConversionService {
             source_profile: Some(source_profile),
             chunk_hashes,
             total_size,
-            content_hash,
+            content_hash: content_hash_text,
             ccs_path: final_ccs_path,
             cache_state: "cold".to_string(),
             scriptlets: ScriptletPackageMetadata::from(&scriptlet_summary),
@@ -151,7 +205,6 @@ impl ConversionService {
     fn build_result_from_existing(
         &self,
         existing: &ConvertedPackage,
-        _repo_pkg: &RepositoryPackage,
     ) -> Result<ServerConversionResult> {
         let artifact = existing.repository_artifact()?;
         let scriptlet_summary = existing.scriptlet_summary()?;
@@ -168,5 +221,178 @@ impl ConversionService {
             scriptlets: ScriptletPackageMetadata::from(&scriptlet_summary),
             timing: None,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{create_test_db, insert_package, insert_repo};
+    use super::*;
+    use conary_core::db::models::RepositoryProvide;
+    use conary_core::repository::versioning::VersionScheme;
+
+    fn cache_fixture(
+        bind_current_digest: bool,
+    ) -> (
+        tempfile::NamedTempFile,
+        tempfile::TempDir,
+        ConversionService,
+        RepositoryPackage,
+        String,
+        String,
+    ) {
+        let (database, conn) = create_test_db();
+        let repository_id = insert_repo(&conn, "fedora-base", "fedora");
+        insert_package(&conn, repository_id, "systemd-udev", "259.5-1.fc44", 42);
+        let package = RepositoryPackage::find_by_name(&conn, "systemd-udev")
+            .unwrap()
+            .pop()
+            .unwrap();
+        let package_id = package.id.unwrap();
+        let source_checksum = package.checksum.clone();
+        let mut provide = RepositoryProvide::new(
+            package_id,
+            "/usr/bin/kernel-install".to_string(),
+            None,
+            "file".to_string(),
+            Some("/usr/bin/kernel-install".to_string()),
+            VersionScheme::Rpm,
+        );
+        provide.insert(&conn).unwrap();
+        let current_digest =
+            RepositoryProvide::conversion_capabilities_digest(&conn, package_id).unwrap();
+
+        let storage = tempfile::tempdir().unwrap();
+        let cache_dir = storage.path().join("cache");
+        let ccs_path = cache_dir.join("packages/existing.ccs");
+        std::fs::create_dir_all(ccs_path.parent().unwrap()).unwrap();
+        std::fs::write(&ccs_path, b"existing").unwrap();
+        let converted_digest = if bind_current_digest {
+            current_digest.clone()
+        } else {
+            conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string()
+        };
+        let mut converted = ConvertedPackage::new_repository(
+            "fedora-44".to_string(),
+            "systemd-udev".to_string(),
+            "259.5-1.fc44".to_string(),
+            "x86_64".to_string(),
+            "rpm".to_string(),
+            source_checksum.clone(),
+            &[],
+            8,
+            "sha256:content".to_string(),
+            ccs_path.to_string_lossy().to_string(),
+            converted_digest,
+        );
+        converted.insert(&conn).unwrap();
+        drop(conn);
+
+        let service = ConversionService::new(
+            storage.path().join("chunks"),
+            cache_dir,
+            database.path().to_path_buf(),
+            None,
+        );
+        (
+            database,
+            storage,
+            service,
+            package,
+            source_checksum,
+            current_digest,
+        )
+    }
+
+    #[tokio::test]
+    async fn cache_hit_requires_the_current_repository_provide_digest() {
+        let (_database, _storage, service, package, source_checksum, current_digest) =
+            cache_fixture(false);
+
+        let result = service
+            .cached_conversion_result_async(
+                "fedora-44",
+                &package,
+                &source_checksum,
+                &current_digest,
+            )
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+        let conn = conary_core::db::open(&service.db_path).unwrap();
+        assert!(
+            ConvertedPackage::find_repository_by_checksum(&conn, "fedora-44", &source_checksum)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_hit_reuses_an_exact_metadata_bound_artifact() {
+        let (_database, _storage, service, package, source_checksum, current_digest) =
+            cache_fixture(true);
+
+        let result = service
+            .cached_conversion_result_async(
+                "fedora-44",
+                &package,
+                &source_checksum,
+                &current_digest,
+            )
+            .await
+            .unwrap()
+            .expect("exact conversion cache hit");
+
+        assert_eq!(result.cache_state, "hot");
+        assert_eq!(result.name, "systemd-udev");
+    }
+
+    #[tokio::test]
+    async fn cache_hit_rejects_a_checksum_alias_with_conflicting_package_identity() {
+        let (_database, _storage, service, package, source_checksum, current_digest) =
+            cache_fixture(true);
+        let conn = conary_core::db::open(&service.db_path).unwrap();
+        let mut alias = RepositoryPackage::new(
+            package.repository_id,
+            "aliased-systemd".to_string(),
+            package.version.clone(),
+            VersionScheme::Rpm,
+            source_checksum.clone(),
+            package.size,
+            "https://example.com/aliased-systemd.rpm".to_string(),
+        );
+        alias.architecture = package.architecture.clone();
+        alias.insert(&conn).unwrap();
+        let alias_id = alias.id.unwrap();
+        let mut provide = RepositoryProvide::new(
+            alias_id,
+            "/usr/bin/kernel-install".to_string(),
+            None,
+            "file".to_string(),
+            Some("/usr/bin/kernel-install".to_string()),
+            VersionScheme::Rpm,
+        );
+        provide.insert(&conn).unwrap();
+        assert_eq!(
+            RepositoryProvide::conversion_capabilities_digest(&conn, alias_id).unwrap(),
+            current_digest
+        );
+        drop(conn);
+
+        let error = service
+            .cached_conversion_result_async("fedora-44", &alias, &source_checksum, &current_digest)
+            .await
+            .expect_err("one checksum cannot alias two current package identities")
+            .to_string();
+
+        assert!(error.contains("conflicting repository package identity"));
+        let conn = conary_core::db::open(&service.db_path).unwrap();
+        assert!(
+            ConvertedPackage::find_repository_by_checksum(&conn, "fedora-44", &source_checksum)
+                .unwrap()
+                .is_some(),
+            "the current artifact for the original identity must not be deleted"
+        );
     }
 }

--- a/apps/remi/src/server/conversion/test_support.rs
+++ b/apps/remi/src/server/conversion/test_support.rs
@@ -2,7 +2,7 @@
 //! Shared test helpers for Remi conversion child modules.
 
 use conary_core::ccs::convert::{ConversionResult, ScriptletBundleSummary};
-use conary_core::db::models::{Repository, RepositoryPackage};
+use conary_core::db::models::{ConvertedPackage, Repository, RepositoryPackage, RepositoryProvide};
 use conary_core::db::schema;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -46,6 +46,54 @@ pub(super) fn insert_package(
     );
     pkg.architecture = Some("x86_64".to_string());
     pkg.insert(conn).unwrap();
+}
+
+/// Seed the exact repository source row that makes a converted fixture current,
+/// then bind the fixture to the source row's normalized capability projection.
+pub(crate) fn seed_repository_conversion_source(
+    conn: &rusqlite::Connection,
+    converted: &mut ConvertedPackage,
+) -> i64 {
+    let artifact = converted.repository_artifact().unwrap();
+    let source_profile = artifact.source_profile.to_string();
+    let package_name = artifact.package_name.to_string();
+    let package_version = artifact.package_version.to_string();
+    let package_architecture = artifact.package_architecture.to_string();
+    let original_checksum = converted.original_checksum.clone();
+    let profile =
+        conary_core::repository::supported_profiles::profile_by_public_id(&source_profile)
+            .unwrap_or_else(|| panic!("test conversion must use exact profile '{source_profile}'"));
+
+    let repository_name = format!("conversion-fixture-{source_profile}");
+    let repository_id = match Repository::find_by_name(conn, &repository_name).unwrap() {
+        Some(repository) => repository.id.expect("persisted fixture repository"),
+        None => {
+            let mut repository = Repository::new(
+                repository_name,
+                format!("https://example.invalid/{source_profile}"),
+            );
+            repository.source_profile = Some(source_profile.clone());
+            repository.insert(conn).unwrap()
+        }
+    };
+
+    let mut package = RepositoryPackage::new(
+        repository_id,
+        package_name,
+        package_version,
+        profile.version_scheme(),
+        original_checksum,
+        1,
+        "https://example.invalid/package".to_string(),
+    );
+    package.architecture = Some(package_architecture);
+    package.source_profile = Some(source_profile);
+    let repository_package_id = package.insert(conn).unwrap();
+
+    converted.repository_provides_digest = Some(
+        RepositoryProvide::conversion_capabilities_digest(conn, repository_package_id).unwrap(),
+    );
+    repository_package_id
 }
 
 fn production_source_without_comments(path: &Path) -> String {

--- a/apps/remi/src/server/conversion/workflow.rs
+++ b/apps/remi/src/server/conversion/workflow.rs
@@ -3,6 +3,7 @@
 
 use super::ConversionService;
 use super::lookup::PackageDownloadRefresh;
+use super::metadata::RepositoryConversionMetadata;
 use super::persistence::PersistConversionInput;
 use crate::server::conversion_timing::{
     ConversionPhase, ConversionPhaseTiming, ConversionSkippedPhase, ConversionTimingReport,
@@ -23,6 +24,7 @@ struct ParsedConversion {
     original_checksum: String,
     conversion_result: ConversionResult,
     repo_pkg: RepositoryPackage,
+    repository_provides_digest: String,
     phase_timings: Vec<ConversionPhaseTiming>,
     skipped_phases: Vec<ConversionSkippedPhase>,
 }
@@ -127,8 +129,16 @@ impl ConversionService {
         let original_checksum_text = original_checksum.to_prefixed_string();
 
         let started = Instant::now();
+        let repository_metadata = self
+            .load_repository_conversion_metadata_async(&repo_pkg)
+            .await?;
         if let Some(existing) = self
-            .cached_conversion_result_async(source_feed.id(), &repo_pkg, &original_checksum_text)
+            .cached_conversion_result_async(
+                source_feed.id(),
+                &repo_pkg,
+                &original_checksum_text,
+                &repository_metadata.digest,
+            )
             .await?
         {
             timing.record(ConversionPhase::CacheLookup, started.elapsed());
@@ -144,6 +154,7 @@ impl ConversionService {
             parse_service.parse_and_convert_package(
                 &source_profile,
                 repo_pkg,
+                repository_metadata,
                 pkg_path,
                 output_dir,
                 original_checksum,
@@ -180,6 +191,7 @@ impl ConversionService {
                 original_checksum: parsed.original_checksum,
                 conversion_result: parsed.conversion_result,
                 repo_pkg: parsed.repo_pkg,
+                repository_provides_digest: parsed.repository_provides_digest,
                 chunk_hashes: stored_chunks.chunk_hashes,
             })
         })
@@ -222,6 +234,7 @@ impl ConversionService {
         &self,
         source_profile: &str,
         repo_pkg: RepositoryPackage,
+        repository_metadata: RepositoryConversionMetadata,
         pkg_path: PathBuf,
         output_dir: PathBuf,
         original_checksum: conary_core::hash::Hash,
@@ -229,7 +242,6 @@ impl ConversionService {
         let mut phase_timings = Vec::new();
         let mut skipped_phases = Vec::new();
 
-        let conn = conary_core::db::open(&self.db_path)?;
         let started = Instant::now();
         let (mut metadata, files, format) = self.parse_package(&pkg_path, source_profile)?;
         phase_timings.push(ConversionPhaseTiming {
@@ -239,7 +251,7 @@ impl ConversionService {
 
         let started = Instant::now();
         Self::apply_repository_identity(&mut metadata, &repo_pkg);
-        Self::merge_repository_provides(&conn, &repo_pkg, &mut metadata)?;
+        Self::merge_repository_provides(&repository_metadata, &mut metadata)?;
         info!(
             "Parsed: {} v{} ({} files, {} native provides)",
             metadata.name,
@@ -290,6 +302,7 @@ impl ConversionService {
             original_checksum: original_checksum.to_prefixed_string(),
             conversion_result,
             repo_pkg,
+            repository_provides_digest: repository_metadata.digest,
             phase_timings,
             skipped_phases,
         })

--- a/apps/remi/src/server/delta_manifests.rs
+++ b/apps/remi/src/server/delta_manifests.rs
@@ -416,6 +416,7 @@ pub fn get_delta(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::server::conversion::test_support::seed_repository_conversion_source;
     use conary_core::db::models::{CONVERSION_VERSION, ConvertedPackage};
     use conary_core::db::schema;
     use tempfile::NamedTempFile;
@@ -468,8 +469,12 @@ mod tests {
             total_size,
             format!("sha256:content-{name}-{version}"),
             format!("/data/{name}-{version}.ccs"),
+            conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
         );
         pkg.conversion_version = conversion_version;
+        if conversion_version == CONVERSION_VERSION {
+            seed_repository_conversion_source(conn, &mut pkg);
+        }
         pkg.insert(conn).unwrap();
     }
 
@@ -493,6 +498,7 @@ mod tests {
             total_size,
             format!("sha256:content-{name}-{version}"),
             format!("/data/{name}-{version}.ccs"),
+            conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
         );
         pkg.conversion_version = CONVERSION_VERSION - 1;
         pkg.insert(conn).unwrap();

--- a/apps/remi/src/server/federated_index.rs
+++ b/apps/remi/src/server/federated_index.rs
@@ -480,6 +480,7 @@ mod tests {
             42,
             format!("sha256:{package}-{version}-content"),
             format!("/tmp/{package}-{version}.ccs"),
+            conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
         );
         converted.conversion_version = CONVERSION_VERSION - 1;
         converted.insert(conn).unwrap();

--- a/apps/remi/src/server/handlers/chunks/tests.rs
+++ b/apps/remi/src/server/handlers/chunks/tests.rs
@@ -1,5 +1,6 @@
 // apps/remi/src/server/handlers/chunks/tests.rs
 use super::*;
+use crate::server::conversion::test_support::seed_repository_conversion_source;
 
 #[test]
 fn batch_fetch_request_rejects_removed_json_format() {
@@ -41,9 +42,12 @@ async fn chunk_state_with_db(
             11,
             format!("sha256:content-{index}"),
             format!("/tmp/pkg-{index}.ccs"),
+            conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
         );
         if stale {
             converted.conversion_version = CONVERSION_VERSION - 1;
+        } else {
+            seed_repository_conversion_source(&conn, &mut converted);
         }
         converted.insert(&conn).unwrap();
     }

--- a/apps/remi/src/server/handlers/detail.rs
+++ b/apps/remi/src/server/handlers/detail.rs
@@ -624,7 +624,7 @@ fn query_overview(db_path: &std::path::Path) -> anyhow::Result<OverviewStats> {
     // Total current converted packages.
     let mut total_converted = 0_i64;
     for converted in ConvertedPackage::list_repository_conversions(&conn)? {
-        if !converted.needs_reconversion() {
+        if converted.repository_metadata_is_current(&conn)? {
             converted.repository_artifact()?;
             converted.scriptlet_summary()?;
             total_converted += 1;
@@ -839,8 +839,14 @@ mod tests {
         conn.execute(
             "INSERT INTO repository_packages
              (repository_id, name, version, architecture, description, checksum, size, download_url, version_scheme)
-             VALUES (?1, ?2, ?3, ?4, 'test package', 'sha256:repo', 3, 'https://example.invalid/pkg.rpm', 'rpm')",
-            rusqlite::params![repository_id, name, version, architecture],
+             VALUES (?1, ?2, ?3, ?4, 'test package', ?5, 3, 'https://example.invalid/pkg.rpm', 'rpm')",
+            rusqlite::params![
+                repository_id,
+                name,
+                version,
+                architecture,
+                format!("sha256:source-{name}-{version}")
+            ],
         )
         .unwrap();
     }
@@ -865,6 +871,7 @@ mod tests {
             3,
             format!("sha256:content-{name}-{version}"),
             format!("/tmp/{name}-{version}.ccs"),
+            conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
         );
         converted.conversion_version = conversion_version;
         converted.insert(conn).unwrap();
@@ -889,6 +896,7 @@ mod tests {
             3,
             format!("sha256:content-{name}-{version}"),
             format!("/tmp/{name}-{version}.ccs"),
+            conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
         );
         converted.conversion_version = CONVERSION_VERSION - 1;
         converted.insert(conn).unwrap();
@@ -947,6 +955,7 @@ mod tests {
             "x86_64",
             CONVERSION_VERSION,
         );
+        seed_repository_package(&conn, "fedora", "current", "1.0", Some("x86_64"));
 
         let overview = query_overview(temp_file.path()).unwrap();
 

--- a/apps/remi/src/server/handlers/index.rs
+++ b/apps/remi/src/server/handlers/index.rs
@@ -132,8 +132,8 @@ fn build_metadata(
     }
     repo_packages.retain(|pkg| pkg.size > 0);
 
-    // Query converted packages once so we can both mark repo-backed entries as
-    // converted and surface packages that exist only in Remi's CCS store.
+    // Query current conversions once to mark their exact repository-backed
+    // entries as converted.
     let converted_packages = load_converted_metadata_rows(&conn, profile.id())?;
     let converted_set: HashSet<PackageKey> = converted_packages
         .iter()
@@ -191,38 +191,6 @@ fn build_metadata(
         })
         .collect::<Result<Vec<_>, anyhow::Error>>()?;
 
-    let existing_keys: HashSet<PackageKey> = packages
-        .iter()
-        .map(|pkg| {
-            package_key(
-                &pkg.name,
-                &pkg.version,
-                pkg.release.as_deref(),
-                pkg.architecture.as_deref(),
-            )
-        })
-        .collect();
-    for converted in converted_packages {
-        let key = package_key(
-            &converted.name,
-            &converted.version,
-            None,
-            converted.architecture.as_deref(),
-        );
-        if !existing_keys.contains(&key) {
-            packages.push(PackageEntry {
-                name: converted.name,
-                version: converted.version,
-                release: None,
-                architecture: converted.architecture,
-                converted: true,
-                provides: Vec::new(),
-                requirement_groups: Vec::new(),
-                metadata: metadata_with_scriptlets(None, Some(&converted.scriptlets))?,
-            });
-        }
-    }
-
     // Sort by name, then version
     packages.sort_by(|a, b| {
         a.name
@@ -274,29 +242,6 @@ struct ConvertedMetadataRow {
     scriptlets: ScriptletPackageMetadata,
 }
 
-/// Build converted package entries for this distro.
-#[cfg(test)]
-fn build_converted_packages(
-    conn: &Connection,
-    source_profile: &str,
-) -> Result<Vec<PackageEntry>, anyhow::Error> {
-    load_converted_metadata_rows(conn, source_profile)?
-        .into_iter()
-        .map(|row| {
-            Ok(PackageEntry {
-                name: row.name,
-                version: row.version,
-                release: None,
-                architecture: row.architecture,
-                converted: true,
-                provides: Vec::new(),
-                requirement_groups: Vec::new(),
-                metadata: metadata_with_scriptlets(None, Some(&row.scriptlets))?,
-            })
-        })
-        .collect()
-}
-
 fn load_converted_metadata_rows(
     conn: &Connection,
     source_profile: &str,
@@ -307,14 +252,6 @@ fn load_converted_metadata_rows(
         let name = artifact.package_name.to_string();
         let version = artifact.package_version.to_string();
         let architecture = Some(artifact.package_architecture.to_string());
-
-        // Pre-architecture Remi conversion records cannot be addressed safely
-        // once native metadata has multilib packages and epoch-aware versions.
-        // Keep uploaded CCS fixtures visible, but do not advertise ambiguous
-        // repo-derived conversions as installable repository metadata.
-        if architecture.is_none() && converted.original_format != "ccs" {
-            continue;
-        }
 
         let scriptlet_summary = converted.scriptlet_summary()?;
 

--- a/apps/remi/src/server/handlers/index/tests.rs
+++ b/apps/remi/src/server/handlers/index/tests.rs
@@ -5,7 +5,7 @@ use crate::server::native_publish::test_support::seed_native_publication;
 use conary_core::ccs::convert::ScriptletBundleSummary;
 use conary_core::db::models::{
     ConvertedPackage, Repository, RepositoryPackage, RepositoryRequirement,
-    RepositoryRequirementGroup as DbRequirementGroup, Trove, TroveType,
+    RepositoryRequirementGroup as DbRequirementGroup,
 };
 use conary_core::db::schema;
 use conary_core::repository::dependency_model::{
@@ -43,6 +43,7 @@ fn insert_converted_with_summary(
         42,
         format!("sha256:{package}-{version}-content"),
         format!("/tmp/{package}-{version}.ccs"),
+        conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
     );
     converted.set_scriptlet_metadata(&summary).unwrap();
     converted.insert(conn).unwrap();
@@ -415,6 +416,7 @@ fn test_build_metadata_with_converted_packages() {
         2048,
         "sha256:content".to_string(),
         "/path/to/nginx.ccs".to_string(),
+        conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
     );
     converted.insert(&conn).unwrap();
 
@@ -437,7 +439,7 @@ fn test_build_metadata_with_converted_packages() {
 }
 
 #[test]
-fn test_build_metadata_with_converted_only_package() {
+fn metadata_omits_conversion_without_current_repository_source() {
     let (temp_file, conn) = create_test_db();
 
     let mut repo = Repository::new("fedora".to_string(), "https://example.com".to_string());
@@ -455,27 +457,24 @@ fn test_build_metadata_with_converted_only_package() {
         1277,
         "fixture-hash".to_string(),
         "/conary/cache/packages/conary-test-fixture-1.0.0.ccs".to_string(),
+        conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
     );
     converted.insert(&conn).unwrap();
 
     let metadata = build_metadata(temp_file.path(), "fedora").unwrap();
 
-    assert_eq!(metadata.package_count, 1);
-    assert_eq!(metadata.converted_count, 1);
-
-    let fixture = metadata
-        .packages
-        .iter()
-        .find(|p| p.name == "conary-test-fixture")
-        .unwrap();
-    assert_eq!(fixture.version, "1.0.0");
-    assert!(fixture.converted);
-    assert!(fixture.provides.is_empty());
-    assert!(fixture.requirement_groups.is_empty());
+    assert_eq!(metadata.package_count, 0);
+    assert_eq!(metadata.converted_count, 0);
+    assert!(
+        metadata
+            .packages
+            .iter()
+            .all(|package| package.name != "conary-test-fixture")
+    );
 }
 
 #[test]
-fn metadata_merges_public_scriptlet_metadata_for_repo_backed_and_converted_only_rows() {
+fn metadata_merges_public_scriptlet_metadata_only_for_current_repository_rows() {
     let (temp_file, conn) = create_test_db();
 
     let mut repo = Repository::new("fedora".to_string(), "https://example.com".to_string());
@@ -516,6 +515,7 @@ fn metadata_merges_public_scriptlet_metadata_for_repo_backed_and_converted_only_
         2048,
         "sha256:repo-backed-content".to_string(),
         "/cache/repo-backed.ccs".to_string(),
+        conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
     );
     repo_backed
         .set_scriptlet_metadata(&ScriptletBundleSummary {
@@ -536,6 +536,7 @@ fn metadata_merges_public_scriptlet_metadata_for_repo_backed_and_converted_only_
         4096,
         "sha256:converted-only-content".to_string(),
         "/cache/converted-only.ccs".to_string(),
+        conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
     );
     converted_only
         .set_scriptlet_metadata(&ScriptletBundleSummary {
@@ -566,23 +567,11 @@ fn metadata_merges_public_scriptlet_metadata_for_repo_backed_and_converted_only_
         Some("native-lifecycle")
     );
 
-    let converted_only = metadata
-        .packages
-        .iter()
-        .find(|pkg| pkg.name == "converted-only")
-        .unwrap();
-    assert!(converted_only.converted);
-    let converted_only_scriptlets = converted_only
-        .metadata
-        .as_ref()
-        .unwrap()
-        .get("scriptlets")
-        .unwrap();
-    assert_eq!(
-        converted_only_scriptlets
-            .get("scriptlet_fidelity")
-            .and_then(serde_json::Value::as_str),
-        Some("native-lifecycle")
+    assert!(
+        metadata
+            .packages
+            .iter()
+            .all(|package| package.name != "converted-only")
     );
 
     let unconverted = metadata
@@ -710,96 +699,6 @@ fn test_find_repository_not_found() {
 
     let found = find_repository_for_profile(&conn, "fedora-44").unwrap();
     assert!(found.is_none());
-}
-
-#[test]
-fn test_build_converted_packages() {
-    let (_temp_file, conn) = create_test_db();
-
-    // Add converted packages for different distros
-    let mut fedora_pkg = ConvertedPackage::new_repository(
-        "fedora-44".to_string(),
-        "nginx".to_string(),
-        "1.24.0".to_string(),
-        "x86_64".to_string(),
-        "rpm".to_string(),
-        "sha256:fed1".to_string(),
-        &[],
-        1024,
-        "sha256:c1".to_string(),
-        "/path/1.ccs".to_string(),
-    );
-    fedora_pkg.insert(&conn).unwrap();
-
-    let mut arch_pkg = ConvertedPackage::new_repository(
-        "arch".to_string(),
-        "nginx".to_string(),
-        "1.24.0".to_string(),
-        "x86_64".to_string(),
-        "arch".to_string(),
-        "sha256:arch1".to_string(),
-        &[],
-        1024,
-        "sha256:c2".to_string(),
-        "/path/2.ccs".to_string(),
-    );
-    arch_pkg.insert(&conn).unwrap();
-
-    // Query for fedora - should only get fedora packages
-    let fedora_set = build_converted_packages(&conn, "fedora-44").unwrap();
-    assert_eq!(fedora_set.len(), 1);
-    assert_eq!(fedora_set[0].name, "nginx");
-    assert_eq!(fedora_set[0].version, "1.24.0");
-    assert!(fedora_set[0].converted);
-
-    // Query for arch - should only get arch packages
-    let arch_set = build_converted_packages(&conn, "arch").unwrap();
-    assert_eq!(arch_set.len(), 1);
-    assert_eq!(arch_set[0].name, "nginx");
-    assert_eq!(arch_set[0].version, "1.24.0");
-
-    // Query for ubuntu - should be empty
-    let ubuntu_set = build_converted_packages(&conn, "ubuntu-26.04").unwrap();
-    assert!(ubuntu_set.is_empty());
-}
-
-#[test]
-fn test_build_converted_packages_ignores_null_fields() {
-    let (_temp_file, conn) = create_test_db();
-
-    // Add a client-side converted package (no package_name/version/distro)
-    let mut trove = Trove::new(
-        "installed-client".to_string(),
-        "1.0".to_string(),
-        TroveType::Package,
-        conary_core::repository::versioning::VersionScheme::Conary,
-    );
-    let trove_id = trove.insert(&conn).unwrap();
-    let mut client_pkg =
-        ConvertedPackage::new_installed(trove_id, "rpm".to_string(), "sha256:client".to_string());
-    client_pkg.insert(&conn).unwrap();
-
-    // Add a server-side converted package
-    let mut server_pkg = ConvertedPackage::new_repository(
-        "fedora-44".to_string(),
-        "curl".to_string(),
-        "8.5.0".to_string(),
-        "x86_64".to_string(),
-        "rpm".to_string(),
-        "sha256:server".to_string(),
-        &[],
-        512,
-        "sha256:c".to_string(),
-        "/path/curl.ccs".to_string(),
-    );
-    server_pkg.insert(&conn).unwrap();
-
-    let set = build_converted_packages(&conn, "fedora-44").unwrap();
-
-    // Should only include the server-side package with non-null fields
-    assert_eq!(set.len(), 1);
-    assert_eq!(set[0].name, "curl");
-    assert_eq!(set[0].version, "8.5.0");
 }
 
 #[test]

--- a/apps/remi/src/server/handlers/oci.rs
+++ b/apps/remi/src/server/handlers/oci.rs
@@ -547,14 +547,13 @@ fn build_manifest(
         )?
     };
 
-    let converted = match converted {
-        Some(converted) if !converted.needs_reconversion() => {
-            converted.scriptlet_summary()?;
-            converted
-        }
-        None => return Ok(None),
-        Some(_) => return Ok(None),
+    let Some(converted) = converted else {
+        return Ok(None);
     };
+    if !converted.repository_metadata_is_current(&conn)? {
+        return Ok(None);
+    }
+    converted.scriptlet_summary()?;
 
     let artifact = converted.repository_artifact()?;
     let chunk_hashes = &artifact.chunk_hashes;
@@ -651,7 +650,7 @@ fn build_catalog(db_path: &std::path::Path) -> Result<OciCatalog, anyhow::Error>
     let conn = Connection::open(db_path)?;
     let mut repositories = Vec::new();
     for converted in ConvertedPackage::list_repository_conversions(&conn)? {
-        if converted.needs_reconversion() {
+        if !converted.repository_metadata_is_current(&conn)? {
             continue;
         }
         converted.scriptlet_summary()?;

--- a/apps/remi/src/server/handlers/oci/tests.rs
+++ b/apps/remi/src/server/handlers/oci/tests.rs
@@ -1,5 +1,6 @@
 // apps/remi/src/server/handlers/oci/tests.rs
 use super::*;
+use crate::server::conversion::test_support::seed_repository_conversion_source;
 use conary_core::db::models::{CONVERSION_VERSION, ConvertedPackage};
 use conary_core::db::schema;
 use tempfile::NamedTempFile;
@@ -32,7 +33,9 @@ fn insert_converted_package(
         4096,
         format!("sha256:content-{}-{}", name, version),
         format!("/data/{}-{}.ccs", name, version),
+        conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
     );
+    seed_repository_conversion_source(conn, &mut pkg);
     pkg.insert(conn).unwrap();
 }
 
@@ -56,6 +59,7 @@ fn insert_stale_converted_package(
         4096,
         format!("sha256:content-{}-{}", name, version),
         format!("/data/{}-{}.ccs", name, version),
+        conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
     );
     pkg.conversion_version = CONVERSION_VERSION - 1;
     pkg.insert(conn).unwrap();
@@ -90,9 +94,12 @@ async fn oci_blob_state_with_db(
             10,
             format!("sha256:content-{index}"),
             format!("/tmp/pkg-{index}.ccs"),
+            conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
         );
         if stale {
             converted.conversion_version = CONVERSION_VERSION - 1;
+        } else {
+            seed_repository_conversion_source(&conn, &mut converted);
         }
         converted.insert(&conn).unwrap();
     }

--- a/apps/remi/src/server/handlers/packages.rs
+++ b/apps/remi/src/server/handlers/packages.rs
@@ -357,7 +357,7 @@ fn check_converted(
     )?;
 
     if let Some(converted) = existing {
-        if converted.needs_reconversion() {
+        if !converted.repository_metadata_is_current(&conn)? {
             return Ok(ConvertedManifestLookup::Missing);
         }
         let artifact = converted.repository_artifact()?;
@@ -729,7 +729,7 @@ fn converted_ccs_path_for_download(
         return Ok(ConvertedDownloadLookup::Missing);
     };
 
-    if converted.needs_reconversion() {
+    if !converted.repository_metadata_is_current(&conn)? {
         return Ok(ConvertedDownloadLookup::Missing);
     }
     converted.scriptlet_summary()?;

--- a/apps/remi/src/server/handlers/packages/tests.rs
+++ b/apps/remi/src/server/handlers/packages/tests.rs
@@ -1,5 +1,6 @@
 // apps/remi/src/server/handlers/packages/tests.rs
 use super::*;
+use crate::server::conversion::test_support::seed_repository_conversion_source;
 use crate::server::native_publish::test_support::seed_native_publication;
 use conary_core::ccs::convert::ScriptletBundleSummary;
 use conary_core::db::models::{CONVERSION_VERSION, ChunkAccess, ConvertedPackage};
@@ -98,12 +99,14 @@ fn converted_manifest_includes_typed_lifecycle_summary() {
         3,
         "sha256:content".to_string(),
         ccs_path.to_string_lossy().to_string(),
+        conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
     );
     let summary = ScriptletBundleSummary {
         scriptlet_fidelity: "native-free".to_string(),
         ..ScriptletBundleSummary::default()
     };
     converted.set_scriptlet_metadata(&summary).unwrap();
+    seed_repository_conversion_source(&conn, &mut converted);
     converted.insert(&conn).unwrap();
     ChunkAccess::new("sha256:chunk".to_string(), 3)
         .upsert(&conn)
@@ -143,10 +146,12 @@ fn malformed_current_conversion_metadata_is_an_internal_data_error() {
         8,
         "sha256:content".to_string(),
         ccs_path.to_string_lossy().to_string(),
+        conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
     );
     converted
         .set_scriptlet_metadata(&ScriptletBundleSummary::default())
         .unwrap();
+    seed_repository_conversion_source(&conn, &mut converted);
     converted.insert(&conn).unwrap();
     conn.execute(
         "UPDATE converted_packages SET scriptlet_summary_json = '{broken' WHERE original_checksum = ?1",
@@ -182,6 +187,7 @@ fn converted_ccs_path_for_download_rejects_stale_conversion_records() {
         17,
         "sha256:content".to_string(),
         ccs_path.to_string_lossy().to_string(),
+        conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
     );
     converted.conversion_version = CONVERSION_VERSION - 1;
     converted.insert(&conn).unwrap();

--- a/apps/remi/src/server/handlers/sparse.rs
+++ b/apps/remi/src/server/handlers/sparse.rs
@@ -487,6 +487,7 @@ mod tests {
             42,
             content_hash.to_string(),
             format!("/tmp/{package}-{version}.ccs"),
+            conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
         );
         converted.conversion_version = CONVERSION_VERSION - 1;
         converted.insert(conn).unwrap();
@@ -697,6 +698,7 @@ mod tests {
             2048,
             "sha256:content_abc".to_string(),
             "/data/nginx.ccs".to_string(),
+            conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
         );
         converted.insert(&conn).unwrap();
 
@@ -738,6 +740,7 @@ mod tests {
             2048,
             "sha256:content_abc".to_string(),
             "/data/nginx.ccs".to_string(),
+            conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
         );
         converted.conversion_version = CONVERSION_VERSION - 1;
         converted.insert(&conn).unwrap();
@@ -768,6 +771,7 @@ mod tests {
             2048,
             "sha256:i686-content".to_string(),
             "/data/libffi-i686.ccs".to_string(),
+            conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
         );
         converted.insert(&conn).unwrap();
 

--- a/apps/remi/src/server/index_gen.rs
+++ b/apps/remi/src/server/index_gen.rs
@@ -136,7 +136,7 @@ fn generate_index_for_profile(
     // Get all converted packages
     let mut converted = Vec::new();
     for candidate in ConvertedPackage::list_repository_conversions(&conn)? {
-        if !candidate.needs_reconversion() {
+        if candidate.repository_metadata_is_current(&conn)? {
             candidate.repository_artifact()?;
             candidate.scriptlet_summary()?;
             converted.push(candidate);
@@ -450,6 +450,7 @@ mod tests {
             3,
             "sha256:content".to_string(),
             "/cache/pkg.ccs".to_string(),
+            conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
         );
         converted
             .set_scriptlet_metadata(&ScriptletBundleSummary {
@@ -496,6 +497,7 @@ mod tests {
             42,
             "sha256:stale-only-content".to_string(),
             "/tmp/stale-only.ccs".to_string(),
+            conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
         );
         converted.conversion_version = conary_core::db::models::CONVERSION_VERSION - 1;
 

--- a/apps/remi/src/server/prewarm.rs
+++ b/apps/remi/src/server/prewarm.rs
@@ -459,6 +459,7 @@ mod tests {
 
     #[test]
     fn prewarm_rebuilds_stale_rows_and_skips_current_rows() {
+        use crate::server::conversion::test_support::seed_repository_conversion_source;
         use conary_core::db::schema;
         use tempfile::NamedTempFile;
 
@@ -478,6 +479,7 @@ mod tests {
             3,
             "sha256:pkg-1.0-content".to_string(),
             "/tmp/pkg-1.0.ccs".to_string(),
+            conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
         );
         stale.conversion_version = CONVERSION_VERSION - 1;
         stale.insert(&conn).unwrap();
@@ -493,7 +495,9 @@ mod tests {
             3,
             "sha256:pkg-2.0-content".to_string(),
             "/tmp/pkg-2.0.ccs".to_string(),
+            conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
         );
+        seed_repository_conversion_source(&conn, &mut current);
         current.insert(&conn).unwrap();
 
         assert_eq!(

--- a/apps/remi/src/server/routes.rs
+++ b/apps/remi/src/server/routes.rs
@@ -525,6 +525,8 @@ mod tests {
 
     #[tokio::test]
     async fn package_downloads_are_not_content_encoded() {
+        use crate::server::conversion::test_support::seed_repository_conversion_source;
+
         let temp = tempfile::TempDir::new().unwrap();
         let storage_root = temp.path().join("storage");
         let db_path = storage_root.join("metadata/conary.db");
@@ -554,7 +556,9 @@ mod tests {
             ccs_bytes.len() as i64,
             "sha256:ccs".to_string(),
             ccs_path.to_string_lossy().to_string(),
+            conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
         );
+        seed_repository_conversion_source(&conn, &mut converted);
         converted.insert(&conn).unwrap();
         drop(conn);
 

--- a/apps/remi/src/server/search.rs
+++ b/apps/remi/src/server/search.rs
@@ -571,7 +571,7 @@ fn current_conversion_search_keys(
 ) -> Result<HashSet<SearchConversionKey>> {
     let mut keys = HashSet::new();
     for converted in ConvertedPackage::list_repository_conversions(conn)? {
-        if !converted.needs_reconversion() {
+        if converted.repository_metadata_is_current(conn)? {
             let artifact = converted.repository_artifact()?;
             converted.scriptlet_summary()?;
             keys.insert(SearchConversionKey {
@@ -682,6 +682,7 @@ mod tests {
             42,
             format!("sha256:{package}-{version}-content"),
             format!("/tmp/{package}-{version}.ccs"),
+            conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
         );
         converted.conversion_version = CONVERSION_VERSION - 1;
         converted.insert(conn).unwrap();

--- a/crates/conary-core/src/db/current_schema/sql/remi.sql
+++ b/crates/conary-core/src/db/current_schema/sql/remi.sql
@@ -12,6 +12,10 @@ CREATE TABLE converted_packages (
             -- Checksum of the original package file. Repository conversion
             -- identity is scoped by exact source_profile.
             original_checksum TEXT NOT NULL,
+            -- Exact normalized repository-provide projection merged into a
+            -- repository conversion. Installed conversions have no repository
+            -- metadata projection.
+            repository_provides_digest TEXT,
             -- Conversion algorithm version (re-convert if upgraded)
             conversion_version INTEGER NOT NULL DEFAULT 1,
             -- When the conversion occurred
@@ -24,6 +28,7 @@ CREATE TABLE converted_packages (
                     AND package_version IS NULL
                     AND source_profile IS NULL
                     AND package_architecture IS NULL
+                    AND repository_provides_digest IS NULL
                     AND chunk_hashes_json IS NULL
                     AND total_size IS NULL
                     AND content_hash IS NULL
@@ -40,6 +45,11 @@ CREATE TABLE converted_packages (
                     AND length(source_profile) > 0
                     AND package_architecture IS NOT NULL
                     AND length(package_architecture) > 0
+                    AND repository_provides_digest IS NOT NULL
+                    AND length(repository_provides_digest) = 71
+                    AND substr(repository_provides_digest, 1, 7) = 'sha256:'
+                    AND substr(repository_provides_digest, 8)
+                        NOT GLOB '*[^0-9a-f]*'
                     AND chunk_hashes_json IS NOT NULL
                     AND json_valid(chunk_hashes_json)
                     AND json_type(chunk_hashes_json) = 'array'

--- a/crates/conary-core/src/db/models/converted.rs
+++ b/crates/conary-core/src/db/models/converted.rs
@@ -11,14 +11,18 @@
 use crate::ccs::convert::ScriptletBundleSummary;
 use crate::error::Result;
 use rusqlite::{Connection, OptionalExtension, Row, params};
+use std::collections::BTreeSet;
 use strum_macros::{AsRefStr, Display, EnumString};
 
 /// Current conversion algorithm version
 /// Bump this when making changes that require re-conversion of existing packages.
 ///
-/// Revision 11 removes the scriptlet publication projection: current conversion
-/// and artifact integrity are the only converted-artifact serving authority.
-pub const CONVERSION_VERSION: i32 = 11;
+/// Revision 12 binds repository conversions to the exact normalized repository
+/// capability projection that influenced their signed CCS authority.
+pub const CONVERSION_VERSION: i32 = 12;
+/// Canonical digest of an empty repository-provide projection.
+pub const EMPTY_REPOSITORY_PROVIDES_DIGEST: &str =
+    "sha256:4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945";
 
 /// Storage and ownership boundary for a converted package.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, AsRefStr, Display, EnumString)]
@@ -37,6 +41,7 @@ pub struct RepositoryConvertedArtifact<'a> {
     pub package_version: &'a str,
     pub source_profile: &'a str,
     pub package_architecture: &'a str,
+    pub repository_provides_digest: &'a str,
     pub chunk_hashes: Vec<String>,
     pub total_size: u64,
     pub content_hash: &'a str,
@@ -54,6 +59,9 @@ pub struct ConvertedPackage {
     pub original_format: String,
     /// Checksum of original package file (skip if already converted)
     pub original_checksum: String,
+    /// Digest of the exact repository-provide projection merged into a
+    /// repository conversion. Installed conversions carry no repository view.
+    pub repository_provides_digest: Option<String>,
     /// Conversion algorithm version (re-convert if upgraded)
     pub conversion_version: i32,
     /// When the conversion occurred
@@ -107,7 +115,7 @@ pub enum ChunkConversionState {
 impl ConvertedPackage {
     /// Column list for SELECT queries.
     const COLUMNS: &'static str = "id, artifact_kind, trove_id, original_format, original_checksum, \
-         conversion_version, converted_at, \
+         repository_provides_digest, conversion_version, converted_at, \
          enhancement_version, extracted_provenance_json, \
          enhancement_status, enhancement_error, enhancement_attempted_at, \
          package_name, package_version, source_profile, chunk_hashes_json, total_size, \
@@ -126,6 +134,7 @@ impl ConvertedPackage {
             trove_id: Some(trove_id),
             original_format,
             original_checksum,
+            repository_provides_digest: None,
             conversion_version: CONVERSION_VERSION,
             converted_at: None,
             // Enhancement starts as pending with version 0
@@ -162,6 +171,7 @@ impl ConvertedPackage {
         total_size: i64,
         content_hash: String,
         ccs_path: String,
+        repository_provides_digest: String,
     ) -> Self {
         let chunk_hashes_json =
             serde_json::to_string(chunk_hashes).expect("a string list always serializes to JSON");
@@ -171,6 +181,7 @@ impl ConvertedPackage {
             trove_id: None,
             original_format,
             original_checksum,
+            repository_provides_digest: Some(repository_provides_digest),
             conversion_version: CONVERSION_VERSION,
             converted_at: None,
             enhancement_version: 0,
@@ -214,24 +225,25 @@ impl ConvertedPackage {
             trove_id: row.get(2)?,
             original_format: row.get(3)?,
             original_checksum: row.get(4)?,
-            conversion_version: row.get(5)?,
-            converted_at: row.get(6)?,
-            enhancement_version: row.get(7)?,
-            extracted_provenance_json: row.get(8)?,
-            enhancement_status: row.get(9)?,
-            enhancement_error: row.get(10)?,
-            enhancement_attempted_at: row.get(11)?,
-            package_name: row.get(12)?,
-            package_version: row.get(13)?,
-            source_profile: row.get(14)?,
-            chunk_hashes_json: row.get(15)?,
-            total_size: row.get(16)?,
-            content_hash: row.get(17)?,
-            ccs_path: row.get(18)?,
-            package_architecture: row.get(19)?,
-            scriptlet_fidelity: row.get(20)?,
-            evidence_digest: row.get(21)?,
-            scriptlet_summary_json: row.get(22)?,
+            repository_provides_digest: row.get(5)?,
+            conversion_version: row.get(6)?,
+            converted_at: row.get(7)?,
+            enhancement_version: row.get(8)?,
+            extracted_provenance_json: row.get(9)?,
+            enhancement_status: row.get(10)?,
+            enhancement_error: row.get(11)?,
+            enhancement_attempted_at: row.get(12)?,
+            package_name: row.get(13)?,
+            package_version: row.get(14)?,
+            source_profile: row.get(15)?,
+            chunk_hashes_json: row.get(16)?,
+            total_size: row.get(17)?,
+            content_hash: row.get(18)?,
+            ccs_path: row.get(19)?,
+            package_architecture: row.get(20)?,
+            scriptlet_fidelity: row.get(21)?,
+            evidence_digest: row.get(22)?,
+            scriptlet_summary_json: row.get(23)?,
         })
     }
 
@@ -240,17 +252,18 @@ impl ConvertedPackage {
         self.validate_artifact_contract()?;
         self.scriptlet_summary()?;
         conn.execute(
-            "INSERT INTO converted_packages (artifact_kind, trove_id, original_format, original_checksum, conversion_version,
+            "INSERT INTO converted_packages (artifact_kind, trove_id, original_format, original_checksum, repository_provides_digest, conversion_version,
                 enhancement_version, extracted_provenance_json, enhancement_status,
                 package_name, package_version, source_profile, chunk_hashes_json, total_size, content_hash, ccs_path, package_architecture,
                 scriptlet_fidelity, evidence_digest,
                 scriptlet_summary_json)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)",
             params![
                 self.artifact_kind.as_ref(),
                 self.trove_id,
                 &self.original_format,
                 &self.original_checksum,
+                &self.repository_provides_digest,
                 self.conversion_version,
                 self.enhancement_version,
                 &self.extracted_provenance_json,
@@ -322,6 +335,61 @@ impl ConvertedPackage {
         self.conversion_version != CONVERSION_VERSION
     }
 
+    /// Check whether this repository artifact still matches the exact current
+    /// source package and normalized provide projection.
+    pub fn repository_metadata_is_current(&self, conn: &Connection) -> Result<bool> {
+        if self.needs_reconversion() {
+            return Ok(false);
+        }
+        let artifact = self.repository_artifact()?;
+        let current_inputs = super::RepositoryProvide::conversion_inputs_for_source_identity(
+            conn,
+            artifact.source_profile,
+            artifact.package_name,
+            artifact.package_version,
+            artifact.package_architecture,
+        )?
+        .into_iter()
+        .map(|(checksum, digest)| (bare_sha256(&checksum).to_string(), digest))
+        .collect::<BTreeSet<_>>();
+        if current_inputs.len() > 1 {
+            return Ok(false);
+        }
+
+        Ok(current_inputs.contains(&(
+            bare_sha256(&self.original_checksum).to_string(),
+            artifact.repository_provides_digest.to_string(),
+        )))
+    }
+
+    /// Remove repository conversion rows invalidated by one exact source
+    /// profile refresh. The caller owns the surrounding repository-sync
+    /// transaction.
+    pub fn reconcile_repository_metadata(conn: &Connection, source_profile: &str) -> Result<usize> {
+        Self::require_public_source_profile(source_profile)?;
+        let mut removed = 0usize;
+        for converted in Self::list_repository_conversions(conn)? {
+            let artifact = converted.repository_artifact()?;
+            if artifact.source_profile != source_profile {
+                continue;
+            }
+            if converted.repository_metadata_is_current(conn)? {
+                continue;
+            }
+            let id = converted.id.ok_or_else(|| {
+                crate::Error::InternalError(
+                    "persisted repository conversion has no row identity".to_string(),
+                )
+            })?;
+            removed += conn.execute(
+                "DELETE FROM converted_packages
+                 WHERE artifact_kind = 'repository' AND id = ?1",
+                [id],
+            )?;
+        }
+        Ok(removed)
+    }
+
     /// Return the exact installed trove identity for an installed conversion.
     pub fn installed_trove_id(&self) -> Result<i64> {
         if self.artifact_kind != ConvertedArtifactKind::Installed {
@@ -364,6 +432,25 @@ impl ConvertedPackage {
         }
         let package_architecture =
             self.required_repository_text("package_architecture", &self.package_architecture)?;
+        let repository_provides_digest = self.required_repository_text(
+            "repository_provides_digest",
+            &self.repository_provides_digest,
+        )?;
+        let repository_provides_digest = crate::hash::Hash::parse_prefixed(
+            repository_provides_digest,
+        )
+        .map_err(|error| {
+            crate::Error::InternalError(format!(
+                "repository converted package {} has invalid repository_provides_digest: {error}",
+                self.record_identity()
+            ))
+        })?;
+        if repository_provides_digest.algorithm != crate::hash::HashAlgorithm::Sha256 {
+            return Err(crate::Error::InternalError(format!(
+                "repository converted package {} repository_provides_digest must use sha256",
+                self.record_identity()
+            )));
+        }
         let content_hash = self.required_repository_text("content_hash", &self.content_hash)?;
         let ccs_path = self.required_repository_text("ccs_path", &self.ccs_path)?;
         let chunk_hashes_json =
@@ -399,6 +486,10 @@ impl ConvertedPackage {
             package_version,
             source_profile,
             package_architecture,
+            repository_provides_digest: self
+                .repository_provides_digest
+                .as_deref()
+                .expect("validated repository digest is present"),
             chunk_hashes,
             total_size,
             content_hash,
@@ -430,6 +521,7 @@ impl ConvertedPackage {
                     || self.package_version.is_some()
                     || self.source_profile.is_some()
                     || self.package_architecture.is_some()
+                    || self.repository_provides_digest.is_some()
                     || self.chunk_hashes_json.is_some()
                     || self.total_size.is_some()
                     || self.content_hash.is_some()
@@ -493,29 +585,32 @@ impl ConvertedPackage {
         let bare_pattern = format!("%\"{bare_hash}\"%");
         let prefixed_pattern = format!("%\"{prefixed_hash}\"%");
 
-        let mut stmt = conn.prepare(
-            "SELECT chunk_hashes_json, conversion_version,
-                    scriptlet_fidelity, evidence_digest, scriptlet_summary_json
-             FROM converted_packages
+        let sql = format!(
+            "SELECT {} FROM converted_packages
              WHERE artifact_kind = 'repository'
                AND chunk_hashes_json IS NOT NULL
                AND (chunk_hashes_json LIKE ?1 OR chunk_hashes_json LIKE ?2)",
-        )?;
+            Self::COLUMNS
+        );
+        let mut stmt = conn.prepare(&sql)?;
         let rows = stmt
-            .query_map(
-                params![bare_pattern, prefixed_pattern],
-                ChunkConversionCandidate::from_row,
-            )?
+            .query_map(params![bare_pattern, prefixed_pattern], Self::from_row)?
             .collect::<rusqlite::Result<Vec<_>>>()?;
+        drop(stmt);
 
         let mut saw_converted_reference = false;
         for candidate in rows {
-            if !candidate.references_hash(hash)? {
+            let references_hash = candidate
+                .parsed_chunk_hashes()?
+                .into_iter()
+                .any(|chunk_hash| chunk_hash == bare_hash || chunk_hash == prefixed_hash);
+            if !references_hash {
                 continue;
             }
 
             saw_converted_reference = true;
-            if candidate.is_current_conversion()? {
+            if candidate.repository_metadata_is_current(conn)? {
+                candidate.scriptlet_summary()?;
                 return Ok(ChunkConversionState::CurrentConversion);
             }
         }
@@ -591,7 +686,8 @@ impl ConvertedPackage {
         Ok(results)
     }
 
-    /// Find current converted packages for a distribution and optional name.
+    /// Find converted packages whose algorithm, exact source package, and
+    /// normalized repository-provide projection are all current.
     ///
     /// Callers that expose lifecycle metadata must parse `scriptlet_summary()`
     /// so malformed current rows surface as data corruption.
@@ -631,7 +727,15 @@ impl ConvertedPackage {
                 .collect::<rusqlite::Result<Vec<_>>>()?
         };
 
-        Ok(rows)
+        rows.into_iter()
+            .filter_map(
+                |converted| match converted.repository_metadata_is_current(conn) {
+                    Ok(true) => Some(Ok(converted)),
+                    Ok(false) => None,
+                    Err(error) => Some(Err(error)),
+                },
+            )
+            .collect()
     }
 
     /// Find a converted package by source_profile, name, and version (server-side lookup)
@@ -851,55 +955,8 @@ impl ConvertedPackage {
     }
 }
 
-struct ChunkConversionCandidate {
-    chunk_hashes_json: String,
-    conversion_version: i32,
-    scriptlet_fidelity: String,
-    evidence_digest: Option<String>,
-    scriptlet_summary_json: String,
-}
-
-impl ChunkConversionCandidate {
-    fn from_row(row: &Row) -> rusqlite::Result<Self> {
-        Ok(Self {
-            chunk_hashes_json: row.get(0)?,
-            conversion_version: row.get(1)?,
-            scriptlet_fidelity: row.get(2)?,
-            evidence_digest: row.get(3)?,
-            scriptlet_summary_json: row.get(4)?,
-        })
-    }
-
-    fn references_hash(&self, hash: &str) -> Result<bool> {
-        let bare_hash = hash.strip_prefix("sha256:").unwrap_or(hash);
-        let prefixed_hash = format!("sha256:{bare_hash}");
-        let hashes = serde_json::from_str::<Vec<String>>(&self.chunk_hashes_json)?;
-        Ok(hashes
-            .into_iter()
-            .any(|chunk_hash| chunk_hash == bare_hash || chunk_hash == prefixed_hash))
-    }
-
-    fn is_current_conversion(&self) -> Result<bool> {
-        if self.conversion_version != CONVERSION_VERSION {
-            return Ok(false);
-        }
-        let summary = serde_json::from_str::<ScriptletBundleSummary>(&self.scriptlet_summary_json)
-            .map_err(|error| {
-                crate::Error::InternalError(format!(
-                    "converted chunk reference has malformed lifecycle summary JSON: {error}"
-                ))
-            })?;
-        validate_current_scriptlet_summary(&summary)?;
-        if self.scriptlet_fidelity != summary.scriptlet_fidelity
-            || self.evidence_digest != summary.evidence_digest
-        {
-            return Err(crate::Error::InternalError(
-                "converted chunk reference lifecycle summary disagrees with indexed projection columns"
-                    .to_string(),
-            ));
-        }
-        Ok(true)
-    }
+fn bare_sha256(value: &str) -> &str {
+    value.strip_prefix("sha256:").unwrap_or(value)
 }
 
 fn default_scriptlet_summary_json() -> String {

--- a/crates/conary-core/src/db/models/converted/tests.rs
+++ b/crates/conary-core/src/db/models/converted/tests.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use crate::ccs::convert::ScriptletBundleSummary;
-use crate::db::models::{Trove, TroveType};
+use crate::db::models::{RepositoryProvide, Trove, TroveType};
 use crate::db::testing::create_test_db;
 
 fn server_package(checksum: &str, chunk: &str) -> ConvertedPackage {
@@ -17,7 +17,25 @@ fn server_package(checksum: &str, chunk: &str) -> ConvertedPackage {
         42,
         "sha256:content".to_string(),
         "/tmp/fixture.ccs".to_string(),
+        EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
     )
+}
+
+fn seed_server_package_source(conn: &Connection, checksum: &str) {
+    conn.execute(
+        "INSERT INTO repositories (name, url, source_profile)
+         VALUES ('fedora-source', 'https://example.test', 'fedora-44')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO repository_packages
+         (repository_id, name, version, architecture, checksum, size, download_url, version_scheme)
+         VALUES (1, 'fixture', '1.0-1', 'x86_64', ?1, 42,
+                 'https://example.test/fixture.rpm', 'rpm')",
+        [checksum],
+    )
+    .unwrap();
 }
 
 fn installed_package(
@@ -123,6 +141,7 @@ fn stale_rows_are_excluded_from_current_conversion_query() {
 #[test]
 fn current_typed_summary_is_returned_by_current_conversion_query() {
     let (_temp, conn) = create_test_db();
+    seed_server_package_source(&conn, "sha256:source");
     let mut converted = server_package("sha256:source", "sha256:chunk");
     converted.insert(&conn).unwrap();
 
@@ -131,6 +150,36 @@ fn current_typed_summary_is_returned_by_current_conversion_query() {
             .unwrap()
             .len(),
         1
+    );
+}
+
+#[test]
+fn repository_provide_change_invalidates_and_reconciles_conversion() {
+    let (_temp, conn) = create_test_db();
+    seed_server_package_source(&conn, "sha256:source");
+    let mut converted = server_package("sha256:source", "sha256:chunk");
+    converted.insert(&conn).unwrap();
+    assert!(converted.repository_metadata_is_current(&conn).unwrap());
+
+    let mut provide = RepositoryProvide::new(
+        1,
+        "/usr/bin/kernel-install".to_string(),
+        None,
+        "file".to_string(),
+        Some("/usr/bin/kernel-install".to_string()),
+        crate::repository::versioning::VersionScheme::Rpm,
+    );
+    provide.insert(&conn).unwrap();
+
+    assert!(!converted.repository_metadata_is_current(&conn).unwrap());
+    assert_eq!(
+        ConvertedPackage::reconcile_repository_metadata(&conn, "fedora-44").unwrap(),
+        1
+    );
+    assert!(
+        ConvertedPackage::find_repository_by_checksum(&conn, "fedora-44", "sha256:source")
+            .unwrap()
+            .is_none()
     );
 }
 
@@ -196,6 +245,7 @@ fn repository_artifact_rejects_corrupt_chunk_json() {
 #[test]
 fn chunk_conversion_state_uses_current_typed_rows() {
     let (_temp, conn) = create_test_db();
+    seed_server_package_source(&conn, "source");
     let mut converted = server_package("sha256:source", "sha256:chunk");
     converted.insert(&conn).unwrap();
 
@@ -208,6 +258,7 @@ fn chunk_conversion_state_uses_current_typed_rows() {
 #[test]
 fn chunk_conversion_state_errors_on_malformed_current_summary() {
     let (_temp, conn) = create_test_db();
+    seed_server_package_source(&conn, "source");
     let mut converted = server_package("sha256:source", "sha256:chunk");
     converted.insert(&conn).unwrap();
     conn.execute(

--- a/crates/conary-core/src/db/models/mod.rs
+++ b/crates/conary-core/src/db/models/mod.rs
@@ -82,7 +82,7 @@ pub use component_dependency::{ComponentDepType, ComponentDependency, ComponentP
 pub use config::{ConfigBackup, ConfigFile, ConfigSource, ConfigStatus};
 pub use converted::{
     CONVERSION_VERSION, ChunkConversionState, ConvertedArtifactKind, ConvertedPackage,
-    RepositoryConvertedArtifact,
+    EMPTY_REPOSITORY_PROVIDES_DIGEST, RepositoryConvertedArtifact,
 };
 pub use debian_debconf_state::DebianDebconfState;
 pub use delta::{DeltaStats, PackageDelta};

--- a/crates/conary-core/src/db/models/repository_capability.rs
+++ b/crates/conary-core/src/db/models/repository_capability.rs
@@ -3,11 +3,14 @@
 //! Normalized repository-native capability tables.
 
 use crate::error::Result;
-use crate::repository::dependency_model::{ProvideArchitectureQualifier, ProvideVersionRelation};
+use crate::packages::traits::ProvidedCapability;
+use crate::repository::dependency_model::{
+    ProvideArchitectureQualifier, ProvideVersionRelation, RepositoryCapabilityKind,
+};
 use crate::repository::distro::version_scheme_from_db;
 use crate::repository::versioning::VersionScheme;
 use rusqlite::{Connection, Row, params};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -137,6 +140,155 @@ impl RepositoryProvide {
             .query_map([repository_package_id], Self::from_row)?
             .collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(rows)
+    }
+
+    /// Project the exact normalized rows for one repository package into the
+    /// capability type signed into converted CCS authority.
+    pub fn conversion_capabilities(
+        conn: &Connection,
+        repository_package_id: i64,
+    ) -> Result<Vec<ProvidedCapability>> {
+        Self::conversion_capabilities_with_digest(conn, repository_package_id)
+            .map(|(capabilities, _)| capabilities)
+    }
+
+    /// Return one atomic projection and digest for conversion-cache identity.
+    pub fn conversion_capabilities_with_digest(
+        conn: &Connection,
+        repository_package_id: i64,
+    ) -> Result<(Vec<ProvidedCapability>, String)> {
+        Self::project_conversion_capabilities(Self::find_by_repository_package(
+            conn,
+            repository_package_id,
+        )?)
+    }
+
+    /// Load every exact source-package checksum and provider digest for one
+    /// repository conversion identity from a single SQLite read snapshot.
+    pub(crate) fn conversion_inputs_for_source_identity(
+        conn: &Connection,
+        source_profile: &str,
+        package_name: &str,
+        package_version: &str,
+        package_architecture: &str,
+    ) -> Result<Vec<(String, String)>> {
+        let mut stmt = conn.prepare(
+            "SELECT p.id, p.repository_package_id, p.capability, p.version,
+                    p.version_relation, p.kind, p.raw, p.version_scheme,
+                    p.architecture_qualifier_kind, p.architecture,
+                    rp.id, rp.checksum
+             FROM repository_packages rp
+             JOIN repositories r ON r.id = rp.repository_id
+             LEFT JOIN repository_provides p ON p.repository_package_id = rp.id
+             WHERE r.enabled = 1
+               AND r.source_profile = ?1
+               AND rp.name = ?2
+               AND rp.version = ?3
+               AND rp.architecture = ?4
+               AND rp.size > 0
+             ORDER BY rp.id, p.id",
+        )?;
+        let rows = stmt
+            .query_map(
+                params![
+                    source_profile,
+                    package_name,
+                    package_version,
+                    package_architecture,
+                ],
+                |row| {
+                    let provide = row
+                        .get::<_, Option<i64>>(0)?
+                        .map(|_| Self::from_row(row))
+                        .transpose()?;
+                    Ok((row.get::<_, i64>(10)?, row.get::<_, String>(11)?, provide))
+                },
+            )?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        drop(stmt);
+
+        let mut package_inputs = BTreeMap::<i64, (String, Vec<Self>)>::new();
+        for (repository_package_id, checksum, provide) in rows {
+            let (persisted_checksum, provides) = package_inputs
+                .entry(repository_package_id)
+                .or_insert_with(|| (checksum.clone(), Vec::new()));
+            if persisted_checksum != &checksum {
+                return Err(crate::Error::InternalError(format!(
+                    "repository package {repository_package_id} yielded conflicting checksums"
+                )));
+            }
+            if let Some(provide) = provide {
+                provides.push(provide);
+            }
+        }
+
+        package_inputs
+            .into_values()
+            .map(|(checksum, provides)| {
+                let (_, digest) = Self::project_conversion_capabilities(provides)?;
+                Ok((checksum, digest))
+            })
+            .collect()
+    }
+
+    fn project_conversion_capabilities(
+        provides: impl IntoIterator<Item = Self>,
+    ) -> Result<(Vec<ProvidedCapability>, String)> {
+        let mut capabilities = BTreeMap::<Vec<u8>, ProvidedCapability>::new();
+        for provide in provides {
+            let capability = provide.as_provided_capability()?;
+            capability.validate()?;
+            let canonical = crate::json::canonical_json(&capability).map_err(|error| {
+                crate::Error::InternalError(format!(
+                    "failed to canonicalize repository provide projection: {error}"
+                ))
+            })?;
+            capabilities.entry(canonical).or_insert(capability);
+        }
+        let capabilities = capabilities.into_values().collect::<Vec<_>>();
+        let canonical = crate::json::canonical_json(&capabilities).map_err(|error| {
+            crate::Error::InternalError(format!(
+                "failed to canonicalize repository conversion metadata: {error}"
+            ))
+        })?;
+        let digest = crate::hash::sha256_prefixed(&canonical);
+        Ok((capabilities, digest))
+    }
+
+    /// Digest the exact repository-provide projection that influences native
+    /// conversion output.
+    pub fn conversion_capabilities_digest(
+        conn: &Connection,
+        repository_package_id: i64,
+    ) -> Result<String> {
+        Self::conversion_capabilities_with_digest(conn, repository_package_id)
+            .map(|(_, digest)| digest)
+    }
+
+    fn as_provided_capability(&self) -> Result<ProvidedCapability> {
+        let kind = match self.kind.as_str() {
+            "package" => RepositoryCapabilityKind::PackageName,
+            "virtual" => RepositoryCapabilityKind::Virtual,
+            "soname" => RepositoryCapabilityKind::Soname,
+            "file" => RepositoryCapabilityKind::File,
+            "path" => RepositoryCapabilityKind::Path,
+            "binary" => RepositoryCapabilityKind::Binary,
+            "pkgconfig" => RepositoryCapabilityKind::PkgConfig,
+            "generic" => RepositoryCapabilityKind::Generic,
+            other => {
+                return Err(crate::Error::InternalError(format!(
+                    "unsupported normalized repository provide kind '{other}'"
+                )));
+            }
+        };
+        Ok(ProvidedCapability {
+            kind,
+            name: self.capability.clone(),
+            version: self.version.clone(),
+            version_relation: self.version_relation,
+            version_scheme: self.version_scheme,
+            architecture_qualifier: self.architecture_qualifier.clone(),
+        })
     }
 
     /// Load exact provides for a bounded set of repository packages in one
@@ -478,6 +630,54 @@ mod tests {
         let found = RepositoryProvide::find_by_repository_package(&conn, 1).unwrap();
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].version_scheme, VersionScheme::Rpm);
+    }
+
+    #[test]
+    fn conversion_capability_digest_tracks_only_exact_signed_projection() {
+        let conn = test_db();
+        seed_repo_and_package(&conn);
+
+        let empty = RepositoryProvide::conversion_capabilities_digest(&conn, 1).unwrap();
+        let mut shell = RepositoryProvide::new(
+            1,
+            "/usr/bin/sh".to_string(),
+            None,
+            "file".to_string(),
+            Some("first diagnostic spelling".to_string()),
+            VersionScheme::Rpm,
+        );
+        shell.insert(&conn).unwrap();
+        let with_shell = RepositoryProvide::conversion_capabilities_digest(&conn, 1).unwrap();
+        assert_ne!(empty, with_shell);
+
+        let mut duplicate = RepositoryProvide::new(
+            1,
+            "/usr/bin/sh".to_string(),
+            None,
+            "file".to_string(),
+            Some("different diagnostic spelling".to_string()),
+            VersionScheme::Rpm,
+        );
+        duplicate.insert(&conn).unwrap();
+        assert_eq!(
+            RepositoryProvide::conversion_capabilities_digest(&conn, 1).unwrap(),
+            with_shell,
+            "raw diagnostic text and duplicate rows do not change signed capability authority"
+        );
+
+        let mut kernel_install = RepositoryProvide::new(
+            1,
+            "/usr/bin/kernel-install".to_string(),
+            None,
+            "file".to_string(),
+            None,
+            VersionScheme::Rpm,
+        );
+        kernel_install.insert(&conn).unwrap();
+        assert_ne!(
+            RepositoryProvide::conversion_capabilities_digest(&conn, 1).unwrap(),
+            with_shell
+        );
     }
 
     #[test]

--- a/crates/conary-core/src/db/schema.rs
+++ b/crates/conary-core/src/db/schema.rs
@@ -12,15 +12,15 @@ use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 use std::path::Path;
 use tracing::info;
 
-/// Revision 21 of the current-only schema epoch.
+/// Revision 22 of the current-only schema epoch.
 ///
-/// Revision 21 hard-cuts installed and native-lifecycle provenance from its
-/// ambiguous former name to one exact public `source_profile`. It
-/// retains revision 20's exact package release, source-native architecture,
-/// Debian Multi-Arch behavior, typed provider range boundaries, and identity
-/// indexes. Pre-alpha databases from revision 20 must be rebuilt; no
+/// Revision 22 binds every repository conversion to the exact normalized
+/// repository-provide projection signed into its CCS authority. It retains
+/// revision 21's exact public `source_profile`, package release, source-native
+/// architecture, Debian Multi-Arch behavior, typed provider range boundaries,
+/// and identity indexes. Pre-alpha databases from revision 21 must be rebuilt; no
 /// compatibility migration is provided.
-pub const SCHEMA_VERSION: i32 = 21;
+pub const SCHEMA_VERSION: i32 = 22;
 /// Stable identity that distinguishes this epoch from retired schema revisions.
 pub const SCHEMA_EPOCH: &str = "conary-current-v1";
 
@@ -404,10 +404,12 @@ mod tests {
                 "INSERT INTO converted_packages (
                      artifact_kind, original_format, original_checksum,
                      package_name, package_version, source_profile, package_architecture,
-                     chunk_hashes_json, total_size, content_hash, ccs_path
+                     repository_provides_digest, chunk_hashes_json, total_size,
+                     content_hash, ccs_path
                  ) VALUES (
                      'repository', 'rpm', ?1, 'fixture', '1.0-1', 'fedora-44',
-                     ?2, '[\"sha256:chunk\"]', 42, 'sha256:content',
+                     ?2, 'sha256:4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945',
+                     '[\"sha256:chunk\"]', 42, 'sha256:content',
                      '/tmp/fixture.ccs'
                  )",
                 params![checksum, architecture],

--- a/crates/conary-core/src/generation/gc.rs
+++ b/crates/conary-core/src/generation/gc.rs
@@ -169,7 +169,7 @@ impl CasReachability {
         }
 
         for converted in crate::db::models::ConvertedPackage::list_repository_conversions(conn)? {
-            if converted.needs_reconversion() {
+            if !converted.repository_metadata_is_current(conn)? {
                 continue;
             }
             converted.scriptlet_summary()?;
@@ -365,7 +365,9 @@ fn should_skip_recent_object(path: &Path, now: SystemTime, grace_period: Duratio
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::models::{ConvertedPackage, FileEntry};
+    use crate::db::models::{
+        ConvertedPackage, FileEntry, Repository, RepositoryPackage, RepositoryProvide,
+    };
     use crate::db::schema;
     use crate::payload::{PayloadContentAuthority, PayloadNode, ResolvedPayloadNode};
     use tempfile::TempDir;
@@ -382,6 +384,46 @@ mod tests {
         let dir = objects_dir.join(prefix);
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join(suffix), content).unwrap();
+    }
+
+    fn seed_repository_source(conn: &Connection, converted: &mut ConvertedPackage) -> i64 {
+        let artifact = converted.repository_artifact().unwrap();
+        let source_profile = artifact.source_profile.to_string();
+        let package_name = artifact.package_name.to_string();
+        let package_version = artifact.package_version.to_string();
+        let package_architecture = artifact.package_architecture.to_string();
+        let original_checksum = converted.original_checksum.clone();
+        let profile =
+            crate::repository::supported_profiles::profile_by_public_id(&source_profile).unwrap();
+
+        let repository_name = format!("gc-fixture-{source_profile}");
+        let repository_id = match Repository::find_by_name(conn, &repository_name).unwrap() {
+            Some(repository) => repository.id.expect("persisted fixture repository"),
+            None => {
+                let mut repository = Repository::new(
+                    repository_name,
+                    format!("https://example.invalid/{source_profile}"),
+                );
+                repository.source_profile = Some(source_profile.clone());
+                repository.insert(conn).unwrap()
+            }
+        };
+        let mut package = RepositoryPackage::new(
+            repository_id,
+            package_name,
+            package_version,
+            profile.version_scheme(),
+            original_checksum,
+            1,
+            "https://example.invalid/package".to_string(),
+        );
+        package.architecture = Some(package_architecture);
+        package.source_profile = Some(source_profile);
+        let repository_package_id = package.insert(conn).unwrap();
+        converted.repository_provides_digest = Some(
+            RepositoryProvide::conversion_capabilities_digest(conn, repository_package_id).unwrap(),
+        );
+        repository_package_id
     }
 
     #[test]
@@ -493,7 +535,7 @@ mod tests {
     #[test]
     fn malformed_explicit_chunk_authority_fails_closed() {
         let conn = create_test_db();
-        ConvertedPackage::new_repository(
+        let mut converted = ConvertedPackage::new_repository(
             "fedora-44".to_string(),
             "pkg".to_string(),
             "1".to_string(),
@@ -504,9 +546,10 @@ mod tests {
             1,
             "content".to_string(),
             "/tmp/pkg.ccs".to_string(),
-        )
-        .insert(&conn)
-        .unwrap();
+            crate::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
+        );
+        seed_repository_source(&conn, &mut converted);
+        converted.insert(&conn).unwrap();
         let error = CasReachability::new()
             .protect_current_database(&conn)
             .expect_err("malformed chunk authority must abort");
@@ -530,7 +573,9 @@ mod tests {
             1,
             current.clone(),
             "/tmp/current.ccs".to_string(),
+            crate::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
         );
+        seed_repository_source(&conn, &mut current_conversion);
         current_conversion.insert(&conn).unwrap();
         let mut stale_conversion = ConvertedPackage::new_repository(
             "fedora-44".to_string(),
@@ -543,6 +588,7 @@ mod tests {
             1,
             stale.clone(),
             "/tmp/stale.ccs".to_string(),
+            crate::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
         );
         stale_conversion.conversion_version =
             crate::db::models::CONVERSION_VERSION.saturating_sub(1);

--- a/crates/conary-core/src/repository/sync/native.rs
+++ b/crates/conary-core/src/repository/sync/native.rs
@@ -1,7 +1,7 @@
 // conary-core/src/repository/sync/native.rs
 
 use crate::db::models::{
-    Repository, RepositoryPackage, RepositoryProvide, RepositoryRequirement,
+    ConvertedPackage, Repository, RepositoryPackage, RepositoryProvide, RepositoryRequirement,
     RepositoryRequirementGroup as DbRequirementGroup,
 };
 use crate::error::{Error, Result};
@@ -29,6 +29,9 @@ pub(super) fn persist_native_sync_rows(
 
     persist_synced_package_rows(&tx, repo_id, synced_packages)?;
     link_canonical_ids(&tx, repo_id)?;
+    if let Some(source_profile) = repo.source_profile.as_deref() {
+        ConvertedPackage::reconcile_repository_metadata(&tx, source_profile)?;
+    }
 
     repo.last_sync = Some(current_timestamp());
     repo.update(&tx)?;

--- a/crates/conary-core/src/repository/sync/tests.rs
+++ b/crates/conary-core/src/repository/sync/tests.rs
@@ -4,8 +4,9 @@ mod tests {
     use super::*;
     use crate::ccs::signing::SigningKeyPair;
     use crate::db::models::{
-        RepositoryPackage, RepositoryPackageKey, RepositoryProvide, RepositoryRequirement,
-        RepositoryRequirementGroup as DbRequirementGroup, SecurityAdvisorySupport,
+        ConvertedPackage, RepositoryPackage, RepositoryPackageKey, RepositoryProvide,
+        RepositoryRequirement, RepositoryRequirementGroup as DbRequirementGroup,
+        SecurityAdvisorySupport,
     };
     use crate::db::schema::ensure_current;
     use crate::hash::sha256;

--- a/crates/conary-core/src/repository/sync/tests/native.rs
+++ b/crates/conary-core/src/repository/sync/tests/native.rs
@@ -171,6 +171,97 @@ fn native_sync_persists_generator_selected_rpm_file_providers_without_reclassifi
 }
 
 #[test]
+fn native_sync_invalidates_conversion_when_exact_provides_change() {
+    let conn = Connection::open_in_memory().unwrap();
+    ensure_current(&conn).unwrap();
+
+    let mut repo = Repository::new(
+        "fedora-44".to_string(),
+        "https://example.com/fedora".to_string(),
+    );
+    repo.source_profile = Some("fedora-44".to_string());
+    repo.insert(&conn).unwrap();
+    let repo_id = repo.id.unwrap();
+
+    let synced_row = |include_kernel_install: bool| {
+        let mut metadata = PackageMetadata::new(
+            "systemd-udev".to_string(),
+            "259.5-1.fc44".to_string(),
+            "sha256:systemd-udev".to_string(),
+            1024,
+            "https://example.com/fedora/systemd-udev.rpm".to_string(),
+            RepositoryDependencyFlavor::Rpm,
+            VersionScheme::Rpm,
+        );
+        metadata.architecture = Some("x86_64".to_string());
+        metadata.provides = vec![dep_model::RepositoryProvide::package_name(
+            "systemd-udev".to_string(),
+            Some("259.5-1.fc44".to_string()),
+        )];
+        if include_kernel_install {
+            metadata.provides.push(dep_model::RepositoryProvide::file(
+                "/usr/bin/kernel-install".to_string(),
+            ));
+        }
+        let provides = normalized_repository_capabilities(&metadata);
+        let mut package = RepositoryPackage::new(
+            repo_id,
+            metadata.name,
+            metadata.version,
+            VersionScheme::Rpm,
+            metadata.checksum,
+            metadata.size as i64,
+            metadata.download_url,
+        );
+        package.architecture = metadata.architecture;
+        package.source_profile = Some("fedora-44".to_string());
+        SyncedPackageRow {
+            package,
+            provides,
+            requirement_groups: Vec::new(),
+            requirement_group_clauses: Vec::new(),
+        }
+    };
+
+    persist_native_sync_rows(&conn, &mut repo, vec![synced_row(false)]).unwrap();
+    let repository_package_id = RepositoryPackage::find_by_repository(&conn, repo_id)
+        .unwrap()
+        .pop()
+        .unwrap()
+        .id
+        .unwrap();
+    let digest =
+        RepositoryProvide::conversion_capabilities_digest(&conn, repository_package_id).unwrap();
+    let mut converted = ConvertedPackage::new_repository(
+        "fedora-44".to_string(),
+        "systemd-udev".to_string(),
+        "259.5-1.fc44".to_string(),
+        "x86_64".to_string(),
+        "rpm".to_string(),
+        "sha256:systemd-udev".to_string(),
+        &[],
+        1,
+        "sha256:converted".to_string(),
+        "/tmp/systemd-udev.ccs".to_string(),
+        digest,
+    );
+    converted.insert(&conn).unwrap();
+
+    persist_native_sync_rows(&conn, &mut repo, vec![synced_row(true)]).unwrap();
+
+    assert!(
+        ConvertedPackage::find_repository_by_checksum(
+            &conn,
+            "fedora-44",
+            "sha256:systemd-udev"
+        )
+        .unwrap()
+        .is_none(),
+        "a conversion signed before the new exact file provider must not remain current"
+    );
+}
+
+#[test]
 fn test_remi_sparse_entry_builds_normalized_capabilities() {
     let entry = RemiSparseResolutionVersionEntry {
         version: "6.19.6-200.fc44".to_string(),

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-29
-revision: 13
+last_updated: 2026-07-30
+revision: 14
 summary: Document Remi source, sparse sync, signing, canonical-map, repository trust, conversion, publication, and serving authority
 ---
 
@@ -257,11 +257,15 @@ The current schema separates installed conversions from repository-serving
 artifacts with a required discriminator. Installed rows require an exact trove
 identity and cannot carry serving fields. Repository rows require their exact
 distro/name/version/architecture identity, chunk list, total size, content
-hash, and CCS path; public and OCI handlers validate that typed artifact
-instead of filling missing fields with guesses or empty values. Architecture is
-a required constructor and API-view field, and the current schema rejects
-missing or empty values. Local conversion tracking is written only after the
-CCS install transaction commits.
+hash, CCS path, and SHA-256 digest of the normalized repository-provide
+projection merged into signed CCS authority; public, OCI, index, search, chunk,
+and garbage-collection paths validate that typed artifact instead of filling
+missing fields with guesses or empty values. Architecture and the repository
+provide digest are required constructor and API-view fields, and the current
+schema rejects missing, empty, or malformed values. Schema revision 22 is a
+pre-alpha hard cut: prior databases are rebuilt and re-ingested from configured
+repository authority rather than migrated. Local conversion tracking is
+written only after the CCS install transaction commits.
 
 Ready conversion means the artifact carries a source-independent Conary
 lifecycle contract. A client may install it on any target whose typed
@@ -287,9 +291,16 @@ local filesystem paths are not part of any public response.
 
 Server conversion has two terminal outcomes: ready or failed. A ready
 conversion is advertised and served when its conversion version and lifecycle
-summary are current and its CCS/CAS objects exist. Lifecycle program content,
-diagnostic classes, package names, provides, and command-name matches do not
-create a second serving decision.
+summary are current, its stored repository-provide digest exactly matches the
+current normalized source package, and its CCS/CAS objects exist. A native
+metadata refresh removes mismatched conversion rows in the same SQLite
+transaction. Cold conversion carries one immutable provider snapshot through
+cache lookup, CCS signing, and persistence, then revalidates it under the
+database write transaction so a concurrent refresh cannot publish mixed
+authority. CCS cache files use their emitted content hash as the local filename
+instead of a mutable package-name/version slot. Lifecycle program content,
+diagnostic classes, package names, and command-name matches do not create a
+second serving decision.
 
 Every route resolves the public route slug to one exact persisted source
 profile and uses the same current-row validation. A stale row is reconverted;


### PR DESCRIPTION
## Problem

The Fedora supported-host proof reached corrected sparse metadata but still received a CCS conversion created before the exact `/usr/bin/kernel-install` provider was present. The upstream RPM checksum had not changed, while Remi's converted artifact incorporates normalized repository-provide rows that live outside the RPM bytes. A checksum/version-only cache could therefore serve signed CCS authority built from stale inputs.

## Fix

- Persist a SHA-256 digest of the exact canonical repository-provide projection on every repository conversion.
- Require that digest in the repository artifact constructor and typed API view.
- Carry one immutable package/provider snapshot through cache lookup, conversion, signing, and persistence; revalidate both under an immediate SQLite transaction.
- Load current source checksum/provider inputs in one joined SQLite snapshot and fail closed when enabled repositories disagree.
- Reconcile invalidated conversion rows transactionally during native metadata refresh.
- Use content-addressed CCS cache filenames instead of mutable package/version slots.
- Apply the same exact current-row decision to package serving, sparse/index generation, OCI, search, delta, prewarm, chunks, and CAS reachability.
- Remove the superseded converted-only public metadata lane; native CCS publication remains owned by `native_package_publications`.

## Schema and deployment impact

This is the intended pre-alpha hard cut:

- current schema revision: 22
- conversion revision: 12
- prior Remi databases must be rebuilt and repository metadata re-ingested; no compatibility migration is added
- old converted rows are not accepted as current

## Verification

Passed on commit `5663502f`:

- `cargo test -p conary-core -p remi --quiet`
  - conary-core: 3,220 passed, 2 fixture-gated ignored
  - Remi: 588 library + 5 binary + 3 CLI tests passed
- `cargo test -p conary --test conversion_integration golden_conversion` (4 passed)
- `cargo test -p conary --test packaging_m4c` (1 passed)
- `bash scripts/test-remi-deploy-helper.sh`
- `bash scripts/check-doc-truth.sh`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Follow-through

Keep #196 open after merge until the schema hard cut is released/deployed, Fedora metadata is re-ingested and queried independently, and the #137 TGE02 transaction is rerun against the rebuilt conversion.

Refs #196
Refs #137
Refs #210