### PR TITLE
fix(remi): serialize conversion database writes

### DIFF
--- a/apps/remi/src/server/conversion.rs
+++ b/apps/remi/src/server/conversion.rs
@@ -5,6 +5,7 @@
 //! to CCS format, storing chunks in the CAS.
 
 mod benchmark;
+mod database;
 mod lookup;
 mod metadata;
 mod persistence;
@@ -16,6 +17,7 @@ mod types;
 mod workflow;
 
 use crate::server::R2Store;
+use database::ConversionDatabaseWriter;
 use std::path::PathBuf;
 use std::sync::Arc;
 pub use types::{ConversionBenchmarkEvidence, ScriptletPackageMetadata, ServerConversionResult};
@@ -33,6 +35,8 @@ pub struct ConversionService {
     r2_store: Option<Arc<R2Store>>,
     /// Remi-owned per-distro TUF keys used to authenticate converted CCS.
     repository_keys_dir: Option<PathBuf>,
+    /// Shared owner for the short SQLite mutation phases of conversion work.
+    database_writer: ConversionDatabaseWriter,
 }
 
 impl ConversionService {
@@ -48,7 +52,13 @@ impl ConversionService {
             db_path,
             r2_store,
             repository_keys_dir: None,
+            database_writer: ConversionDatabaseWriter::default(),
         }
+    }
+
+    pub(crate) fn with_r2_store(mut self, r2_store: Option<Arc<R2Store>>) -> Self {
+        self.r2_store = r2_store;
+        self
     }
 
     pub fn with_repository_keys_dir(mut self, keys_dir: Option<PathBuf>) -> Self {
@@ -76,5 +86,22 @@ mod tests {
         assert_eq!(service.db_path, PathBuf::from("/db.sqlite"));
         assert!(service.r2_store.is_none());
         assert!(service.repository_keys_dir.is_none());
+    }
+
+    #[test]
+    fn cloned_services_share_the_conversion_database_writer() {
+        let service = ConversionService::new(
+            PathBuf::from("/chunks"),
+            PathBuf::from("/cache"),
+            PathBuf::from("/db.sqlite"),
+            None,
+        );
+        let clone = service.clone();
+
+        assert!(
+            service
+                .database_writer
+                .shares_owner_with(&clone.database_writer)
+        );
     }
 }

--- a/apps/remi/src/server/conversion/database.rs
+++ b/apps/remi/src/server/conversion/database.rs
@@ -1,0 +1,90 @@
+// apps/remi/src/server/conversion/database.rs
+//! Process-local ownership for Remi conversion database mutations.
+
+use anyhow::{Result, anyhow};
+use std::sync::{Arc, Mutex};
+
+/// Serializes the short SQLite mutation phases shared by conversion work.
+///
+/// SQLite admits one writer at a time. Conversion download, parsing, CCS
+/// emission, CAS storage, and R2 upload remain concurrent; only the database
+/// transactions that publish their results pass through this owner.
+#[derive(Clone, Default)]
+pub(super) struct ConversionDatabaseWriter {
+    gate: Arc<Mutex<()>>,
+}
+
+impl ConversionDatabaseWriter {
+    pub(super) fn execute<T>(&self, operation: impl FnOnce() -> Result<T>) -> Result<T> {
+        let _guard = self
+            .gate
+            .lock()
+            .map_err(|_| anyhow!("conversion database writer lock is poisoned"))?;
+        operation()
+    }
+
+    #[cfg(test)]
+    pub(super) fn shares_owner_with(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.gate, &other.gate)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::TransactionBehavior;
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    fn initialized_db(temp_dir: &tempfile::TempDir) -> PathBuf {
+        let db_path = temp_dir.path().join("remi.db");
+        conary_core::db::init(&db_path).unwrap();
+        let conn = conary_core::db::open_fast(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE conversion_writer_probe (
+                value INTEGER PRIMARY KEY
+            );",
+        )
+        .unwrap();
+        db_path
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn shared_writer_serializes_tiny_timeout_sqlite_transactions() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let db_path = initialized_db(&temp_dir);
+        let writer = ConversionDatabaseWriter::default();
+
+        let mut tasks = Vec::new();
+        for value in 0..32_i64 {
+            let db_path = db_path.clone();
+            let writer = writer.clone();
+            tasks.push(tokio::task::spawn_blocking(move || {
+                writer.execute(|| {
+                    let mut conn = conary_core::db::open_fast(&db_path)?;
+                    conn.busy_timeout(Duration::from_millis(1))?;
+                    let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                    tx.execute(
+                        "INSERT INTO conversion_writer_probe (value) VALUES (?1)",
+                        [value],
+                    )?;
+                    std::thread::sleep(Duration::from_millis(2));
+                    tx.commit()?;
+                    Ok(())
+                })
+            }));
+        }
+
+        for task in tasks {
+            task.await.unwrap().unwrap();
+        }
+
+        let conn = conary_core::db::open_fast(&db_path).unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM conversion_writer_probe", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(count, 32);
+    }
+}

