### PR TITLE
fix(db): reject corrupt persisted statuses

### DIFF
--- a/crates/conary-core/src/db/current_schema/sql/package_manager.sql
+++ b/crates/conary-core/src/db/current_schema/sql/package_manager.sql
@@ -405,7 +405,8 @@ CREATE TABLE changeset_triggers (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             changeset_id INTEGER NOT NULL REFERENCES changesets(id) ON DELETE CASCADE,
             trigger_id INTEGER NOT NULL REFERENCES triggers(id) ON DELETE CASCADE,
-            status TEXT NOT NULL DEFAULT 'pending',
+            status TEXT NOT NULL DEFAULT 'pending'
+                CHECK(status IN ('pending', 'running', 'completed', 'failed', 'skipped')),
             matched_files INTEGER NOT NULL DEFAULT 0,
             started_at TEXT,
             completed_at TEXT,

--- a/crates/conary-core/src/db/current_schema/sql/repository.sql
+++ b/crates/conary-core/src/db/current_schema/sql/repository.sql
@@ -131,14 +131,25 @@ CREATE TABLE derived_packages (
             created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
             updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
             -- Status: pending (not built), built, stale (parent updated), error
-            status TEXT NOT NULL DEFAULT 'pending',
+            status TEXT NOT NULL DEFAULT 'pending'
+                CHECK(status IN ('pending', 'built', 'stale', 'error')),
             -- Built trove ID (when status = built)
             built_trove_id INTEGER REFERENCES troves(id) ON DELETE SET NULL,
             -- Model file this came from (NULL if created via CLI)
             model_source TEXT,
             -- Error message if status = error
-            error_message TEXT
-        , last_built_version TEXT, last_built_parent_version TEXT, build_artifact_hash TEXT, build_artifact_path TEXT, build_artifact_size INTEGER);
+            error_message TEXT,
+            last_built_version TEXT,
+            last_built_parent_version TEXT,
+            build_artifact_hash TEXT,
+            build_artifact_path TEXT,
+            build_artifact_size INTEGER,
+            CHECK (
+                (version_policy = 'inherit' AND version_suffix IS NULL AND specific_version IS NULL)
+                OR (version_policy = 'suffix' AND version_suffix IS NOT NULL AND specific_version IS NULL)
+                OR (version_policy = 'specific' AND version_suffix IS NULL AND specific_version IS NOT NULL)
+            )
+        );
 CREATE INDEX idx_derived_packages_parent ON derived_packages(parent_name);
 CREATE INDEX idx_derived_packages_status ON derived_packages(status);
 CREATE INDEX idx_derived_packages_built ON derived_packages(built_trove_id);

--- a/crates/conary-core/src/db/models/derived.rs
+++ b/crates/conary-core/src/db/models/derived.rs
@@ -11,7 +11,9 @@
 
 use crate::error::Result;
 use rusqlite::{Connection, OptionalExtension, Row, params};
