### PR TITLE
docs(ccs): specify lossless source authority

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-07-30
-revision: 38
-summary: Describe workspace architecture, repository trust, package transactions, lifecycle execution, typed carrier security, generation GC, and service boundaries
+last_updated: 2026-08-03
+revision: 39
+summary: Describe workspace architecture, source-authority projections, repository trust, package transactions, lifecycle execution, typed carrier security, generation GC, and service boundaries
 ---
 
 # Conary Architecture
@@ -172,7 +172,7 @@ crates/conary-core/      Core library crate
     |   +-- rpm.rs       RPM parser
     |   +-- deb.rs       DEB parser
     |   +-- arch.rs      Arch parser
-    |   +-- common.rs    Unified PackageMetadata
+    |   +-- common.rs    Current unified PackageMetadata bridge; W5 removal target
     +-- ccs/             Native package format
     |   +-- builder.rs   CCS package builder
     |   +-- manifest.rs  Root CCS TOML/CBOR manifest schema and validation hub
@@ -313,7 +313,9 @@ This is the primary operation. The flow from
    +-- Download package(s) - parallel via rayon if multiple
    |   +-- For Remi: fetch CCS chunks, assemble package
    |   +-- For foreign formats: download RPM/DEB/Arch package file
-   +-- Parse package metadata into unified PackageMetadata
+   +-- Parse source metadata into the current unified PackageMetadata bridge
+   |   +-- W5 replaces this with lossless RPM, Debian, or ALPM authority
+   |   +-- Explicit fallible projections serve resolution, CCS, and transactions
    +-- Detect package format (magic bytes or extension)
    +-- Convert RPM/DEB/Arch input to source-independent CCS on-the-fly
    +-- Resolve source requirements against the typed host capability inventory
@@ -666,9 +668,16 @@ reverified against the model's explicit `[include].trusted_keys`; unsigned
 collections, missing trust roots, signer-ID mismatches, and stale cache
 metadata fail closed.
 
-**Unified format pipeline**: All package formats (RPM, DEB, Arch) are parsed
-into a common `PackageMetadata` struct. Conversion to the native CCS format
-happens transparently, either on the client or via the Remi server.
+**Source package authority pipeline**: The current parser implementation still
+routes RPM, Debian, and Arch facts through a common `PackageMetadata` bridge.
+That bridge is an active pre-alpha removal target because it conflates exact
+identity, declared capabilities, and format-specific configuration
+declarations before a consumer is known. The W5 contract in
+[`docs/specs/source-package-authority.md`](specs/source-package-authority.md)
+replaces it with lossless format-specific authority and explicit fallible
+projections for dependency resolution, CCS authoring, and native transaction
+planning. Conversion remains transparent to the caller, but normalization is
+owned by the named consumer rather than initial parsing.
 
 **Namespace isolation**: Scriptlets run in Linux containers (mount, PID, IPC,
 UTS namespaces) with resource limits. Capability enforcement uses mandatory

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-07-30
-revision: 58
-summary: Route exact Remi signing, serialized selected-root mutation, full-adoption captured-root continuity, typed rollback lineage, canonical-map authority, carrier security, typed generation GC, exact release authority, and subsystem proof through current feature owners.
+last_updated: 2026-08-03
+revision: 59
+summary: Route lossless source authority, exact Remi signing, selected-root mutation, rollback lineage, canonical-map authority, carrier security, generation GC, release authority, and subsystem proof through current feature owners.
 ---
 
 # Assistant Subsystem Map
@@ -136,7 +136,11 @@ commands.
 - CCS authoring, conversion, native package contracts, and repository feed
   profiles:
   `docs/modules/feature-ownership.md` slugs `ccs`, `packaging`, and `profiles`,
-  plus `docs/modules/ccs.md` and `docs/modules/recipe.md`. Native authoring
+  plus `docs/modules/ccs.md`,
+  `docs/specs/source-package-authority.md`, and `docs/modules/recipe.md`.
+  The source-authority specification owns the W5 lossless RPM, Debian, ALPM,
+  and CCS models plus their resolution, conversion, and transaction
+  projections. Native authoring
   content flow starts in `crates/conary-core/src/ccs/builder.rs`,
   `builder/source.rs`, `policy/content.rs`, and `builder/package_writer.rs`.
   Debian lifecycle