--- a/apps/remi/src/server/conversion/persistence.rs
+++ b/apps/remi/src/server/conversion/persistence.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result, anyhow, ensure};
 use conary_core::ccs::convert::ConversionResult;
 use conary_core::db::models::{ConvertedPackage, RepositoryPackage, RepositoryProvide};
 use conary_core::packages::common::PackageMetadata;
-use rusqlite::TransactionBehavior;
+use rusqlite::{Connection, TransactionBehavior};
 use std::path::PathBuf;
 use tracing::info;
 
@@ -22,7 +22,70 @@ pub(super) struct PersistConversionInput {
     pub(super) chunk_hashes: Vec<String>,
 }
 
+enum CacheInspection {
+    Current(Box<ServerConversionResult>),
+    Missing,
+    Stale,
+}
+
+enum PersistOutcome {
+    Existing(Box<ServerConversionResult>),
+    Inserted,
+}
+
 impl ConversionService {
+    fn inspect_cached_conversion(
+        &self,
+        conn: &Connection,
+        source_profile: &str,
+        repo_pkg: &RepositoryPackage,
+        original_checksum: &str,
+        repository_provides_digest: &str,
+    ) -> Result<CacheInspection> {
+        let repository_package_id = repo_pkg
+            .id
+            .context("repository conversion package has no persisted identity")?;
+        let current_package = RepositoryPackage::find_by_id(conn, repository_package_id)?
+            .context("repository package metadata changed during conversion cache lookup")?;
+        ensure!(
+            repository_package_conversion_inputs_match(repo_pkg, &current_package),
+            "repository package identity changed during conversion cache lookup"
+        );
+        let Some(existing) =
+            ConvertedPackage::find_repository_by_checksum(conn, source_profile, original_checksum)?
+        else {
+            return Ok(CacheInspection::Missing);
+        };
+
+        let artifact = existing.repository_artifact()?;
+        let expected_architecture = repo_pkg
+            .architecture
+            .as_deref()
+            .context("repository conversion package has no exact architecture")?;
+        let artifact_matches_package = artifact.source_profile == source_profile
+            && artifact.package_name == repo_pkg.name
+            && artifact.package_version == repo_pkg.version
+            && artifact.package_architecture == expected_architecture;
+        let metadata_is_current = existing.repository_metadata_is_current(conn)?;
+        let ccs_path = PathBuf::from(artifact.ccs_path);
+        if metadata_is_current {
+            ensure!(
+                artifact_matches_package,
+                "current conversion checksum maps to a conflicting repository package identity"
+            );
+        }
+        if metadata_is_current
+            && artifact.repository_provides_digest == repository_provides_digest
+            && ccs_path.exists()
+        {
+            return Ok(CacheInspection::Current(Box::new(
+                self.build_result_from_existing(&existing)?,
+            )));
+        }
+
+        Ok(CacheInspection::Stale)
+    }
+
     pub(super) async fn cached_conversion_result_async(
         &self,
         source_profile: &str,
@@ -37,67 +100,54 @@ impl ConversionService {
         let repository_provides_digest = repository_provides_digest.to_string();
 
         tokio::task::spawn_blocking(move || {
-            let mut conn = conary_core::db::open(&service.db_path)?;
-            let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-            let repository_package_id = repo_pkg
-                .id
-                .context("repository conversion package has no persisted identity")?;
-            let current_package = RepositoryPackage::find_by_id(&tx, repository_package_id)?
-                .context("repository package metadata changed during conversion cache lookup")?;
-            ensure!(
-                repository_package_conversion_inputs_match(&repo_pkg, &current_package),
-                "repository package identity changed during conversion cache lookup"
-            );
-            let Some(existing) = ConvertedPackage::find_repository_by_checksum(
+            let mut conn = crate::server::open_runtime_db(&service.db_path)?;
+            let tx = conn.transaction()?;
+            let inspection = service.inspect_cached_conversion(
                 &tx,
                 &source_profile,
+                &repo_pkg,
                 &original_checksum,
-            )?
-            else {
-                tx.commit()?;
-                return Ok(None);
-            };
-
-            let artifact = existing.repository_artifact()?;
-            let expected_architecture = repo_pkg
-                .architecture
-                .as_deref()
-                .context("repository conversion package has no exact architecture")?;
-            let artifact_matches_package = artifact.source_profile == source_profile
-                && artifact.package_name == repo_pkg.name
-                && artifact.package_version == repo_pkg.version
-                && artifact.package_architecture == expected_architecture;
-            let metadata_is_current = existing.repository_metadata_is_current(&tx)?;
-            let ccs_path = PathBuf::from(artifact.ccs_path);
-            if metadata_is_current {
-                ensure!(
-                    artifact_matches_package,
-                    "current conversion checksum maps to a conflicting repository package identity"
-                );
-            }
-            if metadata_is_current
-                && artifact.repository_provides_digest == repository_provides_digest
-                && ccs_path.exists()
-            {
-                info!(
-                    "Package already converted (checksum: {})",
-                    original_checksum
-                );
-                let result = service.build_result_from_existing(&existing)?;
-                tx.commit()?;
-                return Ok(Some(result));
-            }
-
-            info!(
-                "Stale conversion record (CCS file missing or conversion input changed), re-converting"
-            );
-            ConvertedPackage::delete_repository_by_checksum(
-                &tx,
-                &source_profile,
-                &original_checksum,
+                &repository_provides_digest,
             )?;
             tx.commit()?;
-            Ok(None)
+            match inspection {
+                CacheInspection::Current(result) => {
+                    info!("Package already converted (checksum: {})", original_checksum);
+                    return Ok(Some(*result));
+                }
+                CacheInspection::Missing => return Ok(None),
+                CacheInspection::Stale => {}
+            }
+
+            let writer = service.database_writer.clone();
+            writer.execute(|| {
+                let mut conn = crate::server::open_runtime_db(&service.db_path)?;
+                let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                let inspection = service.inspect_cached_conversion(
+                    &tx,
+                    &source_profile,
+                    &repo_pkg,
+                    &original_checksum,
+                    &repository_provides_digest,
+                )?;
+                let result = match inspection {
+                    CacheInspection::Current(result) => Some(*result),
+                    CacheInspection::Missing => None,
+                    CacheInspection::Stale => {
+                        info!(
+                            "Stale conversion record (CCS file missing or conversion input changed), re-converting"
+                        );
+                        ConvertedPackage::delete_repository_by_checksum(
+                            &tx,
+                            &source_profile,
+                            &original_checksum,
+                        )?;
+                        None
+                    }
+                };
+                tx.commit()?;
+                Ok(result)
+            })
         })
         .await
         .map_err(|e| anyhow!("conversion cache lookup task panicked: {e}"))?
@@ -142,31 +192,13 @@ impl ConversionService {
         }
         std::fs::copy(ccs_path, &final_ccs_path)?;
 
-        let mut conn = conary_core::db::open(&self.db_path)?;
-        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        let repository_package_id = repo_pkg
-            .id
-            .context("converted repository package has no persisted identity")?;
-        let current_package = RepositoryPackage::find_by_id(&tx, repository_package_id)?
-            .context("repository package metadata changed while conversion was running")?;
-        ensure!(
-            repository_package_conversion_inputs_match(&repo_pkg, &current_package),
-            "repository package identity changed while conversion was running"
-        );
-        let current_repository_provides_digest =
-            RepositoryProvide::conversion_capabilities_digest(&tx, repository_package_id)?;
-        ensure!(
-            current_repository_provides_digest == repository_provides_digest,
-            "repository provide authority changed while conversion was running"
-        );
-
         let mut converted = ConvertedPackage::new_repository(
             source_profile.clone(),
             metadata.name.clone(),
             metadata.version.clone(),
             package_architecture.clone(),
             format.to_string(),
-            original_checksum,
+            original_checksum.clone(),
             &chunk_hashes,
             persisted_total_size,
             content_hash_text.clone(),
@@ -174,12 +206,59 @@ impl ConversionService {
             repository_provides_digest,
         );
         converted.set_scriptlet_metadata(&conversion_result.scriptlet_metadata)?;
-        ensure!(
-            converted.repository_metadata_is_current(&tx)?,
-            "repository source metadata changed while conversion was running"
-        );
-        converted.insert(&tx)?;
-        tx.commit()?;
+        let writer = self.database_writer.clone();
+        let outcome = writer.execute(|| {
+            let mut conn = crate::server::open_runtime_db(&self.db_path)?;
+            let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+
+            match self.inspect_cached_conversion(
+                &tx,
+                &source_profile,
+                &repo_pkg,
+                &original_checksum,
+                converted.repository_artifact()?.repository_provides_digest,
+            )? {
+                CacheInspection::Current(result) => {
+                    tx.commit()?;
+                    return Ok(PersistOutcome::Existing(result));
+                }
+                CacheInspection::Stale => {
+                    ConvertedPackage::delete_repository_by_checksum(
+                        &tx,
+                        &source_profile,
+                        &original_checksum,
+                    )?;
+                }
+                CacheInspection::Missing => {}
+            }
+
+            let repository_package_id = repo_pkg
+                .id
+                .context("converted repository package has no persisted identity")?;
+            let current_package = RepositoryPackage::find_by_id(&tx, repository_package_id)?
+                .context("repository package metadata changed while conversion was running")?;
+            ensure!(
+                repository_package_conversion_inputs_match(&repo_pkg, &current_package),
+                "repository package identity changed while conversion was running"
+            );
+            let current_repository_provides_digest =
+                RepositoryProvide::conversion_capabilities_digest(&tx, repository_package_id)?;
+            ensure!(
+                current_repository_provides_digest
+                    == converted.repository_artifact()?.repository_provides_digest,
+                "repository provide authority changed while conversion was running"
+            );
+            ensure!(
+                converted.repository_metadata_is_current(&tx)?,
+                "repository source metadata changed while conversion was running"
+            );
+            converted.insert(&tx)?;
+            tx.commit()?;
+            Ok(PersistOutcome::Inserted)
+        })?;
+        if let PersistOutcome::Existing(result) = outcome {
+            return Ok(*result);
+        }
 
         info!(
             "Recorded conversion in database (source_profile={}, name={}, version={})",
@@ -323,6 +402,50 @@ mod tests {
         let conn = conary_core::db::open(&service.db_path).unwrap();
         assert!(
             ConvertedPackage::find_repository_by_checksum(&conn, "fedora-44", &source_checksum)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_miss_remains_read_only_while_another_writer_is_active() {
+        let (_database, _storage, service, package, source_checksum, current_digest) =
+            cache_fixture(true);
+        let conn = conary_core::db::open(&service.db_path).unwrap();
+        ConvertedPackage::delete_repository_by_checksum(&conn, "fedora-44", &source_checksum)
+            .unwrap();
+        drop(conn);
+
+        let db_path = service.db_path.clone();
+        let (locked_tx, locked_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let holder = std::thread::spawn(move || {
+            let mut conn = conary_core::db::open(&db_path).unwrap();
+            let tx = conn
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .unwrap();
+            locked_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+            tx.commit().unwrap();
+        });
+        locked_rx.recv().unwrap();
+
+        let lookup = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            service.cached_conversion_result_async(
+                "fedora-44",
+                &package,
+                &source_checksum,
+                &current_digest,
+            ),
+        )
+        .await;
+        release_tx.send(()).unwrap();
+        holder.join().unwrap();
+
+        assert!(
+            lookup
+                .expect("cache miss must not wait for the SQLite writer")
                 .unwrap()
                 .is_none()
         );

--- a/apps/remi/src/server/conversion/storage.rs
+++ b/apps/remi/src/server/conversion/storage.rs
@@ -144,23 +144,27 @@ impl ConversionService {
 
         if !exact_sizes.is_empty() {
             let db_path = self.db_path.clone();
+            let writer = self.database_writer.clone();
             tokio::task::spawn_blocking(move || -> Result<()> {
-                let mut conn = crate::server::open_runtime_db(&db_path)?;
-                let tx = conn.transaction()?;
-                for (hash, size) in exact_sizes {
-                    if let Some(existing) = ChunkAccess::find_by_hash(&tx, &hash)?
-                        && existing.size_bytes != size
-                    {
-                        anyhow::bail!(
-                            "chunk {hash} size disagrees with persisted CAS authority: \
-                             {} != {size}",
-                            existing.size_bytes
-                        );
+                writer.execute(|| {
+                    let mut conn = crate::server::open_runtime_db(&db_path)?;
+                    let tx =
+                        conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+                    for (hash, size) in exact_sizes {
+                        if let Some(existing) = ChunkAccess::find_by_hash(&tx, &hash)?
+                            && existing.size_bytes != size
+                        {
+                            anyhow::bail!(
+                                "chunk {hash} size disagrees with persisted CAS authority: \
+                                 {} != {size}",
+                                existing.size_bytes
+                            );
+                        }
+                        ChunkAccess::new(hash, size).upsert(&tx)?;
                     }
-                    ChunkAccess::new(hash, size).upsert(&tx)?;
-                }
-                tx.commit()?;
-                Ok(())
+                    tx.commit()?;
+                    Ok(())
+                })
             })
             .await
             .context("join exact chunk-size persistence task")??;

--- a/apps/remi/src/server/handlers/packages.rs
+++ b/apps/remi/src/server/handlers/packages.rs
@@ -417,20 +417,9 @@ async fn run_conversion(state: Arc<RwLock<ServerState>>, job_id: JobId) {
                 return;
             }
         };
-        // Clone the conversion service config for use outside the lock
-        let svc = crate::server::ConversionService::new(
-            state_guard.config.chunk_dir.clone(),
-            state_guard.config.cache_dir.clone(),
-            state_guard.config.db_path.clone(),
-            state_guard.r2_store.clone(),
-        )
-        .with_repository_keys_dir(
-            state_guard
-                .config
-                .release_publish
-                .repository_keys_dir
-                .clone(),
-        );
+        // Clone the state-owned service so requests and prewarm work retain
+        // the same conversion database writer.
+        let svc = state_guard.conversion_service.clone();
         (job, svc)
     };
 

--- a/apps/remi/src/server/mod.rs
+++ b/apps/remi/src/server/mod.rs
@@ -451,7 +451,12 @@ pub async fn run_server_from_config(remi_config: &RemiConfig) -> Result<()> {
                         remi_config.r2.r2_redirect
                     );
                     let mut state_w = state.write().await;
-                    state_w.r2_store = Some(Arc::new(store));
+                    let store = Arc::new(store);
+                    state_w.r2_store = Some(Arc::clone(&store));
+                    state_w.conversion_service = state_w
+                        .conversion_service
+                        .clone()
+                        .with_r2_store(Some(store));
                     state_w.r2_redirect = remi_config.r2.r2_redirect;
                 }
                 Err(e) => {
@@ -577,6 +582,10 @@ pub async fn run_server_from_config(remi_config: &RemiConfig) -> Result<()> {
             let state = state.read().await;
             state.job_manager.semaphore()
         };
+        let prewarm_conversion_service = {
+            let state = state.read().await;
+            state.conversion_service.clone()
+        };
         tracing::info!(
             "  Metadata refresh: enabled every {}s",
             refresh_interval.as_secs()
@@ -627,6 +636,7 @@ pub async fn run_server_from_config(remi_config: &RemiConfig) -> Result<()> {
                         for outcome in prewarm::run_prewarm_jobs(
                             eligible_jobs,
                             Arc::clone(&prewarm_conversion_permits),
+                            prewarm_conversion_service.clone(),
                         )
                         .await
                         {

--- a/apps/remi/src/server/prewarm.rs
+++ b/apps/remi/src/server/prewarm.rs
@@ -84,12 +84,13 @@ pub struct PackagePopularity {
 
 /// Run pre-warming job
 pub async fn run_prewarm(config: &PrewarmConfig) -> Result<PrewarmResult> {
-    run_prewarm_with_permits(config, None).await
+    run_prewarm_with_permits(config, None, None).await
 }
 
 async fn run_prewarm_with_permits(
     config: &PrewarmConfig,
     conversion_permits: Option<&Semaphore>,
+    shared_conversion_service: Option<ConversionService>,
 ) -> Result<PrewarmResult> {
     let source_profile =
         conary_core::repository::supported_profiles::profile_for_remi_route(&config.distro)
@@ -127,14 +128,18 @@ async fn run_prewarm_with_permits(
         });
     }
 
-    // Create conversion service
-    let conversion_service = ConversionService::new(
-        config.chunk_dir.clone().into(),
-        config.cache_dir.clone().into(),
-        config.db_path.clone().into(),
-        None, // R2 not available in prewarm context
-    )
-    .with_repository_keys_dir(config.repository_keys_dir.clone());
+    // Server-owned prewarm jobs clone the same service as request conversions.
+    // The standalone command owns an isolated service because it is the only
+    // conversion authority in that process.
+    let conversion_service = shared_conversion_service.unwrap_or_else(|| {
+        ConversionService::new(
+            config.chunk_dir.clone().into(),
+            config.cache_dir.clone().into(),
+            config.db_path.clone().into(),
+            None,
+        )
+        .with_repository_keys_dir(config.repository_keys_dir.clone())
+    });
 
     let mut result = PrewarmResult {
         packages_processed: 0,

--- a/apps/remi/src/server/prewarm/scheduler.rs
+++ b/apps/remi/src/server/prewarm/scheduler.rs
@@ -2,6 +2,7 @@
 //! Bounded, fair scheduling across exact source-profile prewarm jobs.
 
 use super::{PrewarmConfig, PrewarmResult, run_prewarm_with_permits};
+use crate::server::ConversionService;
 use anyhow::Result;
 use futures::future::join_all;
 use std::future::Future;
@@ -23,9 +24,13 @@ pub(crate) struct PrewarmJobOutcome {
 pub(crate) async fn run_prewarm_jobs(
     jobs: Vec<PrewarmConfig>,
     conversion_permits: Arc<Semaphore>,
+    conversion_service: ConversionService,
 ) -> Vec<PrewarmJobOutcome> {
-    run_prewarm_jobs_with(jobs, conversion_permits, |job, permits| async move {
-        run_prewarm_with_permits(&job, Some(permits.as_ref())).await
+    run_prewarm_jobs_with(jobs, conversion_permits, move |job, permits| {
+        let conversion_service = conversion_service.clone();
+        async move {
+            run_prewarm_with_permits(&job, Some(permits.as_ref()), Some(conversion_service)).await
+        }
     })
     .await
 }


### PR DESCRIPTION
## Primary Issue

Refs #221

Design / Plan / Roadmap: blocks the current #196 TGE02 integration gate; Refs #151.

## Problem And Outcome

Request-driven conversions and each concurrent prewarm profile constructed independent `ConversionService` instances. Their cache lookup, chunk-size persistence, and final converted-package persistence contended independently for SQLite's single writer, producing `database is locked` HTTP 500 responses and downstream job timeouts during the first current TGE02 run.

After this change, one state-owned conversion service and its cloneable database-writer owner are shared by request and post-refresh prewarm work. Only short SQLite mutation phases serialize; download, parse, CCS emission, CAS, and R2 work remain concurrent. Cache hits and misses use a deferred read transaction, while stale deletion revalidates under the writer boundary.

## Changes

- add one cloneable conversion database writer owner and route stale deletion, chunk-size upserts, and converted-package publication through it
- clone `ServerState::conversion_service` for request jobs and all concurrent prewarm profiles instead of reconstructing independent services
- keep R2 write-through configuration on the state-owned conversion service
- recheck the conversion cache under the writer boundary so concurrent identical conversions reuse the winner instead of racing the unique row
- add regressions proving 32 writers commit with a 1 ms SQLite busy timeout and cache misses remain read-only while another writer is active

## Scope

- In scope: process-local Remi conversion database ownership and request/prewarm service wiring
- Out of scope: target-root identity bootstrap and identical shared regular-file ownership found by the same TGE02 run; tracked separately before the gate is rerun

## Ownership / Boundary

- Owning subsystem: Remi conversion/publication (`remi` feature card)
- Boundary changed or preserved: `ConversionService` now owns conversion SQLite mutation coordination; SQLite remains the persisted authority
- Persisted state or public surface impact: no schema or API shape change; prevents transient conversion HTTP 500 responses during concurrent prewarm/request work
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code
- [x] Updated subsystem docs or maps when the "look here first" path changed (not required; ownership routing is unchanged)
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs (release/deploy/production proof remains after merge)

```text
cargo fmt --all -- --check
cargo test -p remi conversion
  78 library tests passed; 1 conversion CLI test passed
cargo test -p remi --quiet
  591 library + 5 binary + 3 CLI passed; 2 doctests ignored
cargo test -p conary --test conversion_integration golden_conversion
  4 passed
cargo test -p conary --test packaging_m4c
  1 passed
cargo clippy -p remi --all-targets -- -D warnings
cargo clippy --workspace --all-targets -- -D warnings
```

## Review And Merge Notes

- Review focus: read-only cache inspection, stale-row revalidation, shared request/prewarm service ownership, and the deliberately narrow serialized mutation boundary
- User or developer impact: conversions no longer fail solely because post-refresh prewarm and public jobs reach SQLite together
- Required-check bypass: not used