### PR TITLE
fix(adopt): preserve global hardlink topology

### DIFF
--- a/apps/conary/src/commands/adopt/system.rs
+++ b/apps/conary/src/commands/adopt/system.rs
@@ -27,7 +27,8 @@ use tracing::warn;
 mod captured_root;
 mod live_root;
 use captured_root::{
-    capture_live_selected_root, ensure_complete_native_partition, synchronize_captured_root,
+    bind_package_payloads_to_selected_root, capture_live_selected_root,
+    ensure_complete_native_partition, synchronize_captured_root,
 };
 use live_root::adopt_live_root_as_full_package;
 
@@ -467,6 +468,14 @@ pub async fn cmd_adopt_system(
     } else {
         None
     };
+    if let Some(captured) = captured_selected_root.as_ref() {
+        bind_package_payloads_to_selected_root(
+            captured,
+            pre_collected
+                .iter_mut()
+                .flat_map(|package| package.files.iter_mut()),
+        )?;
+    }
 
     // DB-only transaction: all PM queries and CAS writes are already done.
     write_db_checkpoint(db_path, CheckpointReason::PreMutation)?;

--- a/apps/conary/src/commands/adopt/system/captured_root.rs
+++ b/apps/conary/src/commands/adopt/system/captured_root.rs
@@ -19,7 +19,7 @@ use conary_core::repository::versioning::VersionScheme;
 use conary_core::runtime_root::ConaryRuntimeRoot;
 use rusqlite::Transaction;
 
-use super::LIVE_ROOT_PACKAGE_NAME;
+use super::{CapturedAdoptionFile, LIVE_ROOT_PACKAGE_NAME};
 
 const CAPTURED_ROOT_VERSION: &str = "snapshot";
 