@@ -213,6 +217,7 @@ commands.
 
 - [`docs/modules/federation.md`](../modules/federation.md) for federation background
 - [`docs/modules/ccs.md`](../modules/ccs.md) for CCS format and conversion context
+- [`docs/specs/source-package-authority.md`](../specs/source-package-authority.md) for lossless RPM, Debian, ALPM, and CCS authority plus explicit consumer projections
 - [`docs/specs/foreign-package-lifecycle-contracts.md`](../specs/foreign-package-lifecycle-contracts.md) for authoritative RPM, Debian, and Arch lifecycle ABIs, transaction order, arguments, triggers, and payload visibility
 - [`docs/modules/feature-ownership.md`](../modules/feature-ownership.md) for feature ownership cards, neighboring systems, and interaction verification gates
 - [`docs/modules/test-fixtures.md`](../modules/test-fixtures.md) for Remi and CCS fixture ownership and proof commands

--- a/docs/modules/ccs.md
+++ b/docs/modules/ccs.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-07-30
-revision: 57
-summary: Convert foreign packages through typed authoring, host capability, lifecycle, and native export contracts
+last_updated: 2026-08-03
+revision: 58
+summary: Convert foreign packages through lossless source authority, typed authoring, host capability, lifecycle, and native export contracts
 ---
 
 # CCS Module (conary-core/src/ccs/)
@@ -357,6 +357,23 @@ CCS sits at the center of Conary's format pipeline. All package formats
 CAS-compatible content (SHA-256 keyed blobs), and the chunking system
 enables delta-efficient distribution via the Remi server.
 
+### Source authority design target
+
+The current parser-to-converter bridge still uses the flattened
+`PackageMetadata`, `ProvidedCapability`, and `ConfigFileInfo` types. W5 removes
+that bridge; new conversion work must not add another consumer to it. The
+canonical target is
+[`docs/specs/source-package-authority.md`](../specs/source-package-authority.md):
+RPM, Debian, and ALPM parsers retain their native ontologies, and named
+fallible projections serve dependency resolution, CCS authoring, and native
+transaction planning. Exact identity is separate from declared capabilities,
+and source config declarations are separate from materialized payload nodes.
+
+Issues #104 and #105 implement that hard cut as sibling slices. Until both
+land, this section describes the active design target rather than shipped CCS
+behavior; [`docs/specs/ccs-format-v2.md`](../specs/ccs-format-v2.md) remains the
+current signed-format contract.
+
 ## Fixture Ownership
 
 The first fixture ownership map for CCS conversion lives in
@@ -663,4 +680,5 @@ component selection; no script-disabling bypass exists, and component names
 do not infer lifecycle ownership.
 
 See also: [docs/specs/ccs-format-v2.md](/docs/specs/ccs-format-v2.md),
+[docs/specs/source-package-authority.md](/docs/specs/source-package-authority.md),
 [docs/ARCHITECTURE.md](/docs/ARCHITECTURE.md).

--- a/docs/roadmaps/development-roadmap.md
+++ b/docs/roadmaps/development-roadmap.md
@@ -1,11 +1,11 @@
 ---
-last_updated: 2026-07-31
-revision: 10
+last_updated: 2026-08-03
+revision: 11
 summary: Track Conary's cross-distro package milestone, ordered workstreams, evidence, blockers, and post-milestone horizons
 proof_baseline: "immutable v0.14.0 at fe23a604b64ea6f7cc87fce8298911e2245e027f and production remi-v0.9.5 at 101dba655257f1ff3d1bee689d9c5ac8b2b68cbd; exact asset, deployment, and released-package proof complete"
 current_milestone: first external tester loop
-active_workstream: W4 Source Fidelity Hard Cut
-next_workstream: W5 Source Authority Model
+active_workstream: W5 Source Authority Model
+next_workstream: W6 Authority Audit Closure
 ---
 
 # Codebase Development Roadmap
