### PR TITLE
fix(conary-test): retain Docker build failure output

### DIFF
--- a/apps/conary-test/src/container/lifecycle.rs
+++ b/apps/conary-test/src/container/lifecycle.rs
@@ -5,13 +5,13 @@ use async_trait::async_trait;
 use bollard::Docker;
 use bollard::container::LogOutput;
 use bollard::exec::{CreateExecOptions, StartExecOptions, StartExecResults};
-use bollard::models::{ContainerCreateBody, HostConfig};
+use bollard::models::{BuildInfo, ContainerCreateBody, HostConfig};
 use bollard::query_parameters::{
     BuildImageOptions, DownloadFromContainerOptions, KillContainerOptions, ListImagesOptions,
     LogsOptions, RemoveContainerOptions, StopContainerOptions, UploadToContainerOptions,
 };
 use bytes::Bytes;
-use futures::StreamExt;
+use futures::{Stream, StreamExt};
 use std::collections::HashMap;
 use std::io::Read as _;
 use std::path::Path;
@@ -24,6 +24,49 @@ use super::backend::{
     ContainerBackend, ContainerConfig, ContainerId, ContainerInspection, ExecResult, ImageInfo,
     VolumeMount,
 };
+
+const BUILD_OUTPUT_TAIL_BYTES: usize = 32 * 1024;
+
+#[derive(Default)]
+struct BuildOutputTail {
+    output: String,
+    omitted_bytes: usize,
+}
+
+impl BuildOutputTail {
+    fn push(&mut self, chunk: &str) {
+        self.output.push_str(chunk);
+        if self.output.len() <= BUILD_OUTPUT_TAIL_BYTES {
+            return;
+        }
+
+        let mut drain_through = self.output.len() - BUILD_OUTPUT_TAIL_BYTES;
+        while !self.output.is_char_boundary(drain_through) {
+            drain_through += 1;
+        }
+        self.output.drain(..drain_through);
+        self.omitted_bytes += drain_through;
+    }
+
+    fn failure(&self, summary: impl std::fmt::Display) -> String {
+        let retained = self.output.trim_end();
+        if retained.is_empty() {
+            return summary.to_string();
+        }
+
+        let omission = if self.omitted_bytes == 0 {
+            String::new()
+        } else {
+            format!(
+                "[... {} earlier Docker build output bytes omitted ...]\n",
+                self.omitted_bytes
+            )
+        };
+        format!(
+            "{summary}\nDocker build output tail ({BUILD_OUTPUT_TAIL_BYTES}-byte limit):\n{omission}{retained}"
+        )
+    }
+}
 
 struct RunningExec {
     container_id: ContainerId,
@@ -124,6 +167,38 @@ impl BollardBackend {
         }
         lines
     }