@@ -61,6 +61,45 @@ pub(super) fn capture_live_selected_root(
     scan_selected_root_with_exclusions(Path::new("/"), cas, &exclusions)
         .map_err(anyhow::Error::from)
         .context("failed to capture exact selected-root continuity state")
+}
+
+/// Replace independently captured package nodes with the authority from the
+/// complete selected-root scan.
+///
+/// A one-path capture cannot identify hardlink peers. Complete full adoption
+/// therefore uses it only as preflight and CAS staging; the durable package
+/// claims are rebound here to the same global topology that owns unclaimed
+/// selected-root paths.
+pub(super) fn bind_package_payloads_to_selected_root<'a>(
+    captured: &CapturedSelectedRoot,
+    files: impl IntoIterator<Item = &'a mut CapturedAdoptionFile>,
+) -> conary_core::Result<()> {
+    let mut entries = HashMap::new();
+    for entry in captured
+        .generation
+        .entries
+        .iter()
+        .chain(&captured.state.entries)
+    {
+        if entries.insert(entry.path.as_str(), entry).is_some() {
+            return Err(conary_core::Error::ConfigError(format!(
+                "complete selected-root capture contains duplicate path {}",
+                entry.path
+            )));
+        }
+    }
+
+    for file in files {
+        let Some(entry) = entries.get(file.source.0.as_str()) else {
+            // Ephemeral and capture-runtime domains are intentionally absent
+            // from the complete selected-root snapshot. Their package claim
+            // retains the exact independently captured node.
+            continue;
+        };
+        file.node = entry.node.clone();
+        file.content = entry.content.clone();
+    }
+    Ok(())
 }
 
 pub(super) fn synchronize_captured_root(
@@ -347,6 +386,7 @@ mod tests {
     use conary_core::generation::root_manifest::{
         SelectedRootCaptureExclusions, scan_selected_root_with_exclusions,
     };
+    use conary_core::packages::InstalledFileAbsencePolicy;
     use conary_core::payload::PayloadNodeKind;
     use std::os::unix::fs::PermissionsExt;
 
@@ -377,6 +417,11 @@ mod tests {
         std::fs::write(root.join("run/private"), b"ephemeral").unwrap();
         std::fs::write(root.join("var/lib/conary/conary.db"), b"runtime").unwrap();
         std::fs::write(root.join("etc/owned-primary"), b"hardlinked").unwrap();
+        std::fs::hard_link(
+            root.join("etc/owned-primary"),
+            root.join("etc/owned-secondary"),
+        )
+        .unwrap();
         std::fs::hard_link(
             root.join("etc/owned-primary"),
             root.join("etc/unowned-link"),
@@ -434,22 +479,42 @@ mod tests {
         );
         package.installed_by_changeset_id = Some(changeset_id);
         let package_id = package.insert(&tx).unwrap();
-        for path in [
-            "/etc",
-            "/etc/owned-primary",
-            "/usr",
-            "/usr/bin",
-            "/usr/bin/owned",
-        ] {
+        for path in ["/etc", "/usr", "/usr/bin", "/usr/bin/owned"] {
+            let entry = entries[path];
+            let mut file = FileEntry::new(
+                path.to_string(),
+                entry.node.clone(),
+                entry.content.clone(),
+                package_id,
+            );
+            file.insert_or_replace(&tx, ExistingDirectoryMaterialization::ApplyIncoming)
+                .unwrap();
+        }
+
+        let mut package_hardlinks = ["/etc/owned-primary", "/etc/owned-secondary"].map(|path| {
             let entry = entries[path];
             let mut node = entry.node.clone();
-            if path == "/etc/owned-primary" {
-                node.source.kind = PayloadNodeKind::Regular {
-                    hardlink_identity: None,
-                };
+            node.source.kind = PayloadNodeKind::Regular {
+                hardlink_identity: None,
+            };
+            CapturedAdoptionFile {
+                source: (
+                    path.to_string(),
+                    0,
+                    0,
+                    None,
+                    None,
+                    None,
+                    None,
+                    InstalledFileAbsencePolicy::Required,
+                ),
+                node,
+                content: entries["/etc/owned-primary"].content.clone(),
             }
-            let mut file =
-                FileEntry::new(path.to_string(), node, entry.content.clone(), package_id);
+        });
+        bind_package_payloads_to_selected_root(&captured, package_hardlinks.iter_mut()).unwrap();
+        for captured in package_hardlinks {
+            let mut file = captured.file_entry(package_id);
             file.insert_or_replace(&tx, ExistingDirectoryMaterialization::ApplyIncoming)
                 .unwrap();
         }
@@ -458,7 +523,7 @@ mod tests {
         let first = synchronize_captured_root(&tx, first_changeset, &captured).unwrap();
         assert!(first.changed);
         assert!(first.captured_entries > 0);
-        assert!(first.package_entries >= 5);
+        assert!(first.package_entries >= 6);
 
         let captured_trove = Trove::list_all(&tx)
             .unwrap()
@@ -486,6 +551,9 @@ mod tests {
         let linked = FileEntry::find_by_path(&tx, "/etc/unowned-link")
             .unwrap()
             .unwrap();
+        let package_linked = FileEntry::find_by_path(&tx, "/etc/owned-secondary")
+            .unwrap()
+            .unwrap();
         let PayloadNodeKind::Regular {
             hardlink_identity: Some(primary_identity),
         } = primary.node.source.kind
@@ -494,6 +562,11 @@ mod tests {
         };
         let PayloadNodeKind::Hardlink { identity, target } = linked.node.source.kind else {
             panic!("captured-root hardlink lost its typed link authority");
+        };
+        assert_eq!(identity, primary_identity);
+        assert_eq!(target, "/etc/owned-primary");
+        let PayloadNodeKind::Hardlink { identity, target } = package_linked.node.source.kind else {
+            panic!("package-owned hardlink lost its typed link authority");
         };
         assert_eq!(identity, primary_identity);
         assert_eq!(target, "/etc/owned-primary");


### PR DESCRIPTION
Closes #242

Refs #137 and #151.

## What changed

- rebind complete full-adoption package captures to the one global selected-root scan before database mutation
- retain independently captured authority only for intentionally excluded ephemeral/runtime domains
- extend captured-root partition proof across package-owned and unowned members of the same hardlink set

## Root cause and impact

One-path package capture cannot observe inode peers, so every package hardlink member initially looked like an independent regular file. The later complete-root scan correctly produced a global hardlink graph, but an exclusive package claim could not be reconciled to its hardlink materialization.

Package ownership and captured-root ownership now consume the same final topology authority. Fedora's `e2mmpstatus`/`dumpe2fs` hardlink set can therefore be adopted without weakening exclusive sharing or inventing regular-to-hardlink equivalence.

## Verification

```text
cargo test -p conary --lib full_capture_partitions_package_and_unowned_authority_exactly
  1 passed; 0 failed

cargo test -p conary --lib commands::adopt
  61 passed; 0 failed

cargo clippy -p conary --lib -- -D warnings
cargo fmt --check
git diff --check
```

The final Fedora 44 Group O adoption cases remain an integration gate on the combined #151 head after this PR is merged there.
