### PR TITLE
release(remi): prepare 0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [remi-v0.9.5] - 2026-07-30
+
+### Fixed
+- support source-defined shared payload claims (#226)
+- preserve prerequisite ordering authority (#225)
+- serialize conversion database writes (#222)
+
 ## [remi-v0.9.4] - 2026-07-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4857,7 +4857,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remi"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/apps/remi/Cargo.toml
+++ b/apps/remi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remi"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]


### PR DESCRIPTION
## Primary Issue

Refs #196

Design / Plan / Roadmap: `docs/operations/release-artifact-matrix.md`

## Problem And Outcome

Remi 0.9.4 is the current production baseline, but the Fedora 44 TGE rerun
requires three fixes merged after that immutable release:

- one shared SQLite mutation owner for request and prewarm conversions (#222);
- typed RPM prerequisite authority through repository conversion (#225);
- the generalized shared-payload contract consumed by the integrated client
  proof (#226).

This PR prepares the canonical `remi-v0.9.5` release input. It does not tag,
publish, deploy, re-ingest, or close #196 by itself.

## Changes

- Bump `apps/remi/Cargo.toml` and the exact lockfile package entry from 0.9.4
  to 0.9.5.
- Add the canonical `remi-v0.9.5` changelog entry for #222, #225, and #226.

## Scope

- In scope: immutable Remi 0.9.5 release preparation.
- Out of scope: tag publication, production deployment, schema/conversion
  re-ingest proof, TGE02/TISO01, and issue closure.

## Ownership / Boundary

- Owning subsystem: Release Construction, Publication, Deployment, And Proof
  (`release`).
- Boundary changed or preserved: version manifests and changelog identify the
  exact reviewed release commit; tag, assets, deployment, and production
  behavior remain later independent gates.
- Persisted state or public surface impact: deploying 0.9.5 will rebuild
  disposable pre-alpha Remi state where required by the merged conversion
  contract and repopulate all configured sources.
- [x] Checked `docs/modules/feature-ownership.md`.

## Verification

- [x] Listed exact verification commands.
- [x] Added/updated release metadata.
- [x] Ran the owning focused proof.
- [x] Ran deployment interaction gates.
- [x] Ran full Remi and workspace lint proof.
- [x] Kept #196, #221, #223, and #224 open for production/TGE evidence.

```text
bash scripts/release.sh remi --dry-run --target remi=0.9.5
bash scripts/agent-context.sh --feature release --run focused
bash scripts/agent-context.sh --feature release --run gate
cargo test -p remi
cargo clippy --workspace --all-targets -- -D warnings
cargo fmt --all -- --check
bash scripts/check-doc-truth.sh
git diff --check
```

Observed on exact head `a88ba15aaa6abdbb63e2ecc12b1a87a3c7c2ea8b`:

- all 5 release-focused commands passed;
- both deploy-helper interaction commands passed;
- Remi: 591 library, 5 binary, and 3 CLI-help tests passed; 2 doctests
  intentionally ignored;
- workspace Clippy, formatting, documentation truth, and diff checks passed;
- explicit release authority resolved to `remi-v0.9.5`.

## Review And Merge Notes

- Review focus: exact version ownership, canonical tag resolution, changelog
  scope, and absence of premature publication claims.
- User or developer impact: none until the exact merge commit is tagged and
  the resulting release is independently deployed and verified.
- Required-check bypass: not used.
