### PR TITLE
fix(scriptlet): project selected-root /dev/null

### DIFF
--- a/crates/conary-core/src/scriptlet/boot_runtime_capture.rs
+++ b/crates/conary-core/src/scriptlet/boot_runtime_capture.rs
@@ -288,11 +288,12 @@ impl BootRuntimeHandler {
             .map(|(key, value)| (key.as_str(), value.as_str()))
             .collect::<Vec<_>>();
         apply_sanitized_command_env(&mut command, &environment);
-        configure_target_command_boundary(&mut command, &self.root).map_err(|error| {
-            LifecycleBridgeHandlerError::new(format!(
-                "cannot establish selected-root boot provider boundary: {error}"
-            ))
-        })?;
+        let _boundary =
+            configure_target_command_boundary(&mut command, &self.root).map_err(|error| {
+                LifecycleBridgeHandlerError::new(format!(
+                    "cannot establish selected-root boot provider boundary: {error}"
+                ))
+            })?;
         let mut child = command.spawn().map_err(|error| {
             LifecycleBridgeHandlerError::new(format!(
                 "cannot spawn selected-root boot provider {provider}: {error}"

--- a/crates/conary-core/src/scriptlet/process.rs
+++ b/crates/conary-core/src/scriptlet/process.rs
@@ -21,6 +21,9 @@ use uuid::Uuid;
 
 const TARGET_SCRIPT_NAME: &str = "scriptlet";
 
+mod device_projection;
+use device_projection::TargetDeviceProjection;
+
 #[derive(Clone, Copy)]
 pub(super) struct ScriptletProcess<'a> {
     pub(super) phase: &'a str,
@@ -42,9 +45,11 @@ pub(super) struct TargetRootScript {
     extra_directories: Vec<String>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug)]
+#[must_use = "the selected-root boundary guard must live until its child process exits"]
 pub(crate) struct TargetExecutionBoundary {
     pub(crate) contract: &'static str,
+    _device_projection: TargetDeviceProjection,
 }
 
 #[derive(Debug, Clone)]
@@ -360,6 +365,9 @@ impl ScriptletExecutor {
 
 /// Attach Conary's closed lifecycle boundary to a child that executes exact
 /// argv inside a materialized selected root.
+///
+/// The returned guard owns transient selected-root mountpoints and must remain
+/// alive until the child exits.
 pub(crate) fn configure_target_command_boundary(
     command: &mut Command,
     root: &Path,
@@ -400,8 +408,12 @@ pub(super) fn configure_target_command_boundary_with_mounts(
     let root = root.to_path_buf();
     let bind_mounts = bind_mounts.to_vec();
     let prepared_boundary = ScriptletBoundary::prepare()?;
+    let device_projection = TargetDeviceProjection::stage(&root)?;
+    let device_source = PathBuf::from("/dev/null");
+    let device_target = root.join("dev/null");
     let boundary = TargetExecutionBoundary {
         contract: SCRIPTLET_BOUNDARY_ABI_V2,
+        _device_projection: device_projection,
     };
 
     // Safety: pre_exec runs between fork and exec in the child process.
@@ -419,6 +431,18 @@ pub(super) fn configure_target_command_boundary_with_mounts(
             )
             .map_err(|error| {
                 std::io::Error::other(format!("mount --make-rprivate failed: {error}"))
+            })?;
+            nix::mount::mount(
+                Some(device_source.as_path()),
+                device_target.as_path(),
+                None::<&str>,
+                nix::mount::MsFlags::MS_BIND,
+                None::<&str>,
+            )
+            .map_err(|error| {
+                std::io::Error::other(format!(
+                    "failed to project controlled /dev/null into lifecycle root: {error}"
+                ))
             })?;
             for bind in &bind_mounts {
                 nix::mount::mount(
@@ -461,8 +485,11 @@ fn prepared_stdin(content: &[u8]) -> Result<File> {
 #[cfg(test)]
 mod tests {
     use super::super::{PackageFormat, ScriptletExecutor};
-    use super::ScriptletProcess;
+    use super::{ScriptletProcess, configure_target_command_boundary};
+    use crate::scriptlet::test_support::materialized_root;
+    use std::fs;
     use std::path::Path;
+    use std::process::{Command, Stdio};
 
     #[test]
     fn test_execute_with_chroot_requires_root() {
@@ -540,5 +567,64 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(error.contains("host root '/'"));
+    }
+
+    #[test]
+    fn rpm_shell_lifecycle_projects_dev_null_without_persisting_a_device_tree() {
+        const TEST_NAME: &str = "scriptlet::process::tests::rpm_shell_lifecycle_projects_dev_null_without_persisting_a_device_tree";
+        const CRYPTO_POLICIES_PRE: &[u8] =
+            br#"# Drop removed javasystem backend; can be dropped in F43
+rm -f "/etc/crypto-policies/back-ends/javasystem.config" 2>/dev/null || :
+# Drop removed openssl backend; can be dropped in F44
+rm -f "/etc/crypto-policies/back-ends/openssl.config" 2>/dev/null || :
+exit 0"#;
+        let Some(root) = materialized_root(TEST_NAME, &["/bin/sh", "/bin/rm"]) else {
+            return;
+        };
+        assert_eq!(
+            crate::hash::sha256(CRYPTO_POLICIES_PRE),
+            "aabf5a4deffd8880422c0fcf0abc16b0831e78841d104dcdd6e29b0aeaa30d69"
+        );
+        let backends = root.host_path("/etc/crypto-policies/back-ends");
+        fs::create_dir_all(&backends).unwrap();
+        let javasystem = backends.join("javasystem.config");
+        let openssl = backends.join("openssl.config");
+        fs::write(&javasystem, b"stale java policy\n").unwrap();
+        fs::write(&openssl, b"stale openssl policy\n").unwrap();
+
+        let script = root.host_path("/tmp/crypto-policies-pre");
+        fs::write(&script, CRYPTO_POLICIES_PRE).unwrap();
+
+        let mut command = Command::new("/bin/sh");
+        command
+            .arg("/tmp/crypto-policies-pre")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .env_clear()
+            .env("LC_ALL", "C")
+            .env("LANG", "C")
+            .env("PATH", "/usr/sbin:/usr/bin:/sbin:/bin");
+        let boundary = configure_target_command_boundary(&mut command, root.path())
+            .expect("prepare selected-root lifecycle boundary");
+        let output = command.output().expect("execute exact Fedora RPM pre body");
+        drop(boundary);
+
+        assert!(
+            output.status.success(),
+            "unexpected status: {:?}",
+            output.status
+        );
+        assert!(
+            output.stderr.is_empty(),
+            "exact Fedora body wrote warnings: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(!javasystem.exists(), "stale javasystem backend survived");
+        assert!(!openssl.exists(), "stale openssl backend survived");
+        assert!(
+            !root.host_path("/dev").exists(),
+            "ephemeral device projection leaked into the selected root"
+        );
     }
 }

--- a/crates/conary-core/src/scriptlet/process.rs
+++ b/crates/conary-core/src/scriptlet/process.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 const TARGET_SCRIPT_NAME: &str = "scriptlet";
 
 mod device_projection;
-use device_projection::TargetDeviceProjection;
+use device_projection::{TargetDeviceProjection, attach_device_projection};
 
 #[derive(Clone, Copy)]
 pub(super) struct ScriptletProcess<'a> {
@@ -409,8 +409,7 @@ pub(super) fn configure_target_command_boundary_with_mounts(
     let bind_mounts = bind_mounts.to_vec();
     let prepared_boundary = ScriptletBoundary::prepare()?;
     let device_projection = TargetDeviceProjection::stage(&root)?;
-    let device_source = PathBuf::from("/dev/null");
-    let device_target = root.join("dev/null");
+    let device_projection_plan = device_projection.plan();
     let boundary = TargetExecutionBoundary {
         contract: SCRIPTLET_BOUNDARY_ABI_V2,
         _device_projection: device_projection,
@@ -432,14 +431,7 @@ pub(super) fn configure_target_command_boundary_with_mounts(
             .map_err(|error| {
                 std::io::Error::other(format!("mount --make-rprivate failed: {error}"))
             })?;
-            nix::mount::mount(
-                Some(device_source.as_path()),
-                device_target.as_path(),
-                None::<&str>,
-                nix::mount::MsFlags::MS_BIND,
-                None::<&str>,
-            )
-            .map_err(|error| {
+            attach_device_projection(&root, device_projection_plan).map_err(|error| {
                 std::io::Error::other(format!(
                     "failed to project controlled /dev/null into lifecycle root: {error}"
                 ))

--- a/crates/conary-core/src/scriptlet/process/device_projection.rs
+++ b/crates/conary-core/src/scriptlet/process/device_projection.rs
@@ -11,6 +11,11 @@ use std::io;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::path::Path;
 
+// Stable Linux UAPI values from <linux/mount.h>. The libc crate does not
+// expose these names on every static target that Conary supports.
+const MOVE_MOUNT_F_EMPTY_PATH: libc::c_uint = 0x0000_0004;
+const MOVE_MOUNT_T_EMPTY_PATH: libc::c_uint = 0x0000_0040;
+
 #[derive(Debug)]
 pub(super) struct TargetDeviceProjection {
     _mountpoint: TargetDeviceMountpoint,
@@ -253,7 +258,7 @@ pub(super) fn attach_device_projection(
             empty.as_ptr(),
             target.as_raw_fd(),
             empty.as_ptr(),
-            libc::MOVE_MOUNT_F_EMPTY_PATH | libc::MOVE_MOUNT_T_EMPTY_PATH,
+            MOVE_MOUNT_F_EMPTY_PATH | MOVE_MOUNT_T_EMPTY_PATH,
         )
     };
     if result < 0 {

--- a/crates/conary-core/src/scriptlet/process/device_projection.rs
+++ b/crates/conary-core/src/scriptlet/process/device_projection.rs
@@ -7,38 +7,49 @@ use nix::errno::Errno;
 use nix::fcntl::{OFlag, open, openat};
 use nix::sys::stat::{Mode, SFlag, fstat, mkdirat};
 use nix::unistd::{UnlinkatFlags, unlinkat};
-use std::os::fd::OwnedFd;
+use std::io;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::path::Path;
 
 #[derive(Debug)]
 pub(super) struct TargetDeviceProjection {
     _mountpoint: TargetDeviceMountpoint,
+    plan: TargetDeviceProjectionPlan,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct TargetDeviceProjectionPlan {
+    root: FileIdentity,
+    dev: FileIdentity,
+    target: FileIdentity,
 }
 
 #[derive(Debug)]
 struct TargetDeviceMountpoint {
     root_fd: OwnedFd,
     dev_fd: OwnedFd,
-    created_dev: bool,
-    created_null: bool,
+    created_dev: Option<FileIdentity>,
+    created_null: Option<FileIdentity>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FileIdentity {
+    device: libc::dev_t,
+    inode: libc::ino_t,
 }
 
 impl TargetDeviceProjection {
     pub(super) fn stage(root: &Path) -> Result<Self> {
         let source_fd = open(
             "/dev/null",
-            OFlag::O_RDWR | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+            OFlag::O_PATH | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
             Mode::empty(),
         )
         .map_err(|error| projection_error(root, format!("cannot open host /dev/null: {error}")))?;
         let source_stat = fstat(&source_fd).map_err(|error| {
             projection_error(root, format!("cannot inspect host /dev/null: {error}"))
         })?;
-        let source_kind = SFlag::from_bits_truncate(source_stat.st_mode);
-        if source_kind != SFlag::S_IFCHR
-            || libc::major(source_stat.st_rdev) != 1
-            || libc::minor(source_stat.st_rdev) != 3
-        {
+        if !is_linux_null_device(&source_stat) {
             return Err(projection_error(
                 root,
                 "host /dev/null is not the Linux null character device (1:3)",
@@ -51,6 +62,9 @@ impl TargetDeviceProjection {
             Mode::empty(),
         )
         .map_err(|error| projection_error(root, format!("cannot open root: {error}")))?;
+        let root_identity = file_identity(&root_fd).map_err(|error| {
+            projection_error(root, format!("cannot inspect selected root: {error}"))
+        })?;
 
         let (dev_fd, created_dev) = match openat(
             &root_fd,
@@ -87,11 +101,20 @@ impl TargetDeviceProjection {
                 ));
             }
         };
+        let created_dev = created_dev
+            .then(|| file_identity(&dev_fd))
+            .transpose()
+            .map_err(|error| {
+                projection_error(root, format!("cannot inspect created /dev: {error}"))
+            })?;
+        let dev_identity = file_identity(&dev_fd).map_err(|error| {
+            projection_error(root, format!("cannot inspect selected-root /dev: {error}"))
+        })?;
         let mut mountpoint = TargetDeviceMountpoint {
             root_fd,
             dev_fd,
             created_dev,
-            created_null: false,
+            created_null: None,
         };
 
         let (target_fd, created_null) = match openat(
@@ -124,36 +147,209 @@ impl TargetDeviceProjection {
                 ));
             }
         };
-        mountpoint.created_null = created_null;
-        let target_kind = SFlag::from_bits_truncate(
-            fstat(&target_fd)
-                .map_err(|error| {
-                    projection_error(root, format!("cannot inspect /dev/null: {error}"))
-                })?
-                .st_mode,
-        );
+        let target_stat = fstat(&target_fd).map_err(|error| {
+            projection_error(root, format!("cannot inspect /dev/null: {error}"))
+        })?;
+        let target_kind = SFlag::from_bits_truncate(target_stat.st_mode);
         if target_kind != SFlag::S_IFREG && target_kind != SFlag::S_IFCHR {
             return Err(projection_error(
                 root,
                 "existing /dev/null is neither a regular mountpoint nor a character device",
             ));
         }
+        if created_null {
+            mountpoint.created_null = Some(FileIdentity::from_stat(&target_stat));
+        }
 
         Ok(Self {
             _mountpoint: mountpoint,
+            plan: TargetDeviceProjectionPlan {
+                root: root_identity,
+                dev: dev_identity,
+                target: FileIdentity::from_stat(&target_stat),
+            },
         })
     }
+
+    pub(super) fn plan(&self) -> TargetDeviceProjectionPlan {
+        self.plan
+    }
+}
+
+pub(super) fn attach_device_projection(
+    root: &Path,
+    plan: TargetDeviceProjectionPlan,
+) -> io::Result<()> {
+    let source = open(
+        "/dev/null",
+        OFlag::O_PATH | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+        Mode::empty(),
+    )
+    .map_err(io::Error::from)?;
+    let source_stat = fstat(&source).map_err(io::Error::from)?;
+    if !is_linux_null_device(&source_stat) {
+        return Err(io::Error::other(
+            "host /dev/null is not the Linux null character device (1:3)",
+        ));
+    }
+
+    let root_fd = open(
+        root,
+        OFlag::O_PATH | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+        Mode::empty(),
+    )
+    .map_err(io::Error::from)?;
+    require_identity(&root_fd, plan.root, "selected root changed after staging")?;
+    let dev_fd = openat(
+        &root_fd,
+        "dev",
+        OFlag::O_PATH | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+        Mode::empty(),
+    )
+    .map_err(io::Error::from)?;
+    require_identity(
+        &dev_fd,
+        plan.dev,
+        "selected-root /dev changed after staging",
+    )?;
+    let target = openat(
+        &dev_fd,
+        "null",
+        OFlag::O_PATH | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+        Mode::empty(),
+    )
+    .map_err(io::Error::from)?;
+    require_identity(
+        &target,
+        plan.target,
+        "selected-root /dev/null changed after staging",
+    )?;
+
+    let empty = c"";
+    // Safety: open_tree returns a new descriptor or -1 and reads only the
+    // supplied empty C string. Both input descriptors remain owned by the
+    // pre-exec closure.
+    let tree_fd = unsafe {
+        libc::syscall(
+            libc::SYS_open_tree,
+            source.as_raw_fd(),
+            empty.as_ptr(),
+            libc::OPEN_TREE_CLONE | libc::OPEN_TREE_CLOEXEC | libc::AT_EMPTY_PATH as libc::c_uint,
+        )
+    };
+    if tree_fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // Safety: the successful syscall returned a new owned descriptor.
+    let tree_fd = unsafe { OwnedFd::from_raw_fd(tree_fd as libc::c_int) };
+
+    // Safety: move_mount reads only the supplied empty C strings and attaches
+    // the detached tree to the exact target descriptor. The descriptor owners
+    // outlive the syscall.
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_move_mount,
+            tree_fd.as_raw_fd(),
+            empty.as_ptr(),
+            target.as_raw_fd(),
+            empty.as_ptr(),
+            libc::MOVE_MOUNT_F_EMPTY_PATH | libc::MOVE_MOUNT_T_EMPTY_PATH,
+        )
+    };
+    if result < 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    require_identity(
+        &root_fd,
+        plan.root,
+        "selected root changed during projection",
+    )?;
+    let current_dev = openat(
+        &root_fd,
+        "dev",
+        OFlag::O_PATH | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+        Mode::empty(),
+    )
+    .map_err(io::Error::from)?;
+    require_identity(
+        &current_dev,
+        plan.dev,
+        "selected-root /dev changed during projection",
+    )?;
+    let current_target = openat(
+        &current_dev,
+        "null",
+        OFlag::O_PATH | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+        Mode::empty(),
+    )
+    .map_err(io::Error::from)?;
+    let current_stat = fstat(&current_target).map_err(io::Error::from)?;
+    if !is_linux_null_device(&current_stat) {
+        return Err(io::Error::other(
+            "selected-root /dev/null does not expose the projected Linux null device",
+        ));
+    }
+    Ok(())
 }
 
 impl Drop for TargetDeviceMountpoint {
     fn drop(&mut self) {
-        if self.created_null {
+        if self
+            .created_null
+            .is_some_and(|identity| entry_has_identity(&self.dev_fd, "null", false, identity))
+        {
             let _ = unlinkat(&self.dev_fd, "null", UnlinkatFlags::NoRemoveDir);
         }
-        if self.created_dev {
+        if self
+            .created_dev
+            .is_some_and(|identity| entry_has_identity(&self.root_fd, "dev", true, identity))
+        {
             let _ = unlinkat(&self.root_fd, "dev", UnlinkatFlags::RemoveDir);
         }
     }
+}
+
+impl FileIdentity {
+    fn from_stat(stat: &libc::stat) -> Self {
+        Self {
+            device: stat.st_dev,
+            inode: stat.st_ino,
+        }
+    }
+}
+
+fn file_identity(fd: &OwnedFd) -> nix::Result<FileIdentity> {
+    fstat(fd).map(|stat| FileIdentity::from_stat(&stat))
+}
+
+fn require_identity(fd: &OwnedFd, expected: FileIdentity, detail: &str) -> io::Result<()> {
+    let actual = file_identity(fd).map_err(io::Error::from)?;
+    if actual != expected {
+        return Err(io::Error::other(detail));
+    }
+    Ok(())
+}
+
+fn is_linux_null_device(stat: &libc::stat) -> bool {
+    SFlag::from_bits_truncate(stat.st_mode) == SFlag::S_IFCHR
+        && libc::major(stat.st_rdev) == 1
+        && libc::minor(stat.st_rdev) == 3
+}
+
+fn entry_has_identity(
+    parent: &OwnedFd,
+    name: &str,
+    directory: bool,
+    expected: FileIdentity,
+) -> bool {
+    let mut flags = OFlag::O_PATH | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC;
+    if directory {
+        flags |= OFlag::O_DIRECTORY;
+    }
+    openat(parent, name, flags, Mode::empty())
+        .and_then(|fd| file_identity(&fd))
+        .is_ok_and(|identity| identity == expected)
 }
 
 fn projection_error(root: &Path, detail: impl std::fmt::Display) -> Error {
@@ -168,8 +364,9 @@ fn projection_error(root: &Path, detail: impl std::fmt::Display) -> Error {
 
 #[cfg(test)]
 mod tests {
-    use super::TargetDeviceProjection;
+    use super::{TargetDeviceProjection, attach_device_projection};
     use std::fs;
+    use std::os::unix::fs::MetadataExt;
 
     #[test]
     fn removes_only_mountpoints_created_for_the_projection() {
@@ -229,5 +426,44 @@ mod tests {
             "unexpected error: {error}"
         );
         assert_eq!(fs::read(outside.path()).unwrap(), b"outside sentinel\n");
+    }
+
+    #[test]
+    fn pins_mount_target_and_preserves_replacement_during_cleanup() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::NamedTempFile::new().unwrap();
+        fs::write(outside.path(), b"outside sentinel\n").unwrap();
+
+        let projection = TargetDeviceProjection::stage(root.path()).unwrap();
+        let pinned_identity = projection.plan.target;
+        let dev = root.path().join("dev");
+        fs::rename(dev.join("null"), dev.join("original-null")).unwrap();
+        std::os::unix::fs::symlink(outside.path(), dev.join("null")).unwrap();
+
+        let current_metadata = fs::metadata(dev.join("null")).unwrap();
+        assert_ne!(pinned_identity.inode, current_metadata.ino());
+
+        drop(projection);
+
+        assert!(dev.join("null").is_symlink());
+        assert_eq!(fs::read(outside.path()).unwrap(), b"outside sentinel\n");
+    }
+
+    #[test]
+    fn refuses_replaced_mount_target_before_projection() {
+        let root = tempfile::tempdir().unwrap();
+        let projection = TargetDeviceProjection::stage(root.path()).unwrap();
+        let plan = projection.plan();
+        let dev = root.path().join("dev");
+        fs::rename(dev.join("null"), dev.join("original-null")).unwrap();
+        fs::write(dev.join("null"), b"replacement").unwrap();
+
+        let error = attach_device_projection(root.path(), plan)
+            .expect_err("projection must reject a target replaced after staging");
+
+        assert_eq!(
+            error.to_string(),
+            "selected-root /dev/null changed after staging"
+        );
     }
 }

--- a/crates/conary-core/src/scriptlet/process/device_projection.rs
+++ b/crates/conary-core/src/scriptlet/process/device_projection.rs
@@ -1,0 +1,233 @@
+// conary-core/src/scriptlet/process/device_projection.rs
+
+//! Controlled selected-root device projection for lifecycle execution.
+
+use crate::error::{Error, Result, ScriptletFailureKind};
+use nix::errno::Errno;
+use nix::fcntl::{OFlag, open, openat};
+use nix::sys::stat::{Mode, SFlag, fstat, mkdirat};
+use nix::unistd::{UnlinkatFlags, unlinkat};
+use std::os::fd::OwnedFd;
+use std::path::Path;
+
+#[derive(Debug)]
+pub(super) struct TargetDeviceProjection {
+    _mountpoint: TargetDeviceMountpoint,
+}
+
+#[derive(Debug)]
+struct TargetDeviceMountpoint {
+    root_fd: OwnedFd,
+    dev_fd: OwnedFd,
+    created_dev: bool,
+    created_null: bool,
+}
+
+impl TargetDeviceProjection {
+    pub(super) fn stage(root: &Path) -> Result<Self> {
+        let source_fd = open(
+            "/dev/null",
+            OFlag::O_RDWR | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+            Mode::empty(),
+        )
+        .map_err(|error| projection_error(root, format!("cannot open host /dev/null: {error}")))?;
+        let source_stat = fstat(&source_fd).map_err(|error| {
+            projection_error(root, format!("cannot inspect host /dev/null: {error}"))
+        })?;
+        let source_kind = SFlag::from_bits_truncate(source_stat.st_mode);
+        if source_kind != SFlag::S_IFCHR
+            || libc::major(source_stat.st_rdev) != 1
+            || libc::minor(source_stat.st_rdev) != 3
+        {
+            return Err(projection_error(
+                root,
+                "host /dev/null is not the Linux null character device (1:3)",
+            ));
+        }
+
+        let root_fd = open(
+            root,
+            OFlag::O_PATH | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+            Mode::empty(),
+        )
+        .map_err(|error| projection_error(root, format!("cannot open root: {error}")))?;
+
+        let (dev_fd, created_dev) = match openat(
+            &root_fd,
+            "dev",
+            OFlag::O_PATH | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+            Mode::empty(),
+        ) {
+            Ok(fd) => (fd, false),
+            Err(Errno::ENOENT) => {
+                mkdirat(&root_fd, "dev", Mode::from_bits_truncate(0o755)).map_err(|error| {
+                    projection_error(root, format!("cannot create /dev: {error}"))
+                })?;
+                let fd = match openat(
+                    &root_fd,
+                    "dev",
+                    OFlag::O_PATH | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+                    Mode::empty(),
+                ) {
+                    Ok(fd) => fd,
+                    Err(error) => {
+                        let _ = unlinkat(&root_fd, "dev", UnlinkatFlags::RemoveDir);
+                        return Err(projection_error(
+                            root,
+                            format!("cannot reopen created /dev: {error}"),
+                        ));
+                    }
+                };
+                (fd, true)
+            }
+            Err(error) => {
+                return Err(projection_error(
+                    root,
+                    format!("cannot open /dev without following links: {error}"),
+                ));
+            }
+        };
+        let mut mountpoint = TargetDeviceMountpoint {
+            root_fd,
+            dev_fd,
+            created_dev,
+            created_null: false,
+        };
+
+        let (target_fd, created_null) = match openat(
+            &mountpoint.dev_fd,
+            "null",
+            OFlag::O_PATH | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+            Mode::empty(),
+        ) {
+            Ok(fd) => (fd, false),
+            Err(Errno::ENOENT) => {
+                let fd = openat(
+                    &mountpoint.dev_fd,
+                    "null",
+                    OFlag::O_WRONLY
+                        | OFlag::O_CREAT
+                        | OFlag::O_EXCL
+                        | OFlag::O_NOFOLLOW
+                        | OFlag::O_CLOEXEC,
+                    Mode::from_bits_truncate(0o600),
+                )
+                .map_err(|error| {
+                    projection_error(root, format!("cannot create /dev/null mountpoint: {error}"))
+                })?;
+                (fd, true)
+            }
+            Err(error) => {
+                return Err(projection_error(
+                    root,
+                    format!("cannot open /dev/null without following links: {error}"),
+                ));
+            }
+        };
+        mountpoint.created_null = created_null;
+        let target_kind = SFlag::from_bits_truncate(
+            fstat(&target_fd)
+                .map_err(|error| {
+                    projection_error(root, format!("cannot inspect /dev/null: {error}"))
+                })?
+                .st_mode,
+        );
+        if target_kind != SFlag::S_IFREG && target_kind != SFlag::S_IFCHR {
+            return Err(projection_error(
+                root,
+                "existing /dev/null is neither a regular mountpoint nor a character device",
+            ));
+        }
+
+        Ok(Self {
+            _mountpoint: mountpoint,
+        })
+    }
+}
+
+impl Drop for TargetDeviceMountpoint {
+    fn drop(&mut self) {
+        if self.created_null {
+            let _ = unlinkat(&self.dev_fd, "null", UnlinkatFlags::NoRemoveDir);
+        }
+        if self.created_dev {
+            let _ = unlinkat(&self.root_fd, "dev", UnlinkatFlags::RemoveDir);
+        }
+    }
+}
+
+fn projection_error(root: &Path, detail: impl std::fmt::Display) -> Error {
+    Error::scriptlet(
+        ScriptletFailureKind::SandboxSetupUnavailable,
+        format!(
+            "cannot prepare controlled /dev/null projection for selected root {}: {detail}",
+            root.display()
+        ),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TargetDeviceProjection;
+    use std::fs;
+
+    #[test]
+    fn removes_only_mountpoints_created_for_the_projection() {
+        let empty_root = tempfile::tempdir().unwrap();
+        {
+            let _projection = TargetDeviceProjection::stage(empty_root.path()).unwrap();
+            assert!(empty_root.path().join("dev/null").is_file());
+        }
+        assert!(!empty_root.path().join("dev").exists());
+
+        let populated_root = tempfile::tempdir().unwrap();
+        fs::create_dir(populated_root.path().join("dev")).unwrap();
+        fs::write(
+            populated_root.path().join("dev/null"),
+            b"existing mountpoint",
+        )
+        .unwrap();
+        {
+            let _projection = TargetDeviceProjection::stage(populated_root.path()).unwrap();
+        }
+        assert_eq!(
+            fs::read(populated_root.path().join("dev/null")).unwrap(),
+            b"existing mountpoint"
+        );
+    }
+
+    #[test]
+    fn refuses_selected_root_symlink_escape() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(outside.path(), root.path().join("dev")).unwrap();
+
+        let error = TargetDeviceProjection::stage(root.path())
+            .expect_err("device projection must reject a selected-root /dev symlink");
+
+        assert!(
+            error
+                .to_string()
+                .contains("controlled /dev/null projection"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(fs::read_dir(outside.path()).unwrap().count(), 0);
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::NamedTempFile::new().unwrap();
+        fs::write(outside.path(), b"outside sentinel\n").unwrap();
+        fs::create_dir(root.path().join("dev")).unwrap();
+        std::os::unix::fs::symlink(outside.path(), root.path().join("dev/null")).unwrap();
+
+        let error = TargetDeviceProjection::stage(root.path())
+            .expect_err("device projection must reject a selected-root /dev/null symlink");
+
+        assert!(
+            error
+                .to_string()
+                .contains("controlled /dev/null projection"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(fs::read(outside.path()).unwrap(), b"outside sentinel\n");
+    }
+}

--- a/crates/conary-core/src/trigger/execution.rs
+++ b/crates/conary-core/src/trigger/execution.rs
@@ -46,12 +46,13 @@ impl TriggerExecutor<'_> {
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
-        configure_target_command_boundary(&mut command, self.root).map_err(|error| {
-            Error::TriggerError(format!(
-                "Failed to establish selected-root boundary for '{}': {error}",
-                trigger.name
-            ))
-        })?;
+        let _boundary =
+            configure_target_command_boundary(&mut command, self.root).map_err(|error| {
+                Error::TriggerError(format!(
+                    "Failed to establish selected-root boundary for '{}': {error}",
+                    trigger.name
+                ))
+            })?;
         let child = command.spawn().map_err(|e| {
             Error::TriggerError(format!(
                 "Failed to spawn '{}' in selected root {}: {}",


### PR DESCRIPTION
## Primary Issue

Closes #233

Design / Plan / Roadmap: issue acceptance criteria and the `install` feature ownership card

## Problem And Outcome

Selected-root lifecycle execution chrooted directly into the materialized target without projecting `/dev/null`. Ordinary RPM shell redirection therefore failed before its command ran; warning-only lifecycle could report success while leaving stale configuration behind.

After this change, every command using the shared selected-root lifecycle boundary receives the fixed Linux null device as an ephemeral bind mount. The projection rejects link escapes, never exposes arbitrary host devices, and removes only mountpoints it created.

## Changes

- add a focused selected-root device projection owner under `scriptlet/process/`
- validate host `/dev/null` as the Linux 1:3 character device
- stage `/dev` and `/dev/null` descriptor-relatively without following links
- clone only host `/dev/null` as a detached mount and attach it to the inode-pinned selected-root target inside the child mount namespace
- revalidate the selected root, `/dev`, and `/dev/null` identities after namespace creation and fail closed on replacement
- retain an explicit boundary guard until each child exits, then remove only unchanged transient mountpoints
- execute the exact Fedora 44 `crypto-policies` `%pre` bytes and pin their recorded SHA-256
- prove stale backend files are removed without stderr warnings and that selected-root device state does not leak
- prove existing mountpoints are preserved and `/dev` or `/dev/null` symlink escapes are rejected

## Scope

- In scope: the shared selected-root lifecycle process boundary used by shell scriptlets, exact native argv, triggers, and lifecycle bridge providers
- Out of scope: arbitrary device projection, source-package-manager execution, package-name or distro special cases, and broader VM fixture changes

## Ownership / Boundary

- Owning subsystem: install / native lifecycle, with focused implementation ownership in `crates/conary-core/src/scriptlet/process/device_projection.rs`
- Boundary changed or preserved: preserves the single private selected-root lifecycle boundary while adding one fixed device ABI projection
- Persisted state or public surface impact: none; mountpoints are ephemeral and existing target nodes remain untouched
- [x] Checked `docs/modules/feature-ownership.md`; the existing `scriptlet/process.rs` look-here-first route remains current

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code
- [x] Updated subsystem docs or maps when the "look here first" path changed (not applicable; route unchanged)
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs (exact-head supported-host VM proof remains a pre-merge gate on this PR)

```text
- cargo test -p conary-core --lib scriptlet::process -- --nocapture
  - 8 passed
- cargo test -p conary-core native_lifecycle
  - 53 passed
- cargo test -p conary-core trigger::
  - 13 passed
- cargo test -p conary-core lifecycle_bridge
  - 10 passed
- cargo test -p conary --lib commands::install
  - 192 passed; 1 ignored (intentional network conformance proof)
- cargo test -p conary --test live_host_mutation_safety
  - 21 passed
- cargo test -p conary --test conversion_integration
  - 16 passed
- cargo fmt --check
- bash scripts/check-doc-truth.sh
- cargo clippy --workspace --all-targets -- -D warnings
- bash scripts/build-static-conary.sh
  - static PIE built for x86_64-unknown-linux-musl; `conary 0.14.0`
- cargo run -p conary-test -- run --suite phase3-group-o-generation-export --distro fedora44 --phase 3
  - exact head `04050f82a6d3865ba633f6d0f5b2e18151c7828d`
  - 5 passed; 0 failed; 0 skipped; 0 cancelled
  - TGE02 `supported_host_generation_export_boots`: 2,367,923 ms
  - result SHA-256: `581847af3f57861c110b0280a4fa4576a16af99c050c2064a85efa980752121a`
- git diff --check
```

The first Group O attempt exposed that the static-musl `libc` surface did not export the two stable Linux `move_mount` flag names. The branch now owns the UAPI values explicitly; the static build and the full Group O rerun above passed on the final exact head.

## Review And Merge Notes

- Review focus: descriptor-relative staging and cleanup, guard lifetime across every caller, and the fixed-device-only mount contract
- User or developer impact: RPM lifecycle redirections to `/dev/null` work inside selected roots, preventing warning-only false success from retaining stale files
- Required-check bypass: not used