@@ -208,7 +208,10 @@ the stated scope, not whether a workstream happens to be active.
 - **Outcome:** ordinary Fedora and Arch repository packages stop failing
   conversion on Conary-invented invariants, and hosted Remi health becomes
   evidence bearing.
-- **Execution status:** active. This is the current workstream.
+- **Execution status:** implementation issues complete; aggregate gate
+  closeout remains active. The owned #98, #99, #102, #103, and #107 slices are
+  closed, while #110 still owns the typed corpus vocabulary required to report
+  the aggregate prewarm gate without message-text authority.
 - **Issues:** #102 (P0), #103 (P0), #98 (P0), #99 (P0, split into three
   slices), plus #107 for the Remi readiness probe.
 - **Ordering:** #102, #103, and #107 run in parallel with #98
@@ -244,7 +247,10 @@ the stated scope, not whether a workstream happens to be active.
 - **Outcome:** source package facts are preserved in their native ontology and
   normalized at each consumer's boundary, so the class of defect behind #98,
   #99, #104, and #105 cannot recur.
-- **Execution status:** blocked on W4.
+- **Execution status:** active. #108 owns the specification and roadmap
+  transition; #104 and #105 remain ordered after that design authority. W4's
+  aggregate proof can close in parallel because its source-format
+  implementation prerequisites are already merged.
 - **Issues:** #108 (design specification under `docs/specs/`), then #104 and
   #105 as sibling implementation slices.
 - **Rationale:** `PackageMetadata` and the flat `ProvidedCapability` and

--- a/docs/specs/ccs-format-v2.md
+++ b/docs/specs/ccs-format-v2.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-07-29
-revision: 8
-summary: Canonical signed CCS v2 authority, archive, payload, and trust contract
+last_updated: 2026-08-03
+revision: 9
+summary: Canonical current signed CCS v2 authority, archive, payload, and trust contract pending the W5 hard cut
 ---
 
 # CCS Package Format v2
@@ -251,6 +251,16 @@ Readers reject every `format_version` other than `2`. The format-1 rejection
 test uses a small hand-authored retired header so the repository does not need
 a v1 writer, schema, projection, fixture factory, or format specification.
 Git history is the only source for the removed pre-alpha implementation.
+
+## Planned W5 Hard Cut
+
+This document describes current shipped behavior. The approved W5 target in
+[`source-package-authority.md`](source-package-authority.md) replaces v2 with
+one current-only v3 authority that separates exact identity from capability
+provenance and source config declarations from materialized payload nodes.
+Issues #104 and #105 implement that sibling sequence. Until both land, no v3
+behavior is claimed here; after they land, v2 readers, writers, fixtures, and
+adapters are deleted rather than retained as compatibility paths.
 
 ## Proof
 

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-07-30
-revision: 38
-summary: Define source-independent lifecycle, generation activation, and configuration transactions for RPM, Debian, and Arch packages
+last_updated: 2026-08-03
+revision: 39
+summary: Define source-independent lifecycle, source-authority handoff, generation activation, and configuration transactions for RPM, Debian, and Arch packages
 ---
 
 # Foreign Package Lifecycle Contracts
@@ -11,6 +11,12 @@ from RPM, Debian, and Arch packages. The package managers expose finite,
 documented lifecycle ABIs around arbitrary program bodies. Conary models those
 ABIs directly; it does not infer lifecycle meaning from program text or
 delegate execution to the source package manager.
+
+[`source-package-authority.md`](source-package-authority.md) owns the upstream
+package identity, provision, payload-record, and config-declaration models plus
+their fallible projection into this lifecycle and transaction contract. This
+document remains the owner of event order, arguments, installed config state,
+and selected-root execution.
 
 ## Cross-Distro Product Contract
 

