### PR TITLE
fix(model): apply package set atomically

### DIFF
--- a/apps/conary/src/commands/install/conversion.rs
+++ b/apps/conary/src/commands/install/conversion.rs
@@ -7,22 +7,21 @@
 
 use super::super::open_db;
 use super::PackageFormatType;
-use super::batch::{BatchInstaller, prepare_ccs_package_for_batch, prepare_package_for_batch};
+use super::batch::{BatchInstaller, prepare_ccs_package_for_batch};
 use super::dep_resolution;
 use super::dependencies::resolved_repository_deps_from_sat_result;
+use super::repository_batch::{RepositoryBatchSelection, prepare_repository_batch};
 use super::{
     CcsEnvelopeAuthority, CcsTransactionInstallOptions, InstallIntent, RepositoryInstallProvenance,
-    repository_install_provenance_from_package, verify_ccs_package_authority,
+    verify_ccs_package_authority,
 };
 use anyhow::{Context, Result};
 use conary_core::ccs::CcsPackage;
 use conary_core::ccs::convert::{
     ConversionOptions, NativePackageConverter, ScriptletBundleSummary,
 };
-use conary_core::db::paths::keyring_dir;
 use conary_core::packages::PackageFormat;
 use conary_core::packages::common::PackageMetadata;
-use conary_core::repository;
 use conary_core::repository::versioning::VersionScheme;
 use conary_core::resolver::{SatPackage, SatSource};
 use conary_core::scriptlet::SandboxMode;
@@ -69,7 +68,7 @@ fn selected_ccs_release_matches(ccs_release: Option<&str>, selected_release: Opt
     }
 }
 
