### PR TITLE
release(remi): prepare 0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [remi-v0.9.4] - 2026-07-30
+
+### Fixed
+- bind conversions to repository metadata (#219)
+- retain deferred IMA signatures (#208)
+
 ## [remi-v0.9.3] - 2026-07-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4857,7 +4857,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remi"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/apps/remi/Cargo.toml
+++ b/apps/remi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remi"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]


### PR DESCRIPTION
## Primary Issue

Refs #196

Related: #137, #208, #210, #219

Design / Plan / Roadmap: `docs/operations/release-artifact-matrix.md`; release ownership card in `docs/modules/feature-ownership.md`

## Problem And Outcome

Production Remi 0.9.3 predates the schema-22 conversion-cache correction merged through #219. Its conversion rows do not bind the cached CCS artifact to the exact normalized repository-provider projection, so a metadata-only provider correction can still serve an older artifact for unchanged native bytes.

Prepare an immutable Remi 0.9.4 patch identity so the exact merged service can pass release CI, hard-cut deployment/repopulation, independent production proof, and the final Fedora supported-host gate. After merge, the repository owns Remi version 0.9.4 and an accurate changelog entry. Tagging, deployment, and production/KVM proof remain post-merge gates.

## Changes

- bump the Remi crate and lockfile from 0.9.3 to 0.9.4
- record the repository-metadata cache binding from #219 and deferred IMA-signature retention from #208 in the Remi 0.9.4 changelog

## Scope

- In scope: release identity and changelog metadata for already-merged fixes
- Out of scope: release tag creation, deployment, production verification, and Fedora KVM proof; those occur only after exact-head PR CI and post-merge validation succeed

## Ownership / Boundary

- Owning subsystem: release assembly / Remi packaging
- Boundary changed or preserved: preserves the release workflow as the sole authority for the immutable version/tag/deploy chain
- Persisted state or public surface impact: no runtime behavior change in this PR; the later deployment hard-cuts disposable Remi state to schema revision 22 and repopulates it from exact configured sources
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed (not applicable: release metadata only)
- [x] Ran affected-package verification directly when touching service or daemon code
- [x] Updated subsystem docs or maps when the "look here first" path changed (not applicable: ownership is unchanged)
- [x] Ran the broader interaction gate when the feature ownership card required it (not applicable: no behavior changes in this release-metadata slice)
- [x] Updated the primary issue with any acceptance criteria left for later PRs

```text
- cargo fmt --all --check
- bash scripts/check-doc-truth.sh
- ./scripts/release.sh remi --dry-run --target remi=0.9.4
- bash scripts/check-release-matrix.sh
- bash scripts/test-release-matrix.sh
- cargo test -p remi --quiet
```

Observed: formatting and documentation truth passed; release-matrix policy and all matrix fixtures passed; the explicit dry run resolved canonical tag `remi-v0.9.4`; Remi passed 588 library, 5 binary, and 3 CLI tests with no failures (2 doctest examples ignored).

The implementation merge `33d8c79241161d60b241c443b9d91e2e0c001b71` also passed exact post-merge validation run 30551655019 before this release branch was created.

## Review And Merge Notes

- Review focus: exact version identity, changelog scope, schema-hard-cut impact wording, and preservation of the tag-after-post-merge-validation gate
- User or developer impact: enables corrected conversion cache authority to reach production before final Fedora KVM validation
- Required-check bypass: not used