### PR TITLE
fix(db): add retired schema rebuild path

### DIFF
--- a/apps/conary/src/cli/system.rs
+++ b/apps/conary/src/cli/system.rs
@@ -48,6 +48,21 @@ pub enum SystemCommands {
         db: DbArgs,
     },
 
+    /// Snapshot and replace a retired pre-alpha database
+    #[command(name = "rebuild-db")]
+    RebuildDatabase {
+        #[command(flatten)]
+        db: DbArgs,
+
+        /// Explicitly discard active repository and installed-package state
+        #[arg(long, required = true)]
+        discard_state: bool,
+
+        /// Confirm replacing the active database after preserving a snapshot
+        #[arg(short = 'y', long)]
+        yes: bool,
+    },
+
     /// Generate shell completions
     Completions {
         /// Shell to generate completions for

--- a/apps/conary/src/command_risk.rs
+++ b/apps/conary/src/command_risk.rs
@@ -15,6 +15,7 @@ pub enum CommandRisk {
     DryRunOnly,
     HookRefreshDbMutation,
     DbMutation,
+    DestructiveDbMutation,
     /// Internal boot continuation authorized by an exact generation artifact
     /// and kernel command-line contract rather than an interactive `--yes`.
     GenerationBootActivation,
@@ -38,7 +39,9 @@ impl CommandRiskPolicy {
     pub fn requires_apply_intent(&self) -> bool {
         matches!(
             self.risk,
-            CommandRisk::ActiveHostMutation | CommandRisk::AlwaysLive
+            CommandRisk::DestructiveDbMutation
+                | CommandRisk::ActiveHostMutation
+                | CommandRisk::AlwaysLive
         ) && !self.dry_run
     }
 
@@ -49,7 +52,9 @@ impl CommandRiskPolicy {
             | CommandRisk::DryRunOnly
             | CommandRisk::HookRefreshDbMutation
             | CommandRisk::GenerationBootActivation => None,
-            CommandRisk::DbMutation => Some(LiveMutationClass::LiveConaryState),
+            CommandRisk::DbMutation | CommandRisk::DestructiveDbMutation => {
+                Some(LiveMutationClass::LiveConaryState)
+            }
             CommandRisk::ActiveHostMutation => {
                 Some(LiveMutationClass::CurrentlyLiveEvenWithRootArguments)
             }
@@ -262,6 +267,12 @@ fn classify_try(
 fn classify_system(command: &cli::SystemCommands) -> Option<CommandRiskPolicy> {
     match command {
         cli::SystemCommands::Init { .. } => Some(local_state("conary system init")),
+        cli::SystemCommands::RebuildDatabase { yes, .. } => Some(policy_with_intent(
+            "conary system rebuild-db",
+            CommandRisk::DestructiveDbMutation,
+            false,
+            *yes,
+        )),
         cli::SystemCommands::Completions { .. }
         | cli::SystemCommands::History { .. }
         | cli::SystemCommands::Verify { .. }

--- a/apps/conary/src/command_risk/tests.rs
+++ b/apps/conary/src/command_risk/tests.rs
@@ -255,6 +255,24 @@ fn classify_system_init_and_repo_sync_as_local_state_mutations() {
 }
 
 #[test]
+fn retired_schema_rebuild_requires_explicit_discard_and_confirmation() {
+    assert!(
+        parse_cli(&["conary", "system", "rebuild-db", "--yes"]).is_err(),
+        "the destructive semantic must be explicit"
+    );
+
+    let unconfirmed = policy(&["conary", "system", "rebuild-db", "--discard-state"]);
+    assert_eq!(unconfirmed.risk, CommandRisk::DestructiveDbMutation);
+    assert!(unconfirmed.requires_ack());
+    assert!(!unconfirmed.apply_intent);
+
+    let confirmed = policy(&["conary", "system", "rebuild-db", "--discard-state", "--yes"]);
+    assert_eq!(confirmed.risk, CommandRisk::DestructiveDbMutation);
+    assert!(confirmed.requires_ack());
+    assert!(confirmed.apply_intent);
+}
+
+#[test]
 fn classify_adoption_dry_runs_with_precise_labels() {
     let package = policy(&["conary", "system", "adopt", "curl", "--dry-run"]);
     assert_eq!(

--- a/apps/conary/src/commands/mod.rs
+++ b/apps/conary/src/commands/mod.rs
@@ -181,7 +181,7 @@ pub use state::{
     cmd_state_create, cmd_state_diff, cmd_state_list, cmd_state_prune, cmd_state_restore,
     cmd_state_show,
 };
-pub use system::{cmd_init, cmd_rollback, cmd_verify};
+pub use system::{cmd_init, cmd_rebuild_database, cmd_rollback, cmd_verify};
 pub use triggers::{
     cmd_trigger_add, cmd_trigger_disable, cmd_trigger_enable, cmd_trigger_list, cmd_trigger_remove,
     cmd_trigger_run, cmd_trigger_show,

--- a/apps/conary/src/commands/system.rs
+++ b/apps/conary/src/commands/system.rs
@@ -2,12 +2,14 @@
 //! System management commands (init, verify, rollback)
 
 mod init;
+mod rebuild_database;
 mod rollback_command;
 mod rollback_restore;
 
 pub use init::cmd_init;
 #[cfg(test)]
 use init::{NATIVE_REPOSITORY_SEEDS, paths_refer_to_same_location, validate_init_privileges};
+pub use rebuild_database::cmd_rebuild_database;
 pub use rollback_command::cmd_rollback;
 #[cfg(test)]
 use rollback_command::cmd_rollback_with_forced_precommit_failure;

--- a/apps/conary/src/commands/system/init.rs
+++ b/apps/conary/src/commands/system/init.rs
@@ -126,6 +126,10 @@ pub async fn cmd_init(db_path: &str) -> Result<()> {
         .map_err(|err| init_failure_context(db_path_ref, &runtime_root, err))?;
     crate::ui::status("Initialized", &format!("database at {db_path}"));
 
+    configure_current_database(db_path).await
+}
+
+pub(super) async fn configure_current_database(db_path: &str) -> Result<()> {
     let mut conn = open_db(db_path)?;
     info!("Adding default repositories...");
     let host_capabilities = conary_core::ccs::HostCapabilityInventory::discover()
@@ -167,7 +171,7 @@ pub async fn cmd_init(db_path: &str) -> Result<()> {
     Ok(())
 }
 
-fn require_init_privileges(db_path: &Path) -> Result<()> {
+pub(super) fn require_init_privileges(db_path: &Path) -> Result<()> {
     #[cfg(unix)]
     {
         validate_init_privileges(db_path, nix::unistd::Uid::effective().is_root())?;
@@ -462,16 +466,20 @@ fn init_failure_context(
     source: conary_core::Error,
 ) -> anyhow::Error {
     let parent = db_path.parent().unwrap_or_else(|| Path::new("."));
+    let safe_next_step = if matches!(&source, conary_core::Error::SchemaRebuildRequired { .. }) {
+        "run `conary system rebuild-db --discard-state --yes` with the same --db-path to preserve a retired snapshot and replace the active database; do not run it unless the active Conary state is disposable"
+    } else {
+        "verify the database parent is a writable directory, or pass --db-path to a writable test location; do not remove existing Conary runtime state unless you have confirmed it is disposable"
+    };
     anyhow!(
         "could not initialize Conary database at {}: {}\n\
          database parent: {}\n\
          runtime root: {}\n\
-         safe next step: verify the database parent is a writable directory, \
-         or pass --db-path to a writable test location; do not remove existing \
-         Conary runtime state unless you have confirmed it is disposable",
+         safe next step: {}",
         db_path.display(),
         source,
         parent.display(),
-        runtime_root.root().display()
+        runtime_root.root().display(),
+        safe_next_step
     )
 }

--- a/apps/conary/src/commands/system/rebuild_database.rs
+++ b/apps/conary/src/commands/system/rebuild_database.rs
@@ -1,0 +1,29 @@
+// conary/src/commands/system/rebuild_database.rs
+
+use super::init::{configure_current_database, require_init_privileges};
+use anyhow::Result;
+use std::path::Path;
+use tracing::info;
+
+/// Snapshot a retired pre-alpha database and replace its active state.
+pub async fn cmd_rebuild_database(db_path: &str) -> Result<()> {
+    let db_path = Path::new(db_path);
+    require_init_privileges(db_path)?;
+    info!(database = %db_path.display(), "Rebuilding retired Conary database");
+
+    let outcome = conary_core::db::rebuild::rebuild_discarding_state(db_path)?;
+    crate::ui::status(
+        "Rebuilt",
+        &format!("database at {} with the current schema", db_path.display()),
+    );
+    crate::ui::field("Retired schema", &outcome.observed_schema);
+    crate::ui::field(
+        "Retired snapshot",
+        &outcome.retired_snapshot_path.display().to_string(),
+    );
+    configure_current_database(db_path.to_string_lossy().as_ref()).await?;
+    crate::ui::note(
+        "Repository metadata and installed-package state were discarded; resync repositories and explicitly re-adopt any native packages that Conary should track.",
+    );
+    Ok(())
+}

--- a/apps/conary/src/commands/system/tests.rs
+++ b/apps/conary/src/commands/system/tests.rs
@@ -1,9 +1,9 @@
 // apps/conary/src/commands/system/tests.rs
 
 use super::{
-    NATIVE_REPOSITORY_SEEDS, cmd_init, cmd_rollback, cmd_rollback_with_forced_precommit_failure,
-    paths_refer_to_same_location, restore_snapshot, restore_snapshots_to_live_root,
-    validate_init_privileges,
+    NATIVE_REPOSITORY_SEEDS, cmd_init, cmd_rebuild_database, cmd_rollback,
+    cmd_rollback_with_forced_precommit_failure, paths_refer_to_same_location, restore_snapshot,
+    restore_snapshots_to_live_root, validate_init_privileges,
 };
 use crate::commands::{
     FileSnapshot, NativeLifecycleSnapshot, RollbackSystemAuthority, TroveSnapshot,
@@ -39,6 +39,73 @@ use std::path::{Path, PathBuf};
 
 #[path = "tests/rollback.rs"]
 mod rollback;
+
+#[tokio::test]
+async fn init_retired_schema_refusal_names_exact_rebuild_command_without_mutating() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("conary.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE schema_version (
+            version INTEGER PRIMARY KEY,
+            applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+        INSERT INTO schema_version (version) VALUES (66);",
+    )
+    .unwrap();
+    drop(conn);
+
+    let error = cmd_init(db_path_str).await.unwrap_err().to_string();
+
+    assert!(
+        error.contains("conary system rebuild-db --discard-state --yes"),
+        "{error}"
+    );
+    assert_eq!(
+        conary_core::db::schema::inspect(&db_path).unwrap(),
+        conary_core::db::schema::SchemaCompatibility::RebuildRequired {
+            observed: "retired migration-chain schema version 66".to_string()
+        }
+    );
+}
+
+#[tokio::test]
+async fn rebuild_database_resolves_retired_schema_and_seeds_current_authority() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("conary.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE schema_version (
+            version INTEGER PRIMARY KEY,
+            applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+        INSERT INTO schema_version (version) VALUES (66);",
+    )
+    .unwrap();
+    drop(conn);
+
+    cmd_rebuild_database(db_path_str).await.unwrap();
+
+    assert_eq!(
+        conary_core::db::schema::inspect(&db_path).unwrap(),
+        conary_core::db::schema::SchemaCompatibility::Current
+    );
+    let current = conary_core::db::open(&db_path).unwrap();
+    conary_core::ccs::HostCapabilityInventory::load_required(&current).unwrap();
+    assert!(
+        Repository::find_by_name(&current, "remi-fedora-44")
+            .unwrap()
+            .is_some()
+    );
+    assert_eq!(
+        std::fs::read_dir(temp_dir.path().join("backups"))
+            .unwrap()
+            .count(),
+        1
+    );
+}
 
 #[tokio::test]
 async fn init_seeds_every_builtin_source_feed_without_a_host_distro() {

--- a/apps/conary/src/dispatch/root/tests.rs
+++ b/apps/conary/src/dispatch/root/tests.rs
@@ -592,6 +592,7 @@ fn commands_without_db_args_do_not_use_try_session_preflight_scope() {
         ]
         .as_slice(),
         ["conary", "system", "completions", "bash"].as_slice(),
+        ["conary", "system", "rebuild-db", "--discard-state", "--yes"].as_slice(),
         [
             "conary",
             "ccs",

--- a/apps/conary/src/dispatch/root/try_preflight.rs
+++ b/apps/conary/src/dispatch/root/try_preflight.rs
@@ -141,7 +141,9 @@ pub(super) fn command_uses_try_session_preflight_db(command: &Commands) -> bool 
             cli::BootstrapCommands::VerifyConvergence { .. }
             | cli::BootstrapCommands::DiffSeeds { .. },
         )
-        | Commands::System(cli::SystemCommands::Completions { .. })
+        | Commands::System(
+            cli::SystemCommands::Completions { .. } | cli::SystemCommands::RebuildDatabase { .. },
+        )
         | Commands::Ccs(
             cli::CcsCommands::Init { .. }
             | cli::CcsCommands::Build { .. }
@@ -508,6 +510,7 @@ fn selected_verify_db_path(command: &cli::VerifyCommands) -> &str {
 fn selected_system_db_path(command: &cli::SystemCommands) -> &str {
     match command {
         cli::SystemCommands::Init { db, .. }
+        | cli::SystemCommands::RebuildDatabase { db, .. }
         | cli::SystemCommands::History { db, .. }
         | cli::SystemCommands::Adopt { db, .. }
         | cli::SystemCommands::Unadopt { db, .. }

--- a/apps/conary/src/dispatch/system.rs
+++ b/apps/conary/src/dispatch/system.rs
@@ -21,6 +21,20 @@ pub(super) async fn dispatch_system_command(sys_cmd: cli::SystemCommands) -> Res
     match sys_cmd {
         cli::SystemCommands::Init { db } => commands::cmd_init(&db.db_path).await,
 
+        cli::SystemCommands::RebuildDatabase {
+            db,
+            discard_state: _,
+            yes,
+        } => {
+            require_live_mutation(
+                MutationIntent::from_apply_intent(yes),
+                Cow::Borrowed("conary system rebuild-db"),
+                LiveMutationClass::LiveConaryState,
+                false,
+            )?;
+            commands::cmd_rebuild_database(&db.db_path).await
+        }
+
         cli::SystemCommands::Completions { shell } => {
             let mut cmd = Cli::command();
             generate(shell, &mut cmd, "conary", &mut io::stdout());

--- a/apps/conary/tests/live_host_mutation_safety.rs
+++ b/apps/conary/tests/live_host_mutation_safety.rs
@@ -373,6 +373,38 @@ fn removed_system_gc_surface_is_rejected() {
 }
 
 #[test]
+fn retired_schema_rebuild_refuses_without_confirmation_before_mutation() {
+    let temp = tempfile::tempdir().unwrap();
+    let db_path = temp.path().join("conary.db");
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE schema_version (
+            version INTEGER PRIMARY KEY,
+            applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+        INSERT INTO schema_version (version) VALUES (66);",
+    )
+    .unwrap();
+    drop(conn);
+    let before = fs::read(&db_path).unwrap();
+
+    let output = run_conary(&[
+        "system",
+        "rebuild-db",
+        "--discard-state",
+        "--db-path",
+        db_path.to_str().unwrap(),
+    ]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("conary system rebuild-db"), "{stderr}");
+    assert!(stderr.contains("--yes"), "{stderr}");
+    assert_eq!(fs::read(&db_path).unwrap(), before);
+    assert!(!temp.path().join("backups").exists());
+}
+
+#[test]
 fn system_adopt_package_refuses_without_live_mutation_flag() {
     let (_tmp, db_path) = common::setup_command_test_db();
 

--- a/crates/conary-core/src/corpus/failure.rs
+++ b/crates/conary-core/src/corpus/failure.rs
@@ -203,6 +203,7 @@ fn core_variant_name(error: &Error) -> &'static str {
         Error::Io(_) => "Io",
         Error::IoError(_) => "IoError",
         Error::InitError(_) => "InitError",
+        Error::SchemaRebuildRequired { .. } => "SchemaRebuildRequired",
         Error::MissingId(_) => "MissingId",
         Error::VersionParse(_) => "VersionParse",
         Error::VersionComparison(_) => "VersionComparison",

--- a/crates/conary-core/src/db/mod.rs
+++ b/crates/conary-core/src/db/mod.rs
@@ -12,6 +12,7 @@ pub mod backup;
 pub mod current_schema;
 pub mod models;
 pub mod paths;
+pub mod rebuild;
 pub mod schema;
 
 use crate::error::{Error, Result};

--- a/crates/conary-core/src/db/rebuild.rs
+++ b/crates/conary-core/src/db/rebuild.rs
@@ -1,0 +1,183 @@
+// conary-core/src/db/rebuild.rs
+
+//! Explicit current-schema replacement for retired pre-alpha databases.
+
+use super::backup::backup_dir_for_db_path;
+use super::schema::{self, SchemaCompatibility};
+use crate::filesystem::durable::sync_parent_directory;
+use crate::{Error, Result};
+use chrono::Utc;
+use rusqlite::{Connection, OpenFlags};
+use std::ffi::OsString;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DatabaseRebuildOutcome {
+    pub observed_schema: String,
+    pub retired_snapshot_path: PathBuf,
+}
+
+/// Replace a retired database with the one current pre-alpha schema.
+///
+/// This deliberately does not infer installed state from runtime artifacts.
+/// The complete committed retired database is first consolidated into a
+/// durable SQLite snapshot so an operator can inspect or recover it manually.
+pub fn rebuild_discarding_state(path: impl AsRef<Path>) -> Result<DatabaseRebuildOutcome> {
+    let path = path.as_ref();
+    let observed_schema = match schema::inspect(path)? {
+        SchemaCompatibility::RebuildRequired { observed } => observed,
+        SchemaCompatibility::Current => {
+            return Err(Error::InitError(format!(
+                "database at {} already uses the current schema; refusing to discard it",
+                path.display()
+            )));
+        }
+        SchemaCompatibility::Fresh => {
+            return Err(Error::InitError(format!(
+                "database at {} is fresh; run `conary system init` instead",
+                path.display()
+            )));
+        }
+    };
+
+    let retired_snapshot_path = create_retired_snapshot(path)?;
+    remove_active_database_files(path)?;
+
+    if let Err(init_error) = super::init(path) {
+        if let Err(restore_error) = restore_retired_snapshot(path, &retired_snapshot_path) {
+            return Err(Error::InitError(format!(
+                "failed to initialize the replacement database: {init_error}; also failed to restore the retired snapshot: {restore_error}"
+            )));
+        }
+        return Err(init_error);
+    }
+
+    Ok(DatabaseRebuildOutcome {
+        observed_schema,
+        retired_snapshot_path,
+    })
+}
+
+fn create_retired_snapshot(db_path: &Path) -> Result<PathBuf> {
+    let backup_dir = backup_dir_for_db_path(db_path);
+    std::fs::create_dir_all(&backup_dir)?;
+
+    let now = Utc::now();
+    let timestamp = now.format("%Y%m%dT%H%M%SZ");
+    let unique = now
+        .timestamp_nanos_opt()
+        .unwrap_or_else(|| now.timestamp_micros() * 1_000);
+    let snapshot_path = backup_dir.join(format!(
+        "conary-db-{timestamp}-{unique}-retired-schema.sqlite"
+    ));
+    let snapshot_string = snapshot_path.to_string_lossy().into_owned();
+
+    let source = Connection::open_with_flags(
+        db_path,
+        OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    source.execute("VACUUM main INTO ?1", [snapshot_string.as_str()])?;
+    drop(source);
+
+    File::open(&snapshot_path)?.sync_all()?;
+    sync_parent_directory(&snapshot_path)?;
+    Ok(snapshot_path)
+}
+
+fn remove_active_database_files(db_path: &Path) -> Result<()> {
+    for path in [
+        sqlite_sidecar_path(db_path, "-wal"),
+        sqlite_sidecar_path(db_path, "-shm"),
+        db_path.to_path_buf(),
+    ] {
+        remove_if_exists(&path)?;
+    }
+    Ok(())
+}
+
+fn restore_retired_snapshot(db_path: &Path, snapshot_path: &Path) -> Result<()> {
+    remove_active_database_files(db_path)?;
+    std::fs::copy(snapshot_path, db_path)?;
+    File::open(db_path)?.sync_all()?;
+    sync_parent_directory(db_path)
+}
+
+fn sqlite_sidecar_path(db_path: &Path, suffix: &str) -> PathBuf {
+    let mut path = OsString::from(db_path.as_os_str());
+    path.push(suffix);
+    PathBuf::from(path)
+}
+
+fn remove_if_exists(path: &Path) -> Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => sync_parent_directory(path),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(Error::Io(error)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_retired_database(path: &Path) {
+        let conn = Connection::open(path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE schema_version (
+                version INTEGER PRIMARY KEY,
+                applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            INSERT INTO schema_version (version) VALUES (66);
+            CREATE TABLE retired_evidence (value TEXT NOT NULL);
+            INSERT INTO retired_evidence (value) VALUES ('preserved');",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn retired_database_is_snapshotted_and_replaced_with_current_schema() {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("conary.db");
+        create_retired_database(&db_path);
+
+        let outcome = rebuild_discarding_state(&db_path).unwrap();
+
+        assert_eq!(
+            outcome.observed_schema,
+            "retired migration-chain schema version 66"
+        );
+        assert_eq!(
+            schema::inspect(&db_path).unwrap(),
+            SchemaCompatibility::Current
+        );
+        assert!(outcome.retired_snapshot_path.exists());
+        let retired = Connection::open(&outcome.retired_snapshot_path).unwrap();
+        assert_eq!(
+            retired
+                .query_row("SELECT value FROM retired_evidence", [], |row| {
+                    row.get::<_, String>(0)
+                })
+                .unwrap(),
+            "preserved"
+        );
+    }
+
+    #[test]
+    fn rebuild_refuses_current_and_fresh_databases() {
+        let temp = tempfile::tempdir().unwrap();
+        let current = temp.path().join("current.db");
+        super::super::init(&current).unwrap();
+        let current_error = rebuild_discarding_state(&current).unwrap_err().to_string();
+        assert!(current_error.contains("already uses the current schema"));
+        assert_eq!(
+            schema::inspect(&current).unwrap(),
+            SchemaCompatibility::Current
+        );
+
+        let fresh = temp.path().join("missing.db");
+        let fresh_error = rebuild_discarding_state(&fresh).unwrap_err().to_string();
+        assert!(fresh_error.contains("run `conary system init` instead"));
+        assert!(!fresh.exists());
+    }
+}

--- a/crates/conary-core/src/db/schema.rs
+++ b/crates/conary-core/src/db/schema.rs
@@ -167,10 +167,11 @@ fn database_is_fresh(conn: &Connection) -> Result<bool> {
 }
 
 fn rebuild_required(observed: &str) -> Error {
-    Error::InitError(format!(
-        "database uses {observed}; this pre-alpha build supports only schema epoch \
-         {SCHEMA_EPOCH} revision {SCHEMA_VERSION}. Rebuild the database from authoritative inputs"
-    ))
+    Error::SchemaRebuildRequired {
+        observed: observed.to_string(),
+        supported_epoch: SCHEMA_EPOCH.to_string(),
+        supported_revision: SCHEMA_VERSION,
+    }
 }
 
 #[cfg(test)]
@@ -211,7 +212,7 @@ mod tests {
     }
 
     #[test]
-    fn read_only_inspection_names_exact_deployment_action() {
+    fn read_only_inspection_reports_schema_compatibility_without_mutation() {
         let missing_dir = tempfile::tempdir().unwrap();
         let missing = missing_dir.path().join("missing.db");
         assert_eq!(inspect(&missing).unwrap(), SchemaCompatibility::Fresh);
@@ -683,7 +684,7 @@ mod tests {
                 error.contains(&format!("migration-chain schema version {version}")),
                 "{error}"
             );
-            assert!(error.contains("Rebuild the database"));
+            assert!(error.contains("schema rebuild required"), "{error}");
         }
     }
 
@@ -706,7 +707,7 @@ mod tests {
 
         let error = ensure_current(&conn).unwrap_err().to_string();
         assert!(error.contains("unversioned non-empty"));
-        assert!(error.contains("Rebuild the database"));
+        assert!(error.contains("schema rebuild required"), "{error}");
         assert!(!table_exists(&conn, "troves").unwrap());
     }
 
@@ -726,7 +727,7 @@ mod tests {
 
             let error = ensure_current(&conn).unwrap_err().to_string();
             assert!(error.contains("unversioned non-empty"), "{error}");
-            assert!(error.contains("Rebuild the database"), "{error}");
+            assert!(error.contains("schema rebuild required"), "{error}");
             assert!(!table_exists(&conn, "troves").unwrap());
         }
     }

--- a/crates/conary-core/src/error.rs
+++ b/crates/conary-core/src/error.rs
@@ -58,6 +58,16 @@ pub enum Error {
     #[error("Failed to initialize database: {0}")]
     InitError(String),
 
+    /// An existing database belongs to a retired pre-alpha schema.
+    #[error(
+        "Database schema rebuild required: database uses {observed}; this pre-alpha build supports only schema epoch {supported_epoch} revision {supported_revision}"
+    )]
+    SchemaRebuildRequired {
+        observed: String,
+        supported_epoch: String,
+        supported_revision: i32,
+    },
+
     /// Missing ID on model object (required for update/query operations)
     #[error("Missing ID: {0}")]
     MissingId(String),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -94,6 +94,7 @@ crates/conary-core/      Core library crate
     +-- operations.rs    Shared operation vocabulary across CLI and daemon boundaries
     +-- db/              Database layer
     |   +-- schema.rs    Current pre-alpha schema epoch initializer and rebuild gate
+    |   +-- rebuild.rs   Explicit retired-schema snapshot and active-state replacement
     |   +-- current_schema/ One schema split into package-manager, repository, and Remi ownership files
     |   +-- models/      ORM-style model structs
     |   |   +-- try_session.rs M1b package try session state
@@ -581,11 +582,14 @@ The schema itself is split by ownership under
 `crates/conary-core/src/db/current_schema/sql/`: local package-manager state,
 repository/service state, and Remi conversion/administration state.
 
-Databases from retired schema revisions are rejected with an explicit rebuild
-requirement. Conary does not carry a schema compatibility chain or attempt to
-preserve derived queue and workflow history while there are no external users.
-Rebuilds must come from authoritative package, repository, and conversion
-inputs.
+Databases from retired schema revisions are rejected with an exact recovery
+command. `conary system rebuild-db --discard-state --yes` consolidates the
+retired SQLite state into a durable snapshot under the Conary backup directory,
+then creates the one current schema and current repository/host-capability
+authority. It does not infer installed state from generation artifacts: the
+operator must resync repository metadata and explicitly re-adopt native packages
+that Conary should track. `conary system init` remains non-destructive and does
+not carry a compatibility chain or silently reset an existing database.
 
 The stable table families are:
 

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -106,8 +106,10 @@ two independent reasons found on 2026-07-28:
 - They ship a bootstrap-built `/var/lib/conary/conary.db` at migration-chain
   schema version 66. The schema epoch hard cut in df607ee8 (#61, 2026-07-26)
   retired it, so `conary system init` refuses inside them with
-  `database uses retired migration-chain schema version 66`. #157 owns the
-  product gap that the refusal names a rebuild no command performs.
+  `database uses retired migration-chain schema version 66`. Use the explicit
+  `conary system rebuild-db --discard-state --yes` path only when that fixture's
+  active Conary state is disposable; it preserves the retired database as a
+  snapshot and initializes current repository/host-capability authority.
 
 The Fedora image ships no `/var/lib/conary` at all, so `system init` creates a
 fresh database at the current schema.

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-04
-revision: 60
-summary: Route lossless source authority, exact Remi signing, selected-root mutation, rollback lineage, canonical-map authority, carrier security, generation GC, release authority, and subsystem proof through current feature owners.
+revision: 61
+summary: Route typed database rebuilds, lossless source authority, exact Remi signing, selected-root mutation, rollback lineage, canonical-map authority, carrier security, generation GC, release authority, and subsystem proof through current feature owners.
 ---
 
 # Assistant Subsystem Map
@@ -54,6 +54,8 @@ commands.
 - Current-schema revision and persisted model-state authority:
   `docs/modules/feature-ownership.md` slug `database-state`, plus
   `crates/conary-core/src/db/schema.rs`,
+  `crates/conary-core/src/db/rebuild.rs`,
+  `apps/conary/src/commands/system/rebuild_database.rs`,
   `crates/conary-core/src/db/current_schema/`, and
   `crates/conary-core/src/db/models/persisted_value.rs`.
 - CLI dispatch and command routing: `docs/modules/feature-ownership.md` slug

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-04
-revision: 63
-summary: Route feature ownership through exact Remi signing, streaming package payloads, serialized selected-root mutation, typed rollback lineage, exact lifecycle, canonical-map authority, carrier security, generation GC, exact release authority, and current canonical docs
+revision: 64
+summary: Route feature ownership through typed database rebuilds, exact Remi signing, streaming package payloads, serialized selected-root mutation, typed rollback lineage, exact lifecycle, canonical-map authority, carrier security, generation GC, exact release authority, and current canonical docs
 ---
 
 # Feature Ownership And Interaction Gates
@@ -48,11 +48,13 @@ Each ownership card uses these fields:
 
 **Slug:** database-state
 
-**Capability:** keep current-schema model enums and tagged values exact,
-fallible on read, constrained on write, and bound to the row that supplied
-them.
+**Capability:** keep current-schema identity, rebuilds, model enums, and tagged
+values exact, fallible on read, constrained on write, and bound to the row that
+supplied them.
 
 **Start here:** `crates/conary-core/src/db/schema.rs`;
+`crates/conary-core/src/db/rebuild.rs`;
+`apps/conary/src/commands/system/rebuild_database.rs`;
 `crates/conary-core/src/db/current_schema/`;
 `crates/conary-core/src/db/models/persisted_value.rs`;
 `crates/conary-core/src/db/models/trigger.rs`;
@@ -60,11 +62,14 @@ them.
 `crates/conary-core/src/db/models/derived.rs`;
 `docs/ARCHITECTURE.md`.
 
-**Neighbor systems:** install trigger execution, derived-package CLI and model
-application, database backup/restore, Remi deployment/readiness, and every
-current-schema SQL owner that persists a typed state.
+**Neighbor systems:** CLI dispatch and destructive-mutation confirmation,
+install trigger execution, derived-package CLI and model application, database
+backup/restore, Remi deployment/readiness, and every current-schema SQL owner
+that persists a typed state.
 
 **Paths:** `crates/conary-core/src/db/schema.rs`;
+`crates/conary-core/src/db/rebuild.rs`;
+`apps/conary/src/commands/system/rebuild_database.rs`;
 `crates/conary-core/src/db/models/mod.rs`;
 `crates/conary-core/src/db/models/persisted_value.rs`;
 `crates/conary-core/src/db/models/trigger.rs`;
@@ -72,8 +77,11 @@ current-schema SQL owner that persists a typed state.
 `crates/conary-core/src/db/models/derived.rs`.
 
 **Focused proof:** `cargo test -p conary-core --lib db::schema`;
+`cargo test -p conary-core --lib db::rebuild`;
 `cargo test -p conary-core --lib db::models::trigger`;
-`cargo test -p conary-core --lib db::models::derived`.
+`cargo test -p conary-core --lib db::models::derived`;
+`cargo test -p conary --lib commands::system`;
+`cargo test -p conary --test live_host_mutation_safety`.
 
 **Interaction gate:** `cargo test -p conary-core`;
 `cargo test -p conary --test features` when derived-package behavior changes.
@@ -85,7 +93,9 @@ the owning specification when a persisted product contract changes;
 **Safety notes:** persisted values never select a semantic default after a
 parse failure. Current-schema shape changes increment `SCHEMA_VERSION`, reject
 older databases, and state the authoritative rebuild path; do not add a
-migration, fallback reader, or compatibility alias.
+migration, fallback reader, or compatibility alias. A destructive rebuild
+requires explicit discard intent and confirmation, preserves a durable retired
+snapshot first, and never infers installed state from generation artifacts.
 
 ## CLI Dispatch And Command Routing
 

--- a/docs/modules/test-fixtures.md
+++ b/docs/modules/test-fixtures.md
@@ -556,7 +556,9 @@ Each fixture family should record:
   second, independent reason: those images ship a bootstrap-built
   `/var/lib/conary/conary.db` at migration-chain schema version 66, and the
   schema epoch hard cut in df607ee8 (#61, 2026-07-26) retired it, so
-  `conary system init` refuses inside them. #157 owns that product gap.
+  `conary system init` refuses inside them. When the fixture state is
+  disposable, `conary system rebuild-db --discard-state --yes` snapshots that
+  database and initializes current repository/host-capability authority.
 - **Current evidence:** the 2026-07-16 Fedora 44 Group O local KVM run passed
   all five cases against `minimal-boot-v4`, the version the suites targeted at
   the time; a focused recompiled-harness TGE01 rerun also passed with the


### PR DESCRIPTION
## Primary Issue

Closes #157

Design / Plan / Roadmap: issue #157's explicit drop-and-recreate option; artifact-derived reconstruction remains out of scope.

## Problem And Outcome

Retired pre-alpha databases correctly fail current-schema validation, but `conary system init` previously ended at a generic instruction to rebuild from authoritative inputs even though no command implemented that action.

After this change, the typed refusal names `conary system rebuild-db --discard-state --yes`. The command consolidates the committed retired SQLite state into a durable snapshot, replaces only the active database with the one current schema, and seeds current repository and host-capability authority.

## Changes

- add typed `SchemaRebuildRequired` authority shared by Conary and Remi without embedding CLI-specific guidance in core
- add `conary system rebuild-db --discard-state --yes` with a distinct destructive-DB risk class and try-session preflight bypass
- snapshot retired state with SQLite `VACUUM INTO`, durably sync it, replace the database and sidecars, and restore the snapshot if current-schema initialization fails
- refuse current or fresh databases instead of treating the command as a reset shortcut
- seed current repositories and host capability inventory after replacement
- add core, command, CLI-risk, preflight, and no-mutation-before-confirmation regressions
- update architecture, fixture guidance, subsystem routing, and the `database-state` ownership card

## Scope

- In scope: explicit disposal of retired active DB state after a recoverable snapshot; current-schema initialization; repository/host-authority seeding; exact CLI recovery guidance.
- Out of scope: inferring installed state from generations or CAS; changing schema revision 25; deleting CAS or generation artifacts; compatibility migrations or fallback readers.

## Ownership / Boundary

- Owning subsystem: `database-state`, with CLI dispatch as the interaction boundary.
- Boundary changed or preserved: core owns typed schema compatibility and exact SQLite replacement; the Conary CLI alone owns its command-specific recovery guidance and confirmation.
- Persisted state or public surface impact: the active retired DB is replaced only after `--discard-state --yes`; a durable retired snapshot remains in the Conary backup directory. The new CLI command is public.
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code
- [x] Updated subsystem docs or maps when the "look here first" path changed
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs

```text
- cargo test -p conary-core --lib db::schema --no-fail-fast
- cargo test -p conary-core --lib db::rebuild --no-fail-fast
- cargo test -p conary-core --lib db::models::trigger --no-fail-fast
- cargo test -p conary-core --lib db::models::derived --no-fail-fast
- cargo check -p conary
- cargo test -p conary --lib cli::tests --no-fail-fast
- cargo test -p conary --test live_host_mutation_safety --no-fail-fast
- cargo run -p conary -- system completions bash >/dev/null
- cargo test -p conary --test query --no-fail-fast
- cargo test -p conary --test query_scripts --no-fail-fast
- cargo test -p conary --test cli_daily_ux --no-fail-fast
- cargo test -p conary --lib commands::model --no-fail-fast
- cargo test -p conary-core --no-fail-fast
- cargo test -p conary --no-fail-fast
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --check
- bash scripts/check-doc-truth.sh
- bash scripts/test-doc-truth.sh
- bash scripts/test-agent-context.sh
- bash scripts/agent-context.sh --validate
- git diff --check
```

## Review And Merge Notes

- Review focus: crash/failure behavior around retired snapshot creation and active DB replacement; command confirmation and preflight ordering; core-versus-CLI error ownership.
- User or developer impact: operators crossing a pre-alpha schema cut now have a discoverable, explicit path instead of a dead-end error.
- Required-check bypass: not used