-fn validate_selected_repository_ccs_identity(
+pub(super) fn validate_selected_repository_ccs_identity(
     ccs_pkg: &CcsPackage,
     selected: &SatPackage,
     repository_provenance: Option<&RepositoryInstallProvenance>,
@@ -162,7 +161,7 @@ fn validate_selected_repository_ccs_identity(
     Ok(())
 }
 
-fn validate_selected_repository_native_identity(
+pub(super) fn validate_selected_repository_native_identity(
     artifact_name: &str,
     artifact_version: &str,
     artifact_package_release: Option<&str>,
@@ -567,108 +566,18 @@ pub async fn install_ccs_artifact(opts: CcsArtifactInstallOptions<'_>) -> Result
         }
     }
 
-    let conn = open_db(db_path)?;
-    let to_download = dep_resolution::exact_repository_downloads(&conn, &selected_dependencies)?;
-    let temp_dir = TempDir::new()?;
-    let keyring_dir = keyring_dir(db_path);
-    let downloaded =
-        repository::download_dependencies(&to_download, temp_dir.path(), &keyring_dir).await?;
-    if downloaded.len() != to_download.len() {
-        anyhow::bail!(
-            "repository dependency downloader returned {} artifacts for {} exact selections",
-            downloaded.len(),
-            to_download.len()
-        );
-    }
-    let mut prepared_packages = Vec::with_capacity(downloaded.len() + 1);
-    // `download_dependencies` preserves request order. Pair each artifact with
-    // the exact row already checked by `exact_repository_downloads` so
-    // co-installable identities with the same package name cannot alias.
-    for ((dep_name, package_with_repo), (downloaded_name, dep_path)) in
-        to_download.iter().zip(&downloaded)
-    {
-        if dep_name != downloaded_name {
-            anyhow::bail!(
-                "repository dependency download order drifted: expected {dep_name}, received {downloaded_name}"
-            );
-        }
-        let provenance = repository_install_provenance_from_package(
-            &package_with_repo.package,
-            &package_with_repo.repository,
-        )?;
-        let expected = selected_dependencies
-            .iter()
-            .find(|dependency| {
-                dependency.package.repo_package_id == package_with_repo.package.id
-                    && dependency.package.repository_id == package_with_repo.repository.id
-            })
-            .with_context(|| {
-                format!(
-                    "downloaded dependency {dep_name} has no exact SAT-selected repository identity"
-                )
-            })?;
-        let reason = format!("Required by {}", ccs_pkg.name());
-        if dep_path
-            .extension()
-            .and_then(|extension| extension.to_str())
-            .is_some_and(|extension| extension.eq_ignore_ascii_case("ccs"))
-        {
-            let dep_ccs_path = dep_path
-                .to_str()
-                .context("Invalid CCS dependency path (non-UTF8)")?;
-            let verified_dependency = verify_ccs_package_authority(
-                db_path,
-                dep_path,
-                &CcsEnvelopeAuthority::Repository,
-                Some(&provenance),
-            )?;
-            let dependency = CcsPackage::from_verified_archive(dep_ccs_path, &verified_dependency)
-                .with_context(|| {
-                    format!("Failed to construct verified CCS dependency {dep_name}")
-                })?;
-            validate_selected_repository_ccs_identity(
-                &dependency,
-                &expected.package,
-                Some(&provenance),
-            )?;
-            crate::commands::ccs::validate_ccs_capability_declaration(&dependency)?;
-            prepared_packages.push(prepare_ccs_package_for_batch(
-                &dependency,
-                db_path,
-                conary_core::db::models::InstallReason::Dependency,
-                &reason,
-                allow_downgrade,
-                intent,
-                Some(provenance),
-            )?);
-        } else {
-            let Some(mut prepared) = prepare_package_for_batch(
-                dep_path,
-                db_path,
-                conary_core::db::models::InstallReason::Dependency,
-                &reason,
-                allow_downgrade,
-                provenance.source_profile.as_deref(),
-            )?
-            else {
-                anyhow::bail!(
-                    "SAT selected dependency {dep_name}, but its exact artifact is already installed"
-                );
-            };
-            validate_selected_repository_native_identity(
-                &prepared.name,
-                &prepared.version,
-                prepared.package_release.as_deref(),
-                prepared.architecture.as_deref(),
-                prepared.semantics.version_scheme,
-                &expected.package,
-                &provenance,
-            )?;
-            prepared.repository_provenance = Some(provenance);
-            prepared_packages.push(prepared);
-        }
-    }
-    prepared_packages.push(prepare_ccs_package_for_batch(
+    let selections = selected_dependencies
+        .into_iter()
+        .map(|selected| RepositoryBatchSelection {
+            selected,
+            install_reason: conary_core::db::models::InstallReason::Dependency,
+            selection_reason: format!("Required by {}", ccs_pkg.name()),
+            allow_downgrade,
+            intent,
+        })
+        .collect();
+    let mut prepared = prepare_repository_batch(db_path, selections).await?;
+    prepared.push(prepare_ccs_package_for_batch(
         &ccs_pkg,
         db_path,
         conary_core::db::models::InstallReason::Explicit,
@@ -679,8 +588,7 @@ pub async fn install_ccs_artifact(opts: CcsArtifactInstallOptions<'_>) -> Result
     )?);
 
     println!("Installing CCS package...");
-    let result =
-        BatchInstaller::new(db_path, sandbox_mode).install_batch_with_result(prepared_packages)?;
+    let result = prepared.install_with_result(BatchInstaller::new(db_path, sandbox_mode))?;
     Ok(Some(result.exact_trove_id(&ccs_pkg)?))
 }
 

--- a/apps/conary/src/commands/install/mod.rs
+++ b/apps/conary/src/commands/install/mod.rs
@@ -19,8 +19,10 @@ pub(super) mod native_graph;
 mod native_lifecycle;
 mod options;
 mod ownership_mode;
+mod package_set;
 mod payload_identity;
 mod prepare;
+mod repository_batch;
 mod resolve;
 mod restore;
 mod rollback_snapshot;
@@ -34,6 +36,7 @@ pub use batch::{BatchInstaller, prepare_package_for_batch};
 pub use command::cmd_install;
 pub(crate) use command::cmd_install_replatform;
 pub use ownership_mode::OwnershipMode;
+pub(crate) use package_set::{PackageSetRequest, install_package_set};
 
 #[allow(unused_imports)]
 pub(crate) use ccs_transaction::{

--- a/apps/conary/src/commands/install/package_set.rs
+++ b/apps/conary/src/commands/install/package_set.rs
@@ -1,0 +1,110 @@
+// apps/conary/src/commands/install/package_set.rs
+
+//! One atomic repository transaction for a declarative package request set.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+use conary_core::db::models::InstallReason;
+use conary_core::repository::resolution_policy::RequestScope;
+use conary_core::scriptlet::SandboxMode;
+use conary_core::version::VersionConstraint;
+
+use super::InstallIntent;
+use super::batch::BatchInstaller;
+use super::dependencies::resolved_repository_deps_from_sat_result;
+use super::repository_batch::{RepositoryBatchSelection, prepare_repository_batch};
+use super::source_policy::resolve_canonical_name;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PackageSetRequest {
+    pub(crate) name: String,
+    pub(crate) version: Option<String>,
+    pub(crate) selection_reason: String,
+    pub(crate) allow_downgrade: bool,
+}
+
+/// Resolve, authenticate, prepare, and execute one complete package request set.
+pub(crate) async fn install_package_set(
+    db_path: &str,
+    sandbox_mode: SandboxMode,
+    requests: Vec<PackageSetRequest>,
+) -> Result<usize> {
+    if requests.is_empty() {
+        return Ok(0);
+    }
+    crate::commands::hint_unconfigured_source_policy();
+
+    let conn = super::super::open_db(db_path)?;
+    let policy =
+        conary_core::repository::load_effective_policy(&conn, RequestScope::Any)?.resolution;
+    let mut resolved_requests = BTreeMap::new();
+    for request in requests {
+        let name = resolve_canonical_name(&conn, &request.name, None, &policy)?
+            .unwrap_or_else(|| request.name.clone());
+        if resolved_requests.insert(name.clone(), request).is_some() {
+            anyhow::bail!("model package set resolves more than one root request to {name}");
+        }
+    }
+    let solver_requests = resolved_requests
+        .iter()
+        .map(|(name, request)| {
+            let constraint = request
+                .version
+                .as_deref()
+                .map(VersionConstraint::parse)
+                .transpose()
+                .with_context(|| format!("invalid model version for package {name}"))?
+                .unwrap_or(VersionConstraint::Any);
+            Ok((name.clone(), constraint))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let solved = conary_core::resolver::solve_install_with_policy(&conn, &solver_requests, &policy)
+        .context("failed to solve the complete model package set")?;
+    if let Some(conflict) = solved.conflict_message.as_deref() {
+        anyhow::bail!("cannot apply model package set: {conflict}");
+    }
+    for name in resolved_requests.keys() {
+        if !solved
+            .install_order
+            .iter()
+            .any(|package| package.name == *name)
+        {
+            anyhow::bail!("model root package {name} is absent from the exact SAT selection");
+        }
+    }
+    let selected = resolved_repository_deps_from_sat_result(&solved, "model package set");
+    if selected.is_empty() {
+        return Ok(0);
+    }
+    let selections = selected
+        .into_iter()
+        .map(|selected| {
+            if let Some(root) = resolved_requests.get(&selected.package.name) {
+                RepositoryBatchSelection {
+                    selected,
+                    install_reason: InstallReason::Explicit,
+                    selection_reason: root.selection_reason.clone(),
+                    allow_downgrade: root.allow_downgrade,
+                    intent: InstallIntent::PackageChange,
+                }
+            } else {
+                RepositoryBatchSelection {
+                    selected,
+                    install_reason: InstallReason::Dependency,
+                    selection_reason: "Required by model package set".to_string(),
+                    allow_downgrade: false,
+                    intent: InstallIntent::PackageChange,
+                }
+            }
+        })
+        .collect();
+    let prepared = prepare_repository_batch(db_path, selections).await?;
+    let root_count = resolved_requests.len();
+    println!(
+        "Installing model package set ({} explicit roots)...",
+        root_count
+    );
+    prepared.install(BatchInstaller::new(db_path, sandbox_mode))?;
+    Ok(root_count)
+}

--- a/apps/conary/src/commands/install/repository_batch.rs
+++ b/apps/conary/src/commands/install/repository_batch.rs
@@ -1,0 +1,163 @@
+// apps/conary/src/commands/install/repository_batch.rs
+
+//! Authenticated preparation of exact repository selections for one batch.
+
+use super::batch::{
+    BatchInstallResult, BatchInstaller, PreparedPackage, prepare_ccs_package_for_batch,
+    prepare_package_for_batch,
+};
+use super::conversion::{
+    validate_selected_repository_ccs_identity, validate_selected_repository_native_identity,
+};
+use super::{
+    CcsEnvelopeAuthority, InstallIntent, repository_install_provenance_from_package,
+    verify_ccs_package_authority,
+};
+use anyhow::{Context, Result};
+use conary_core::ccs::CcsPackage;
+use conary_core::db::models::InstallReason;
+use conary_core::db::paths::keyring_dir;
+use conary_core::repository;
+use tempfile::TempDir;
+
+use super::dep_resolution::{self, ResolvedDep};
+
+pub(super) struct RepositoryBatchSelection {
+    pub(super) selected: ResolvedDep,
+    pub(super) install_reason: InstallReason,
+    pub(super) selection_reason: String,
+    pub(super) allow_downgrade: bool,
+    pub(super) intent: InstallIntent,
+}
+
+pub(super) struct PreparedRepositoryBatch {
+    packages: Vec<PreparedPackage>,
+    _download_root: TempDir,
+}
+
+impl PreparedRepositoryBatch {
+    pub(super) fn push(&mut self, package: PreparedPackage) {
+        self.packages.push(package);
+    }
+
+    pub(super) fn install(self, installer: BatchInstaller<'_>) -> Result<()> {
+        installer.install_batch(self.packages)
+    }
+
+    pub(super) fn install_with_result(
+        self,
+        installer: BatchInstaller<'_>,
+    ) -> Result<BatchInstallResult> {
+        installer.install_batch_with_result(self.packages)
+    }
+}
+
+pub(super) async fn prepare_repository_batch(
+    db_path: &str,
+    selections: Vec<RepositoryBatchSelection>,
+) -> Result<PreparedRepositoryBatch> {
+    let selected = selections
+        .iter()
+        .map(|selection| selection.selected.clone())
+        .collect::<Vec<_>>();
+    let conn = super::super::open_db(db_path)?;
+    let to_download = dep_resolution::exact_repository_downloads(&conn, &selected)?;
+    drop(conn);
+
+    let download_root = TempDir::new()?;
+    let downloaded = repository::download_dependencies(
+        &to_download,
+        download_root.path(),
+        &keyring_dir(db_path),
+    )
+    .await?;
+    if downloaded.len() != selections.len() || to_download.len() != selections.len() {
+        anyhow::bail!(
+            "repository package-set downloader returned {} artifacts for {} exact selections",
+            downloaded.len(),
+            selections.len()
+        );
+    }
+
+    let mut packages = Vec::with_capacity(selections.len());
+    for (((expected_name, package_with_repo), (downloaded_name, path)), selection) in
+        to_download.iter().zip(&downloaded).zip(&selections)
+    {
+        if expected_name != downloaded_name || expected_name != &selection.selected.package.name {
+            anyhow::bail!(
+                "repository package-set download order drifted: expected {}, received {}",
+                selection.selected.package.name,
+                downloaded_name
+            );
+        }
+        let provenance = repository_install_provenance_from_package(
+            &package_with_repo.package,
+            &package_with_repo.repository,
+        )?;
+
+        if path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("ccs"))
+        {
+            let ccs_path = path
+                .to_str()
+                .context("Invalid CCS package path (non-UTF8)")?;
+            let verified = verify_ccs_package_authority(
+                db_path,
+                path,
+                &CcsEnvelopeAuthority::Repository,
+                Some(&provenance),
+            )?;
+            let package =
+                CcsPackage::from_verified_archive(ccs_path, &verified).with_context(|| {
+                    format!("Failed to construct verified CCS package {downloaded_name}")
+                })?;
+            validate_selected_repository_ccs_identity(
+                &package,
+                &selection.selected.package,
+                Some(&provenance),
+            )?;
+            crate::commands::ccs::validate_ccs_capability_declaration(&package)?;
+            packages.push(prepare_ccs_package_for_batch(
+                &package,
+                db_path,
+                selection.install_reason.clone(),
+                &selection.selection_reason,
+                selection.allow_downgrade,
+                selection.intent,
+                Some(provenance),
+            )?);
+        } else {
+            let Some(mut package) = prepare_package_for_batch(
+                path,
+                db_path,
+                selection.install_reason.clone(),
+                &selection.selection_reason,
+                selection.allow_downgrade,
+                provenance.source_profile.as_deref(),
+            )?
+            else {
+                anyhow::bail!(
+                    "SAT selected package {downloaded_name}, but its exact artifact is already installed"
+                );
+            };
+            validate_selected_repository_native_identity(
+                &package.name,
+                &package.version,
+                package.package_release.as_deref(),
+                package.architecture.as_deref(),
+                package.semantics.version_scheme,
+                &selection.selected.package,
+                &provenance,
+            )?;
+            package.repository_provenance = Some(provenance);
+            packages.push(package);
+        }
+    }
+
+    Ok(PreparedRepositoryBatch {
+        packages,
+        _download_root: download_root,
+    })
+}

--- a/apps/conary/src/commands/model/apply.rs
+++ b/apps/conary/src/commands/model/apply.rs
@@ -1,6 +1,7 @@
 // src/commands/model/apply.rs
 
 mod derived;
+mod packages;
 
 use std::path::Path;
 
@@ -13,7 +14,7 @@ use crate::commands::install::cmd_install_replatform;
 use crate::commands::replatform_rendering::{
     render_replatform_blocked_reason, render_replatform_execution_plan,
 };
-use crate::commands::{InstallOptions, SandboxMode, cmd_install, cmd_remove};
+use crate::commands::{InstallOptions, SandboxMode};
 use anyhow::{Context, Result, anyhow};
 use conary_core::db::models::{
     DistroPin, Repository, RepositoryPackage, Trove, TroveType, settings,
@@ -23,6 +24,7 @@ use conary_core::model::parser::SystemModel;
 use conary_core::model::{DiffAction, replatform_execution_plan};
 use conary_core::repository::SETTINGS_KEY_ALLOWED_DISTROS;
 use derived::{build_derived_package, create_derived_from_model};
+use packages::apply_package_changes;
 use rusqlite::Connection;
 #[cfg(test)]
 use std::cell::Cell;
@@ -587,179 +589,6 @@ fn maybe_fail_replatform_metadata_for_test() -> Result<()> {
 #[cfg(not(test))]
 fn maybe_fail_replatform_metadata_for_test() -> Result<()> {
     Ok(())
-}
-
-/// Apply package install/remove actions from the model diff.
-///
-/// Returns `(applied_count, error_list)`.
-pub(super) async fn apply_package_changes(
-    db_path: &str,
-    root: &str,
-    actions: &[&DiffAction],
-    strict: bool,
-) -> Result<(usize, Vec<String>)> {
-    let mut applied = 0usize;
-    let mut errors = Vec::new();
-
-    for action in actions {
-        if let DiffAction::Remove {
-            package,
-            current_version,
-            architectures,
-        } = action
-        {
-            let iterations = architectures.len().max(1);
-            for arch in architectures
-                .iter()
-                .map(Some)
-                .chain(std::iter::once(None))
-                .take(iterations)
-            {
-                match arch {
-                    Some(arch) => {
-                        println!("Removing {} {} [{}]...", package, current_version, arch)
-                    }
-                    None => println!("Removing {} {}...", package, current_version),
-                }
-
-                match cmd_remove(
-                    package,
-                    db_path,
-                    Some(current_version.clone()),
-                    arch.cloned(),
-                    SandboxMode::Always,
-                    false,
-                )
-                .await
-                {
-                    Ok(()) => {
-                        println!("  Removed {}", package);
-                        applied += 1;
-                    }
-                    Err(e) => {
-                        let msg = match arch {
-                            Some(arch) => {
-                                format!(
-                                    "Remove '{}' {} [{}]: {}",
-                                    package, current_version, arch, e
-                                )
-                            }
-                            None => format!("Remove '{}' {}: {}", package, current_version, e),
-                        };
-                        eprintln!("{}", crate::ui::row_line(crate::ui::Status::Fail, &[&msg]));
-                        if strict {
-                            anyhow::bail!(msg);
-                        }
-                        errors.push(msg);
-                    }
-                }
-            }
-        }
-    }
-
-    for action in actions {
-        match action {
-            DiffAction::Install { package, pin, .. } => {
-                println!(
-                    "Installing {}{}...",
-                    package,
-                    display_pin_suffix(pin.as_deref())
-                );
-                match cmd_install(
-                    package,
-                    InstallOptions {
-                        db_path,
-                        root,
-                        version: pin.clone(),
-                        package_release: None,
-                        repo: None,
-                        architecture: None,
-                        dry_run: false,
-                        no_deps: false,
-                        selection_reason: Some("Installed by model apply"),
-                        sandbox_mode: SandboxMode::Always,
-                        allow_downgrade: false,
-                        convert_to_ccs: false,
-                        ownership: None,
-                        yes: true,
-                        from_profile: None,
-                        repository_provenance: None,
-                    },
-                )
-                .await
-                {
-                    Ok(()) => {
-                        println!("  Installed {}", package);
-                        applied += 1;
-                    }
-                    Err(e) => {
-                        let msg = format!("Install '{}': {}", package, e);
-                        eprintln!("{}", crate::ui::row_line(crate::ui::Status::Fail, &[&msg]));
-                        if strict {
-                            anyhow::bail!(msg);
-                        }
-                        errors.push(msg);
-                    }
-                }
-            }
-            DiffAction::Update {
-                package,
-                current_version,
-                target_version,
-            } => {
-                println!(
-                    "Updating {} from {} to {}...",
-                    package, current_version, target_version
-                );
-                match cmd_install(
-                    package,
-                    InstallOptions {
-                        db_path,
-                        root,
-                        version: Some(target_version.clone()),
-                        package_release: None,
-                        repo: None,
-                        architecture: None,
-                        dry_run: false,
-                        no_deps: false,
-                        selection_reason: Some("Updated by model apply"),
-                        sandbox_mode: SandboxMode::Always,
-                        allow_downgrade: true,
-                        convert_to_ccs: false,
-                        ownership: None,
-                        yes: true,
-                        from_profile: None,
-                        repository_provenance: None,
-                    },
-                )
-                .await
-                {
-                    Ok(()) => {
-                        println!("  Updated {} to {}", package, target_version);
-                        applied += 1;
-                    }
-                    Err(e) => {
-                        let msg = format!(
-                            "Update '{}' {} -> {}: {}",
-                            package, current_version, target_version, e
-                        );
-                        eprintln!("{}", crate::ui::row_line(crate::ui::Status::Fail, &[&msg]));
-                        if strict {
-                            anyhow::bail!(msg);
-                        }
-                        errors.push(msg);
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-
-    Ok((applied, errors))
-}
-
-fn display_pin_suffix(pin: Option<&str>) -> String {
-    pin.map(|pin| format!(" ({})", pin)).unwrap_or_default()
 }
 
 /// Apply derived-package build/rebuild actions.

--- a/apps/conary/src/commands/model/apply/packages.rs
+++ b/apps/conary/src/commands/model/apply/packages.rs
@@ -1,0 +1,200 @@
+// apps/conary/src/commands/model/apply/packages.rs
+
+//! Atomic package-set execution for declarative model actions.
+
+use anyhow::Result;
+use conary_core::model::DiffAction;
+
+use crate::commands::install::{PackageSetRequest, install_package_set};
+use crate::commands::{SandboxMode, cmd_remove};
+
+/// Apply removal actions, then one atomic install/update package set.
+///
+/// Returns `(applied_count, error_list)`.
+pub(super) async fn apply_package_changes(
+    db_path: &str,
+    _root: &str,
+    actions: &[&DiffAction],
+    strict: bool,
+) -> Result<(usize, Vec<String>)> {
+    let mut applied = 0usize;
+    let mut errors = Vec::new();
+
+    for action in actions {
+        if let DiffAction::Remove {
+            package,
+            current_version,
+            architectures,
+        } = action
+        {
+            let iterations = architectures.len().max(1);
+            for arch in architectures
+                .iter()
+                .map(Some)
+                .chain(std::iter::once(None))
+                .take(iterations)
+            {
+                match arch {
+                    Some(arch) => {
+                        println!("Removing {} {} [{}]...", package, current_version, arch)
+                    }
+                    None => println!("Removing {} {}...", package, current_version),
+                }
+
+                match cmd_remove(
+                    package,
+                    db_path,
+                    Some(current_version.clone()),
+                    arch.cloned(),
+                    SandboxMode::Always,
+                    false,
+                )
+                .await
+                {
+                    Ok(()) => {
+                        println!("  Removed {}", package);
+                        applied += 1;
+                    }
+                    Err(error) => {
+                        let message = match arch {
+                            Some(arch) => format!(
+                                "Remove '{}' {} [{}]: {}",
+                                package, current_version, arch, error
+                            ),
+                            None => {
+                                format!("Remove '{}' {}: {}", package, current_version, error)
+                            }
+                        };
+                        eprintln!(
+                            "{}",
+                            crate::ui::row_line(crate::ui::Status::Fail, &[&message])
+                        );
+                        if strict {
+                            anyhow::bail!(message);
+                        }
+                        errors.push(message);
+                    }
+                }
+            }
+        }
+    }
+
+    let requests = package_set_requests(actions);
+    if requests.is_empty() {
+        return Ok((applied, errors));
+    }
+    for action in actions {
+        match action {
+            DiffAction::Install { package, pin, .. } => match pin {
+                Some(pin) => println!("Installing {} ({})...", package, pin),
+                None => println!("Installing {}...", package),
+            },
+            DiffAction::Update {
+                package,
+                current_version,
+                target_version,
+            } => println!(
+                "Updating {} from {} to {}...",
+                package, current_version, target_version
+            ),
+            _ => {}
+        }
+    }
+
+    match install_package_set(db_path, SandboxMode::Always, requests.clone()).await {
+        Ok(count) => {
+            for action in actions {
+                match action {
+                    DiffAction::Install { package, .. } => println!("  Installed {}", package),
+                    DiffAction::Update {
+                        package,
+                        target_version,
+                        ..
+                    } => println!("  Updated {} to {}", package, target_version),
+                    _ => {}
+                }
+            }
+            applied += count;
+        }
+        Err(error) => {
+            let message = format!("Model package set: {error}");
+            eprintln!(
+                "{}",
+                crate::ui::row_line(crate::ui::Status::Fail, &[&message])
+            );
+            if strict {
+                anyhow::bail!(message);
+            }
+            errors.push(message);
+        }
+    }
+
+    Ok((applied, errors))
+}
+
+fn package_set_requests(actions: &[&DiffAction]) -> Vec<PackageSetRequest> {
+    actions
+        .iter()
+        .filter_map(|action| match action {
+            DiffAction::Install { package, pin, .. } => Some(PackageSetRequest {
+                name: package.clone(),
+                version: pin.clone(),
+                selection_reason: "Installed by model apply".to_string(),
+                allow_downgrade: false,
+            }),
+            DiffAction::Update {
+                package,
+                target_version,
+                ..
+            } => Some(PackageSetRequest {
+                name: package.clone(),
+                version: Some(target_version.clone()),
+                selection_reason: "Updated by model apply".to_string(),
+                allow_downgrade: true,
+            }),
+            _ => None,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_and_update_actions_form_one_typed_package_set() {
+        let install = DiffAction::Install {
+            package: "dbus-broker".to_string(),
+            pin: None,
+            optional: false,
+        };
+        let remove = DiffAction::Remove {
+            package: "old".to_string(),
+            current_version: "1-1".to_string(),
+            architectures: vec!["x86_64".to_string()],
+        };
+        let update = DiffAction::Update {
+            package: "systemd".to_string(),
+            current_version: "258-1".to_string(),
+            target_version: "259-1".to_string(),
+        };
+
+        assert_eq!(
+            package_set_requests(&[&install, &remove, &update]),
+            [
+                PackageSetRequest {
+                    name: "dbus-broker".to_string(),
+                    version: None,
+                    selection_reason: "Installed by model apply".to_string(),
+                    allow_downgrade: false,
+                },
+                PackageSetRequest {
+                    name: "systemd".to_string(),
+                    version: Some("259-1".to_string()),
+                    selection_reason: "Updated by model apply".to_string(),
+                    allow_downgrade: true,
+                },
+            ]
+        );
+    }
+}

--- a/apps/conary/src/commands/model/apply/tests.rs
+++ b/apps/conary/src/commands/model/apply/tests.rs
@@ -3,7 +3,8 @@
 use super::super::context::compute_model_diff;
 use super::super::test_support::{
     ReplatformMetadataFailpointReset, build_test_ccs_package,
-    insert_test_repository_package_resolution, insert_test_static_ccs_repository, serve_test_file,
+    build_test_ccs_package_with_payloads_and_relations, insert_test_repository_package_resolution,
+    insert_test_static_ccs_repository, serve_test_file, typed_rpm_model_post_helper_bundle,
     typed_rpm_replatform_upgrade_bundle,
 };
 use super::*;
@@ -14,6 +15,42 @@ use conary_core::model::parser::SystemModel;
 use conary_core::repository::SETTINGS_KEY_ALLOWED_DISTROS;
 use conary_core::repository::resolution_policy::DependencyMixingPolicy;
 use tempfile::tempdir;
+
+fn published_or_pending_generation_has_path(db_path: &std::path::Path, path: &str) -> bool {
+    let runtime_root =
+        conary_core::runtime_root::ConaryRuntimeRoot::from_db_path(db_path.to_path_buf());
+    if let Some(generation) =
+        conary_core::generation::mount::current_generation(runtime_root.root()).unwrap()
+    {
+        let artifact = conary_core::generation::artifact::load_generation_artifact(
+            &runtime_root.generation_path(generation),
+        )
+        .unwrap();
+        return artifact
+            .generation_root
+            .entries
+            .iter()
+            .chain(&artifact.mutable_state.entries)
+            .any(|entry| entry.path == path);
+    }
+
+    let conn = conary_core::db::open(db_path).unwrap();
+    let debt = conary_core::db::models::GenerationPublication::pending_recoverable(&conn)
+        .unwrap()
+        .pop()
+        .expect("model package-set install should retain exact publication debt");
+    let captured = crate::commands::generation::selected_root::load_publication_candidate(
+        &runtime_root,
+        &debt,
+    )
+    .unwrap();
+    captured
+        .generation
+        .entries
+        .iter()
+        .chain(&captured.state.entries)
+        .any(|entry| entry.path == path)
+}
 
 fn replatform_variant(architecture: Option<&str>, marker: &str) -> Trove {
     let mut trove = Trove::new(
@@ -169,6 +206,188 @@ allowed_distros = ["arch"]
         Some("[\"arch\"]".to_string())
     );
     assert!(DistroPin::get_current(&conn).unwrap().is_none());
+}
+
+#[tokio::test]
+async fn test_model_apply_installs_explicit_roots_in_one_lifecycle_transaction() {
+    const TEST_NAME: &str = "commands::model::apply::tests::test_model_apply_installs_explicit_roots_in_one_lifecycle_transaction";
+    if !crate::commands::test_helpers::run_exact_test_in_user_mount_namespace(TEST_NAME) {
+        return;
+    }
+
+    use conary_core::db::models::{
+        InstallReason, RepositoryPackage, RepositoryProvide, RepositoryRequirement,
+        RepositoryRequirementGroup as DbRepositoryRequirementGroup, Trove,
+    };
+    use conary_core::repository::dependency_model::{
+        RepositoryCapabilityKind, RepositoryRequirementClause, RepositoryRequirementGroup,
+        RepositoryRequirementKind,
+    };
+
+    let (_temp_file, db_path) = create_test_db();
+    crate::commands::test_helpers::seed_test_bootable_runtime(std::path::Path::new(&db_path));
+    let temp_dir = tempdir().unwrap();
+    let install_root = temp_dir.path().join("root");
+    std::fs::create_dir_all(&install_root).unwrap();
+
+    let consumer_name = "a-model-consumer";
+    let provider_name = "z-model-provider";
+    let version = "1-1";
+    let libsystemd = "libmodel-systemd.so.0()(64bit)";
+    let requirement = RepositoryRequirementGroup::simple(
+        RepositoryRequirementKind::Depends,
+        RepositoryRequirementClause {
+            name: libsystemd.to_string(),
+            capability_kind: Some(RepositoryCapabilityKind::Soname),
+            version_constraint: None,
+            architecture_qualifier: Default::default(),
+            native_text: Some(libsystemd.to_string()),
+        },
+    );
+    let consumer_path = build_test_ccs_package_with_payloads_and_relations(
+        temp_dir.path(),
+        consumer_name,
+        version,
+        conary_core::repository::versioning::VersionScheme::Rpm,
+        Some(typed_rpm_model_post_helper_bundle(consumer_name, version)),
+        vec![(
+            format!("/usr/bin/{consumer_name}"),
+            b"#!/bin/sh\nexit 0\n".to_vec(),
+            0o755,
+        )],
+        vec![requirement.clone()],
+        Vec::new(),
+    );
+    let provider_path = build_test_ccs_package_with_payloads_and_relations(
+        temp_dir.path(),
+        provider_name,
+        version,
+        conary_core::repository::versioning::VersionScheme::Rpm,
+        None,
+        vec![(
+            "/usr/lib/systemd/systemd-update-helper".to_string(),
+            b"#!/bin/sh\nprintf observed > /model-post-observed\n".to_vec(),
+            0o755,
+        )],
+        Vec::new(),
+        vec![libsystemd.to_string()],
+    );
+    let (consumer_url, _consumer_server) = serve_test_file(consumer_path.clone());
+    let (provider_url, _provider_server) = serve_test_file(provider_path.clone());
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    DistroPin::set(&conn, "fedora-44", DependencyMixingPolicy::Strict).unwrap();
+    let repository_id = insert_test_static_ccs_repository(
+        &conn,
+        "fedora",
+        "https://example.test/fedora",
+        "fedora-44",
+    );
+    let mut package_ids = std::collections::HashMap::new();
+    for (name, package_path, package_url) in [
+        (consumer_name, &consumer_path, consumer_url),
+        (provider_name, &provider_path, provider_url),
+    ] {
+        let checksum = conary_core::hash::sha256(&std::fs::read(package_path).unwrap());
+        let mut package = RepositoryPackage::new(
+            repository_id,
+            name.to_string(),
+            version.to_string(),
+            conary_core::repository::versioning::VersionScheme::Rpm,
+            checksum,
+            std::fs::metadata(package_path)
+                .unwrap()
+                .len()
+                .try_into()
+                .unwrap(),
+            package_url,
+        );
+        package.architecture = Some("x86_64".to_string());
+        package.source_profile = Some("fedora-44".to_string());
+        let package_id = package.insert(&conn).unwrap();
+        package_ids.insert(name, package_id);
+        insert_test_repository_package_resolution(&conn, repository_id, package_id, name, version);
+    }
+    let consumer_id = package_ids[consumer_name];
+    let provider_id = package_ids[provider_name];
+    let mut requirement_group = DbRepositoryRequirementGroup::new(
+        consumer_id,
+        requirement.kind.as_str().to_string(),
+        "hard".to_string(),
+        serde_json::to_string(&requirement.expression).unwrap(),
+    );
+    requirement_group.native_text = requirement.native_text.clone();
+    let group_id = requirement_group.insert(&conn).unwrap();
+    let clause = &requirement.alternatives[0];
+    RepositoryRequirement::new(
+        consumer_id,
+        group_id,
+        clause.name.clone(),
+        clause.version_constraint.clone(),
+        "soname".to_string(),
+        "runtime".to_string(),
+        clause.native_text.clone(),
+    )
+    .insert(&conn)
+    .unwrap();
+    RepositoryProvide::new(
+        provider_id,
+        libsystemd.to_string(),
+        None,
+        "soname".to_string(),
+        Some(libsystemd.to_string()),
+        conary_core::repository::versioning::VersionScheme::Rpm,
+    )
+    .insert(&conn)
+    .unwrap();
+    drop(conn);
+
+    let model_path = temp_dir.path().join("system.toml");
+    std::fs::write(
+        &model_path,
+        r#"
+[model]
+version = 1
+install = ["a-model-consumer", "z-model-provider"]
+
+[system.pin]
+distro = "fedora-44"
+strength = "strict"
+"#,
+    )
+    .unwrap();
+
+    let result = cmd_model_apply(ApplyOptions {
+        model_path: model_path.to_str().unwrap(),
+        db_path: &db_path,
+        root: install_root.to_str().unwrap(),
+        dry_run: false,
+        skip_optional: false,
+        strict: true,
+        autoremove: false,
+        offline: true,
+    });
+    let _mount_skip = crate::commands::composefs_ops::test_mount_skip_guard();
+    result.await.unwrap();
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let mut changeset_ids = Vec::new();
+    for name in [consumer_name, provider_name] {
+        let installed = Trove::find_by_name(&conn, name).unwrap();
+        assert_eq!(installed.len(), 1, "{name} must be installed exactly once");
+        assert_eq!(installed[0].install_reason, InstallReason::Explicit);
+        assert_eq!(
+            installed[0].selection_reason.as_deref(),
+            Some("Installed by model apply")
+        );
+        changeset_ids.push(installed[0].installed_by_changeset_id);
+    }
+    assert_eq!(changeset_ids[0], changeset_ids[1]);
+    assert!(changeset_ids[0].is_some());
+    assert!(published_or_pending_generation_has_path(
+        std::path::Path::new(&db_path),
+        "/model-post-observed"
+    ));
 }
 
 #[tokio::test]

--- a/apps/conary/src/commands/model/test_support.rs
+++ b/apps/conary/src/commands/model/test_support.rs
@@ -18,42 +18,91 @@ pub(super) fn build_test_ccs_package(
     version_scheme: conary_core::repository::versioning::VersionScheme,
     native_lifecycle: Option<NativeLifecycleBundle>,
 ) -> PathBuf {
+    build_test_ccs_package_with_payloads(
+        dir,
+        name,
+        version,
+        version_scheme,
+        native_lifecycle,
+        vec![
+            (
+                format!("/usr/bin/{name}"),
+                format!("#!/bin/sh\necho {name} {version}\n").into_bytes(),
+                0o755,
+            ),
+            (
+                "/usr/sbin/init".to_string(),
+                format!("#!/bin/sh\nexec /usr/bin/{name}\n").into_bytes(),
+                0o755,
+            ),
+        ],
+    )
+}
+
+pub(super) fn build_test_ccs_package_with_payloads(
+    dir: &Path,
+    name: &str,
+    version: &str,
+    version_scheme: conary_core::repository::versioning::VersionScheme,
+    native_lifecycle: Option<NativeLifecycleBundle>,
+    payloads: Vec<(String, Vec<u8>, u32)>,
+) -> PathBuf {
+    build_test_ccs_package_with_payloads_and_relations(
+        dir,
+        name,
+        version,
+        version_scheme,
+        native_lifecycle,
+        payloads,
+        Vec::new(),
+        Vec::new(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn build_test_ccs_package_with_payloads_and_relations(
+    dir: &Path,
+    name: &str,
+    version: &str,
+    version_scheme: conary_core::repository::versioning::VersionScheme,
+    native_lifecycle: Option<NativeLifecycleBundle>,
+    payloads: Vec<(String, Vec<u8>, u32)>,
+    requirements: Vec<conary_core::repository::dependency_model::RepositoryRequirementGroup>,
+    provided_sonames: Vec<String>,
+) -> PathBuf {
     use conary_core::ccs::builder::write_signed_current_ccs_package;
     use conary_core::ccs::manifest::Platform;
     use conary_core::ccs::{BuildResult, CcsManifest, ComponentData, FileEntry};
     use conary_core::hash;
     use conary_core::payload::{PayloadContentAuthority, PayloadNode};
 
-    let binary_content = format!("#!/bin/sh\necho {name} {version}\n").into_bytes();
-    let binary_hash = hash::sha256(&binary_content);
-    let init_content = format!("#!/bin/sh\nexec /usr/bin/{name}\n").into_bytes();
-    let init_hash = hash::sha256(&init_content);
-    let files = vec![
-        FileEntry {
-            path: format!("/usr/bin/{name}"),
-            node: PayloadNode::regular(0o755),
-            content: Some(PayloadContentAuthority {
-                sha256: binary_hash.clone(),
-                size: binary_content.len() as u64,
-            }),
-            component: "runtime".to_string(),
-            chunks: None,
-        },
-        FileEntry {
-            path: "/usr/sbin/init".to_string(),
-            node: PayloadNode::regular(0o755),
-            content: Some(PayloadContentAuthority {
-                sha256: init_hash.clone(),
-                size: init_content.len() as u64,
-            }),
-            component: "runtime".to_string(),
-            chunks: None,
-        },
-    ];
-    let component_size = (binary_content.len() + init_content.len()) as u64;
+    let mut objects = HashMap::new();
+    let files = payloads
+        .into_iter()
+        .map(|(path, content, mode)| {
+            let content_hash = hash::sha256(&content);
+            objects.insert(content_hash.clone(), content.clone());
+            FileEntry {
+                path,
+                node: PayloadNode::regular(mode),
+                content: Some(PayloadContentAuthority {
+                    sha256: content_hash,
+                    size: content.len() as u64,
+                }),
+                component: "runtime".to_string(),
+                chunks: None,
+            }
+        })
+        .collect::<Vec<_>>();
+    let component_size = files
+        .iter()
+        .filter_map(|file| file.content.as_ref().map(|content| content.size))
+        .sum();
     let package_path = dir.join(format!("{name}-{version}.ccs"));
     let mut manifest = CcsManifest::new_minimal(name, version);
     manifest.package.version_scheme = version_scheme;
+    manifest.requirements = requirements;
+    manifest.provides.sonames = provided_sonames;
     manifest.package.platform = Some(Platform {
         os: "linux".to_string(),
         arch: Some("x86_64".to_string()),
@@ -74,8 +123,7 @@ pub(super) fn build_test_ccs_package(
         )]),
         files: files.clone(),
         payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
-            &files,
-            HashMap::from([(binary_hash, binary_content), (init_hash, init_content)]),
+            &files, objects,
         )
         .unwrap(),
         total_size: 0,
@@ -85,6 +133,88 @@ pub(super) fn build_test_ccs_package(
     let signing_key = crate::commands::ccs::load_or_create_local_dev_key().unwrap();
     write_signed_current_ccs_package(&result, &package_path, &signing_key, true).unwrap();
     package_path
+}
+
+pub(super) fn typed_rpm_model_post_helper_bundle(
+    package: &str,
+    version: &str,
+) -> NativeLifecycleBundle {
+    let body = r#"local helper = io.open("/usr/lib/systemd/systemd-update-helper", "r")
+if helper then
+    helper:close()
+    local marker = assert(io.open("/model-post-observed", "w"))
+    marker:write("observed")
+    marker:close()
+end
+"#;
+    let entry = NativeLifecycleEntry {
+        id: "rpm:%post".to_string(),
+        native_slot: "%post".to_string(),
+        kind: NativeLifecycleEntryKind::Executable,
+        phase: LifecyclePath::PostInstall,
+        lifecycle_paths: vec!["install:post".to_string()],
+        interpreter: "<lua>".to_string(),
+        interpreter_args: Vec::new(),
+        body_sha256: conary_core::hash::sha256_prefixed(body.as_bytes()),
+        body: body.to_string(),
+        body_encoding: None,
+        native_invocation: NativeInvocation {
+            args: vec!["1".to_string()],
+            chroot: Some("install-root".to_string()),
+            ..Default::default()
+        },
+        transaction_order: TransactionOrder {
+            position: "after-payload".to_string(),
+            before: Vec::new(),
+            after: vec!["payload".to_string()],
+        },
+        timeout_ms: 30_000,
+        sandbox: None,
+        capabilities: Vec::new(),
+        evidence_digest: Some(conary_core::hash::sha256_prefixed(
+            b"model package-set post helper fixture",
+        )),
+        source_evidence_refs: vec!["capture:rpm:%post".to_string()],
+        rpm_trigger: None,
+        rpm_runtime: Some(RpmRuntimeMetadata {
+            program: RpmProgram::EmbeddedLua,
+            body_transforms: Vec::new(),
+            critical: true,
+            criticality: RpmCriticality::Header,
+            raw_flags: 0,
+            unknown_flags: 0,
+            install_prefixes: Vec::new(),
+            macro_context: Default::default(),
+            header_context: Default::default(),
+            package_rpm_version: None,
+        }),
+        rpm_sysusers: None,
+        deb_maintainer: None,
+        arch_install: None,
+        arch_hook: None,
+        residual_lifecycle: None,
+    };
+    NativeLifecycleBundle {
+        schema: NATIVE_LIFECYCLE_SCHEMA_V1.to_string(),
+        schema_revision: conary_core::ccs::native_lifecycle::NATIVE_LIFECYCLE_SCHEMA_REVISION,
+        source_format: SourceFormat::Rpm,
+        source_family: "fedora-rhel".to_string(),
+        source_profile: Some("fedora-44".to_string()),
+        source_release: Some("44".to_string()),
+        source_arch: Some("x86_64".to_string()),
+        source_package: package.to_string(),
+        source_version: version.to_string(),
+        source_checksum: None,
+        version_scheme: VersionScheme::Rpm,
+        conversion_tool: "remi".to_string(),
+        conversion_tool_version: "0.9.5".to_string(),
+        conversion_policy: "model-package-set-test".to_string(),
+        evidence_digest: Some(conary_core::hash::sha256_prefixed(
+            format!("{package}-{version}-model-package-set").as_bytes(),
+        )),
+        scriptlet_fidelity: ScriptletFidelity::NativeLifecycle,
+        entries: vec![entry],
+    }
 }
 
 pub(super) fn insert_test_static_ccs_repository(

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -62,8 +62,11 @@ commands.
   `apps/conary/src/commands/generation/selected_root.rs`, and
   `apps/conary/src/commands/generation/publication.rs`. Single-package install
   execution starts in
-  `apps/conary/src/commands/install/transaction/selected_root.rs`; removal starts
-  in `apps/conary/src/commands/remove/native_graph.rs`. The selected-root
+  `apps/conary/src/commands/install/transaction/selected_root.rs`; declarative
+  multi-root selection and authenticated batch preparation start in
+  `apps/conary/src/commands/install/package_set.rs` and
+  `apps/conary/src/commands/install/repository_batch.rs`; removal starts in
+  `apps/conary/src/commands/remove/native_graph.rs`. The selected-root
   session acquires and owns the canonical runtime mutation lock before
   materialization; the lock implementation starts in
   `crates/conary-core/src/transaction/mod.rs`. Exact rollback execution and

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -403,6 +403,12 @@ target matrices, or command-text exceptions. If the selected root cannot
 satisfy a typed interpreter or source-manager semantic, preflight reports that
 semantic before mutation so the missing model can be engineered.
 
+Model apply resolves every install and update root together, authenticates the
+exact SAT-selected repository closure, and executes that closure as one batch.
+Typed package relations therefore order provider payloads and dependent
+lifecycle programs inside one package-set transition; model diff iteration
+order is never transaction authority.
+
 ## Flow Behavior
 
 ### Native Package Adoption
@@ -605,8 +611,13 @@ state requires an explicit scoped install, update, or replatform operation.
   replatform summaries
 - `apps/conary/src/commands/model/apply.rs` for model apply execution and
   replatform install dispatch
+- `apps/conary/src/commands/model/apply/packages.rs` for model package-set
+  aggregation and atomic install/update dispatch
 - `apps/conary/src/commands/model/apply/derived.rs` for persisted
   derived-package definition and build ownership
+- `apps/conary/src/commands/install/package_set.rs` for multi-root SAT
+  selection and `apps/conary/src/commands/install/repository_batch.rs` for
+  authenticated preparation of the exact selected closure
 - `apps/conary/src/commands/model/remote_diff.rs` and
   `apps/conary/src/commands/model/lock.rs` for remote include drift and
   lockfile behavior


### PR DESCRIPTION
Closes #243
Refs #151

## Problem

Model apply dispatched each explicit install/update action through a separate selected-root transaction. Typed lifecycle programs could therefore run before a separately requested provider had been installed, even when exact repository relations required that provider.

## Summary

- resolve all model install/update roots and their authenticated repository closure in one SAT plan
- prepare the exact selected artifacts before mutation and execute them through one `BatchInstaller` transaction
- share repository artifact authentication/preparation with converted CCS dependency closure installs
- keep model apply orchestration focused in `model/apply/packages.rs`
- document the package-set and repository-batch ownership paths
- add a regression with reversed explicit-root order where typed soname authority orders the provider payload before consumer post-install lifecycle

## Verification

- `cargo test -p conary --lib commands::model` (32 passed)
- `cargo test -p conary --lib commands::install` (187 passed, 1 ignored network conformance test)
- `cargo test -p conary --lib commands::install::conversion` (20 passed)
- `cargo test -p conary --test model_apply` (2 passed)
- `cargo test -p conary --test conversion_integration` (16 passed)
- `cargo test -p conary --test live_host_mutation_safety` (21 passed)
- `cargo test -p conary --test query_scripts` (15 passed)
- `cargo test -p conary model` (35 unit/filter matches plus 5 feature, 1 safety, and 2 model-apply tests passed)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `bash scripts/check-doc-truth.sh`
- `git diff --check`

Group O qcow2 proof remains pending integration into PR #151.