### PR TITLE
docs: record supported-host proof truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Merge validation](https://github.com/ConaryLabs/Conary/actions/workflows/merge-validation.yml/badge.svg?branch=main)](https://github.com/ConaryLabs/Conary/actions/workflows/merge-validation.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Release candidate: v0.14.0](https://img.shields.io/badge/release_candidate-v0.14.0-orange.svg)](CHANGELOG.md)
+[![Release: v0.14.0](https://img.shields.io/badge/release-v0.14.0-blue.svg)](https://github.com/ConaryLabs/Conary/releases/tag/v0.14.0)
 
 **Website:** [conary.io](https://conary.io) | **Packages:** [remi.conary.io](https://remi.conary.io) | **Discussions:** [GitHub Discussions](https://github.com/ConaryLabs/Conary/discussions)
 
@@ -54,14 +54,17 @@ attach only a reviewed support bundle.
 
 ## Try It
 
-Release candidate `v0.14.0` is not tester-authoritative until the
+Release `v0.14.0` is published and artifact-verified, but it predates fixes
+discovered while completing the supported-host generation export/boot proof.
+It is therefore not current tester-authoritative. The
 [release artifact matrix](docs/operations/release-artifact-matrix.md) records
-its exact publication, checksums, deployment, and released-package proof. Do
-not download or install the candidate before that gate opens. Once verified,
-install it only on a VM or non-critical host.
+the exact release proof and this limitation. If you inspect the released
+artifact, install it only on a VM or non-critical host; do not treat its result
+as validation of the unreleased fixes.
 
-Then choose a source whose package format differs from the host and run the
-complete bounded loop:
+After a later release is pinned and the tester guide is resumed, choose a
+source whose package format differs from the host and run the complete bounded
+loop:
 
 ```bash
 source=ubuntu-26.04  # Fedora/Arch hosts; use fedora-44 on Ubuntu

--- a/crates/conary-core/src/generation/builder/create.rs
+++ b/crates/conary-core/src/generation/builder/create.rs
@@ -43,7 +43,7 @@ pub fn materialize_selected_root_from_db(
     materialize_selected_root_from_db_with_authority(conn, objects_dir, selected_root).map(drop)
 }
 
-/// Bootstrap a writable selected root and return the exact typed authority
+/// Initialize a writable selected root and return the exact typed authority
 /// used for materialization.
 ///
 /// The returned manifests let staging callers retain metadata that the

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-07-28
-revision: 41
-summary: Document selected-generation cross-source package lifecycle proof from source and published native packages
+last_updated: 2026-07-31
+revision: 43
+summary: Document selected-generation lifecycle proof and the current Fedora supported-host generation export gates
 ---
 
 # Integration Testing
@@ -112,10 +112,11 @@ two independent reasons found on 2026-07-28:
 The Fedora image ships no `/var/lib/conary` at all, so `system init` creates a
 fresh database at the current schema.
 
-Historical evidence below predates both the re-base and the #61 schema cut, and
-was recorded against `minimal-boot-v4`.
+The 2026-07-31 supported-host evidence below is current. Earlier evidence
+predates both the re-base and the #61 schema cut and was recorded against
+`minimal-boot-v4`.
 
-Current 2026-07-16 W1 Group O local KVM evidence is green. The source fixture
+Historical 2026-07-16 W1 Group O local KVM evidence was green. The source fixture
 was `minimal-boot-v4`, expanded to 20 GiB for full CAS adoption and paired with
 the versioned disposable `conaryos-test-key-v4` identity. The runner discovers
 Fedora's `/usr/share/edk2/x64/OVMF_CODE.4m.fd`, attaches OVMF as read-only
@@ -142,15 +143,27 @@ TGE01 booted the downloaded image under KVM and passed in 63,320 ms.
 `conary system init --db-path` against a scratch-disk root, adds the Fedora 44
 Remi profile, installs a test-time-built `conary-qemu-test-access` CCS package
 for harness SSH and unit enablement, applies `fixture-system.toml` with
-`conary model apply --yes --no-autoremove`, then publishes with
-`conary system generation publish --yes`. `model apply` issues one install per
-model entry, so every intermediate publication fails and prints a pending
-warning; the accumulated candidate is completed by the single `publish` step,
-which is the asserted one. No bootstrap surface is involved and the manifest
-system has no cross-suite artifact passing, so each suite assembles its own
-root.
+`conary model apply --yes --no-autoremove`, then converges publication with
+`conary system generation publish --yes`. `model apply` resolves the changed
+entries as one exact-source SAT package set and executes one lifecycle
+transaction; successful apply may therefore publish the complete closure
+automatically. The shared convergence helper treats the final `publish` as
+idempotent: it must either clear residual debt or confirm publication is
+already current, after which `generation pending` must report no debt and the
+exact numeric target of the selected-generation link is validated. No
+bootstrap surface is involved and the manifest system has no cross-suite
+artifact passing, so each suite assembles its own root.
 
-The source QEMU image for Groups N and O must already include the runtime
+Both supported-host manifests format the scratch root as ext4 with the
+`verity` feature before initializing it. Composefs publication enables
+fs-verity on `root.erofs` and fails closed when the selected root's backing
+filesystem cannot provide it; plain ext4 is therefore not a valid fixture
+substitute. The convergence helper preserves the publish exit status, prints
+its full log, and queries the latest typed
+`generation_publications.last_error` so a failed gate records the exact
+publication cause.
+
+The source QEMU image for Groups N, O, and P must already include the runtime
 generation toolchain (`cpio`, `dracut`, `depmod`, `systemd-repart`, `qemu-img`,
 FAT/ext4 mkfs tools, and composefs inspection tools as needed). Group P uses the
 same source fixture and provisions ISO helper packages through Conary when
@@ -166,14 +179,13 @@ profile and the binary is a test-staging artifact, not a release artifact.
 
 `scripts/build-qemu-guest-image.sh` builds such an image from a pinned official
 Fedora Cloud Base qcow2 plus provisioning, and `bash
-scripts/test-build-qemu-guest-image.sh` is its fast proof. It exists because the
-active `minimal-boot-*` fixtures are conaryOS artifacts of the bootstrap
-pipeline and have no regeneration path once that pipeline is removed. The
-manifests still name the `minimal-boot-*` images; pointing them at a
-Fedora-based image is a separate change, so treat the builder as the
-regeneration path rather than as the fixture the suites currently boot. See
-`docs/modules/test-fixtures.md` under `qemu-source-image-fixtures` for the
-image contract and the identity/size rotation helper. The focused
+scripts/test-build-qemu-guest-image.sh` is its fast proof. The current
+manifests name `fedora44-guest-v2`; the builder is the regeneration authority
+for that Fedora-based fixture. The retired `minimal-boot-*` conaryOS artifacts
+have no regeneration path once the bootstrap pipeline is removed and remain
+historical evidence only. See `docs/modules/test-fixtures.md` under
+`qemu-source-image-fixtures` for the image contract and the identity/size
+rotation helper. The focused
 2026-05-21 KVM run passed the superseded bootstrap-run form of `TISO01`: it
 exported that generation to ISO, copied the ISO and provenance sidecar back to
 `target/local-validation/group-p-iso-export/`, booted the ISO with
@@ -346,7 +358,25 @@ Current Group N QEMU evidence from 2026-05-21:
   Current installs materialize DB/CAS state when no generation exists and
   publish `/conary/current` through the same atomic package transaction.
 
-Current Group O QEMU export evidence from 2026-07-16:
+Current Group O QEMU export evidence from 2026-07-31:
+
+- `cargo run -p conary-test -- run --suite phase3-group-o-generation-export --distro fedora44 --phase 3`:
+  passed 5 / failed 0 / skipped 0 / cancelled 0 against
+  `fedora44-guest-v2`
+- Passed cases:
+  - `TGE01` `installed_generation_export_fails_closed_without_self_contained_root`: 116022ms
+  - `TGE03` `installed_generation_build_rejects_missing_runtime_cas_object`: 552439ms
+  - `TGE04` `installed_runtime_generation_export_boots`: 994129ms
+  - `TGE05` `installed_runtime_generation_export_preserves_file_capability_xattrs`: 2973162ms
+  - `TGE02` `supported_host_generation_export_boots`: 2383246ms
+- TGE02 assembled the Fedora root through ordinary signed Remi CCS installs,
+  published with zero debt, exported the selected generation, and booted the
+  qcow2 under UEFI. TGE04 and TGE05 retained their installed-runtime and
+  file-capability carrier proof.
+- Full artifact hashes and the exact implementation head are recorded on PR
+  #151; this is local x86_64 KVM evidence, not hosted CI.
+
+Historical Group O QEMU export evidence from 2026-07-16:
 
 - `cargo run -p conary-test -- run --suite phase3-group-o-generation-export --distro fedora44 --phase 3`:
   passed 5 / failed 0 / skipped 0 / cancelled 0 against `minimal-boot-v4`
@@ -365,9 +395,9 @@ Current Group O QEMU export evidence from 2026-07-16:
   available from `https://remi.conary.io/test-artifacts/`. An isolated-cache
   download matched the source hashes and passed a 63,320 ms TGE01 KVM boot.
 - The `TGE02` in this and the older dated block is the superseded
-  `bootstrap_run_generation_export_boots` case. It was replaced by
-  `supported_host_generation_export_boots`, which has no run of its own yet.
-  The `TGE01`, `TGE03`, `TGE04`, and `TGE05` results are unaffected.
+  `bootstrap_run_generation_export_boots` case. Current supported-host proof is
+  recorded above. The `TGE01`, `TGE03`, `TGE04`, and `TGE05` results remain
+  useful historical evidence.
 
 Historical Group O QEMU export evidence from 2026-05-21:
 
@@ -387,7 +417,21 @@ Keep Group O in the release-candidate rotation because it is still the full
 boot/export proof for installed-runtime and supported-host generation
 artifacts.
 
-Group P ISO export evidence from 2026-05-21, against the superseded
+Current Group P ISO export evidence from 2026-07-31:
+
+- `cargo run -p conary-test -- run --suite phase3-group-p-iso-export --distro fedora44 --phase 3`:
+  passed `TISO01`, 1 passed / 0 failed / 0 skipped / 0 cancelled against
+  `fedora44-guest-v2` in 2326789ms
+- `TISO01` assembled the supported-host generation through ordinary signed
+  Remi CCS installs, emitted the ISO and provenance sidecar, copied both back,
+  booted the read-only ISO under UEFI, selected the exact generation, and
+  retained a writable `/etc` overlay.
+- The ISO was 667713536 bytes with SHA-256
+  `ff6bd95bcd3ac9ceb27712f4acda0328ef4edc97139a8047d310cb415998338b`;
+  the provenance sidecar records the same size and hash. Full provenance and
+  exact-head identity are recorded on PR #151.
+
+Historical Group P ISO export evidence from 2026-05-21, against the superseded
 bootstrap-run form of `TISO01`:
 
 - `cargo run -p conary-test -- list`: passed; includes
@@ -406,9 +450,9 @@ bootstrap-run form of `TISO01`:
   `rootfstype=iso9660`, generation artifact files, and a writable `/etc`
   overlay on the read-only carrier.
 - `TISO01` is now `supported_host_generation_iso_export_boots` on the
-  supported-host fixture and has no run of its own yet. The carrier and
-  provenance assertions above are unchanged by the re-base; the basis that
-  produces the generation is what changed.
+  supported-host fixture. Its current proof is recorded above; the carrier and
+  provenance assertions survived the re-base while the generation basis
+  changed.
 
 Fast workspace verification from 2026-05-14:
 

--- a/docs/guides/agent-assisted-tester-loop.md
+++ b/docs/guides/agent-assisted-tester-loop.md
@@ -1,7 +1,8 @@
 ---
-last_updated: 2026-07-29
-revision: 13
-summary: Pin the agent-supervised cross-distro package tester loop to v0.14.0
+last_updated: 2026-07-31
+revision: 14
+status: paused
+summary: Preserve the v0.14.0 tester-loop shape while execution waits for a release containing the supported-host fixes
 ---
 
 # Agent-Assisted Tester Loop
@@ -14,17 +15,23 @@ stays responsible for approving every command that mutates system state.
 Use a disposable VM, a snapshot, or a non-critical host. Do not run this loop
 first on an irreplaceable daily driver.
 
-This guide is pinned to `v0.14.0`. Do not begin the loop until the
+**Do not run this guide while its frontmatter status is `paused`.** Its
+`v0.14.0` commands are retained so the next release can be re-pinned without
+losing the reviewed flow, but that immutable release predates fixes discovered
+during supported-host generation bring-up and is not current tester authority.
+Resume only after this guide names a later release and the
 [current release artifact matrix](https://github.com/ConaryLabs/Conary/blob/main/docs/operations/release-artifact-matrix.md)
-records that tag as published and independently verified, and the release page
-publishes the package for this host plus `SHA256SUMS`. Do not continue when the
-downloaded package fails checksum verification.
+records that exact tag as published and independently verified.
 
 ## Copy-Paste Agent Prompt
 
 Paste this into the agent running inside the VM or snapshot:
 
 ```text
+First read the guide frontmatter. If its status is paused, stop without
+downloading or installing anything and explain that no current pinned tester
+release exists.
+
 I want you to help me run the Conary first external tester loop on this host.
 
 Read this guide first:

--- a/docs/modules/test-fixtures.md
+++ b/docs/modules/test-fixtures.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-07-31
-revision: 29
-summary: Map fixture ownership, including bounded CCS install-prefix authoring, cross-source lifecycle proof, the public v4 QEMU image contract, Fedora guest regeneration, and RPM root-anchor conversion
+revision: 30
+summary: Map fixture ownership, including supported-host generation export, Fedora guest regeneration, and cross-source lifecycle proof
 ---
 
 # Test Fixtures And Proof Maps
@@ -450,7 +450,9 @@ Each fixture family should record:
   lifecycle applies unit preset policy. The symlinks are produced by
   `stage-links.sh` rather than checked in, because the harness copies fixtures
   with `scp -r`, which would materialize a checked-in link as a copy of its
-  target.
+  target. `publish-selected-generation.sh` is the shared idempotent
+  publication-convergence and selected-generation assertion used by both
+  carriers.
 - **Consumes:** Group O `TGE02`
   (`supported_host_generation_export_boots`) and Group P `TISO01`
   (`supported_host_generation_iso_export_boots`).
@@ -470,27 +472,40 @@ Each fixture family should record:
   exact-source SAT package set and executes one lifecycle transaction. The
   suite verifies the selected generation contains networkd enablement before
   export, then requires an independently reachable SSH boot of the qcow2 or ISO
-  artifact. Exact-head live evidence belongs on the owning pull request rather
-  than in this map.
+  artifact.
+- **Current evidence:** the 2026-07-31 PR #151 implementation proof passed all
+  five Group O qcow2 cases and the Group P ISO case on Fedora 44. The shared
+  final helper is idempotent, requires zero pending publication debt, and
+  validates the exact numeric selected-generation target. Full timings and
+  artifact identities belong on the owning pull request rather than in this
+  map.
 - **Safety notes:** The staged `authorized_keys` carries the
   `__CONARY_QEMU_TEST_PUBLIC_KEY__` placeholder and is substituted in the guest
   with the disposable harness key; no real credential belongs in this fixture.
   The suites assemble into a scratch-disk `--db-path` root and never mutate the
-  guest's live root.
+  guest's live root. That scratch filesystem must be ext4 with the `verity`
+  feature: composefs generation publication enables fs-verity on `root.erofs`
+  and truthfully fails closed when the backing filesystem lacks it. A failed
+  convergence attempt must retain and print the typed
+  `generation_publications.last_error`.
 
 ### qemu-source-image-fixtures
 
 - **Owner:** image construction: `scripts/build-qemu-guest-image.sh`;
   unprivileged identity/size rotation:
-  `scripts/bootstrap-vm/rotate-qemu-test-identity.sh`; QEMU execution and
-  download cache: `apps/conary-test/src/engine/qemu.rs`.
+  `scripts/bootstrap-vm/rotate-qemu-test-identity.sh`; QEMU orchestration and
+  download cache: `apps/conary-test/src/engine/qemu.rs`; bounded live console
+  capture: `apps/conary-test/src/engine/qemu/console.rs`; cross-guest static
+  client staging: `scripts/build-static-conary.sh`.
 - **Purpose:** Keep a versioned, generation-builder-ready qcow2 source image
   paired with a disposable SSH identity and enough root-filesystem headroom
   for full live-root adoption into CAS.
-- **Fixture sources:** versioned `minimal-boot-vN.qcow2` artifacts and the
-  matching versioned `conaryos-test-key-vN` test artifact served by Remi;
-  active consumers
-  are the Phase 3 QEMU manifests under
+- **Fixture sources:** the pinned official Fedora Cloud Base 44 qcow2 and
+  provisioning contract in `scripts/build-qemu-guest-image.sh`, producing the
+  active immutable `fedora44-guest-v2` artifact served by Remi with the
+  `conaryos-test-key-v4` disposable identity. The historical
+  `minimal-boot-vN.qcow2` artifacts and matching versioned keys remain evidence
+  only. Active consumers are the Phase 3 QEMU manifests under
   `apps/conary/tests/integration/remi/manifests/`.
 - **Consumes:** Groups N, O, and P plus composefs modernization QEMU steps.
 - **Fast proof:** `bash scripts/test-build-qemu-guest-image.sh`;

--- a/docs/operations/external-tester-outreach.md
+++ b/docs/operations/external-tester-outreach.md
@@ -1,8 +1,8 @@
 ---
-last_updated: 2026-07-29
-revision: 6
+last_updated: 2026-07-31
+revision: 7
 status: postponed
-target_release: v0.14.0
+target_release: unassigned
 summary: Postponed multi-venue launch packet for the first cross-distro tester loop
 ---
 
@@ -11,16 +11,17 @@ summary: Postponed multi-venue launch packet for the first cross-distro tester l
 > **POSTPONED; NO NEW DATE IS ASSIGNED:** the current qualifying milestone is
 > 0/10. The two earlier supported-host reports remain useful adoption and
 > onboarding evidence, but neither installed a source package whose format
-> differed from the host's native format. Release candidate `v0.14.0` is not
-> yet publication or tester authority. Do not publish the copy below until its
-> release proof and the separate external cached-history and venue-eligibility
-> gates are closed.
+> differed from the host's native format. Release `v0.14.0` is published and
+> artifact-verified, but supported-host bring-up subsequently exposed defects
+> whose fixes remain unreleased. It is not current tester authority. Do not
+> publish the copy below until a later immutable release is named here and the
+> W7, external cached-history, and venue-eligibility gates are closed.
 
-`v0.14.0` is the target release for this packet. It becomes pinned only after
-the release artifact matrix records its published tag, checksums, signature,
-installed-binary proof, live deployment, and released-package cross-distro
-lifecycle. The maintainer assigns fresh dates only after every remaining gate
-closes, then posts manually and remains available to answer comments.
+The venue copy below retains its `v0.14.0` wording as an unpublishable draft
+until a replacement release exists; replacing the version without exact
+release evidence would create false authority. The maintainer re-pins and
+assigns fresh dates only after every remaining gate closes, then posts manually
+and remains available to answer comments.
 
 ## Show HN Submission
 
@@ -185,14 +186,17 @@ failed attempts are useful evidence.
   reports as non-qualifying historical evidence.
 - [x] Rewrite the venue copy around the cross-distro package loop.
 - [x] Retire the passed 2026-07-20 through 2026-07-22 dates.
-- [ ] Publish immutable `v0.14.0` with RPM, DEB, Arch, CCS, checksums, and the
+- [x] Publish immutable `v0.14.0` with RPM, DEB, Arch, CCS, checksums, and the
   required signature and installed-binary evidence.
-- [ ] Record exact cross-distro install/query/update-preview/remove proof for
+- [x] Record exact cross-distro install/query/update-preview/remove proof for
   the released binary on supported hosts.
-- [ ] Deploy the exact release sites and independently verify live status and
+- [x] Deploy the exact release sites and independently verify live status and
   body claims.
-- [ ] Update the release artifact matrix and milestone tracker with exact
+- [x] Update the release artifact matrix and milestone tracker with exact
   release, deployment, and Remi population evidence.
+- [ ] Publish and independently verify a later immutable Conary release that
+  contains the supported-host fixes discovered after `v0.14.0`, then replace
+  every pinned version and URL in this draft.
 - [ ] Obtain GitHub Support confirmation that cached pre-rewrite pull-request
   and commit views have been dereferenced.
 - [ ] Re-check each venue's current rules and account eligibility immediately

--- a/docs/operations/release-artifact-matrix.md
+++ b/docs/operations/release-artifact-matrix.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-07-29
-revision: 20
-summary: Track the v0.14.0 and Remi 0.9.0 release candidates without treating pending proof as authority
+last_updated: 2026-07-31
+revision: 21
+summary: Record published Conary 0.14.0 and deployed Remi 0.9.5 while keeping release proof separate from current tester authority
 ---
 
 # Release Artifact Matrix
@@ -17,11 +17,16 @@ the absolute run date, distro, suite, and pass counts.
 
 ## Current Release Suite
 
-Issue #165 prepares Conary `v0.14.0` and `remi-v0.9.0`. Neither candidate is
-current release or production authority yet. Their tag objects, reviewed
-commits, workflow runs, assets, checksums, deployment results, and independent
-behavior proof remain pending below. The previously verified release suite
-continues to serve users until every applicable gate is complete.
+Conary `v0.14.0` is an immutable published limited-preview release with exact
+asset, deployment, and released-package proof. It is not current
+tester-authoritative: supported-host generation bring-up after the tag exposed
+product defects whose fixes remain unreleased on issue #137 and PR #151. The
+release remains valid evidence for the exact tree it contains; later source
+proof does not retroactively change that tree.
+
+Remi `0.9.5` is the current immutable release and production authority. Its
+exact release, protected deployment, independent asset identity, and live
+health proof are recorded below.
 
 The build-only conaryd and conary-test releases retain their existing immutable
 lineage. Broad external outreach remains separately postponed at 0/10
@@ -29,47 +34,69 @@ qualifying completions.
 
 | Product | Artifact classes | Release workflow | Source authority | Release URL | Required evidence | Preview support | Known caveats | Source-build fallback |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `conary` | binary, `.ccs`, `.rpm`, `.deb`, `.pkg.tar.zst` | `.github/workflows/release-build.yml`, `scripts/release.sh conary`, `scripts/release-matrix.sh` | candidate `v0.14.0`; annotated tag object and reviewed commit pending | https://github.com/ConaryLabs/Conary/releases/tag/v0.14.0 | publication, checksums, GitHub digests, detached signature, current binary/self-update, deployment, endpoint, site, released-package lifecycle, SBOM, and provenance proof all pending | not yet preview-supported | use only after this matrix records complete proof; supported scope will remain disposable, snapshotted, or explicitly non-critical x86_64 Fedora 44, Ubuntu 26.04 LTS, and Arch hosts | `cargo build -p conary` |
-| `remi` | binary and deploy bundle | `.github/workflows/release-build.yml`, `scripts/release.sh remi`, `scripts/release-matrix.sh` | candidate `remi-v0.9.0`; annotated tag object and reviewed commit pending | https://github.com/ConaryLabs/Conary/releases/tag/remi-v0.9.0 | publication, checksums, installed identity, signature, protected deployment, current schema/source/signing state, conversions, full health, public converted CCS, SBOM, and provenance proof all pending | not yet production authority | the prior verified deployment remains authoritative until exact release and live proof complete | `cargo build -p remi` |
+| `conary` | binary, `.ccs`, `.rpm`, `.deb`, `.pkg.tar.zst` | `.github/workflows/release-build.yml`, `scripts/release.sh conary`, `scripts/release-matrix.sh` | annotated tag object `c36c767c7169ff519a96dfdc7bedfa757211f334`, reviewed commit `fe23a604b64ea6f7cc87fce8298911e2245e027f` | https://github.com/ConaryLabs/Conary/releases/tag/v0.14.0 | immutable publication, checksums/GitHub digests, detached CCS signature, deployment, self-update endpoint, three-distro released-package lifecycle, and Fedora sparse-sync proof complete; no SBOM or provenance sidecar published | published limited-preview artifact; not current tester-authoritative after unreleased supported-host fixes | use only on disposable, snapshotted, or explicitly non-critical x86_64 Fedora 44, Ubuntu 26.04 LTS, and Arch hosts; current source fixes are not part of this artifact | `cargo build -p conary` |
+| `remi` | binary and deploy bundle | `.github/workflows/release-build.yml`, `scripts/release.sh remi`, `scripts/release-matrix.sh` | annotated tag object `f2bf17f0086a7f8ea4be3e032336551c4e6089c1`, reviewed commit `101dba655257f1ff3d1bee689d9c5ac8b2b68cbd` | https://github.com/ConaryLabs/Conary/releases/tag/remi-v0.9.5 | immutable publication, checksums/GitHub digests, raw/tar identity, installed identity, protected deployment, schema/source/signing state, conversions, full health, and public serving proof complete; no detached signature, SBOM, or provenance sidecar published | current production authority | distribution and a wider stranger-operated path remain limited | `cargo build -p remi` |
 | `conaryd` | binary and tarball | `.github/workflows/release-build.yml`, `scripts/release.sh conaryd`, `scripts/release-matrix.sh` | annotated tag object `381ee55cd051234dd78647ef5d7a8c3250c6b9df`, commit `a231276a900bbe8a8ccb6a0942f104cba2ab86b4` | https://github.com/ConaryLabs/Conary/releases/tag/conaryd-v0.7.0 | exact publication, checksums, raw/tar identity, binary version, build-only routing, signature, SBOM, and provenance recorded below | release artifact only; no deployment | Forge staging remains paused; package jobs retain the CLI live-mutation acknowledgement boundary | `cargo build -p conaryd` |
 | `conary-test` | binary and tarball | `.github/workflows/release-build.yml`, `scripts/release.sh conary-test`, `scripts/release-matrix.sh` | annotated tag object `6c4a8cb4bb2c6e89f359a8ceb89ac40a5ce06890`, commit `a231276a900bbe8a8ccb6a0942f104cba2ab86b4` | https://github.com/ConaryLabs/Conary/releases/tag/conary-test-v0.9.0 | exact publication, checksums, raw/tar identity, binary version, suite inventory, build-only routing, signature, SBOM, and provenance recorded below | release artifact only; no deployment | QEMU/KVM suites require a capable local host while remote validation is paused | `cargo build -p conary-test` |
 
 ## Recorded Evidence
 
-### Conary 0.14.0 candidate
+### Conary 0.14.0
 
-- Owned manifests, packaging metadata, the generated man page, site release
-  data, tester guide, and changelog are prepared for `v0.14.0` on issue #165.
-- The annotated tag object and peeled reviewed commit are pending.
-- Exact-tag release-build and publication are pending. No asset inventory,
-  checksum, GitHub digest, detached-signature, installed-binary, or forced
-  self-update result is claimed.
-- Protected deployment, public endpoint identity, exact-tag site content,
-  branded HTTP 404, and released native-package lifecycle proof are pending.
-- SBOM and provenance status will be recorded from the published asset
-  inventory rather than inferred from the candidate tree.
+- Annotated tag object `c36c767c7169ff519a96dfdc7bedfa757211f334`
+  peels to reviewed commit
+  `fe23a604b64ea6f7cc87fce8298911e2245e027f`.
+- Exact-tag release-build run `30409720307` passed and published the immutable
+  release on 2026-07-29. Independent downloads matched `SHA256SUMS` and every
+  GitHub digest:
+  - `conary-0.14.0-1.fc44.x86_64.rpm`:
+    `646d89bd8e6de86e8ec983d7cdba942ccfcd45cecc32a3e3efb69576a62dc09a`
+  - `conary_0.14.0-1_amd64.deb`:
+    `6cb55e510dfe2578af530ca89054458cc0b61e33870af09245d1f1e6069eae8d`
+  - `conary-0.14.0-1-x86_64.pkg.tar.zst`:
+    `bab913f539325122ba86fbcc8cdb62dc396657709c55fac78927ae4bbc9d88ec`
+  - `conary-0.14.0.ccs`:
+    `f38fa623880b383fd9d2b49a0b003d2885a826f78d51c874ef216363cc61b3fd`
+  - `conary-0.14.0.ccs.sig`:
+    `9b26ddc8496f23005f5c6c3906c956816d215a73d1d789d6e2062a0763d7975d`
+  - `SHA256SUMS`:
+    `5e7aef32d1dcc31fa5a3779b6cf283704cefa56c4e3e6ab5b842c233e0168c7a`
+  - `metadata.json`:
+    `dfd5e8bb1add27867ca8a631223ce4d7f5f5c649d6b7207373ddc0ddb665418c`
+- Metadata identifies product `conary`, tag `v0.14.0`, version `0.14.0`, and
+  `release_bundle` deployment. No SBOM or provenance sidecar is published.
+- Protected deploy-and-verify run `30412130145` passed exact release-bundle
+  deployment, self-update endpoint and static-site checks, published artifact
+  proof, and installed-package lifecycle proof on Fedora 44, Ubuntu 26.04, and
+  Arch.
+- The released RPM reports `conary 0.14.0`. In a 2,048 MiB Fedora 44 KVM
+  guest it synchronized 76,354 live Fedora packages in 194,288 ms, and the
+  guest database contained exactly 76,354 repository-package rows.
+- The supported-host generation fixes developed after this tag are not in
+  `v0.14.0`. Their qcow2/ISO proof belongs to issue #137 and PR #151 and does
+  not make this older artifact current tester authority.
 
-Expected package asset names after successful publication are:
+### Remi 0.9.5
 
-- `conary-0.14.0-1.fc44.x86_64.rpm`
-- `conary_0.14.0-1_amd64.deb`
-- `conary-0.14.0-1-x86_64.pkg.tar.zst`
-- `conary-0.14.0.ccs`
-- `conary-0.14.0.ccs.sig`
-- `SHA256SUMS`
-- `metadata.json`
-
-### Remi 0.9.0 candidate
-
-- The owned manifest and changelog are prepared for `remi-v0.9.0` on issue
-  #165.
-- The annotated tag object, peeled reviewed commit, exact-tag release-build,
-  publication, three-asset inventory, checksums, binary identity, signature,
-  SBOM, and provenance status are pending.
-- Protected deployment and independent schema, revision, source population,
-  signing-profile, conversion, full-health, and public converted-CCS proof are
-  pending. The candidate must not replace current production authority before
-  those checks pass.
+- Annotated tag object `f2bf17f0086a7f8ea4be3e032336551c4e6089c1`
+  peels to reviewed commit
+  `101dba655257f1ff3d1bee689d9c5ac8b2b68cbd`.
+- Exact-tag release-build run `30583793501` passed and published the immutable
+  release on 2026-07-30. Independent downloads matched every GitHub digest:
+  `metadata.json`
+  `4ee564321ab8826679e880f8a386e7da6bb94589cad35c6374e71a6538f3bd80`,
+  raw binary
+  `8333105420ca30de79a8f312758699a950e7e0f280e80cbebf20302a942cbe14`,
+  and tarball
+  `9144164b9e61e666cc3a801eb08c8ca2d02de2efa09902f3a9e98e2aacf5b40b`.
+- The raw and tar-extracted binaries are byte-identical and report
+  `remi 0.9.5`. This release publishes no detached signature, SBOM, or
+  provenance sidecar.
+- Protected deploy-and-verify run `30585462182` passed at the exact release
+  commit. Independent public proof on 2026-07-31 passed full health 11/11;
+  readiness reports `ready=true` at schema revision 23. Public stats reported
+  83,885 packages, 3,494 downloads, three distributions, and 1,783 converted
+  packages.
 
 ### conaryd 0.7.0 and conary-test 0.9.0
 

--- a/docs/roadmaps/development-roadmap.md
+++ b/docs/roadmaps/development-roadmap.md
@@ -1,8 +1,8 @@
 ---
-last_updated: 2026-07-28
-revision: 8
+last_updated: 2026-07-31
+revision: 10
 summary: Track Conary's cross-distro package milestone, ordered workstreams, evidence, blockers, and post-milestone horizons
-proof_baseline: "v0.13.0 and remi-v0.8.5 at 6f1429c362ac161f1ef817233e72ee9c9a031c11; post-hard-cut release, deployment, and three-distro artifact proof complete"
+proof_baseline: "immutable v0.14.0 at fe23a604b64ea6f7cc87fce8298911e2245e027f and production remi-v0.9.5 at 101dba655257f1ff3d1bee689d9c5ac8b2b68cbd; exact asset, deployment, and released-package proof complete"
 current_milestone: first external tester loop
 active_workstream: W4 Source Fidelity Hard Cut
 next_workstream: W5 Source Authority Model
@@ -39,13 +39,17 @@ installed-runtime, file-capability, and bootstrap-run raw/qcow2 cases against
 `minimal-boot-v4`. That run predates the #61 schema epoch cut, and the
 `minimal-boot-*` lineage cannot run the current build at all: those images ship
 a bootstrap-built Conary database at a retired schema. The suites now target
-`fedora44-guest-v1`, an official Fedora Cloud Base 44 image built by
-`scripts/build-qemu-guest-image.sh` per #153's re-base decision. It has no
-published artifact yet, and no suite run against it is recorded.
-The dated 2026-05-21 Group P QEMU run passed ISO generation-carrier,
-provenance-sidecar, copy-back, read-only carrier boot, and writable `/etc`
-overlay proof. These are local x86_64 evidence, not a broad or current
-remote-validation claim.
+`fedora44-guest-v2`, an official Fedora Cloud Base 44 image built by
+`scripts/build-qemu-guest-image.sh` per #153's re-base decision. Its immutable
+public artifact is pinned at
+`f688ac2a02b0b0558e28de1c97bbcb2e45b6772a4f019b037f72ec584a420174`
+and includes Fedora's packaged systemd-boot EFI binary.
+The dated 2026-07-31 Group O implementation proof passed all five qcow2 cases
+against that fixture, including ordinary signed Remi CCS assembly and
+selected-generation publication. The dated 2026-07-31 Group P implementation
+proof passed its ISO case, including provenance, copy-back, read-only carrier
+boot, and writable `/etc` overlay proof. This is local x86_64 evidence, not a
+broad remote-validation claim.
 
 Bootable-image export is a retained generation capability, not a bootstrap
 capability. Generation keeps raw/qcow2/ISO export with a UEFI QEMU boot proof,
@@ -53,8 +57,8 @@ and that proof now stands on a supported-host fixture: Groups O and P assemble
 a Fedora 44 root from ordinary repository installs on a scratch disk, publish
 it as a generation, export it, and boot the artifact. The bootstrap-run export
 cases and their fixture are gone. The boot lane needs a host with `/dev/kvm`
-and OVMF firmware; remi-dev is the current such host. The re-based suites have
-not yet had a green live run.
+and OVMF firmware; remi-dev is the current such host. The re-based suites are
+green locally on the 2026-07-31 PR #151 implementation.
 
 ## Milestone 1 Exit Condition
 
@@ -117,16 +121,16 @@ the stated scope, not whether a workstream happens to be active.
 | CLI and core package operations | solid | Scope is the limited preview; external use and fresh combined proof matter more than new surface area. |
 | Adoption, unadoption, and native handoff | solid | Proof covers the current three-distro scope; the released Arch package initializes only its exact native profile and synchronizes Remi. |
 | Database, CAS, native parsing, and resolution | solid | Some advanced repository-policy abstractions and integration edges remain incomplete. |
-| Packaging, static repositories, trust, and self-update | solid | `v0.13.0` has exact tag, hashes, detached signature, current signed self-update, deployment, and native RPM/DEB/Arch installed-binary proof. The intentional 0.12 schema boundary requires a fresh native-package install. No SBOM/provenance sidecars are published or planned. |
+| Packaging, static repositories, trust, and self-update | solid | Immutable `v0.14.0` has exact tag, hashes, detached signature, self-update endpoint, deployment, native RPM/DEB/Arch installed-binary proof, and a released Fedora sparse sync. It predates the current supported-host fixes and is not current tester authority. No SBOM/provenance sidecars are published. |
 | CCS conversion and native lifecycle authority | active hard switch | The exact RPM, Debian, and ALPM lifecycle contract is released and deployed; current source-backed format defects are explicit work in #98, #99, and #102 through #105 rather than manual-review authority. These share one root cause: the shared package model normalizes source facts at parse time instead of at each consumer's boundary. W5 owns the structural correction. |
-| Generation build and export | limited | Bootable-image export (raw/qcow2/ISO plus a UEFI QEMU boot proof) is retained and proven from a supported-host fixture rather than from bootstrap; the re-based Group O/P suites await their first green live run. Proven paths are x86_64; non-x86 assets, signed boot authority, and persistent-effect rollback remain later work. |
+| Generation build and export | limited | Bootable-image export (raw/qcow2/ISO plus a UEFI QEMU boot proof) is retained and proven from a supported-host fixture rather than from bootstrap; the re-based Group O/P suites passed locally on 2026-07-31. Proven paths are x86_64; non-x86 assets, signed boot authority, and persistent-effect rollback remain later work. |
 | Model, source selection, and replatforming | limited | Some resolution deltas and builder inputs are not wired end to end. |
 | Bootstrap and self-hosting | limited | Rootful, chroot, fixture, and QEMU dependencies need repeatable current proof. |
-| Remi core and publication | solid | `remi-v0.8.5` is deployed on the current schema with five populated sources, exact signing profiles, fair prewarm, real conversions, and full public health; distribution and a wider stranger-operated path remain limited. `/health/ready` became evidence bearing in #107 and now fails closed on an absent database or an unrunnable probe; the deployed build predates that change until the next release. |
+| Remi core and publication | solid | `remi-v0.9.5` is deployed at schema revision 23 with three populated distributions, exact signing profiles, 1,783 converted packages, and full public health 11/11. Distribution and a wider stranger-operated path remain limited. |
 | conaryd package and query service | limited | Authorization is exact root/daemon/configured-group authority; restart semantics, resolver-backed dry-run proof, and deployment remain incomplete. |
 | Federation | experimental | Only `/v1/federation/directory` is routed and no federation call exists in chunk serving, so the router is a library nothing invokes on a local miss. TLS fingerprint pinning is enforced in code; the documented disagreement is a docs defect. See the federation horizon for measured state and slice ordering. |
 | Advanced derivation, lock, and reproducibility flows | unfinished | Several interfaces exist without complete persisted inputs or update-path integration. |
-| External product readiness | unfinished | The `v0.13.0` released-package matrix is complete, but the revised cross-distro milestone remains 0/10. Outreach is now gated on the W7 corpus proof rather than on venue scheduling alone; cached-history and venue-eligibility clearance remain separate prerequisites. |
+| External product readiness | unfinished | The `v0.14.0` released-package matrix is complete, but the release predates current supported-host fixes and the revised cross-distro milestone remains 0/10. Outreach is gated on a later verified release, W7 corpus proof, cached-history clearance, and venue eligibility. |
 
 ## Workstreams
 
@@ -171,39 +175,31 @@ the stated scope, not whether a workstream happens to be active.
   behind the W4 through W7 engineering gate, because the release proof covers
   a curated lifecycle rather than ordinary repository packages. Outreach state,
   venue eligibility, and the 0/10 tracker are now W8's.
-- **Current truth:** the post-hard-cut release gate is complete at immutable
-  `v0.13.0` with compatible production `remi-v0.8.5`. The released RPM, DEB,
-  and Arch packages passed the Cartesian source-format lifecycle on Fedora 44,
-  Ubuntu 26.04 LTS, and Arch. That lifecycle is a curated proof, not a
-  repository-wide one; W7 owns the ordinary-package corpus.
+- **Current truth:** the latest immutable release is `v0.14.0` with production
+  `remi-v0.9.5`. The released RPM, DEB, and Arch packages passed the Cartesian
+  source-format lifecycle on Fedora 44, Ubuntu 26.04 LTS, and Arch. The
+  release predates fixes found during supported-host generation bring-up, so
+  it remains exact evidence for its own tree but is not current tester
+  authority. W7 owns the ordinary-package corpus.
 - **Execution status:** complete for the release, deployment, and
   published-package proof it owns.
 - **Dependencies:** none remaining.
-- **Proof:** immutable `v0.13.0` published at `2026-07-27T11:57:44Z`;
-  annotated tag object `f8298522fd7fe95a4994184ae20c34cf64096818`
-  peels to `6f1429c362ac161f1ef817233e72ee9c9a031c11`. Exact-tag
-  release-build `30261256730` passed the workspace and four package builders.
-  Independent downloads found exactly seven assets, matched all five
-  `SHA256SUMS` entries and every GitHub digest, and verified the detached CCS
-  signature with the official preceding release key. A copied released 0.13
-  binary forced a signed update through the production channel and remained
-  `conary 0.13.0`; the incompatible 0.12 CCS parser is an intentional hard-cut
-  reinstall boundary, not a compatibility path. Deploy-and-proof run
-  `30263948968` passed: the server's exact seven files match the release,
-  conary.io serves the exact tag and a branded HTTP 404, and native RPM, DEB,
-  and Arch packages each installed and passed the owned Cartesian lifecycle on
-  their matching supported host. Current `remi-v0.8.5` tag object
-  `1d9b8588fe01453bab20f1a7956e4aa9d6263702` peels to the same commit;
-  release-build `30259180128` and protected deploy `30260847616` passed. Live
-  inspection reports schema revision 21, five populated sources, 98,266
-  repository packages, exact Arch/Fedora/Ubuntu signing profiles, 2,368
-  conversions, full health 10/10, and public converted CCS proof. conaryd
-  0.7.0 and conary-test 0.9.0 remain immutable build-only products from
-  `a231276a900bbe8a8ccb6a0942f104cba2ab86b4`. Exact hashes and complete
-  per-product evidence live in the release matrix. No SBOM or provenance
-  sidecars are published. The known conversion failures are owned by #98,
-  #99, and #102 through #105; the false-success unknown API fallback is owned
-  by #67 rather than hidden as release success.
+- **Proof:** immutable `v0.14.0` published on 2026-07-29; annotated tag
+  `c36c767c7169ff519a96dfdc7bedfa757211f334` peels to
+  `fe23a604b64ea6f7cc87fce8298911e2245e027f`. Exact-tag release-build
+  `30409720307` and protected deploy-and-verify `30412130145` passed.
+  Independent downloads matched the seven-asset checksum/digest inventory and
+  detached CCS signature. The released Fedora RPM reports `conary 0.14.0` and
+  synchronized 76,354 live Fedora packages in a 2,048 MiB guest in 194,288 ms.
+  Current `remi-v0.9.5` tag object
+  `f2bf17f0086a7f8ea4be3e032336551c4e6089c1` peels to
+  `101dba655257f1ff3d1bee689d9c5ac8b2b68cbd`; release-build `30583793501`
+  and protected deployment `30585462182` passed. Independent production proof
+  reports installed `remi 0.9.5`, schema revision 23, 83,885 packages, 1,783
+  conversions, three distributions, and full health 11/11. conaryd 0.7.0 and
+  conary-test 0.9.0 remain immutable build-only products. Exact hashes and
+  complete per-product evidence live in the release matrix. No current product
+  publishes an SBOM or provenance sidecar.
 - **Limitations:** the release proof does not establish that ordinary
   repository packages convert. W4 through W7 own that claim.
 
@@ -384,7 +380,7 @@ acceptance criteria, and proof.
 | Native packaging horizon | #70, #51, #72 | P2 |
 | Service and operator horizon | #69, #65, #66, #73 | P2 |
 | System artifacts horizon | #63, #64, #71 | P2 |
-| Closed | #41 closed 2026-07-27 as fixed in v0.13.0; Artix route tracked as W8 evidence | not engineering work |
+| Closed | #41 closed 2026-07-31 after the selected-root alias regression repair and current Fedora export/boot proof; original Artix route tracked as W8 evidence | not engineering work |
 
 ### Known overlaps
 
@@ -416,10 +412,13 @@ authority owners.
 - **#65 and #66 both target fleet-scale control.** #65 is the replatforming
   operation, #66 the typed gateway that would expose it. #66's local typed APIs
   stabilize first.
-- **#41 overlaps #99's path authority but is not open work.** The reported
-  defect shipped fixed in v0.12.0; only reporter confirmation is outstanding.
-  It belongs in a support state, not the engineering queue. Its Artix host
-  remains outside supported scope and is tracked as W8 evidence.
+- **#41 overlaps #99's path authority but is closed engineering work.** The
+  original archive-path repair shipped in v0.12.0, but current Fedora
+  supported-host proof exposed the same property in the live-root
+  materializer. The 2026-07-31 repair reuses the bounded selected-root resolver
+  for install, remove, rollback, and hardlink paths while retaining escape and
+  loop rejection. The original Artix host remains outside supported scope and
+  is tracked as W8 evidence.
 
 ## Post-Milestone Horizons
 
@@ -656,8 +655,10 @@ checksum and CCS-signature verification, production deployment, official
 installed-binary self-update, compatible prewarmed Remi, rollback, and
 clean-host proof. W3's release proof gate was reopened for the supported `htop`
 SONAME repair and again for issue #41's path-safety and support-bundle defects,
-then superseded by the post-hard-cut package authority suite; it closed with
-verified immutable `v0.13.0` and production `remi-v0.8.5`.
+then superseded by the post-hard-cut package authority suite. The latest exact
+release evidence is immutable `v0.14.0` and production `remi-v0.9.5`; the
+Conary artifact predates current supported-host fixes and is not tester
+authority for them.
 
 W3 was subsequently split. Its release gate is complete, and its external
 tester outreach moved to W8 behind an engineering gate, because a bounded

--- a/docs/roadmaps/external-tester-milestone.md
+++ b/docs/roadmaps/external-tester-milestone.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-29
-revision: 6
+last_updated: 2026-07-31
+revision: 7
 status: active
 current_result: 0/10
 summary: Outcome tracker for Conary's first cross-distro external tester milestone
@@ -35,23 +35,22 @@ but does not count as a completion.
 
 ## Release Gate
 
-Release candidate `v0.14.0` is the intended pinned tester release. Its release
-gate remains open until `docs/operations/release-artifact-matrix.md` records:
+The publication gate for `v0.14.0` is complete: the
+`docs/operations/release-artifact-matrix.md` records its annotated tag,
+immutable seven-asset release, checksums and GitHub digests, detached CCS
+signature, deployment, self-update endpoint, and three-distro
+released-package proof. Remi `0.9.5` is the current independently verified
+production authority.
 
-- the annotated tag object and reviewed commit;
-- a terminal exact-tag release-build and the complete seven-asset inventory;
-- matching independent checksums and GitHub digests;
-- detached CCS signature, installed-binary, and self-update proof;
-- exact-tag deployment plus independent endpoint and site verification;
-- native RPM, DEB, and Arch installation and the Cartesian lifecycle proof on
-  Fedora 44, Ubuntu 26.04 LTS, and Arch;
-- compatible `remi-v0.9.0` production identity, schema/source/signing state,
-  full health, and a real public converted CCS artifact;
-- explicit signature, SBOM, and provenance status.
+`v0.14.0` is not the pinned tester release, however. Supported-host generation
+bring-up after that immutable tag exposed product defects whose fixes remain
+unreleased on issue #137 and PR #151. A subsequent immutable release must
+contain and independently prove those fixes before this tracker names a pinned
+tester version. No version is assigned in advance.
 
 Release proof is not an external-user completion. The result therefore remains
-0/10, and broad outreach remains postponed by the separate cached-history and
-venue-eligibility gates.
+0/10, and broad outreach remains postponed by the unreleased-fix gate, the W7
+corpus gate, and the separate cached-history and venue-eligibility gates.
 
 Supported tester hosts are x86_64 Fedora 44, Ubuntu 26.04 LTS, and Arch Linux.
 Use a disposable VM, snapshot, spare system, or other non-critical host.

--- a/scripts/check-doc-truth.sh
+++ b/scripts/check-doc-truth.sh
@@ -281,10 +281,10 @@ check_preview_status() {
     require_match "docs/roadmaps/development-roadmap.md" 'remote Forge validation is paused pending (a new |a )KVM-capable runner|Remote Forge validation is paused pending (a new |a )KVM-capable runner' 'remote Forge paused wording'
     require_match "docs/INTEGRATION-TESTING.md" 'Remote Forge control-plane validation is temporarily paused pending a KVM-capable runner|Forge-backed.*paused' 'remote Forge paused wording'
 
-    require_match "docs/roadmaps/development-roadmap.md" '2026-05-21.*Group O' 'dated Group O evidence'
-    require_match "docs/roadmaps/development-roadmap.md" '2026-05-21.*Group P' 'dated Group P evidence'
-    require_match "docs/INTEGRATION-TESTING.md" 'Group O.*2026-05-21' 'dated Group O evidence'
-    require_match "docs/INTEGRATION-TESTING.md" 'Group P.*2026-05-21' 'dated Group P evidence'
+    require_match "docs/roadmaps/development-roadmap.md" '2026-07-31.*Group O' 'dated Group O evidence'
+    require_match "docs/roadmaps/development-roadmap.md" '2026-07-31.*Group P' 'dated Group P evidence'
+    require_match "docs/INTEGRATION-TESTING.md" 'Group O.*2026-07-31' 'dated Group O evidence'
+    require_match "docs/INTEGRATION-TESTING.md" 'Group P.*2026-07-31' 'dated Group P evidence'
 }
 
 check_release_doc_versions() {
@@ -337,18 +337,28 @@ check_release_doc_versions() {
         if [[ "$planned_status" != "postponed" ]]; then
             report_error "$planned_doc: planned launch packet status must be postponed until release proof exists"
         fi
-        if [[ ! "$target_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            report_error "$planned_doc: target_release must be an exact vMAJOR.MINOR.PATCH tag"
+        require_match "$planned_doc" "$current_tag" "historical current-release baseline ${current_tag}"
+
+        local allowed_target_tag candidate_link_tag candidate_link_label
+        if [[ "$target_tag" == "unassigned" ]]; then
+            allowed_target_tag="$current_tag"
+            candidate_link_tag="$current_tag"
+            candidate_link_label="retained current release ${current_tag} while target_release is unassigned"
+            require_match "$planned_doc" 'NO NEW DATE IS ASSIGNED|[Nn]o .*release is assigned|release is unassigned' 'explicit unassigned launch state'
+        elif [[ "$target_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            allowed_target_tag="$target_tag"
+            candidate_link_tag="$target_tag"
+            candidate_link_label="target release ${target_tag}"
+            require_match "$planned_doc" "$target_tag" "planned target release ${target_tag}"
+        else
+            report_error "$planned_doc: target_release must be an exact vMAJOR.MINOR.PATCH tag or unassigned"
             return
         fi
-
-        require_match "$planned_doc" "$current_tag" "historical current-release baseline ${current_tag}"
-        require_match "$planned_doc" "$target_tag" "planned target release ${target_tag}"
 
         local file line_no text found_tag
         while IFS=: read -r file line_no text; do
             while IFS= read -r found_tag; do
-                if [[ "$found_tag" != "$current_tag" && "$found_tag" != "$target_tag" ]]; then
+                if [[ "$found_tag" != "$current_tag" && "$found_tag" != "$allowed_target_tag" ]]; then
                     report_error "$file:$line_no has release reference outside current/target contract: $text"
                 fi
             done < <(rg -o -P -- '(?<![A-Za-z0-9_-])v[0-9]+\.[0-9]+\.[0-9]+' <<< "$text")
@@ -358,8 +368,8 @@ check_release_doc_versions() {
         )
 
         while IFS=: read -r file line_no text; do
-            if [[ "$text" != *"$target_tag"* ]]; then
-                report_error "$file:$line_no has candidate launch link or checklist item outside target release ${target_tag}: $text"
+            if [[ "$text" != *"$candidate_link_tag"* ]]; then
+                report_error "$file:$line_no has candidate launch link or checklist item outside ${candidate_link_label}: $text"
             fi
         done < <(
             rg -nH -- 'github\.com/ConaryLabs/Conary/(blob|releases/tag)/v|Publish immutable `v' "$planned_doc" ||

--- a/scripts/test-doc-truth.sh
+++ b/scripts/test-doc-truth.sh
@@ -117,8 +117,8 @@ EOF
 
 The cross-distro package-installation preview is active.
 Remote Forge validation is paused pending a KVM-capable runner.
-The 2026-05-21 Group O QEMU run is dated local evidence.
-The 2026-05-21 Group P QEMU run is dated local evidence.
+The 2026-07-31 Group O QEMU run is dated local evidence.
+The 2026-07-31 Group P QEMU run is dated local evidence.
 The current milestone is the first external tester loop.
 See the [detailed development roadmap](docs/roadmaps/development-roadmap.md).
 EOF
@@ -128,8 +128,8 @@ EOF
 
 The first external tester milestone is the current product milestone.
 Remote Forge validation is paused pending a KVM-capable runner.
-The 2026-05-21 Group O QEMU run is dated local evidence.
-The 2026-05-21 Group P QEMU run is dated local evidence.
+The 2026-07-31 Group O QEMU run is dated local evidence.
+The 2026-07-31 Group P QEMU run is dated local evidence.
 EOF
 
     cat > "$root/docs/roadmaps/external-tester-milestone.md" <<'EOF'
@@ -160,8 +160,8 @@ EOF
 # Integration Testing
 
 Remote Forge control-plane validation is temporarily paused pending a KVM-capable runner.
-Current Group O QEMU export evidence from 2026-05-21 is local evidence.
-Current Group P ISO export evidence from 2026-05-21 is local evidence.
+Current Group O QEMU export evidence from 2026-07-31 is local evidence.
+Current Group P ISO export evidence from 2026-07-31 is local evidence.
 EOF
 
     cat > "$root/docs/operations/release-artifact-matrix.md" <<'EOF'
@@ -411,6 +411,24 @@ expect_pass() {
     rm -rf "$tmp"
 }
 
+expect_unassigned_outreach_pass() {
+    local tmp
+    tmp="$(mktemp -d)"
+    make_good_repo "$tmp"
+    sed -i \
+        -e 's/target_release: v0.11.0/target_release: unassigned/' \
+        -e 's/v0.11.0/v0.10.1/g' \
+        "$tmp/docs/operations/external-tester-outreach.md"
+    printf '\nNo new release is assigned.\n' >> "$tmp/docs/operations/external-tester-outreach.md"
+    stage_fixture "$tmp"
+    run_truth "$tmp" > "$tmp/out" 2>&1 || {
+        cat "$tmp/out" >&2
+        rm -rf "$tmp"
+        fail "expected unassigned outreach fixture to pass"
+    }
+    rm -rf "$tmp"
+}
+
 expect_failure() {
     local name="$1"
     local mutator="$2"
@@ -491,6 +509,15 @@ break_tracker_release_version() {
 
 break_outreach_release_version() {
     sed -i 's/v0.10.1/v0.9.2/g' "$1/docs/operations/external-tester-outreach.md"
+}
+
+break_outreach_target_state() {
+    sed -i 's/target_release: v0.11.0/target_release: later/' "$1/docs/operations/external-tester-outreach.md"
+}
+
+break_unassigned_outreach_candidate_version() {
+    sed -i 's/target_release: v0.11.0/target_release: unassigned/' "$1/docs/operations/external-tester-outreach.md"
+    printf '\nNo new release is assigned.\n' >> "$1/docs/operations/external-tester-outreach.md"
 }
 
 break_detailed_remote_forge_evidence() {
@@ -610,6 +637,7 @@ break_frontmatter_revision() {
 }
 
 expect_pass
+expect_unassigned_outreach_pass
 expect_failure "schema drift" break_schema_version 'schema.*68.*SCHEMA_VERSION.*69'
 expect_failure "unknown CLI command reference" break_cli_command_reference 'unknown conary root command'
 expect_failure "retired command doc" break_retired_command_doc 'retired command'
@@ -624,6 +652,8 @@ expect_failure "missing detailed roadmap link" break_root_roadmap_link 'detailed
 expect_failure "missing external tester milestone" break_detailed_roadmap_milestone 'first external tester milestone'
 expect_failure "tracker release version drift" break_tracker_release_version 'stale conary release reference'
 expect_failure "outreach release version drift" break_outreach_release_version 'current-release baseline|outside current/target contract'
+expect_failure "outreach target state" break_outreach_target_state 'exact vMAJOR.MINOR.PATCH tag or unassigned'
+expect_failure "unassigned outreach candidate version" break_unassigned_outreach_candidate_version 'outside current/target contract|outside retained current release'
 expect_failure "missing detailed remote Forge evidence" break_detailed_remote_forge_evidence 'remote Forge paused wording'
 expect_failure "missing detailed Group O evidence" break_detailed_group_o_evidence 'dated Group O evidence'
 expect_failure "missing detailed Group P evidence" break_detailed_group_p_evidence 'dated Group P evidence'

--- a/site/scripts/verify-build.mjs
+++ b/site/scripts/verify-build.mjs
@@ -17,9 +17,9 @@ const pages = [
 	},
 	{
 		file: 'install/index.html',
-		title: 'Install the Conary limited preview — Conary',
+		title: 'Conary tester release status — Conary',
 		canonical: 'https://conary.io/install/',
-		marker: 'Install Conary without skipping the safety gate.'
+		marker: 'Wait for the next verified tester release.'
 	},
 	{
 		file: 'compare/index.html',

--- a/site/src/lib/preview-release.ts
+++ b/site/src/lib/preview-release.ts
@@ -10,13 +10,20 @@ const version = '0.14.0';
 const tag = 'v0.14.0';
 const releaseUrl = `https://github.com/ConaryLabs/Conary/releases/tag/${tag}`;
 const downloadBaseUrl = `https://github.com/ConaryLabs/Conary/releases/download/${tag}`;
+const matrixUrl =
+	'https://github.com/ConaryLabs/Conary/blob/main/docs/operations/release-artifact-matrix.md';
 
 export const previewRelease = {
 	version,
 	tag,
 	releaseUrl,
 	downloadBaseUrl,
-	testerGuideUrl: `https://github.com/ConaryLabs/Conary/blob/${tag}/docs/guides/agent-assisted-tester-loop.md`,
+	matrixUrl,
+	testerAuthority: 'paused',
+	testerAuthorityReason:
+		'v0.14.0 is published and artifact-verified, but it predates supported-host fixes that remain unreleased.',
+	testerGuideUrl:
+		'https://github.com/ConaryLabs/Conary/blob/main/docs/guides/agent-assisted-tester-loop.md',
 	feedbackUrl: 'https://github.com/ConaryLabs/Conary/issues/new?template=pre_alpha_feedback.md',
 	workDirectory: `$HOME/conary-preview-${tag}`,
 	targets: [

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -14,7 +14,7 @@
 <section class="hero">
 	<div class="container grid-12 hero-grid">
 		<div class="hero-copy">
-			<p class="eyebrow">A package system for Linux · {previewRelease.tag}</p>
+			<p class="eyebrow">A package system for Linux · tester loop paused</p>
 			<h1>An RPM that installs on Ubuntu. A DEB that installs on Fedora.</h1>
 			<p class="hero-lede">
 				Conary keeps each package's exact RPM, Debian, or ALPM semantics, executes
@@ -22,7 +22,7 @@
 				transaction and rollback — without invoking dnf, apt, or pacman.
 			</p>
 			<div class="button-row hero-actions">
-				<a href="/install/" class="btn btn-primary">Try what works today</a>
+				<a href="/install/" class="btn btn-primary">Read the current release status</a>
 				<a href="/features/" class="btn btn-secondary">See what is proven</a>
 			</div>
 			<ul class="hero-meta" aria-label="Supported formats and hosts">
@@ -133,12 +133,14 @@
 <section class="section evaluate">
 	<div class="container grid-12">
 		<div class="evaluate-heading">
-			<p class="eyebrow">Available now · limited preview</p>
+			<p class="eyebrow">Source proof active · packaged tester loop paused</p>
 			<h2 class="section-heading">Cross the package boundary deliberately.</h2>
 			<p class="section-copy">
-				The public loop is deliberately focused: inspect a foreign-format package,
-				confirm its exact target capabilities, install it through Conary, and prove
-				that query, update planning, removal, and rollback still agree.
+				The next public loop remains deliberately focused: inspect a foreign-format
+				package, confirm its exact target capabilities, install it through Conary,
+				and prove that query, update planning, removal, and rollback still agree.
+				The published {previewRelease.tag} artifact predates current fixes, so this
+				loop resumes only after a later release is independently verified.
 			</p>
 		</div>
 

--- a/site/src/routes/compare/+page.svelte
+++ b/site/src/routes/compare/+page.svelte
@@ -222,10 +222,11 @@
 				<article class="detail-card maturity-card">
 					<h3>Where Conary is still early</h3>
 					<p>
-						Conary {previewRelease.version} is a limited preview. Native CCS packages are few,
-						the cross-distro lifecycle matrix still needs wider installed-host evidence,
-						generation work is VM-only, and the community and operational evidence are
-						small beside established managers.
+						Conary {previewRelease.version} is an immutable published preview artifact, but
+						it is not current tester authority while supported-host fixes remain unreleased.
+						Native CCS packages are few, the cross-distro lifecycle matrix still needs wider
+						installed-host evidence, generation work is VM-only, and the community and
+						operational evidence are small beside established managers.
 					</p>
 				</article>
 			</div>
@@ -238,7 +239,7 @@
 				<p>Third-party extensions are excluded unless a cell names an add-on or separate stack.</p>
 			</div>
 			<ul class="source-list">
-				<li><a href={previewRelease.testerGuideUrl}>Conary pinned tester guide <span aria-hidden="true">↗</span></a></li>
+				<li><a href={previewRelease.testerGuideUrl}>Conary paused tester guide <span aria-hidden="true">↗</span></a></li>
 				<li><a href="https://github.com/ConaryLabs/Conary/blob/main/docs/modules/source-selection.md">Conary source-selection boundary <span aria-hidden="true">↗</span></a></li>
 				<li><a href="https://documentation.ubuntu.com/release-notes/26.04/summary-for-lts-users/">Ubuntu 26.04 APT summary <span aria-hidden="true">↗</span></a></li>
 				<li><a href="https://dnf5.readthedocs.io/en/latest/commands/history.8.html">DNF5 history commands <span aria-hidden="true">↗</span></a></li>

--- a/site/src/routes/features/+page.svelte
+++ b/site/src/routes/features/+page.svelte
@@ -106,25 +106,28 @@
 
 		<div class="category category-preview" id="preview-supported">
 			<div class="category-heading">
-				<span class="category-status preview">preview-supported</span>
+				<span class="category-status preview">source validation active · release pending</span>
 				<h2 class="category-title">The bounded tester loop</h2>
-				<p>Cross-distro packages with a documented, inspectable transaction workflow.</p>
+				<p>
+					Cross-distro packages have a documented, inspectable transaction workflow.
+					The packaged tester loop is paused until a release contains the current fixes.
+				</p>
 			</div>
 
 			<div class="feature-list">
 				<article class="feature-card feature-lead">
-					<span class="feature-status preview">supported path</span>
+					<span class="feature-status preview">unreleased fixes</span>
 					<h3>Cross-distro package install</h3>
 					<p>
-							Fedora 44, Ubuntu 26.04 LTS, and Arch can consume RPM, DEB, Arch, and
-							CCS inputs through the same Conary transaction path. Dry-run shows the
-							source ABI and typed target capabilities before automatic target preflight.
+						Fedora 44, Ubuntu 26.04 LTS, and Arch can consume RPM, DEB, Arch, and
+						CCS inputs through the same Conary transaction path. Dry-run shows the
+						source ABI and typed target capabilities before automatic target preflight.
 					</p>
 					<!-- svelte-ignore a11y_no_noninteractive_tabindex (horizontal command list needs keyboard scrolling) -->
 					<div class="feature-code scroll-region" role="region" tabindex="0" aria-label="Cross-distro package install commands">
-							<code>sudo conary install ./package.rpm --dry-run</code>
-							<code>sudo conary install ./package.deb --yes</code>
-							<code>sudo conary install ./package.pkg.tar.zst --yes</code>
+						<code>sudo conary install ./package.rpm --dry-run</code>
+						<code>sudo conary install ./package.deb --yes</code>
+						<code>sudo conary install ./package.pkg.tar.zst --yes</code>
 					</div>
 				</article>
 
@@ -153,7 +156,7 @@
 						The tester lane pins a release, verifies its checksum, records exact commands
 						and exit statuses, and asks for concise public evidence without broad host dumps.
 					</p>
-					<a href="/install/" class="feature-action">Run the supported preview <span aria-hidden="true">→</span></a>
+					<a href="/install/" class="feature-action">Read the current release status <span aria-hidden="true">→</span></a>
 				</article>
 			</div>
 		</div>

--- a/site/src/routes/install/+page.svelte
+++ b/site/src/routes/install/+page.svelte
@@ -6,36 +6,58 @@
 </script>
 
 <PageMeta
-	title="Install the Conary limited preview — Conary"
-	description={`Install the Conary ${previewRelease.tag} limited preview on Fedora 44, Ubuntu 26.04 LTS, or Arch and test a package from another distro.`}
+	title="Conary tester release status — Conary"
+	description={`Conary ${previewRelease.tag} is published but not current tester authority; the packaged tester loop is paused until a release contains the supported-host fixes.`}
 	path="/install/"
 />
 
 <PageIntro
-	eyebrow="Preview runbook"
-	title="Install Conary without skipping the safety gate."
-	description={`Use the pinned ${previewRelease.tag} release on a VM or non-critical x86_64 host. Verify Conary, select a non-native package source, and inspect the complete cross-distro transaction before apply.`}
+	eyebrow="Tester loop paused"
+	title="Wait for the next verified tester release."
+	description={previewRelease.testerAuthorityReason}
 />
 
 <section class="install-section">
 	<div class="container install-grid">
 		<aside class="safety-rail" aria-labelledby="safety-title">
 			<p class="eyebrow">Before you start</p>
-			<h2 id="safety-title">Safety gate</h2>
+			<h2 id="safety-title">Current stop gate</h2>
 			<ul>
+				<li>Do not use {previewRelease.tag} as current tester authority.</li>
 				<li>Use a VM, snapshot, or explicitly non-critical host.</li>
 				<li>The packaged tester lane is x86_64.</li>
 				<li>Match Fedora 44, Ubuntu 26.04 LTS, or Arch Linux.</li>
 				<li>Stop if the checksum does not print <code>OK</code>.</li>
 				<li>Ask before every command that can mutate the host.</li>
 			</ul>
-			<a href={previewRelease.releaseUrl} class="btn btn-secondary">
-				Open {previewRelease.tag} release <span aria-hidden="true">↗</span>
+			<a href={previewRelease.matrixUrl} class="btn btn-secondary">
+				Read the release matrix <span aria-hidden="true">↗</span>
 			</a>
 		</aside>
 
 		<div class="install-content">
-			<section class="install-step" id="preflight">
+			<section class="authority-pause" aria-labelledby="authority-pause-title">
+				<p class="eyebrow">No current pinned release</p>
+				<h2 id="authority-pause-title">The package runbook is not open.</h2>
+				<p>
+					{previewRelease.testerAuthorityReason} The exact {previewRelease.tag}
+					artifacts remain available for inspecting that immutable release, but their
+					results do not validate the fixes now under review. This page will reopen
+					only after a later immutable release passes the artifact matrix.
+				</p>
+				<div class="button-row">
+					<a href={previewRelease.matrixUrl} class="btn btn-primary">
+						Read exact release evidence <span aria-hidden="true">↗</span>
+					</a>
+					<a href={previewRelease.releaseUrl} class="btn btn-secondary">
+						Inspect {previewRelease.tag} artifact <span aria-hidden="true">↗</span>
+					</a>
+				</div>
+			</section>
+
+			<details class="retained-runbook">
+				<summary>Retained {previewRelease.tag} commands — historical reference, do not run</summary>
+				<section class="install-step" id="preflight">
 				<div class="step-heading">
 					<span class="step-number">01</span>
 					<div>
@@ -188,7 +210,7 @@
 				</div>
 			</section>
 
-			<section class="install-step report-step" id="report-feedback">
+				<section class="install-step report-step" id="report-feedback">
 				<div class="step-heading">
 					<span class="step-number">06</span>
 					<div>
@@ -232,7 +254,8 @@
 						Read the pinned guide <span aria-hidden="true">↗</span>
 					</a>
 				</div>
-			</section>
+				</section>
+			</details>
 
 			<section class="contributor-panel" id="source-build">
 				<div>
@@ -331,6 +354,37 @@
 
 	.install-content {
 		min-width: 0;
+	}
+
+	.authority-pause {
+		padding: clamp(1.5rem, 4vw, 2.5rem);
+		margin-bottom: clamp(2.5rem, 6vw, 4rem);
+		border: 1px solid var(--color-orange);
+		background: var(--color-layer);
+	}
+
+	.authority-pause h2 {
+		margin-bottom: 0.75rem;
+		font-size: var(--step-section);
+	}
+
+	.authority-pause > p:not(.eyebrow) {
+		max-width: 70ch;
+		color: var(--color-mist);
+	}
+
+	.retained-runbook {
+		margin-bottom: clamp(3rem, 7vw, 5rem);
+		border-top: 1px solid var(--color-border);
+	}
+
+	.retained-runbook summary {
+		padding: 1rem 0;
+		color: var(--color-muted);
+		cursor: pointer;
+		font-family: var(--font-mono);
+		font-size: 0.75rem;
+		letter-spacing: 0.04em;
 	}
 
 	.install-step {


### PR DESCRIPTION
## Primary issue

Refs #137
Refs #210

## Outcome

Reconciles the preserved release, roadmap, fixture, and site truth after the supported-host qcow2 and ISO proof completed. The published v0.14.0 artifact remains immutable evidence for its own tree, while tester guidance now fails closed because that release predates the fixes carried by PR #151.

The final docs preserve the newer one-transaction model contract and package-owned networkd preset, replace stale pre-proof statements with the 2026-07-31 Group O/P results, and teach the doc-truth gate to represent a postponed but unassigned next tester release.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `bash scripts/check-doc-truth.sh`
- `bash scripts/test-doc-truth.sh`
- `bash scripts/check-release-matrix.sh`
- `bash scripts/test-release-matrix.sh`
- `cargo run -p conary-test -- list`
- `cargo test -p conary-test suite_inventory`
- `cargo test -p conary-test distro_config_requires_a_typed_build_context`
- `cargo test -p conary-test focused_native_cross_source_manifest_runs_the_shared_lifecycle_contract`
- `cargo test -p conary-test native_cross_source_`
- `npm ci --prefix site`
- `npm run check --prefix site`
- `npm run build --prefix site`

This sub-PR targets the feature branch for PR #151; the final exact-head CI and boot gates remain owned by that parent PR.
