### PR TITLE
fix(remi): remove dead metadata signature route

### DIFF
--- a/apps/remi/src/server/handlers/index.rs
+++ b/apps/remi/src/server/handlers/index.rs
@@ -6,7 +6,7 @@ use crate::server::conversion::ScriptletPackageMetadata;
 use anyhow::Context;
 use axum::{
     extract::{Path, State},
-    http::{StatusCode, header},
+    http::StatusCode,
     response::{IntoResponse, Response},
 };
 use conary_core::db::models::{ConvertedPackage, RepositoryPackage};
@@ -292,49 +292,6 @@ fn metadata_with_scriptlets(
             Some(serde_json::Value::Object(object))
         }
     })
-}
-
-/// GET /v1/:distro/metadata.sig
-///
-/// Returns GPG signature for repository metadata.
-pub async fn get_metadata_sig(
-    State(state): State<Arc<RwLock<ServerState>>>,
-    Path(distro): Path<String>,
-) -> Response {
-    if let Err(e) = super::validate_supported_distro_route(&distro) {
-        return e;
-    }
-
-    let state = state.read().await;
-    let sig_path = state
-        .config
-        .chunk_dir
-        .parent()
-        .unwrap_or(&state.config.chunk_dir)
-        .join("repo")
-        .join(&distro)
-        .join("metadata.json.sig");
-
-    if !sig_path.exists() {
-        return (StatusCode::NOT_FOUND, "Signature not found").into_response();
-    }
-
-    match tokio::fs::read(&sig_path).await {
-        Ok(sig) => Response::builder()
-            .status(StatusCode::OK)
-            .header(header::CONTENT_TYPE, "application/pgp-signature")
-            .header(header::CACHE_CONTROL, "public, max-age=300")
-            .body(axum::body::Body::from(sig))
-            .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response()),
-        Err(e) => {
-            tracing::error!("Failed to read signature: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to read signature",
-            )
-                .into_response()
-        }
-    }
 }
 
 #[cfg(test)]

--- a/apps/remi/src/server/routes.rs
+++ b/apps/remi/src/server/routes.rs
@@ -476,6 +476,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn metadata_signature_route_is_absent_while_owned_routes_remain() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let db_path = temp.path().join("remi.db");
+        let chunk_dir = temp.path().join("chunks");
+        let cache_dir = temp.path().join("cache");
+        std::fs::create_dir_all(&chunk_dir).unwrap();
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        conary_core::db::init(&db_path).unwrap();
+
+        let state = Arc::new(RwLock::new(
+            ServerState::new(ServerConfig {
+                db_path,
+                chunk_dir,
+                cache_dir,
+                enable_rate_limit: false,
+                enable_audit_log: false,
+                ..ServerConfig::default()
+            })
+            .expect("test server state"),
+        ));
+        let app = create_router(state).await;
+
+        async fn request(app: Router, uri: &str) -> Response {
+            let mut request = Request::builder().uri(uri).body(Body::empty()).unwrap();
+            request
+                .extensions_mut()
+                .insert(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 49152))));
+            app.oneshot(request).await.unwrap()
+        }
+
+        let response = request(app.clone(), "/v1/not-supported/metadata.sig").await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+        let response = request(app.clone(), "/v1/fedora/metadata.sig").await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(body.is_empty(), "removed route must not run a handler");
+
+        let response = request(app.clone(), "/v1/not-supported/metadata").await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let response = request(app, "/v1/not-supported/tuf/root.json").await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
     async fn test_mcp_route_rejects_unauthenticated_requests() {
         let (app, _db_path) = crate::server::handlers::admin::test_helpers::test_app().await;
 

--- a/apps/remi/src/server/routes/public.rs
+++ b/apps/remi/src/server/routes/public.rs
@@ -55,7 +55,6 @@ pub async fn create_router(state: Arc<RwLock<ServerState>>) -> Router {
         .route("/health/ready", get(readiness_check))
         .route("/v1/federation/directory", get(federation::directory))
         .route("/v1/{distro}/metadata", get(index::get_metadata))
-        .route("/v1/{distro}/metadata.sig", get(index::get_metadata_sig))
         .route("/v1/{distro}/packages/{name}", get(packages::get_package))
         .route(
             "/v1/{distro}/packages/{name}/download",


### PR DESCRIPTION
## Primary Issue

Closes #169

Design / Plan / Roadmap: Bounded public-surface hard cut defined by the primary issue.

## Problem And Outcome

Remi advertised `GET /v1/{distro}/metadata.sig`, but no code wrote the `metadata.json.sig` file its handler read. Every supported route therefore exposed a permanently unwritable GPG sidecar endpoint even though current repository trust is owned by exact-profile TUF and CCS signing.

After merge, the dead route and handler are absent. Public repository metadata and TUF routes retain their existing owned behavior.

## Changes

- remove the public `metadata.sig` route registration
- delete the unowned GPG sidecar handler and file lookup
- add router-level regression coverage distinguishing the removed route from the retained metadata and TUF handlers

## Scope

- In scope: removal of the dead public route, handler, and implied GPG sidecar surface
- Out of scope: exact-profile TUF/CCS signing, metadata generation, package serving, or compatibility aliases

## Ownership / Boundary

- Owning subsystem: Remi Publication, Serving, Admin, And Fixture Artifacts
- Boundary changed or preserved: removes an authority-free public surface while preserving exact-profile TUF and CCS signing as the sole repository trust owners
- Persisted state or public surface impact: no schema or persisted-state change; `GET /v1/{distro}/metadata.sig` is intentionally removed
- [x] Checked `docs/modules/feature-ownership.md`; owner and look-here-first paths remain unchanged

## Verification

- [x] Listed the exact verification commands run below
- [x] Added router-level regression coverage
- [x] Ran the affected Remi service package directly
- [x] No subsystem docs or maps changed because no tracked documentation or OpenAPI surface claimed this route
- [x] Ran the full Remi interaction gate because public serving behavior changed
- [x] Exact-head required CI passed on commit `54c651f7da25df875ad4189504493053de3a6aad` in [pr-gate run 30727202146](https://github.com/ConaryLabs/Conary/actions/runs/30727202146)

```text
- cargo test -p remi metadata_signature_route_is_absent_while_owned_routes_remain
  - 1 passed; 0 failed
- cargo test -p remi
  - library: 592 passed; 0 failed
  - binary: 5 passed; 0 failed
  - CLI help: 3 passed; 0 failed
  - doctests: 0 failed; 2 ignored
- bash scripts/check-doc-truth.sh
  - Documentation truth checks passed.
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- git diff --check
```

## Review And Merge Notes

- Review focus: the removed route has no remaining production registration or handler, while metadata and TUF routing still reach their owned handlers
- User or developer impact: Remi no longer advertises a permanently unavailable legacy GPG sidecar
- Required-check bypass: not used
