### PR TITLE
fix(rpm): preserve prerequisite ordering authority

### DIFF
--- a/crates/conary-core/src/ccs/convert/converter/tests.rs
+++ b/crates/conary-core/src/ccs/convert/converter/tests.rs
@@ -317,6 +317,40 @@ fn conversion_result_embeds_native_lifecycle_bundle() {
 }
 
 #[test]
+fn conversion_preserves_strong_source_order_in_signed_ccs_authority() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mut metadata = make_test_metadata();
+    metadata.requirements = vec![
+        crate::repository::requirement::parse_native_requirement(
+            crate::repository::dependency_model::RepositoryRequirementKind::PreDepends,
+            crate::repository::versioning::VersionScheme::Rpm,
+            "setup",
+        )
+        .unwrap(),
+    ];
+
+    let result = passive_test_converter(temp_dir.path())
+        .convert_in_memory_for_test(
+            &metadata,
+            &make_test_files(),
+            "rpm",
+            "sha256:1313131313131313131313131313131313131313131313131313131313131313",
+        )
+        .unwrap();
+    let package = verified_converted_package(&result);
+
+    assert_eq!(
+        result.build_result.manifest.requirements,
+        metadata.requirements
+    );
+    assert_eq!(package.requirements(), metadata.requirements);
+    assert_eq!(
+        package.v2_authority().unwrap().requirements,
+        metadata.requirements
+    );
+}
+
+#[test]
 fn arch_install_conversion_requires_exact_source_profile() {
     let temp_dir = tempfile::tempdir().unwrap();
     let mut metadata = make_test_metadata();

--- a/crates/conary-core/src/db/models/converted.rs
+++ b/crates/conary-core/src/db/models/converted.rs
@@ -17,9 +17,9 @@ use strum_macros::{AsRefStr, Display, EnumString};
 /// Current conversion algorithm version
 /// Bump this when making changes that require re-conversion of existing packages.
 ///
-/// Revision 12 binds repository conversions to the exact normalized repository
-/// capability projection that influenced their signed CCS authority.
-pub const CONVERSION_VERSION: i32 = 12;
+/// Revision 13 preserves source-defined strong dependency ordering in signed
+/// CCS authority.
+pub const CONVERSION_VERSION: i32 = 13;
 /// Canonical digest of an empty repository-provide projection.
 pub const EMPTY_REPOSITORY_PROVIDES_DIGEST: &str =
     "sha256:4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945";

--- a/crates/conary-core/src/packages/rpm.rs
+++ b/crates/conary-core/src/packages/rpm.rs
@@ -212,13 +212,49 @@ pub(crate) fn decode_rpm_requirement(
         rpm_relation_text(name, canonical_version, flags)?
     };
     let group = crate::repository::requirement::parse_native_requirement(
-        RepositoryRequirementKind::Depends,
+        rpm_requirement_kind(flags),
         VersionScheme::Rpm,
         &native_text,
     )
     .map_err(Error::ParseError)?;
     crate::repository::rpm_runtime::simplify_runtime_requirement_group(group, VersionScheme::Rpm)
         .map_err(|error| Error::ParseError(error.to_string()))
+}
+
+/// Project RPM's install-order relation into the shared typed requirement
+/// model.
+///
+/// This mirrors the pinned RPM transaction sorter: `%pre` and `%post`
+/// dependencies are strong install edges, while legacy `Prereq` records are
+/// mapped to `%pre`. Transaction script, erase, verification, runtime-feature,
+/// and meta dependencies do not create strong install edges.
+fn rpm_requirement_kind(flags: DependencyFlags) -> RepositoryRequirementKind {
+    let non_legacy_context = DependencyFlags::POSTTRANS
+        | DependencyFlags::PRETRANS
+        | DependencyFlags::INTERP
+        | DependencyFlags::SCRIPT_PRE
+        | DependencyFlags::SCRIPT_POST
+        | DependencyFlags::SCRIPT_PREUN
+        | DependencyFlags::SCRIPT_POSTUN
+        | DependencyFlags::SCRIPT_VERIFY
+        | DependencyFlags::FIND_REQUIRES
+        | DependencyFlags::RPMLIB
+        | DependencyFlags::KEYRING
+        | DependencyFlags::PREUNTRANS
+        | DependencyFlags::POSTUNTRANS
+        | DependencyFlags::META
+        | DependencyFlags::MISSINGOK;
+    let legacy_prerequisite =
+        flags.intersects(DependencyFlags::PREREQ) && !flags.intersects(non_legacy_context);
+    let ordered_install_script = flags
+        .intersects(DependencyFlags::SCRIPT_PRE | DependencyFlags::SCRIPT_POST)
+        && !flags.intersects(DependencyFlags::MISSINGOK);
+
+    if legacy_prerequisite || ordered_install_script {
+        RepositoryRequirementKind::PreDepends
+    } else {
+        RepositoryRequirementKind::Depends
+    }
 }
 
 /// Canonicalize RPM's source-defined empty serialized epoch to omitted epoch