+
+    async fn consume_build_stream<S>(mut stream: S) -> Result<()>
+    where
+        S: Stream<Item = std::result::Result<BuildInfo, bollard::errors::Error>> + Unpin,
+    {
+        let mut output_tail = BuildOutputTail::default();
+
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(info) => {
+                    if let Some(stream_msg) = &info.stream {
+                        debug!(target: "build", "{}", stream_msg.trim_end());
+                        output_tail.push(stream_msg);
+                    }
+                    if let Some(detail) = &info.error_detail {
+                        let msg = detail.message.as_deref().unwrap_or("unknown error");
+                        bail!(
+                            "{}",
+                            output_tail.failure(format_args!("image build failed: {msg}"))
+                        );
+                    }
+                }
+                Err(error) => {
+                    let context =
+                        output_tail.failure(format_args!("image build stream error: {error}"));
+                    return Err(error).context(context);
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -159,26 +234,12 @@ impl ContainerBackend for BollardBackend {
         // Podman rejects an empty X-Registry-Config header on /build, while
         // bollard emits that header when credentials=None. Pass an explicit
         // empty config map so the header serializes to "{}" instead.
-        let mut stream = self.docker.build_image(
+        let stream = self.docker.build_image(
             options,
             Some(HashMap::new()),
             Some(bollard::body_full(Bytes::from(tar_bytes))),
         );
-
-        while let Some(result) = stream.next().await {
-            match result {
-                Ok(info) => {
-                    if let Some(stream_msg) = &info.stream {
-                        debug!(target: "build", "{}", stream_msg.trim_end());
-                    }
-                    if let Some(detail) = &info.error_detail {
-                        let msg = detail.message.as_deref().unwrap_or("unknown error");
-                        bail!("image build failed: {msg}");
-                    }
-                }
-                Err(e) => return Err(e).context("image build stream error"),
-            }
-        }
+        Self::consume_build_stream(stream).await?;
 
         debug!("image built: {tag}");
         Ok(tag.to_string())
@@ -723,7 +784,10 @@ impl ContainerBackend for BollardBackend {
 
 #[cfg(test)]
 mod tests {
-    use super::BollardBackend;
+    use super::{BUILD_OUTPUT_TAIL_BYTES, BollardBackend};
+    use bollard::errors::Error;
+    use bollard::models::{BuildInfo, ErrorDetail};
+    use futures::stream;
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -759,6 +823,65 @@ mod tests {
         assert_eq!(BollardBackend::normalize_signal_name("SIGKILL"), "KILL");
         assert_eq!(BollardBackend::normalize_signal_name("SIGTERM"), "TERM");
         assert_eq!(BollardBackend::normalize_signal_name("KILL"), "KILL");
+    }
+
+    #[tokio::test]
+    async fn build_error_retains_only_the_bounded_output_tail() {
+        let discarded_line = "old package-manager output that should be discarded\n";
+        let old_output = format!(
+            "discard-this-prefix\n{}",
+            discarded_line.repeat(BUILD_OUTPUT_TAIL_BYTES / discarded_line.len() + 2)
+        );
+        let useful_output = "error: failed retrieving file 'core.db' from mirror.example\n";
+        let build_stream = stream::iter(vec![
+            Ok(BuildInfo {
+                stream: Some(old_output),
+                ..Default::default()
+            }),
+            Ok(BuildInfo {
+                stream: Some(useful_output.to_string()),
+                ..Default::default()
+            }),
+            Ok(BuildInfo {
+                error_detail: Some(ErrorDetail {
+                    message: Some("process exited with status 1".to_string()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        ]);
+
+        let error = BollardBackend::consume_build_stream(build_stream)
+            .await
+            .expect_err("build should fail");
+        let diagnostic = error.to_string();
+
+        assert!(diagnostic.contains("process exited with status 1"));
+        assert!(diagnostic.contains(useful_output.trim_end()));
+        assert!(diagnostic.contains("earlier Docker build output bytes omitted"));
+        assert!(!diagnostic.contains("discard-this-prefix"));
+        assert!(diagnostic.len() < BUILD_OUTPUT_TAIL_BYTES + 512);
+    }
+
+    #[tokio::test]
+    async fn stream_error_includes_preceding_build_output() {
+        let build_stream = stream::iter(vec![
+            Ok(BuildInfo {
+                stream: Some("pacman: failed to synchronize all databases\n".to_string()),
+                ..Default::default()
+            }),
+            Err(Error::DockerStreamError {
+                error: "connection reset".to_string(),
+            }),
+        ]);
+
+        let error = BollardBackend::consume_build_stream(build_stream)
+            .await
+            .expect_err("stream should fail");
+        let diagnostic = error.to_string();
+
+        assert!(diagnostic.contains("Docker stream error: connection reset"));
+        assert!(diagnostic.contains("pacman: failed to synchronize all databases"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Primary Issue

Closes #209

Design / Plan / Roadmap: Bounded diagnostic-preservation slice defined by the primary issue.

## Problem And Outcome

Bollard image builds emitted successful `stream` frames only at debug visibility. When a later frame reported an error, the returned failure retained only Docker's generic instruction status and discarded the package-manager output needed to diagnose it.

After merge, failed builds include the most recent 32 KiB of Docker stream output at normal error visibility. Successful builds remain quiet outside debug logging.

## Changes

- retain a UTF-8-safe, fixed-size tail while consuming Docker build output
- attach the retained tail to both Docker `errorDetail` failures and transport stream failures
- mark omitted earlier bytes when output exceeds the bound
- cover error-detail, transport-error, and truncation behavior with focused tests

## Scope

- In scope: conary-test Bollard image-build diagnostics
- Out of scope: classifying, retrying, or suppressing external package-manager failures; changing image staging or lifecycle behavior

## Ownership / Boundary

- Owning subsystem: conary-test Integration Execution
- Boundary changed or preserved: preserves Bollard as the container-build owner while making its existing stream evidence available on failure
- Persisted state or public surface impact: no persisted schema or public API change; CLI/CI failure diagnostics gain a bounded output tail
- [x] Checked `docs/modules/feature-ownership.md`; no routing or user-visible capability claim changed

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly; no service or daemon code changed
- [x] No subsystem docs or maps changed because the owner and look-here-first paths remain the same
- [x] The broader interaction gate is not required: image staging, native conversion, and lifecycle behavior are unchanged
- [x] Exact-head required CI passed on `9fc94fedb1a4c293dbf9d9798a1921982d68cb10`

```text
- cargo test -p conary-test container::lifecycle::tests
  - 4 passed; 0 failed; 1 ignored
- cargo test -p conary-test
  - library: 358 passed; 0 failed; 1 ignored
  - CLI: 18 passed; 0 failed
- cargo run -p conary-test -- list
  - parsed and listed 29 suites
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- git diff --check
```

- Exact-head CI: https://github.com/ConaryLabs/Conary/actions/runs/30723345760

## Review And Merge Notes

- Review focus: bounded UTF-8-safe truncation, useful tail ordering, and error-only normal visibility
- User or developer impact: container image build failures now expose the recent package-manager output needed for diagnosis
- Required-check bypass: not used