--- a/docs/specs/source-package-authority.md
+++ b/docs/specs/source-package-authority.md
@@ -1,0 +1,348 @@
+---
+last_updated: 2026-08-03
+revision: 1
+summary: Define lossless RPM, Debian, ALPM, and CCS package authority plus explicit consumer projections
+---
+
+# Source Package Authority And Consumer Projections
+
+## Status And Scope
+
+This specification is the design authority for roadmap workstream W5 and
+[issue #108](https://github.com/ConaryLabs/Conary/issues/108). It defines the
+hard-cut target implemented by issues
+[#104](https://github.com/ConaryLabs/Conary/issues/104) and
+[#105](https://github.com/ConaryLabs/Conary/issues/105); it does not claim that
+the target is already shipped.
+
+The current implementation still stores RPM, Debian, and ALPM parser output in
+one `PackageMetadata` value and exposes flattened `ProvidedCapability` and
+`ConfigFileInfo` values through `PackageFormat`. New consumers must not extend
+that surface. W5 removes it after the format-specific models and projections
+below exist.
+
+This specification owns package identity, dependency/provision authority,
+payload and configuration declarations, and their consumer boundaries.
+[`foreign-package-lifecycle-contracts.md`](foreign-package-lifecycle-contracts.md)
+continues to own lifecycle event order, arguments, configuration transactions,
+and selected-root execution. [`ccs-format-v2.md`](ccs-format-v2.md) describes
+the currently shipped signed CCS v2 envelope until the W5 hard cut replaces
+it.
+
+## Governing Rule
+
+> Normalize at the boundary of one named consumer, never while initially
+> parsing source authority.
+
+An RPM fact remains an RPM fact, a Debian fact remains a Debian fact, and an
+ALPM fact remains an ALPM fact until a fallible consumer projection asks for a
+specific target contract. Similar spelling does not establish shared
+semantics. In particular:
+
+- exact package identity is not an entry in a package's declared-provision
+  list;
+- a configuration declaration is not necessarily a materialized payload node;
+- a source path is not a host `std::path::Path`;
+- a payload record, a hardlink-set member, and the effective installed inode
+  are distinct facts; and
+- diagnostic or repository-discovery data is never mutation, publication, or
+  compatibility authority.
+
+No projection may silently discard a fact it needs, fill a missing fact from a
+filename or package name, or preserve an unrepresentable source semantic as an
+untyped string. It either produces the named consumer contract or returns a
+typed projection error before persistence, signing, publication, resolution,
+or mutation.
+
+## Authority Layers
+
+The package path on the build host, authenticated repository location, mirror
+URL, and download checksum identify transport and provenance. They are not
+package semantics. After trust verification, parsing produces one closed
+source-format sum:
+
+```text
+SourcePackageAuthority
+  +-- Rpm(RpmPackageAuthority)
+  +-- Debian(DebianPackageAuthority)
+  +-- Alpm(AlpmPackageAuthority)
+  +-- Ccs(CcsPackageAuthority)
+```
+
+The outer enum provides format dispatch only. It has no common `provides` or
+`config_files` fields and no lowest-common-denominator constructor. Each
+variant owns its exact source identity, relations, declarations, lifecycle,
+payload evidence, and source-path spelling. Shared payload primitives such as
+`PayloadNode`, `PayloadContentAuthority`, and reopenable content streams remain
+shared because they describe the same installed filesystem facts. Shared
+source-package fields do not imply a shared source ontology.
+
+`SourcePathBytes` preserves archive spelling and `DeploymentPath` is the
+fallible, traversal-checked materialization projection. Source parsing never
+passes untrusted archive bytes through a host path parser or lossy Unicode
+conversion. A future non-UTF-8 persistence contract must be an explicit signed
+and database schema decision; it cannot be introduced through diagnostics.
+
+## RPM Authority
+
+The RPM model is pinned to upstream RPM commit
+[`a8f0192aee1c08bd1454ed2ac6ebaf506004b55c`](https://github.com/rpm-software-management/rpm/tree/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c)
+and the corresponding [tag grammar](https://rpm.org/docs/latest/manual/tags).
+The format-specific model preserves:
+
+- exact NEVRA identity, including whether the epoch was absent, version,
+  release, and architecture;
+- each aligned dependency-tag record with its native sense flags, EVR,
+  architecture/color context, header index, and relation family;
+- every explicit `PROVIDENAME`/`PROVIDEVERSION`/`PROVIDEFLAGS` record as a
+  declared capability, separate from NEVRA identity and from RPM runtime
+  features;
+- each file-header record, source path, file flags, verify flags, node
+  metadata, payload association, and hardlink device/inode membership;
+- the content-bearing hardlink member and effective inode projection described
+  by `rpmfilesBuildNLink`, `rpmfiArchiveHasContent`, and `fsmMkfile` without
+  erasing the source records that established it;
+- `%config`, `%config(noreplace)`, `%ghost`, and `%missingok` as independent
+  source flags attached to their exact file record; and
+- the exact RPM lifecycle ABI owned by the lifecycle specification.
+
+RPM tag arrays that must align are validated as one indexed record set. A
+missing mate, impossible flag combination, conflicting payload association, or
+unsupported relation is a typed RPM parse error. The parser never synthesizes
+a self-provider entry: package-name satisfaction is derived from NEVRA by the
+resolution projection.
+
+## Debian Authority
+
+The Debian binary-package model is pinned to
+[Debian Policy 4.7.4.1 package relationships](https://www.debian.org/doc/debian-policy/ch-relationships.html),
+the [binary control-field contract](https://www.debian.org/doc/debian-policy/ch-controlfields.html),
+the [configuration-file contract](https://www.debian.org/doc/debian-policy/ch-files.html#configuration-files),
+and dpkg's pinned dependency implementation at commit
+[`7004a048f4b122c133f1b08661be1399ce0a4dd7`](https://git.dpkg.org/cgit/dpkg/dpkg.git/tree/lib/dpkg/depcon.c?id=7004a048f4b122c133f1b08661be1399ce0a4dd7).
+The format-specific model preserves:
+
+- exact `Package`, `Version`, `Architecture`, and `Multi-Arch` identity fields;
+- each relationship field as its own native family, retaining alternatives,
+  qualifiers, version relation, version boundary, and source order;
+- every explicit `Provides` atom as a virtual capability, including its
+  optional exact-equality version and architecture qualifier, separate from
+  concrete package identity;
+- each data-tar payload record and exact source path;
+- each `DEBIAN/conffiles` declaration as a declaration record with its exact
+  absolute path and optional `remove-on-upgrade` flag; and
+- the exact maintainer-script, trigger, and control-artifact ABI owned by the
+  lifecycle specification.
+
+An unflagged conffile declaration normally refers to one incoming payload
+node. A `remove-on-upgrade` declaration must not have incoming payload.
+Contradictions fail as typed Debian source-authority errors. The declaration is
+preserved separately from the matched node so validation and transaction
+planning can distinguish declaration evidence, incoming bytes, installed old
+state, and removal policy.
+
+## ALPM Authority
+
+The ALPM model is pinned to pacman commit
+[`a6f7467d8c7c4d7e9cc846884e74c0ab7215c48d`](https://gitlab.archlinux.org/pacman/pacman/-/tree/a6f7467d8c7c4d7e9cc846884e74c0ab7215c48d),
+the versioned [PKGINFO grammar](https://man.archlinux.org/man/PKGINFO.5.en), and
+the [PKGBUILD provision and backup contracts](https://man.archlinux.org/man/PKGBUILD.5.en).
+The format-specific model preserves:
+
+- exact `pkgname`, full `pkgver`, `arch`, and package-type identity;
+- each `depend`, `optdepend`, `conflict`, `replaces`, and `provides` assignment
+  as an ordered, typed ALPM relation;
+- every explicit `provides` assignment as a virtual or package capability,
+  even when it deliberately reuses `pkgname` with a compatibility version;
+- each archive payload record, libarchive xattr, source path, and exact node;
+- every `backup` assignment as an ordered relative source declaration,
+  separately from payload matching and the installed three-hash state; and
+- `.INSTALL` functions and ALPM hooks under the lifecycle specification.
+
+A `backup` declaration does not create a payload node. The payload projection
+records whether an exact archive entry matches it; an unmatched declaration is
+retained as signed source evidence and produces no invented file. Update,
+remove, and rollback consume the declaration together with old, current, and
+new content identities according to pacman's documented three-hash behavior.
+
+## CCS Authority
+
+CCS is already a consumer contract, not another foreign-source normalization
+step. Direct CCS authoring produces CCS authority from explicit author input;
+foreign conversion produces it only through the CCS projection below.
+
+W5 establishes one current-only signed authority epoch in which:
+
+- `identity` is the sole exact package identity;
+- `capabilities` contains author-declared, source-declared, or source-derived
+  capabilities with an explicit provenance tag;
+- exact identity is never duplicated inside `capabilities`;
+- source configuration declarations are represented separately from matched
+  materialized config nodes and installed config state; and
+- payload, lifecycle, relations, configuration declarations, and capability
+  provenance participate in signed content identity.
+
+The implementation hard cut promotes CCS v3 as the sole signed package
+authority and deletes v2 reading, writing, fixtures, projections, and fallback
+paths in the same W5 sequence. No release may be cut between the #104 and #105
+sibling slices: together they establish the complete v3 identity/capability
+and configuration shape. Existing v2 artifacts are rebuilt or reconverted;
+they are not adapted.
+
+Capability provenance is a closed enum with at least these roles:
+
+| Role | Meaning |
+|---|---|
+| `author-declared` | Explicit capability in a directly authored CCS package |
+| `source-declared` | Exact RPM, Debian, or ALPM provision with source-format identity and source-record position |
+| `source-derived-file` | Capability derived by one pinned source-format rule from an exact payload record |
+
+Package-name satisfaction comes directly from signed `identity`. It is not a
+fourth capability role. A duplicate or contradictory identity, an unknown
+provenance role, or a provenance/source-format mismatch fails signed-authority
+validation.
+
+## Consumer Projections
+
+### Dependency Resolution
+
+The resolution projection consumes exact source identity, requirements,
+relations, explicit provisions, source version algebra, and architecture
+semantics. It emits the repository/SAT model only after tagging each emitted
+provider with its origin. It derives one exact package-name match from identity
+without adding it to the source-declared provision list.
+
+It may omit payload bytes, xattrs, configuration declarations, lifecycle
+bodies, build-only diagnostics, and transport provenance because none decide a
+SAT match. It may not omit relation alternatives, ordering strength,
+architecture qualifiers, version scheme, provider relation, or capability
+origin.
+
+Failures are typed `ResolutionProjectionError` variants, including malformed
+source relation, unrepresentable architecture qualifier, unsupported version
+relation, and contradictory identity. They retain source format and record
+location; message text is diagnostic only.
+
+### CCS Authoring And Conversion
+
+The CCS projection consumes the complete authenticated source model plus its
+reopenable payload. It must represent exact identity, payload nodes and
+content, relations, capability provenance, configuration declarations,
+lifecycle ABI, and conversion provenance. This projection has no permitted
+semantic loss. Source-only transport details may be omitted only after their
+authenticated digest and conversion boundary are recorded where required.
+
+Failures are typed `CcsProjectionError` variants, including
+`UnrepresentableIdentity`, `UnrepresentableCapability`,
+`UnrepresentableConfigDeclaration`, `PayloadDeclarationMismatch`,
+`MissingLifecycleAuthority`, and `BudgetExceeded`. A failure stops before
+signing or Remi publication. Package-name, path, or distro exceptions are not
+valid recovery.
+
+### Native Transaction Planning
+
+The transaction projection consumes verified CCS authority, installed old
+state, selected-root facts, and the target capability inventory. It derives
+install, update, remove, rollback, trigger, and configuration events. It may
+omit source build metadata, repository fetch hints, and diagnostic evidence;
+it may not omit source lifecycle entries, capability origin needed for
+resolution or persistence, payload ownership, config declarations, old/new
+content identities, source-format order, or recovery actions.
+
+Failures are typed `NativeTransactionProjectionError` variants, including
+missing installed authority, unsupported source event, config state
+contradiction, payload ownership conflict, and missing target capability. They
+stop preflight before mutation. They never become a warning, manual-review
+queue, source-package-manager fallback, or best-effort transaction.
+
+## Ownership And Module Boundaries
+
+The implementation decomposition is ownership-based:
+
+- `packages/rpm/authority.rs`, `packages/deb/authority.rs`, and
+  `packages/arch/authority.rs` own source-format identity, relations,
+  provisions, and config declarations. Existing parser hubs retain dispatch
+  and re-exports only.
+- `packages/source_authority.rs` owns the closed format-dispatch enum. It does
+  not own shared flattened fields.
+- `packages/payload.rs`, `payload.rs`, and `filesystem/source_path.rs` retain
+  their existing shared payload-stream, node, and byte-exact path ownership.
+- `repository/dependency_model.rs` remains a resolution-consumer DTO. Native
+  parsers stop constructing it as their source authority.
+- `ccs/convert/source_projection/` owns the explicit RPM, Debian, and ALPM to
+  CCS projections; `convert/converter.rs` remains orchestration only.
+- the current signed CCS schema directory is replaced by `ccs/v3/`, with
+  identity/capability validation and configuration-declaration validation in
+  separate focused children.
+- native transaction and config transaction modules consume verified CCS
+  authority; they do not parse source packages or recover declarations from
+  payload paths.
+
+New business logic does not go into the existing parser, converter, package,
+or validation hubs. This keeps the affected files below the 1,000-line
+planning gate and makes each source ontology independently reviewable.
+
+## Hard-Cut Deletion And Replacement Map
+
+The W5 implementation is incomplete until these ambiguous surfaces are gone:
+
+| Current surface | Required replacement |
+|---|---|
+| `packages/common.rs::PackageMetadata` and its `packages::PackageMetadata` re-export | Format-specific authority structs plus closed `SourcePackageAuthority` dispatch |
+| `packages/traits.rs::ProvidedCapability` and `PackageFormat::provides()` | Per-format declared-provision records; resolution and CCS projection DTOs exist only at their consumer boundaries |
+| `packages/traits.rs::ConfigFileInfo` and `PackageFormat::config_files()` | Per-format config declaration records plus separate matched payload/config transaction authority |
+| `RpmPackage::{extract_provides, extract_config_files}` | RPM authority parsing in `packages/rpm/authority.rs` |
+| `DebPackage::{convert_provides, parse_conffiles}` | Debian authority parsing in `packages/deb/authority.rs` |
+| `ArchPackage::parse_provides` and the backup-to-`ConfigFileInfo` loop | ALPM authority parsing and explicit backup matching in `packages/arch/authority.rs` |
+| `ccs/convert/converter.rs::signed_native_provides` | Format-specific CCS capability projection with provenance |
+| `ccs/package/v2_projection.rs::{provides_from_v2_authority, config_files_from_v2_authority}` | Verified v3 install and transaction projections that preserve the authority distinction |
+| v2 validation's name-equality self-provider inference | Identity validation plus independent capability-provenance validation |
+| CCS v2 reader, writer, fixtures, and format routing | Sole current CCS v3 contract; v2 artifacts are rejected and rebuilt |
+
+Callers such as batch install, conversion preparation, installed-authority
+snapshots, `provides` persistence, and config persistence move to the named
+consumer DTOs. Renaming the old structs or retaining adapters beside the new
+model does not satisfy this deletion gate.
+
+## Persistence And Rebuild Impact
+
+The signed CCS contract and installed database both change intentionally.
+
+- CCS v3 replaces v2; every local, cached, static-repository, and Remi v2
+  artifact must be rebuilt or reconverted from authenticated source.
+- The current SQLite schema is replaced in place at the next schema revision.
+  Installed and repository provider rows must distinguish identity-derived
+  matches from declared/derived capabilities, and config persistence must
+  distinguish source declarations from materialized node and transaction
+  state.
+- Existing pre-W5 databases are disposable and must be recreated with
+  `conary system init` plus repository resync/reinstallation. No migration,
+  compatibility decoder, dual write, or fallback reader is added.
+- Remi conversion records and indexes tied to v2 authority are rebuilt before
+  public serving. A mixed v2/v3 serving state is invalid.
+
+The exact numeric database revision is chosen at implementation landing time
+from then-current `SCHEMA_VERSION`; this specification fixes the rebuild
+property, not a stale future number.
+
+## Conformance And Closeout
+
+The implementation issues prove the property across formats, not only the two
+reported packages:
+
+- the pinned ASP.NET ALPM fixtures retain exact package identity and their
+  same-name compatibility provision, and resolution distinguishes both;
+- the pinned `bash-completion` ALPM fixture retains its unmatched backup
+  declaration without inventing a payload node;
+- RPM fixtures distinguish NEVRA identity, explicit provides, config/ghost
+  flags, and effective hardlink inode authority;
+- Debian fixtures distinguish concrete identity, versioned virtual provides,
+  ordinary conffiles, and `remove-on-upgrade` declarations;
+- each consumer projection has contract tests for every source variant and
+  every typed refusal; and
+- stale searches prove the flattened structs, helpers, adapters, v2 schema,
+  and compatibility routes are absent.
+
+Focused package parser, resolution, CCS signing/reopen, native transaction,
+Remi conversion/publication, strict workspace Clippy/format, and documentation
+truth gates all pass before W5 closes.


### PR DESCRIPTION
## Primary Issue

Closes #108

Design / Plan / Roadmap:

- `docs/specs/source-package-authority.md`
- W5 Source Authority Model in `docs/roadmaps/development-roadmap.md`

## Problem And Outcome

RPM, Debian, and ALPM parser facts currently pass through one `PackageMetadata` bridge with flattened provider and configuration types. That erases source ontology before dependency resolution, CCS authoring, or transaction planning has named the facts it needs.

After merge, the repository has one durable W5 design authority: format-specific source models, explicit fallible consumer projections, an ownership-based module decomposition, and an exact deletion/rebuild map for #104 and #105. Current CCS v2 behavior remains described truthfully until those implementation slices complete the approved v3 hard cut.

## Changes

- add the canonical lossless source-package authority and consumer-projection specification
- pin RPM, Debian/dpkg, and ALPM authority to upstream contracts
- define identity, declared capability, payload, config declaration, and lifecycle boundaries per format
- define required facts, permitted losses, and typed failures for resolution, CCS, and transaction projections
- choose a sole-current CCS v3 hard cut and record artifact/database rebuild impact
- route the specification from architecture, CCS module, lifecycle/CCS specs, and assistant subsystem map
- advance W5 while retaining the separate outstanding W4 aggregate gate

## Scope

- In scope: durable design authority, routing, deletion/replacement map, persisted/signed rebuild impact, roadmap transition
- Out of scope: implementing #104 or #105, changing runtime behavior, adding compatibility adapters, or claiming CCS v3 is already shipped

## Ownership / Boundary

- Owning subsystem: CCS and native package parsers
- Boundary changed or preserved: documents the future parser-to-consumer authority boundary; runtime remains unchanged
- Persisted state or public surface impact: future CCS v3 artifacts and a current-only SQLite schema rebuild are required by implementation; this PR changes documentation only
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed (no behavior change; documentation truth fixtures exercised)
- [x] Ran affected-package verification directly when touching service or daemon code (not applicable)
- [x] Updated subsystem docs or maps when the "look here first" path changed
- [x] Ran the broader interaction gate when the feature ownership card required it (not applicable to docs-only design)
- [x] Updated #104 and #105 with the specification and PR #252 as their shared design authority

```text
- bash scripts/check-doc-truth.sh
- bash scripts/test-doc-truth.sh
- bash scripts/test-agent-context.sh
- bash scripts/agent-context.sh --validate
- bash scripts/maintainability-drift-report.sh
- git diff --check
```

## Review And Merge Notes

- Review focus: whether the per-format models preserve source authority; whether CCS v3 is the correct coordinated hard cut; whether projection loss/error boundaries and deletion map are complete
- User or developer impact: gives #104 and #105 one implementation target and prevents further consumers of the flattened bridge
- Required-check bypass: not used