--- a/crates/conary-core/src/packages/rpm/tests.rs
+++ b/crates/conary-core/src/packages/rpm/tests.rs
@@ -104,6 +104,40 @@ fn rpm_artifact_requirement_canonicalizes_empty_epoch_at_typed_boundary() {
 }
 
 #[test]
+fn rpm_header_requirement_preserves_strong_install_order() {
+    for flags in [
+        DependencyFlags::PREREQ,
+        DependencyFlags::SCRIPT_PRE,
+        DependencyFlags::SCRIPT_POST,
+    ] {
+        let requirement = decode_rpm_requirement("setup", "", flags).unwrap().unwrap();
+        assert_eq!(
+            requirement.kind,
+            RepositoryRequirementKind::PreDepends,
+            "{flags:?}"
+        );
+    }
+
+    for flags in [
+        DependencyFlags::PRETRANS,
+        DependencyFlags::POSTTRANS,
+        DependencyFlags::INTERP,
+        DependencyFlags::SCRIPT_PREUN,
+        DependencyFlags::SCRIPT_POSTUN,
+        DependencyFlags::SCRIPT_VERIFY,
+        DependencyFlags::META,
+        DependencyFlags::SCRIPT_PRE | DependencyFlags::MISSINGOK,
+    ] {
+        let requirement = decode_rpm_requirement("setup", "", flags).unwrap().unwrap();
+        assert_eq!(
+            requirement.kind,
+            RepositoryRequirementKind::Depends,
+            "{flags:?}"
+        );
+    }
+}
+
+#[test]
 fn rpm_header_relations_preserve_conflicts_and_obsoletes_as_typed_authority() {
     let mut builder =
         rpm::PackageBuilder::new("newpkg", "2", "MIT", "x86_64", "package relation fixture");

--- a/crates/conary-core/src/repository/dependency_model.rs
+++ b/crates/conary-core/src/repository/dependency_model.rs
@@ -84,7 +84,8 @@ pub enum RepositoryCapabilityKind {
 pub enum RepositoryRequirementKind {
     /// Hard runtime dependency (RPM Requires, Debian Depends).
     Depends,
-    /// Must be configured before the depending package (Debian Pre-Depends).
+    /// Source-defined strong installation ordering (Debian Pre-Depends or an
+    /// RPM install prerequirement).
     PreDepends,
     /// Optional / recommended (RPM Suggests, Debian Recommends, Arch optdepends).
     Optional,

--- a/crates/conary-core/src/repository/parsers/fedora.rs
+++ b/crates/conary-core/src/repository/parsers/fedora.rs
@@ -522,6 +522,7 @@ impl FedoraParser {
                                 let mut dep_epoch = None;
                                 let mut dep_ver = None;
                                 let mut dep_rel = None;
+                                let mut dep_pre = None;
 
                                 for attr in e.attributes() {
                                     let attr = attr.map_err(|error| {
@@ -546,6 +547,7 @@ impl FedoraParser {
                                         "epoch" => dep_epoch = Some(value.to_string()),
                                         "ver" => dep_ver = Some(value.to_string()),
                                         "rel" => dep_rel = Some(value.to_string()),
+                                        "pre" => dep_pre = Some(value.to_string()),
                                         _ => {}
                                     }
                                 }
@@ -565,11 +567,18 @@ impl FedoraParser {
                                                 dep_epoch.as_deref(),
                                                 dep_ver.as_deref(),
                                                 dep_rel.as_deref(),
+                                                dep_pre.as_deref(),
                                             )? {
                                                 pkg.dependencies.push(requirement);
                                             }
                                         }
                                         FormatSection::Provides => {
+                                            if dep_pre.is_some() {
+                                                return Err(Error::ParseError(
+                                                    "RPM primary pre marker is valid only on a requires entry"
+                                                        .to_string(),
+                                                ));
+                                            }
                                             let provide = rpm_provide_constraint(
                                                 &name,
                                                 dep_flags.as_deref(),
@@ -580,6 +589,12 @@ impl FedoraParser {
                                             pkg.provides.push((name, provide));
                                         }
                                         FormatSection::Conflicts => {
+                                            if dep_pre.is_some() {
+                                                return Err(Error::ParseError(
+                                                    "RPM primary pre marker is valid only on a requires entry"
+                                                        .to_string(),
+                                                ));
+                                            }
                                             pkg.relations.push((
                                                 RepositoryRequirementKind::Conflict,
                                                 rpm_relation_native_text(
@@ -592,6 +607,12 @@ impl FedoraParser {
                                             ));
                                         }
                                         FormatSection::Obsoletes => {
+                                            if dep_pre.is_some() {
+                                                return Err(Error::ParseError(
+                                                    "RPM primary pre marker is valid only on a requires entry"
+                                                        .to_string(),
+                                                ));
+                                            }
                                             pkg.relations.push((
                                                 RepositoryRequirementKind::Obsolete,
                                                 rpm_relation_native_text(

--- a/crates/conary-core/src/repository/parsers/fedora/relation.rs
+++ b/crates/conary-core/src/repository/parsers/fedora/relation.rs
@@ -49,6 +49,16 @@ fn rpm_flags_to_dependency_flags(name: &str, flags: Option<&str>) -> Result<Depe
     }
 }
 
+fn rpm_pre_to_dependency_flags(name: &str, pre: Option<&str>) -> Result<DependencyFlags> {
+    match pre {
+        None => Ok(DependencyFlags::empty()),
+        Some("1") => Ok(DependencyFlags::PREREQ),
+        Some(value) => Err(Error::ParseError(format!(
+            "unsupported RPM pre marker '{value}' for {name}; createrepo_c emits exactly '1'"
+        ))),
+    }
+}
+
 fn rpm_evr_native_text(
     name: &str,
     flags: Option<&str>,
@@ -168,8 +178,10 @@ pub(super) fn rpm_require_to_group(
     epoch: Option<&str>,
     version: Option<&str>,
     release: Option<&str>,
+    pre: Option<&str>,
 ) -> Result<Option<RepositoryRequirementGroup>> {
-    let dependency_flags = rpm_flags_to_dependency_flags(name, flags)?;
+    let dependency_flags =
+        rpm_flags_to_dependency_flags(name, flags)? | rpm_pre_to_dependency_flags(name, pre)?;
     let evr = rpm_evr_native_text(name, flags, epoch, version, release)?;
     crate::packages::rpm::decode_rpm_requirement(name, &evr, dependency_flags)
 }
@@ -202,6 +214,7 @@ mod tests {
                 Some(epoch),
                 Some("1.02.212"),
                 Some("2.fc44"),
+                None,
             )
             .unwrap()
             .unwrap();
@@ -225,10 +238,31 @@ mod tests {
             Some("invalid"),
             Some("1.02.212"),
             Some("2.fc44"),
+            None,
         )
         .unwrap_err();
 
         assert!(error.to_string().contains("epoch"));
+    }
+
+    #[test]
+    fn requirement_preserves_createrepo_prerequisite_marker() {
+        let requirement = rpm_require_to_group("setup", None, None, None, None, Some("1"))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            requirement.kind,
+            crate::repository::dependency_model::RepositoryRequirementKind::PreDepends
+        );
+    }
+
+    #[test]
+    fn requirement_rejects_noncanonical_prerequisite_marker() {
+        let error =
+            rpm_require_to_group("setup", None, None, None, None, Some("true")).unwrap_err();
+
+        assert!(error.to_string().contains("pre marker"));
     }
 
     #[test]

--- a/crates/conary-core/src/repository/parsers/fedora/tests.rs
+++ b/crates/conary-core/src/repository/parsers/fedora/tests.rs
@@ -190,6 +190,45 @@ fn primary_xml_canonicalizes_empty_requirement_epoch_through_rpm_decoder() {
 }
 
 #[test]
+fn primary_xml_preserves_createrepo_prerequisite_authority() {
+    let xml = primary_package_with_format(
+        r#"
+      <rpm:requires>
+        <rpm:entry name="group(mail)" pre="1"/>
+        <rpm:entry name="setup" pre="1"/>
+        <rpm:entry name="ordinary-provider"/>
+      </rpm:requires>
+"#,
+    );
+
+    let packages = parser()
+        .parse_primary_xml(&xml, "https://example.com")
+        .unwrap();
+    let requirements = &packages[0].requirements;
+
+    assert_eq!(
+        requirements
+            .iter()
+            .map(|requirement| (requirement.native_text.as_deref(), requirement.kind))
+            .collect::<Vec<_>>(),
+        vec![
+            (
+                Some("group(mail)"),
+                crate::repository::dependency_model::RepositoryRequirementKind::PreDepends,
+            ),
+            (
+                Some("setup"),
+                crate::repository::dependency_model::RepositoryRequirementKind::PreDepends,
+            ),
+            (
+                Some("ordinary-provider"),
+                crate::repository::dependency_model::RepositoryRequirementKind::Depends,
+            ),
+        ]
+    );
+}
+
+#[test]
 fn primary_xml_projects_every_generator_selected_file_as_a_typed_provide() {
     // Structure derived from createrepo_c 5cf41fe5d703901d78078ed18c67ab667e446c1a
     // tests/testdata/repodata_snippets/primary_snippet_02.xml. The repository

--- a/docs/modules/ccs.md
+++ b/docs/modules/ccs.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-29
-revision: 55
+last_updated: 2026-07-30
+revision: 56
 summary: Convert foreign packages through typed authoring, host capability, lifecycle, and native export contracts
 ---
 
@@ -214,13 +214,16 @@ uses the projected node and CAS authority.
 **convert/** -- RPM, Debian, and Arch to CCS conversion. Source package parsers
 produce a typed native ABI before conversion: exact lifecycle slots, body
 bytes, interpreters, invocation contracts, trigger/control metadata, and
-package-manager ordering. Conversion persists every executable entry with a
-digest; entry presence is lifecycle authority. It does not decide event order
-by inspecting the script body and it does not suppress an entry because a
-command appears to have a declarative replacement. The resulting CCS is
-executed by Conary on any supported target; conversion and install do not
-delegate lifecycle planning, database mutation, or transaction completion to
-`rpm`, `dpkg`, or `pacman`.
+package-manager ordering. Source-defined strong requirement order, including
+Debian `Pre-Depends` and RPM install prerequisites, is preserved as
+`PreDepends` through repository metadata, signed CCS v2 authority, and
+installed state. Conversion persists every executable entry with a digest;
+entry presence is lifecycle authority. It does not decide event order by
+inspecting the script body and it does not suppress an entry because a command
+appears to have a declarative replacement. The resulting CCS is executed by
+Conary on any supported target; conversion and install do not delegate
+lifecycle planning, database mutation, or transaction completion to `rpm`,
+`dpkg`, or `pacman`.
 Source format and target host are orthogonal: the running system exposes typed
 ABI/libc/loader, init, LSM, filesystem, boot/kernel, and helper capabilities.
 The implemented hook inventory currently records init/systemd, sysusers,

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-29
-revision: 21
+last_updated: 2026-07-30
+revision: 22
 summary: Document exact profile-owned source policy, Remi CCS package authority, canonical map authority, native repository authority, package identity, full-adoption root continuity, and lifecycle handoff
 ---
 
@@ -303,6 +303,15 @@ the same-operator chain and tag-context rules; and constructs repeated `with`
 from the right side as RPM does. The source-pinned Fedora 44 corpus under
 `crates/conary-core/tests/fixtures/rpm/` proves real repository expressions
 without granting those packages exceptional behavior.
+
+RPM-MD prerequisite authority is part of that same signed dependency record.
+Pinned `createrepo_c`
+[`cr_xml_dump_primary()`](https://github.com/rpm-software-management/createrepo_c/blob/5cf41fe5d703901d78078ed18c67ab667e446c1a/src/xml_dump_primary.c#L80-L128)
+emits `pre="1"` only for a Requires entry whose RPM dependency is an install
+prerequisite. The Fedora parser preserves that marker as the typed
+`PreDepends` relation; it does not infer order from a capability or package
+name. Direct RPM parsing projects the corresponding header sense flags through
+the same relation kind.
 
 RPM primary-file authority is derived from `createrepo_c`
 `5cf41fe5d703901d78078ed18c67ab667e446c1a`: its

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-29
-revision: 36
+last_updated: 2026-07-30
+revision: 37
 summary: Define source-independent lifecycle, generation activation, and configuration transactions for RPM, Debian, and Arch packages
 ---
 
@@ -700,6 +700,7 @@ Authoritative references:
 - [`rpm-version(7)`](https://rpm.org/docs/latest/man/rpm-version.7)
 - [RPM package state machine (`lib/psm.cc`)](https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/lib/psm.cc)
 - [RPM transaction orchestration (`lib/transaction.cc`)](https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/lib/transaction.cc)
+- [RPM transaction ordering (`lib/order.cc`)](https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/lib/order.cc)
 - [RPM trigger implementation (`lib/rpmtriggers.cc`)](https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/lib/rpmtriggers.cc)
 - [RPM dependency-set comparison (`lib/rpmds.cc`)](https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/lib/rpmds.cc)
 
@@ -726,6 +727,18 @@ before native RPM version evaluation, while `!=` is not an RPM dependency
 operator. Requires-like and conflict-like tag contexts retain RPM's distinct
 `if`/`unless` nesting checks. The implementation never recognizes a dependency
 by package name or adds a skip/allowlist for repository metadata.
+
+RPM install prerequisites are typed ordering authority, not ordinary
+dependency text. Direct RPM headers map legacy `Prereq` and `%pre`/`%post`
+dependency senses to `PreDepends`; RPM-MD maps the exact signed `pre="1"`
+Requires marker to the same kind. `%pretrans`, `%posttrans`, erase, verification,
+runtime-feature, and meta senses remain ordinary dependency satisfaction
+without becoming strong install edges, matching RPM's `isInstallPreReq()` and
+`isUnorderedReq()` transaction-order masks. Conversion preserves the kind in
+signed CCS authority and installed requirement state. Within a dependency
+cycle, transaction ordering must satisfy those strong edges before applying
+the deterministic fallback for the remaining cycle; package names and
+capability strings never establish that priority.
 
 ### RPM Lifecycle Surface
 


### PR DESCRIPTION
## Primary Issue

Refs #223

Design / Plan / Roadmap: `docs/specs/foreign-package-lifecycle-contracts.md`, `docs/modules/source-selection.md`, and `docs/modules/ccs.md`

## Problem And Outcome

Fedora RPM-MD exposes source-defined install prerequisites through signed `rpm:entry pre="1"` records, while native RPM headers expose the corresponding dependency sense flags. Both intake paths flattened those relations to ordinary `Depends`, so conversion could not preserve RPM's strong ordering authority for transaction-cycle resolution.

After this change, native RPM and RPM-MD intake project exact prerequisite authority to `PreDepends`, signed CCS v2 authority preserves it, and conversion revision 13 invalidates stale converted artifacts. Issue #223 remains open for the stacked install transaction's strong-edge SCC ordering and production gate proof.

## Changes

- Decode legacy RPM `Prereq` and `%pre`/`%post` dependency senses as typed `PreDepends` while retaining unordered and erase-only senses as ordinary dependencies.
- Parse the exact createrepo_c `pre="1"` Requires marker and reject noncanonical or misplaced markers.
- Preserve the typed relation through signed CCS conversion and bump `CONVERSION_VERSION` to 13 so Remi reconverts stale authority.
- Update the source-selection, CCS, and foreign lifecycle contracts with pinned upstream ordering semantics.
- Add native-header, RPM-MD, and signed-CCS regression coverage.

## Scope

- In scope: RPM prerequisite intake, typed transport, CCS persistence, cache invalidation, canonical documentation, and focused proof.
- Out of scope: the issue #223 SCC ordering consumer in the stacked install branch; identical shared-payload ownership tracked by #224.

## Ownership / Boundary

- Owning subsystem: Repository Metadata, Requirements, And SAT Resolution; CCS Authoring, Conversion, Install, And Native Lifecycle Execution.
- Boundary changed or preserved: changes the typed dependency-kind projection while preserving source-owned RPM semantics and existing dependency satisfaction.
- Persisted state or public surface impact: converted artifact revision 13 makes existing repository conversions stale and requires re-conversion; the serialized `pre_depends` kind already exists, so no compatibility decoder or schema migration is introduced.
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code
- [x] Updated subsystem docs or maps when the "look here first" path changed
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs

```text
cargo test -p conary-core
bash scripts/agent-context.sh --feature resolution --run focused
bash scripts/agent-context.sh --feature ccs --run focused
cargo clippy -p conary-core --all-targets -- -D warnings
cargo fmt --all -- --check
bash scripts/check-doc-truth.sh
git diff --check
```

Observed results: all commands passed. `cargo test -p conary-core` reported 3,225 unit tests passed, 2 expected fixture-dependent ignores, all integration tests passed, and all 8 runnable doctests passed (20 ignored documentation examples). The resolution card passed all 7 focused commands; the CCS card passed all 14 focused commands.

## Review And Merge Notes

- Review focus: exact parity with RPM's install-prerequisite masks, strict RPM-MD marker parsing, and conversion-version invalidation.
- User or developer impact: Fedora dependency cycles retain source-defined prerequisite order instead of falling back to package-name order once the stacked consumer lands.
- Required-check bypass: not used