### PR TITLE
fix(generation): require composefs initramfs helper

### DIFF
--- a/apps/conary/tests/fixtures/supported-host-generation-export/fixture-system.toml
+++ b/apps/conary/tests/fixtures/supported-host-generation-export/fixture-system.toml
@@ -22,10 +22,9 @@
 #                           ESP BOOTX64.EFI.
 #   kernel-modules-core     erofs, overlay, iso9660, vfat, and e1000 are
 #                           modules on Fedora 44, not built into kernel-core.
-#   composefs               provides mount.composefs; the dracut module picks
-#                           the helper up with `inst_multiple -o`, so a root
-#                           without it builds an initramfs that fails at
-#                           generation mount with no build-time signal.
+#   composefs               provides mount.composefs; the dracut module requires
+#                           the helper at initramfs build time, so a root
+#                           without it fails before producing a boot carrier.
 #   util-linux-core         also satisfies systemd's
 #                           (util-linux-core or util-linux) rich dependency.
 #   conary-qemu-test-access built and installed by the suite from

--- a/crates/conary-core/tests/generation_composefs_runtime_contract.rs
+++ b/crates/conary-core/tests/generation_composefs_runtime_contract.rs
@@ -62,6 +62,39 @@ install
         .collect()
 }
 
+fn dracut_install_succeeds_with_missing_tool(module: &Path, missing_tool: &str) -> bool {
+    Command::new("bash")
+        .args([
+            "-c",
+            r#"
+source "$1"
+missing_tool="$2"
+moddir=/contract/conary-dracut-module
+install_conary_script() { :; }
+inst_multiple() {
+    optional=0
+    if [ "${1-}" = "-o" ]; then
+        optional=1
+        shift
+    fi
+    for argument in "$@"; do
+        if [ "$argument" = "$missing_tool" ] && [ "$optional" -eq 0 ]; then
+            return 1
+        fi
+    done
+    return 0
+}
+install
+"#,
+            "dracut-missing-tool-contract",
+        ])
+        .arg(module)
+        .arg(missing_tool)
+        .status()
+        .expect("failed to evaluate a missing-tool dracut contract")
+        .success()
+}
+
 #[test]
 fn composefs_preflight_requires_the_mount_helper_and_overlay_stack() {
     let composefs_rs = fs::read_to_string(core_source("generation/composefs.rs"))
@@ -512,10 +545,19 @@ fn dracut_generator_is_the_single_generation_activation_authority() {
         fs::read_to_string(workspace_file("packaging/dracut/90conary/module-setup.sh"))
             .expect("failed to read conary dracut module setup");
     let dracut_module_path = workspace_file("packaging/dracut/90conary/module-setup.sh");
-    let mandatory_dracut_tools = dracut_inst_multiple_calls(&dracut_module_path)
-        .into_iter()
+    let dracut_tool_calls = dracut_inst_multiple_calls(&dracut_module_path);
+    let mandatory_dracut_tools = dracut_tool_calls
+        .iter()
         .filter(|call| !call.iter().any(|argument| argument == "-o"))
         .flatten()
+        .cloned()
+        .collect::<Vec<_>>();
+    let optional_dracut_tools = dracut_tool_calls
+        .iter()
+        .filter(|call| call.iter().any(|argument| argument == "-o"))
+        .flatten()
+        .filter(|argument| argument.as_str() != "-o")
+        .cloned()
         .collect::<Vec<_>>();
 
     assert!(
@@ -572,6 +614,31 @@ fn dracut_generator_is_the_single_generation_activation_authority() {
     assert!(
         mandatory_dracut_tools.iter().any(|tool| tool == "cp"),
         "the initramfs must carry the copy tool required for readonly config-state seeding"
+    );
+    assert!(
+        mandatory_dracut_tools
+            .iter()
+            .any(|tool| tool == "mount.composefs"),
+        "the initramfs build must fail when the composefs mount helper is unavailable"
+    );
+    assert_eq!(
+        optional_dracut_tools,
+        vec!["blkid"],
+        "only the guarded blkid fallback may remain optional in the Conary initramfs"
+    );
+    assert!(
+        dracut_init.contains("if command -v blkid >/dev/null 2>&1; then"),
+        "an optional blkid include must remain guarded at every runtime use"
+    );
+    for tool in &mandatory_dracut_tools {
+        assert!(
+            !dracut_install_succeeds_with_missing_tool(&dracut_module_path, tool),
+            "the initramfs install must propagate a missing mandatory tool: {tool}"
+        );
+    }
+    assert!(
+        dracut_install_succeeds_with_missing_tool(&dracut_module_path, "blkid"),
+        "the guarded blkid fallback may be absent without rejecting the initramfs"
     );
 
     assert!(

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -120,6 +120,7 @@ commands.
   `crates/conary-core/src/generation/builder/carrier_capabilities.rs`,
   `crates/conary-core/src/generation/artifact.rs`,
   `crates/conary-core/src/generation/export.rs`,
+  `packaging/dracut/90conary/` for the initramfs activation runtime,
   `crates/conary-core/src/ccs/hooks/capabilities/filesystem_security.rs`,
   `crates/conary-core/src/activation/systemd.rs`,
   `crates/conary-core/src/activation/systemd/grammar.rs`,

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -497,6 +497,9 @@ and export raw/qcow2/ISO carriers.
 `apps/conary/src/commands/state.rs`;
 `apps/conary/src/commands/provenance.rs`;
 `apps/conary/src/commands/provenance/`;
+`packaging/dracut/90conary/module-setup.sh`;
+`packaging/dracut/90conary/conary-init.sh`;
+`packaging/dracut/90conary/conary-generator.sh`;
 `docs/roadmaps/development-roadmap.md`.
 
 **Neighbor systems:** selected-root lifecycle execution, systemd and
@@ -518,6 +521,7 @@ state, image building, bootstrap validation, conaryd route history.
 `crates/conary-core/src/transaction/recovery.rs`;
 `apps/conary/src/commands/generation/*`;
 `packaging/systemd/conary-generation-activation.service`;
+`packaging/dracut/90conary/*`;
 `apps/conary/src/commands/provenance.rs`;
 `apps/conary/src/commands/provenance/*`.
 
@@ -537,6 +541,7 @@ state, image building, bootstrap validation, conaryd route history.
 `cargo test -p conary --lib commands::generation::activation_intents`;
 `cargo test -p conary --lib commands::generation::gc`;
 `cargo test -p conary-core --test db_backup`;
+`cargo test -p conary-core --test generation_composefs_runtime_contract`;
 `cargo test -p conary --test packaged_onboarding`.
 
 **Interaction gate:** `cargo run -p conary-test -- run --suite phase3-group-o-generation-export --distro fedora44 --phase 3`;

--- a/packaging/dracut/90conary/module-setup.sh
+++ b/packaging/dracut/90conary/module-setup.sh
@@ -41,11 +41,12 @@ install() {
         mkdir \
         modprobe \
         mount \
+        mount.composefs \
         readlink \
         rmdir \
         sleep \
-        switch_root
+        switch_root || return 1
+    # conary-init resolves stable /dev/disk links first and guards blkid as a
+    # fallback, so it is the only runtime executable that remains optional.
     inst_multiple -o blkid
-    # Include mount.composefs if available
-    inst_multiple -o mount.composefs
 }


### PR DESCRIPTION
## Primary Issue

Closes #152

Design / Plan / Roadmap: Generation ownership card in `docs/modules/feature-ownership.md`

## Problem And Outcome

The Conary dracut module installed `mount.composefs` as optional. A selected root without the helper could therefore produce an initramfs that was guaranteed to fail later at boot, and a later optional install call could mask a missing mandatory executable.

After merge, initramfs construction fails immediately when `mount.composefs` or any other mandatory runtime tool is unavailable. Only the guarded `blkid` fallback remains optional.

## Changes

- require `mount.composefs` in the mandatory dracut executable set
- explicitly propagate mandatory `inst_multiple` failures from the dracut `install` function
- extend the Generation runtime contract to simulate every mandatory tool being absent and prove that only guarded `blkid` may be missing
- route the dracut runtime through the Generation ownership card and assistant subsystem map
- update the supported-host fixture explanation to reflect build-time failure

## Scope

- In scope: Conary's dracut module dependency contract, regression coverage, and ownership routing
- Out of scope: changing composefs activation semantics or adding compatibility fallbacks

## Ownership / Boundary

- Owning subsystem: Generation
- Boundary changed or preserved: preserves the Generation activation boundary; moves missing-helper detection from boot time to initramfs build time
- Persisted state or public surface impact: no persisted-state change; invalid boot carriers now fail during construction
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code (not applicable)
- [x] Updated subsystem docs or maps when the "look here first" path changed
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs (none)

```text
- cargo fmt --check
- bash scripts/check-doc-truth.sh
- git diff --check
- cargo test -p conary-core --test generation_composefs_runtime_contract -- --nocapture
  - 18 passed; 0 failed
- bash scripts/agent-context.sh --feature generation --run focused
  - all 18 focused commands passed
- cargo test -p conary-core
  - passed; 0 failed (2 fixture-dependent tests ignored)
- cargo clippy --workspace --all-targets -- -D warnings
- cargo run -p conary-test -- run --suite phase3-group-o-generation-export --distro fedora44 --phase 3
  - first uninterrupted run: 5 passed; 0 failed; 0 skipped; 0 cancelled
```

## Review And Merge Notes

- Review focus: mandatory dracut failure propagation and the missing-tool contract harness
- User or developer impact: systems missing `mount.composefs` now fail while building the initramfs instead of producing an unbootable carrier
- Required-check bypass: not used