-use strum_macros::{AsRefStr, EnumString};
+use strum_macros::AsRefStr;
+
+use super::persisted_value::{InvalidPersistedValue, persisted_value_corruption};
 
 /// Version policy for derived packages
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -26,11 +28,25 @@ pub enum VersionPolicy {
 
 impl VersionPolicy {
     /// Parse version policy from database strings
-    pub fn from_db(policy: &str, suffix: Option<&str>, specific: Option<&str>) -> Self {
-        match policy {
-            "suffix" => VersionPolicy::Suffix(suffix.unwrap_or("+derived").to_string()),
-            "specific" => VersionPolicy::Specific(specific.unwrap_or("1.0.0").to_string()),
-            _ => VersionPolicy::Inherit,
+    pub fn from_db(
+        policy: &str,
+        suffix: Option<&str>,
+        specific: Option<&str>,
+    ) -> std::result::Result<Self, InvalidPersistedValue> {
+        match (policy, suffix, specific) {
+            ("inherit", None, None) => Ok(Self::Inherit),
+            ("suffix", Some(suffix), None) => Ok(Self::Suffix(suffix.to_string())),
+            ("specific", None, Some(specific)) => Ok(Self::Specific(specific.to_string())),
+            ("inherit" | "suffix" | "specific", _, _) => Err(InvalidPersistedValue::new(
+                "derived version policy",
+                policy,
+                "a policy with exactly its required value column",
+            )),
+            (other, _, _) => Err(InvalidPersistedValue::new(
+                "derived version policy",
+                other,
+                "inherit, suffix, or specific",
+            )),
         }
     }
 
@@ -63,7 +79,7 @@ impl VersionPolicy {
 }
 
 /// Build status of a derived package
-#[derive(Debug, Clone, PartialEq, Eq, AsRefStr, EnumString)]
+#[derive(Debug, Clone, PartialEq, Eq, AsRefStr)]
 #[strum(serialize_all = "lowercase")]
 pub enum DerivedStatus {
     /// Not yet built
@@ -80,9 +96,23 @@ impl DerivedStatus {
     pub fn as_str(&self) -> &str {
         self.as_ref()
     }
+}
 
-    pub fn parse(s: &str) -> Self {
-        s.parse().unwrap_or(DerivedStatus::Pending)
+impl TryFrom<&str> for DerivedStatus {
+    type Error = InvalidPersistedValue;
+
+    fn try_from(value: &str) -> std::result::Result<Self, InvalidPersistedValue> {
+        match value {
+            "pending" => Ok(Self::Pending),
+            "built" => Ok(Self::Built),
+            "stale" => Ok(Self::Stale),
+            "error" => Ok(Self::Error),
+            other => Err(InvalidPersistedValue::new(
+                "derived package status",
+                other,
+                "pending, built, stale, or error",
+            )),
+        }
     }
 }
 
@@ -276,14 +306,17 @@ impl DerivedPackage {
     /// Find all derived packages by status
     pub fn find_by_status(conn: &Connection, status: DerivedStatus) -> Result<Vec<Self>> {
         let sql = format!(
-            "SELECT {} FROM derived_packages WHERE status = ?1 ORDER BY name",
+            "SELECT {} FROM derived_packages ORDER BY name",
             Self::COLUMNS
         );
         let mut stmt = conn.prepare(&sql)?;
         let packages = stmt
-            .query_map([status.as_str()], Self::from_row)?
+            .query_map([], Self::from_row)?
             .collect::<std::result::Result<Vec<_>, _>>()?;
-        Ok(packages)
+        Ok(packages
+            .into_iter()
+            .filter(|package| package.status == status)
+            .collect())
     }
 
     /// List all derived packages
@@ -447,24 +480,30 @@ impl DerivedPackage {
 
     /// Convert a database row to a DerivedPackage
     fn from_row(row: &Row) -> rusqlite::Result<Self> {
+        let id: i64 = row.get(0)?;
         let policy_str: String = row.get(5)?;
         let suffix: Option<String> = row.get(6)?;
         let specific: Option<String> = row.get(7)?;
         let status_str: String = row.get(9)?;
+        let version_policy =
+            VersionPolicy::from_db(&policy_str, suffix.as_deref(), specific.as_deref()).map_err(
+                |error| {
+                    persisted_value_corruption("derived_packages", id, "version_policy", 5, error)
+                },
+            )?;
+        let status = DerivedStatus::try_from(status_str.as_str()).map_err(|error| {
+            persisted_value_corruption("derived_packages", id, "status", 9, error)
+        })?;
 
         Ok(Self {
-            id: Some(row.get(0)?),
+            id: Some(id),
             name: row.get(1)?,
             parent_trove_id: row.get(2)?,
             parent_name: row.get(3)?,
             parent_version: row.get(4)?,
-            version_policy: VersionPolicy::from_db(
-                &policy_str,
-                suffix.as_deref(),
-                specific.as_deref(),
-            ),
+            version_policy,
             description: row.get(8)?,
-            status: DerivedStatus::parse(&status_str),
+            status,
             built_trove_id: row.get(10)?,
             last_built_version: row.get(11)?,
             last_built_parent_version: row.get(12)?,
@@ -681,8 +720,34 @@ impl DerivedOverride {
 
 #[cfg(test)]
 mod tests {
+    use super::super::persisted_value::PersistedValueCorruption;
     use super::*;
     use crate::db::testing::create_test_db;
+
+    fn assert_persisted_corruption(
+        error: crate::error::Error,
+        row_id: i64,
+        column_index: usize,
+        column: &str,
+        value: &str,
+    ) {
+        let crate::error::Error::Database(rusqlite::Error::FromSqlConversionFailure(
+            actual_column_index,
+            rusqlite::types::Type::Text,
+            source,
+        )) = error
+        else {
+            panic!("unexpected error: {error}");
+        };
+        assert_eq!(actual_column_index, column_index);
+        let corruption = source
+            .downcast_ref::<PersistedValueCorruption>()
+            .expect("model error must retain typed row corruption");
+        assert_eq!(corruption.table(), "derived_packages");
+        assert_eq!(corruption.row_id(), row_id);
+        assert_eq!(corruption.column(), column);
+        assert_eq!(corruption.value(), value);
+    }
 
     #[test]
     fn test_derived_package_crud() {
@@ -748,6 +813,48 @@ mod tests {
 
         let specific = VersionPolicy::Specific("2.0.0".to_string());
         assert_eq!(specific.compute_version("1.0.0"), "2.0.0");
+    }
+
+    #[test]
+    fn corrupt_status_is_not_hidden_by_status_queries() {
+        let (_temp, conn) = create_test_db();
+        let mut derived = DerivedPackage::new("corrupt-status".into(), "parent".into());
+        let row_id = derived.insert(&conn).unwrap();
+
+        conn.pragma_update(None, "ignore_check_constraints", true)
+            .unwrap();
+        conn.execute(
+            "UPDATE derived_packages SET status = 'maybe-built' WHERE id = ?1",
+            [row_id],
+        )
+        .unwrap();
+        conn.pragma_update(None, "ignore_check_constraints", false)
+            .unwrap();
+
+        let error = DerivedPackage::find_by_status(&conn, DerivedStatus::Pending).unwrap_err();
+        assert_persisted_corruption(error, row_id, 9, "status", "maybe-built");
+    }
+
+    #[test]
+    fn corrupt_version_policy_shape_fails_closed() {
+        let (_temp, conn) = create_test_db();
+        let mut derived = DerivedPackage::new("corrupt-policy".into(), "parent".into());
+        let row_id = derived.insert(&conn).unwrap();
+
+        conn.pragma_update(None, "ignore_check_constraints", true)
+            .unwrap();
+        conn.execute(
+            "UPDATE derived_packages
+             SET version_policy = 'suffix', version_suffix = NULL, specific_version = NULL
+             WHERE id = ?1",
+            [row_id],
+        )
+        .unwrap();
+        conn.pragma_update(None, "ignore_check_constraints", false)
+            .unwrap();
+
+        let error = DerivedPackage::find_by_id(&conn, row_id).unwrap_err();
+        assert_persisted_corruption(error, row_id, 5, "version_policy", "suffix");
     }
 
     #[test]

--- a/crates/conary-core/src/db/models/mod.rs
+++ b/crates/conary-core/src/db/models/mod.rs
@@ -50,6 +50,7 @@ mod native_lifecycle_residual_state;
 mod native_publication;
 mod package_payload_ownership;
 mod payload_claim;
+mod persisted_value;
 mod provenance;
 mod provide_entry;
 mod redirect;
@@ -111,6 +112,7 @@ pub use native_publication::{
 };
 pub use package_payload_ownership::{PackagePayloadEntry, PackagePayloadOwnership};
 pub use payload_claim::{PayloadClaim, PayloadClaimAnchorPolicy};
+pub use persisted_value::{InvalidPersistedValue, PersistedValueCorruption};
 pub use provenance::Provenance;
 pub use provide_entry::ProvideEntry;
 pub use redirect::{Redirect, RedirectType, ResolveResult};

--- a/crates/conary-core/src/db/models/persisted_value.rs
+++ b/crates/conary-core/src/db/models/persisted_value.rs
@@ -1,0 +1,86 @@
+// conary-core/src/db/models/persisted_value.rs
+
+//! Typed failures for persisted enum and tagged-value corruption.
+
+use rusqlite::types::Type;
+use thiserror::Error;
+
+/// A persisted value that cannot be represented by its owning Rust type.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("invalid persisted {kind} value {value:?}: expected {expected}")]
+pub struct InvalidPersistedValue {
+    kind: &'static str,
+    value: String,
+    expected: &'static str,
+}
+
+impl InvalidPersistedValue {
+    pub(super) fn new(
+        kind: &'static str,
+        value: impl Into<String>,
+        expected: &'static str,
+    ) -> Self {
+        Self {
+            kind,
+            value: value.into(),
+            expected,
+        }
+    }
+
+    /// The persisted value that failed validation.
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+}
+
+/// Exact row context for a persisted value that violates its typed contract.
+#[derive(Debug, Error)]
+#[error("database corruption in {table} row {row_id}: column {column} contains {source}")]
+pub struct PersistedValueCorruption {
+    table: &'static str,
+    row_id: i64,
+    column: &'static str,
+    #[source]
+    source: InvalidPersistedValue,
+}
+
+impl PersistedValueCorruption {
+    /// The table containing the corrupt row.
+    pub fn table(&self) -> &str {
+        self.table
+    }
+
+    /// The primary-key identity of the corrupt row.
+    pub fn row_id(&self) -> i64 {
+        self.row_id
+    }
+
+    /// The column containing the corrupt value.
+    pub fn column(&self) -> &str {
+        self.column
+    }
+
+    /// The invalid persisted value.
+    pub fn value(&self) -> &str {
+        self.source.value()
+    }
+}
+
+pub(super) fn persisted_value_corruption(
+    table: &'static str,
+    row_id: i64,
+    column: &'static str,
+    column_index: usize,
+    source: InvalidPersistedValue,
+) -> rusqlite::Error {
+    rusqlite::Error::FromSqlConversionFailure(
+        column_index,
+        Type::Text,
+        Box::new(PersistedValueCorruption {
+            table,
+            row_id,
+            column,
+            source,
+        }),
+    )
+}

--- a/crates/conary-core/src/db/models/trigger.rs
+++ b/crates/conary-core/src/db/models/trigger.rs
@@ -16,7 +16,9 @@ use crate::error::Result;
 use glob::Pattern;
 use rusqlite::{Connection, OptionalExtension, Row, params};
 use std::collections::HashMap;
-use strum_macros::{AsRefStr, EnumString};
+use strum_macros::AsRefStr;
+
+use super::persisted_value::{InvalidPersistedValue, persisted_value_corruption};
 
 /// A trigger defines a handler that runs when files matching a pattern are modified
 #[derive(Debug, Clone)]
@@ -317,7 +319,7 @@ impl TriggerDependency {
 }
 
 /// Status of a trigger in a changeset
-#[derive(Debug, Clone, PartialEq, Eq, AsRefStr, EnumString)]
+#[derive(Debug, Clone, PartialEq, Eq, AsRefStr)]
 #[strum(serialize_all = "lowercase")]
 pub enum TriggerStatus {
     Pending,
@@ -331,9 +333,24 @@ impl TriggerStatus {
     pub fn as_str(&self) -> &str {
         self.as_ref()
     }
+}
 
-    pub fn parse(s: &str) -> Self {
-        s.parse().unwrap_or(TriggerStatus::Pending)
+impl TryFrom<&str> for TriggerStatus {
+    type Error = InvalidPersistedValue;
+
+    fn try_from(value: &str) -> std::result::Result<Self, Self::Error> {
+        match value {
+            "pending" => Ok(Self::Pending),
+            "running" => Ok(Self::Running),
+            "completed" => Ok(Self::Completed),
+            "failed" => Ok(Self::Failed),
+            "skipped" => Ok(Self::Skipped),
+            other => Err(InvalidPersistedValue::new(
+                "trigger status",
+                other,
+                "pending, running, completed, failed, or skipped",
+            )),
+        }
     }
 }
 
@@ -461,23 +478,30 @@ impl ChangesetTrigger {
     /// Get pending triggers for a changeset
     pub fn find_pending(conn: &Connection, changeset_id: i64) -> Result<Vec<Self>> {
         let sql = format!(
-            "SELECT {} FROM changeset_triggers WHERE changeset_id = ?1 AND status = 'pending'",
+            "SELECT {} FROM changeset_triggers WHERE changeset_id = ?1",
             Self::COLUMNS
         );
         let mut stmt = conn.prepare(&sql)?;
         let triggers = stmt
             .query_map([changeset_id], Self::from_row)?
             .collect::<std::result::Result<Vec<_>, _>>()?;
-        Ok(triggers)
+        Ok(triggers
+            .into_iter()
+            .filter(|trigger| trigger.status == TriggerStatus::Pending)
+            .collect())
     }
 
     fn from_row(row: &Row) -> rusqlite::Result<Self> {
+        let id: i64 = row.get(0)?;
         let status_str: String = row.get(3)?;
+        let status = TriggerStatus::try_from(status_str.as_str()).map_err(|error| {
+            persisted_value_corruption("changeset_triggers", id, "status", 3, error)
+        })?;
         Ok(Self {
-            id: Some(row.get(0)?),
+            id: Some(id),
             changeset_id: row.get(1)?,
             trigger_id: row.get(2)?,
-            status: TriggerStatus::parse(&status_str),
+            status,
             matched_files: row.get(4)?,
             started_at: row.get(5)?,
             completed_at: row.get(6)?,
@@ -488,8 +512,10 @@ impl ChangesetTrigger {
 
 #[cfg(test)]
 mod tests {
+    use super::super::persisted_value::PersistedValueCorruption;
     use super::super::trigger_engine::TriggerEngine;
     use super::*;
+    use crate::trigger::TriggerExecutor;
     use tempfile::NamedTempFile;
 
     fn create_test_db() -> (NamedTempFile, Connection) {
@@ -526,7 +552,8 @@ mod tests {
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 changeset_id INTEGER NOT NULL,
                 trigger_id INTEGER NOT NULL,
-                status TEXT NOT NULL DEFAULT 'pending',
+                status TEXT NOT NULL DEFAULT 'pending'
+                    CHECK(status IN ('pending', 'running', 'completed', 'failed', 'skipped')),
                 matched_files INTEGER NOT NULL DEFAULT 0,
                 started_at TEXT,
                 completed_at TEXT,
@@ -644,6 +671,65 @@ mod tests {
         let message = format!("{error:#}");
         assert!(message.contains("corrupt"), "{message}");
         assert!(message.contains("invalid path pattern"), "{message}");
+    }
+
+    #[test]
+    fn corrupt_persisted_status_stops_execution_before_the_handler_loop() {
+        let (_temp, conn) = create_test_db();
+        let mut trigger = Trigger::new(
+            "must-not-run".to_string(),
+            "/usr/lib/*".to_string(),
+            "/bin/true".to_string(),
+        )
+        .unwrap();
+        let trigger_id = trigger.insert(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO changesets (description) VALUES ('corrupt status')",
+            [],
+        )
+        .unwrap();
+        let changeset_id = conn.last_insert_rowid();
+        let mut changeset_trigger = ChangesetTrigger::new(changeset_id, trigger_id);
+        let row_id = changeset_trigger.upsert(&conn).unwrap();
+
+        conn.pragma_update(None, "ignore_check_constraints", true)
+            .unwrap();
+        conn.execute(
+            "UPDATE changeset_triggers SET status = 'already-ran-maybe' WHERE id = ?1",
+            [row_id],
+        )
+        .unwrap();
+        conn.pragma_update(None, "ignore_check_constraints", false)
+            .unwrap();
+
+        let root = tempfile::tempdir().unwrap();
+        let error = TriggerExecutor::new(&conn, root.path())
+            .execute_pending(changeset_id)
+            .unwrap_err();
+        let crate::error::Error::Database(rusqlite::Error::FromSqlConversionFailure(
+            3,
+            rusqlite::types::Type::Text,
+            source,
+        )) = error
+        else {
+            panic!("unexpected error: {error}");
+        };
+        let corruption = source
+            .downcast_ref::<PersistedValueCorruption>()
+            .expect("status error must retain typed row corruption");
+        assert_eq!(corruption.table(), "changeset_triggers");
+        assert_eq!(corruption.row_id(), row_id);
+        assert_eq!(corruption.column(), "status");
+        assert_eq!(corruption.value(), "already-ran-maybe");
+
+        let stored_status: String = conn
+            .query_row(
+                "SELECT status FROM changeset_triggers WHERE id = ?1",
+                [row_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored_status, "already-ran-maybe");
     }
 
     #[test]

--- a/crates/conary-core/src/db/schema.rs
+++ b/crates/conary-core/src/db/schema.rs
@@ -12,13 +12,12 @@ use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 use std::path::Path;
 use tracing::info;
 
-/// Revision 24 of the current-only schema epoch.
+/// Revision 25 of the current-only schema epoch.
 ///
-/// Revision 24 retains revision 23's exact payload claims and selected-root
-/// materialization anchors, and adds exact capability provenance to installed
-/// and repository provider rows. Earlier pre-alpha databases must be rebuilt;
-/// no compatibility migration is provided.
-pub const SCHEMA_VERSION: i32 = 24;
+/// Revision 25 retains revision 24's exact source authority and adds fail-closed
+/// constraints for trigger and derived-package persisted states. Earlier
+/// pre-alpha databases must be rebuilt; no compatibility migration is provided.
+pub const SCHEMA_VERSION: i32 = 25;
 /// Stable identity that distinguishes this epoch from retired schema revisions.
 pub const SCHEMA_EPOCH: &str = "conary-current-v1";
 
@@ -292,6 +291,59 @@ mod tests {
             .unwrap();
         assert_eq!(retired_repo_id, 0);
         assert!(!table_exists(&conn, "package_overrides").unwrap());
+    }
+
+    #[test]
+    fn current_schema_rejects_invalid_trigger_and_derived_states() {
+        let conn = Connection::open_in_memory().unwrap();
+        ensure_current(&conn).unwrap();
+
+        conn.execute(
+            "INSERT INTO changesets (description, status) VALUES ('status checks', 'pending')",
+            [],
+        )
+        .unwrap();
+        let changeset_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO triggers (name, pattern, handler) VALUES ('fixture', '/usr/*', '/bin/true')",
+            [],
+        )
+        .unwrap();
+        let trigger_id = conn.last_insert_rowid();
+
+        for (sql, params) in [
+            (
+                "INSERT INTO changeset_triggers (changeset_id, trigger_id, status)
+                 VALUES (?1, ?2, 'unknown')",
+                [changeset_id, trigger_id],
+            ),
+            (
+                "INSERT INTO changeset_triggers (changeset_id, trigger_id, status)
+                 VALUES (?1, ?2, 'already-ran-maybe')",
+                [changeset_id, trigger_id],
+            ),
+        ] {
+            let error = conn.execute(sql, params).unwrap_err();
+            assert!(
+                error.to_string().contains("CHECK constraint failed"),
+                "{error}"
+            );
+        }
+
+        for sql in [
+            "INSERT INTO derived_packages (name, parent_name, status)
+             VALUES ('invalid-status', 'parent', 'maybe-built')",
+            "INSERT INTO derived_packages (name, parent_name, version_policy)
+             VALUES ('invalid-policy', 'parent', 'invented')",
+            "INSERT INTO derived_packages (name, parent_name, version_policy)
+             VALUES ('missing-suffix', 'parent', 'suffix')",
+        ] {
+            let error = conn.execute(sql, []).unwrap_err();
+            assert!(
+                error.to_string().contains("CHECK constraint failed"),
+                "{error}"
+            );
+        }
     }
 
     #[test]

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-03
-revision: 59
+last_updated: 2026-08-04
+revision: 60
 summary: Route lossless source authority, exact Remi signing, selected-root mutation, rollback lineage, canonical-map authority, carrier security, generation GC, release authority, and subsystem proof through current feature owners.
 ---
 
@@ -32,6 +32,8 @@ bash scripts/agent-context.sh --path <file>
 commands.
 
 - `dispatch`: CLI command routing, namespace dispatch, and command risk labels
+- `database-state`: current-schema revision, constrained persisted states, and
+  fail-closed row decoding
 - `install`: install, update, remove, restore, scriptlet, and live-root mutation
 - `adopt`: adoption, unadoption, takeover, and native-authority handoff
 - `model`: declarative system model diff/apply/check/snapshot/publish/lock
@@ -49,6 +51,11 @@ commands.
 
 ## Canonical Detail Pointers
 
+- Current-schema revision and persisted model-state authority:
+  `docs/modules/feature-ownership.md` slug `database-state`, plus
+  `crates/conary-core/src/db/schema.rs`,
+  `crates/conary-core/src/db/current_schema/`, and
+  `crates/conary-core/src/db/models/persisted_value.rs`.
 - CLI dispatch and command routing: `docs/modules/feature-ownership.md` slug
   `dispatch`, plus `docs/ARCHITECTURE.md`.
 - Install, update, remove, native lifecycle execution, and selected-root

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-30
-revision: 62
+last_updated: 2026-08-04
+revision: 63
 summary: Route feature ownership through exact Remi signing, streaming package payloads, serialized selected-root mutation, typed rollback lineage, exact lifecycle, canonical-map authority, carrier security, generation GC, exact release authority, and current canonical docs
 ---
 
@@ -43,6 +43,49 @@ Each ownership card uses these fields:
 - **Docs to update:** docs that should move with the feature.
 - **Safety notes:** persisted-state, trust, host mutation, fixture,
   private-path, or distro-scope boundaries.
+
+## Persisted Database Model Authority
+
+**Slug:** database-state
+
+**Capability:** keep current-schema model enums and tagged values exact,
+fallible on read, constrained on write, and bound to the row that supplied
+them.
+
+**Start here:** `crates/conary-core/src/db/schema.rs`;
+`crates/conary-core/src/db/current_schema/`;
+`crates/conary-core/src/db/models/persisted_value.rs`;
+`crates/conary-core/src/db/models/trigger.rs`;
+`crates/conary-core/src/db/models/trigger_engine.rs`;
+`crates/conary-core/src/db/models/derived.rs`;
+`docs/ARCHITECTURE.md`.
+
+**Neighbor systems:** install trigger execution, derived-package CLI and model
+application, database backup/restore, Remi deployment/readiness, and every
+current-schema SQL owner that persists a typed state.
+
+**Paths:** `crates/conary-core/src/db/schema.rs`;
+`crates/conary-core/src/db/models/mod.rs`;
+`crates/conary-core/src/db/models/persisted_value.rs`;
+`crates/conary-core/src/db/models/trigger.rs`;
+`crates/conary-core/src/db/models/trigger_engine.rs`;
+`crates/conary-core/src/db/models/derived.rs`.
+
+**Focused proof:** `cargo test -p conary-core --lib db::schema`;
+`cargo test -p conary-core --lib db::models::trigger`;
+`cargo test -p conary-core --lib db::models::derived`.
+
+**Interaction gate:** `cargo test -p conary-core`;
+`cargo test -p conary --test features` when derived-package behavior changes.
+
+**Docs to update:** `docs/ARCHITECTURE.md` when the database contract changes;
+the owning specification when a persisted product contract changes;
+`docs/modules/feature-ownership.md` when model ownership or proof moves.
+
+**Safety notes:** persisted values never select a semantic default after a
+parse failure. Current-schema shape changes increment `SCHEMA_VERSION`, reject
+older databases, and state the authoritative rebuild path; do not add a
+migration, fallback reader, or compatibility alias.
 
 ## CLI Dispatch And Command Routing
 
@@ -645,6 +688,7 @@ packages, install CCS packages, and preserve their exact lifecycle ABIs.
 `packaging/ccs/`;
 `docs/modules/ccs.md`;
 `docs/modules/test-fixtures.md`;
+`docs/specs/source-package-authority.md`;
 `docs/specs/foreign-package-lifecycle-contracts.md`;
 `docs/specs/static-repo-format-v1.md`.
 
@@ -683,6 +727,7 @@ metadata, scriptlet sandboxing (`crates/conary-core/src/scriptlet/mod.rs`,
 `apps/conary/tests/rpm_named_ownership.rs`;
 `packaging/ccs/*`;
 `docs/specs/ccs-format-v3.md`;
+`docs/specs/source-package-authority.md`;
 `docs/specs/foreign-package-lifecycle-contracts.md`.
 
 **Focused proof:** `cargo test -p conary-core ccs::budget`;
@@ -709,6 +754,7 @@ crosses Remi publication;
 `cargo test -p remi conversion` when conversion output affects public serving.
 
 **Docs to update:** `docs/modules/ccs.md`; `docs/modules/test-fixtures.md`;
+`docs/specs/source-package-authority.md`;
 `docs/specs/foreign-package-lifecycle-contracts.md`;
 `docs/specs/static-repo-format-v1.md`; `docs/llms/subsystem-map.md`; the primary
 issue and draft pull request while the change is still in flight.

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -264,9 +264,10 @@ the authenticated source artifact. Public, OCI, index, search, chunk, and
 garbage-collection paths validate that typed artifact instead of filling
 missing fields with guesses or empty values. Architecture and the repository
 provide digest are required constructor and API-view fields, and the current
-schema rejects missing, empty, or malformed values. Schema revision 24 is a
-pre-alpha hard cut: prior databases are rebuilt and re-ingested from configured
-repository authority rather than migrated. Local conversion tracking is
+schema rejects missing, empty, or malformed values. Schema revision 25 retains
+revision 24's source-authority representation and is a pre-alpha hard cut:
+prior databases are rebuilt and re-ingested from configured repository
+authority rather than migrated. Local conversion tracking is
 written only after the CCS install transaction commits.
 
 Ready conversion means the artifact carries a source-independent Conary

--- a/docs/roadmaps/development-roadmap.md
+++ b/docs/roadmaps/development-roadmap.md
@@ -1,11 +1,11 @@
 ---
-last_updated: 2026-08-03
-revision: 11
+last_updated: 2026-08-04
+revision: 12
 summary: Track Conary's cross-distro package milestone, ordered workstreams, evidence, blockers, and post-milestone horizons
 proof_baseline: "immutable v0.14.0 at fe23a604b64ea6f7cc87fce8298911e2245e027f and production remi-v0.9.5 at 101dba655257f1ff3d1bee689d9c5ac8b2b68cbd; exact asset, deployment, and released-package proof complete"
 current_milestone: first external tester loop
-active_workstream: W5 Source Authority Model
-next_workstream: W6 Authority Audit Closure
+active_workstream: W6 Authority Audit Closure
+next_workstream: W7 Just-Works Corpus Gate
 ---
 
 # Codebase Development Roadmap
@@ -272,19 +272,21 @@ the stated scope, not whether a workstream happens to be active.
 - **Outcome:** the finite authority defects in #67 are closed as narrow owned
   slices with proof, and #67 becomes an audit epic rather than an
   implementation issue spanning twelve subsystems.
-- **Execution status:** blocked on W4; overlaps W5.
-- **Issues:** #67 as epic, #109 for the trigger-status gap, plus one narrow issue per remaining ledger item.
+- **Execution status:** active. #109 closes the trigger-status slice; remaining
+  ledger items proceed as narrow issues while the W4 aggregate gate remains
+  active.
+- **Issues:** #67 as epic, #109 complete, plus one narrow issue per remaining ledger item.
+- **Closed ledger items:**
+  - #109 replaces trigger and derived-package status defaults with typed row
+    corruption, validates every candidate row before mutation planning, and
+    constrains the current schema. Schema revision 25 requires rebuilding
+    earlier disposable databases from authoritative inputs.
 - **Ledger gaps found on audit that #67 does not currently own:**
-  - `TriggerStatus::parse` in `db/models/trigger.rs` resolves unknown or
-    corrupt persisted status to `Pending` through `unwrap_or`. #67 covers
-    trigger *patterns*, not trigger *status*. A corrupt persisted status
-    therefore becomes executable pending work, which is a mutation-authority
-    defect rather than a display fallback. Add a ledger entry or a narrow issue.
   - The `sanitize_path` ASCII heuristic is a #67-class invented authority but is
     owned only by #99, and only for ALPM. Cross-reference both.
 - **Priority split within the ledger:** the publish-destination parser, Remi
-  typed transport failures and retry disposition, trigger status, and required
-  source-pin strength are P1 and belong here. The `ccs/policy.rs`
+  typed transport failures and retry disposition, and required source-pin
+  strength are P1 and belong here. The `ccs/policy.rs`
   transformations are P2 and move to W9, because every `BuildPolicyConfig`
   toggle defaults to `false` and `ccs/convert/converter.rs` constructs the
   default, so stripping, shebang rewriting, and man-page compression never run

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -600,11 +600,11 @@ commits each package's files, payload claims, requirements, and provides
 atomically under `AdoptedTrack` or `AdoptedFull`; package names and partial
 warning paths are not ownership authority.
 
-Schema revision 24 is a pre-alpha hard cut: it retains revision 23's
-`directory_claims` to `payload_claims` replacement and adds exact provider
-provenance to installed and repository capability rows. It does not migrate
-earlier databases. Operators rebuild disposable local state from authoritative
-package and repository inputs.
+Schema revision 25 is a pre-alpha hard cut: it retains revision 24's exact
+provider provenance and source-authority representation, and adds fail-closed
+constraints for trigger and derived-package persisted states. It does not
+migrate earlier databases. Operators rebuild disposable local state from
+authoritative package and repository inputs.
 
 A complete unfiltered full-system adoption also performs one exact global
 selected-root capture after every native package capture succeeds. Existing

--- a/docs/specs/source-package-authority.md
+++ b/docs/specs/source-package-authority.md
@@ -313,7 +313,9 @@ The signed CCS contract and installed database both change intentionally.
 
 - CCS v3 replaces v2; every local, cached, static-repository, and Remi v2
   artifact must be rebuilt or reconverted from authenticated source.
-- SQLite schema revision 24 replaces the current schema in place.
+- SQLite schema revision 25 retains revision 24's source-authority hard cut and
+  replaces the current schema in place with fail-closed trigger and
+  derived-package state constraints.
   Installed and repository provider rows must distinguish identity-derived
   matches from declared/derived capabilities, and config persistence must
   distinguish source declarations from materialized node and transaction
@@ -324,8 +326,8 @@ The signed CCS contract and installed database both change intentionally.
 - Remi conversion records and indexes tied to v2 authority are rebuilt before
   public serving. A mixed v2/v3 serving state is invalid.
 
-The rebuild property is intentional: revision 24 has no migration or dual-read
-path from the retired provider representation.
+The rebuild property is intentional: revision 25 has no migration or dual-read
+path from revision 24 or the retired provider representation.
 
 ## Conformance And Closeout
 

--- a/scripts/test-agent-context.sh
+++ b/scripts/test-agent-context.sh
@@ -400,7 +400,8 @@ grep -q $'^profiles\t' <<<"$real_list" || fail "real map --list missing profiles
 grep -q $'^resolution\t' <<<"$real_list" || fail "real map --list missing resolution slug"
 grep -q $'^canonical-map\t' <<<"$real_list" || fail "real map --list missing canonical-map slug"
 grep -q $'^release\t' <<<"$real_list" || fail "real map --list missing release slug"
-[[ "$(wc -l <<<"$real_list")" -eq 16 ]] || fail "real map --list did not print 16 cards"
+grep -q $'^database-state\t' <<<"$real_list" || fail "real map --list missing database-state slug"
+[[ "$(wc -l <<<"$real_list")" -eq 17 ]] || fail "real map --list did not print 17 cards"
 
 "$script" --path apps/conary/src/commands/install/mod.rs > "$tmp/real-install.out"
 grep -q '^slug: install$' "$tmp/real-install.out" \


### PR DESCRIPTION
## Problem

Persisted trigger and derived-package states silently selected `Pending` when decoding an unknown value. Trigger planning also filtered for `pending` in SQL, so a corrupt sibling row could be hidden instead of stopping mutation planning. The current schema did not independently constrain these values.

## Changes

- replace the infallible trigger and derived status parsers with fallible `TryFrom<&str>` implementations
- preserve typed corruption context with the table, row ID, column, and offending value
- validate every changeset-trigger row before selecting pending work, so corruption stops the executor before its handler loop
- harden the audited sibling `DerivedStatus` and `VersionPolicy` authorities
- constrain trigger status, derived status, and version-policy shape in SQLite
- bump the current-only schema to revision 25; revision 24 databases must be rebuilt from authoritative inputs
- add the missing persisted-database ownership card and update current roadmap/spec truth

## Impact

This is the intended pre-alpha hard cut. Existing schema revision 24 databases are rejected and must be recreated or re-ingested from authoritative package, repository, and conversion inputs. No migration, compatibility reader, or repair workflow is introduced.

## Verification

- `cargo test -p conary-core --lib db::schema`
- `cargo test -p conary-core --lib db::models::trigger`
- `cargo test -p conary-core --lib db::models::derived`
- `cargo test -p conary-core`
- `cargo test -p conary --test features`
- `cargo test -p conary`
- `cargo test -p remi deployment`
- `cargo test -p remi readiness`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `bash scripts/check-doc-truth.sh`
- `bash scripts/test-doc-truth.sh`
- `bash scripts/test-agent-context.sh`
- `bash scripts/agent-context.sh --validate`
- `git diff --check`

Closes #109
Refs #67