### PR TITLE
fix(remi): type acquisition retry failures

### DIFF
--- a/crates/conary-core/src/repository/remi.rs
+++ b/crates/conary-core/src/repository/remi.rs
@@ -28,6 +28,8 @@ use tracing::{debug, info, warn};
 use crate::repository::chunk_fetcher::{ChunkFetcher, ChunkFetcherBuilder, CompositeChunkFetcher};
 use std::sync::Arc;
 
+mod acquisition_error;
+use acquisition_error::ReadyPackageAcquisitionError;
 mod async_client;
 pub use async_client::AsyncRemiClient;
 mod protocol;
@@ -72,22 +74,6 @@ fn check_total_chunk_bytes(current: u64, next: u64) -> Result<u64> {
 
 fn identity_get(client: &Client, url: &str) -> reqwest::RequestBuilder {
     client.get(url).header(header::ACCEPT_ENCODING, "identity")
-}
-
-fn is_transient_package_status(status: u16) -> bool {
-    status == 408 || status == 429 || (500..=599).contains(&status)
-}
-
-fn retryable_ready_download_error(error: &Error) -> bool {
-    match error {
-        Error::DownloadError(message) => {
-            message.starts_with("Failed to download ")
-                || message.starts_with("response stream:")
-                || message.starts_with("Remi returned transient HTTP ")
-        }
-        Error::TimeoutError(_) => true,
-        _ => false,
-    }
 }
 
 #[cfg(not(test))]
@@ -186,12 +172,12 @@ impl RemiClient {
         url: &str,
         name: &str,
         distro: &str,
-    ) -> Result<reqwest::Response> {
+    ) -> std::result::Result<reqwest::Response, ReadyPackageAcquisitionError> {
         for attempt in 0..=QUEUE_FULL_MAX_RETRIES {
             let response = identity_get(&self.client, url)
                 .send()
                 .await
-                .download_context(url)?;
+                .map_err(|source| ReadyPackageAcquisitionError::transport(url, source))?;
             let status = response.status().as_u16();
             if status != 503 {
                 return Ok(response);
@@ -199,7 +185,7 @@ impl RemiClient {
 
             let body = response.text().await.unwrap_or_default();
             if attempt == QUEUE_FULL_MAX_RETRIES {
-                return Err(self.core.map_http_error(status, body, name, distro));
+                return Err(self.core.map_http_error(status, body, name, distro).into());
             }
 
             let retry_after = queue_full_retry_delay(attempt + 1);
@@ -527,7 +513,7 @@ impl RemiClient {
         name: &str,
         distro: &str,
         output_dir: &Path,
-    ) -> Result<ReadyPackageDownload> {
+    ) -> std::result::Result<ReadyPackageDownload, ReadyPackageAcquisitionError> {
         let response = self
             .send_download_request_with_queue_retry(url, name, distro)
             .await?;
@@ -542,16 +528,10 @@ impl RemiClient {
                     response.json().await.parse_context("202 response")?;
                 Ok(ReadyPackageDownload::Accepted(accepted))
             }
-            status if is_transient_package_status(status) => {
-                let body = response.text().await.unwrap_or_default();
-                Err(Error::DownloadError(format!(
-                    "Remi returned transient HTTP {}: {}",
-                    status, body
-                )))
-            }
             status => {
                 let body = response.text().await.unwrap_or_default();
-                Err(self.core.map_http_error(status, body, name, distro))
+                let error = self.core.map_http_error(status, body, name, distro);
+                Err(ReadyPackageAcquisitionError::http_response(status, error))
             }
         }
     }
@@ -573,7 +553,7 @@ impl RemiClient {
                 .await
             {
                 Ok(download) => return Ok(download),
-                Err(error) if attempt < max_attempts && retryable_ready_download_error(&error) => {
+                Err(error) if attempt < max_attempts && error.is_retryable() => {
                     let delay = retry_config.delay_for_attempt(attempt);
                     warn!(
                         "Remi download attempt {}/{} for {} failed: {}; retrying in {:?}",
@@ -582,11 +562,13 @@ impl RemiClient {
                     last_error = Some(error);
                     tokio::time::sleep(delay).await;
                 }
-                Err(error) => return Err(error),
+                Err(error) => return Err(error.into_repository_error()),
             }
         }
 
-        Err(last_error.expect("max_attempts is clamped to >= 1, so at least one iteration ran"))
+        Err(last_error
+            .expect("max_attempts is clamped to >= 1, so at least one iteration ran")
+            .into_repository_error())
     }
 
     /// High-level: Fetch a package from Remi and save to disk
@@ -663,7 +645,7 @@ impl RemiClient {
         response: reqwest::Response,
         name: &str,
         output_dir: &Path,
-    ) -> Result<PathBuf> {
+    ) -> std::result::Result<PathBuf, ReadyPackageAcquisitionError> {
         // Get content length for progress bar
         let content_length = response.content_length().unwrap_or(0);
 
@@ -704,7 +686,7 @@ impl RemiClient {
         while let Some(chunk) = response
             .chunk()
             .await
-            .map_err(|e| Error::DownloadError(format!("response stream: {e}")))?
+            .map_err(ReadyPackageAcquisitionError::response_stream)?
         {
             file.write_all(&chunk).io_context("write to output file")?;
 
@@ -730,7 +712,8 @@ impl RemiClient {
             let _ = std::fs::remove_file(&output_path);
             return Err(Error::DownloadError(
                 "Downloaded file is not a valid CCS package (expected gzip)".to_string(),
-            ));
+            )
+            .into());
         }
 
         Ok(output_path)

--- a/crates/conary-core/src/repository/remi/acquisition_error.rs
+++ b/crates/conary-core/src/repository/remi/acquisition_error.rs
@@ -1,0 +1,134 @@
+// conary-core/src/repository/remi/acquisition_error.rs
+
+use crate::error::Error;
+
+/// Exact failure authority for one ready-package acquisition attempt.
+///
+/// Retry disposition is derived from these variants and the HTTP status, never
+/// from the human-readable diagnostics produced by [`std::fmt::Display`].
+#[derive(Debug, thiserror::Error)]
+pub(super) enum ReadyPackageAcquisitionError {
+    #[error("request transport failed for {url}: {source}")]
+    Transport {
+        url: String,
+        #[source]
+        source: reqwest::Error,
+    },
+    #[error("{source}")]
+    HttpResponse {
+        status: u16,
+        #[source]
+        source: Error,
+    },
+    #[error("response stream failed: {source}")]
+    ResponseStream {
+        #[source]
+        source: reqwest::Error,
+    },
+    #[error(transparent)]
+    Fatal(#[from] Error),
+}
+
+impl ReadyPackageAcquisitionError {
+    pub(super) fn transport(url: &str, source: reqwest::Error) -> Self {
+        Self::Transport {
+            url: url.to_string(),
+            source,
+        }
+    }
+
+    pub(super) fn http_response(status: u16, source: Error) -> Self {
+        Self::HttpResponse { status, source }
+    }
+
+    pub(super) fn response_stream(source: reqwest::Error) -> Self {
+        Self::ResponseStream { source }
+    }
+
+    pub(super) fn is_retryable(&self) -> bool {
+        match self {
+            Self::Transport { .. } | Self::ResponseStream { .. } => true,
+            Self::HttpResponse { status, .. } => is_transient_http_status(*status),
+            Self::Fatal(_) => false,
+        }
+    }
+
+    pub(super) fn into_repository_error(self) -> Error {
+        match self {
+            Self::Transport { url, source } => {
+                Error::DownloadError(format!("Failed to download {url}: {source}"))
+            }
+            Self::HttpResponse { source, .. } | Self::Fatal(source) => source,
+            Self::ResponseStream { source } => {
+                Error::DownloadError(format!("response stream: {source}"))
+            }
+        }
+    }
+}
+
+fn is_transient_http_status(status: u16) -> bool {
+    status == 408 || status == 429 || (500..=599).contains(&status)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn http_failure(status: u16, message: &str) -> ReadyPackageAcquisitionError {
+        ReadyPackageAcquisitionError::http_response(
+            status,
+            Error::DownloadError(message.to_string()),
+        )
+    }
+
+    #[test]
+    fn exact_http_status_controls_retry_disposition() {
+        for status in [408, 429, 500, 503, 599] {
+            assert!(
+                http_failure(status, "diagnostic wording is irrelevant").is_retryable(),
+                "HTTP {status} should be retryable"
+            );
+        }
+
+        for status in [400, 401, 403, 404, 409, 600] {
+            assert!(
+                !http_failure(status, "Remi returned transient HTTP 503").is_retryable(),
+                "HTTP {status} should not be retryable"
+            );
+        }
+    }
+
+    #[test]
+    fn fatal_download_wording_cannot_enable_retry() {
+        let error = ReadyPackageAcquisitionError::Fatal(Error::DownloadError(
+            "Failed to download response stream: Remi returned transient HTTP 503".to_string(),
+        ));
+
+        assert!(!error.is_retryable());
+    }
+
+    #[test]
+    fn typed_http_disposition_ignores_diagnostic_wording() {
+        let first = http_failure(500, "first wording");
+        let second = http_failure(500, "completely different wording");
+
+        assert_eq!(first.is_retryable(), second.is_retryable());
+    }
+
+    #[test]
+    fn validation_parse_and_local_failures_are_never_retryable() {
+        let failures = vec![
+            Error::ChecksumMismatch {
+                expected: "expected".to_string(),
+                actual: "actual".to_string(),
+            },
+            Error::ParseError("malformed accepted response".to_string()),
+            Error::IoError("local output failed".to_string()),
+            Error::DownloadError("invalid CCS body".to_string()),
+        ];
+
+        for failure in failures {
+            assert!(!ReadyPackageAcquisitionError::Fatal(failure).is_retryable());
+        }
+    }
+}

--- a/crates/conary-core/src/repository/remi/tests.rs
+++ b/crates/conary-core/src/repository/remi/tests.rs
@@ -305,6 +305,167 @@ async fn write_json_response(listener: &tokio::net::TcpListener, status: &str, b
     socket.write_all(response.as_bytes()).await.unwrap();
 }
 
+async fn spawn_download_server(
+    responses: Vec<Option<Vec<u8>>>,
+) -> (String, std::sync::Arc<std::sync::atomic::AtomicUsize>) {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}", listener.local_addr().unwrap());
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let server_attempts = attempts.clone();
+
+    tokio::spawn(async move {
+        for response in responses {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = socket.read(&mut request).await.unwrap();
+            server_attempts.fetch_add(1, Ordering::SeqCst);
+            if let Some(response) = response {
+                socket.write_all(&response).await.unwrap();
+            }
+        }
+    });
+
+    (base_url, attempts)
+}
+
+fn download_response(status: &str, body: &[u8]) -> Vec<u8> {
+    let mut response = format!(
+        "HTTP/1.1 {status}\r\nContent-Disposition: attachment; filename=\"qemu-img.ccs\"\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    )
+    .into_bytes();
+    response.extend_from_slice(body);
+    response
+}
+
+async fn fetch_test_package(base_url: &str, output_dir: &Path) -> Result<PathBuf> {
+    RemiClient::new(base_url)?
+        .fetch_package(
+            "fedora",
+            "qemu-img",
+            Some("2:10.1.0-7.fc44"),
+            None,
+            output_dir,
+        )
+        .await
+}
+
+#[tokio::test]
+async fn fetch_package_retries_typed_request_transport_failure() {
+    use std::sync::atomic::Ordering;
+
+    let (base_url, attempts) =
+        spawn_download_server(vec![None, Some(download_response("200 OK", &[0x1f, 0x8b]))]).await;
+    let output = tempfile::tempdir().unwrap();
+
+    let path = fetch_test_package(&base_url, output.path())
+        .await
+        .expect("request transport failure should be retried");
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    assert_eq!(std::fs::read(path).unwrap(), [0x1f, 0x8b]);
+}
+
+#[tokio::test]
+async fn fetch_package_retries_exact_transient_http_status() {
+    use std::sync::atomic::Ordering;
+
+    let (base_url, attempts) = spawn_download_server(vec![
+        Some(download_response(
+            "500 Internal Server Error",
+            b"first failure",
+        )),
+        Some(download_response("200 OK", &[0x1f, 0x8b])),
+    ])
+    .await;
+    let output = tempfile::tempdir().unwrap();
+
+    let path = fetch_test_package(&base_url, output.path())
+        .await
+        .expect("transient HTTP status should be retried");
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    assert_eq!(std::fs::read(path).unwrap(), [0x1f, 0x8b]);
+}
+
+#[tokio::test]
+async fn fetch_package_does_not_retry_permanent_http_status() {
+    use std::sync::atomic::Ordering;
+
+    let (base_url, attempts) =
+        spawn_download_server(vec![Some(download_response("403 Forbidden", b"denied"))]).await;
+    let output = tempfile::tempdir().unwrap();
+
+    let error = fetch_test_package(&base_url, output.path())
+        .await
+        .unwrap_err();
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    assert!(error.to_string().contains("HTTP 403"), "{error}");
+}
+
+#[tokio::test]
+async fn fetch_package_does_not_retry_invalid_ccs_body() {
+    use std::sync::atomic::Ordering;
+
+    let (base_url, attempts) =
+        spawn_download_server(vec![Some(download_response("200 OK", b"not-gzip"))]).await;
+    let output = tempfile::tempdir().unwrap();
+
+    let error = fetch_test_package(&base_url, output.path())
+        .await
+        .unwrap_err();
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    assert!(
+        error.to_string().contains("not a valid CCS package"),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn fetch_package_does_not_retry_local_output_failure() {
+    use std::sync::atomic::Ordering;
+
+    let (base_url, attempts) =
+        spawn_download_server(vec![Some(download_response("200 OK", &[0x1f, 0x8b]))]).await;
+    let output = tempfile::tempdir().unwrap();
+    let missing_output_dir = output.path().join("missing");
+
+    let error = fetch_test_package(&base_url, &missing_output_dir)
+        .await
+        .unwrap_err();
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    assert!(error.to_string().contains("create output file"), "{error}");
+}
+
+#[tokio::test]
+async fn fetch_package_does_not_retry_malformed_accepted_response() {
+    use std::sync::atomic::Ordering;
+
+    let (base_url, attempts) = spawn_download_server(vec![Some(download_response(
+        "202 Accepted",
+        br#"{"status":"queued"}"#,
+    ))])
+    .await;
+    let output = tempfile::tempdir().unwrap();
+
+    let error = fetch_test_package(&base_url, output.path())
+        .await
+        .unwrap_err();
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    assert!(error.to_string().contains("202 response"), "{error}");
+}
+
 #[tokio::test]
 async fn fetch_package_retries_transient_body_stream_failure() {
     use std::sync::{


### PR DESCRIPTION
## Primary Issue

Closes #257

Refs #67 and roadmap workstream W6.

## Problem And Outcome

The ready-package Remi client decided retryability by matching three human-facing `Error::DownloadError` prefixes. Diagnostic wording could therefore disable a required acquisition retry or make a fatal failure retryable.

After this change, one private `ReadyPackageAcquisitionError` owner carries request transport, exact HTTP status, response-stream, and fatal failure variants through the retry loop. Retry disposition matches only typed variants and the exact 408/429/5xx status contract. Conversion back to the public repository error happens only when the operation returns to its caller.

## Changes

- add a focused typed acquisition-error module under the Remi client
- classify request transport and response-stream failures at their source
- carry exact HTTP status independently from the diagnostic error
- preserve queue-full 503 backoff and conversion polling behavior
- keep local I/O, checksum, parse/protocol, CCS validation, and permanent HTTP failures non-retryable
- delete `retryable_ready_download_error` and all production message-prefix authority
- add socket-level regressions for retryable and fatal acquisition classes
- add unit proof that diagnostic wording cannot change retry disposition

## Scope And Impact

- Owning subsystem: repository resolution / Remi package acquisition
- Persisted or public contract impact: none
- Schema or compatibility path: none
- Deleted authority: `retryable_ready_download_error`, `is_transient_package_status`, and the three retry-controlling message-prefix checks
- New typed owner: `repository::remi::acquisition_error::ReadyPackageAcquisitionError`

## Verification

```text
cargo test -p conary-core repository::remi --no-fail-fast
  36 passed
bash scripts/agent-context.sh --feature resolution --run focused
  all 7 commands passed
cargo test -p conary-core --no-fail-fast
  3319 passed, 2 ignored; all integration targets and doctests passed
cargo clippy --workspace --all-targets -- -D warnings
cargo fmt --check
bash scripts/agent-context.sh --feature resolution --run gate
  all 6 commands passed
bash scripts/check-doc-truth.sh
bash scripts/test-doc-truth.sh
bash scripts/test-agent-context.sh
bash scripts/agent-context.sh --validate
git diff --check
```

The two ignored core tests require pinned external RPM fixture environment variables; no test failed.

## Review Notes

Review focus:

- the distinction between retryable request/HTTP/stream failures and fatal local/protocol/validation failures
- preservation of the existing queue-full 503 retry path
- confirmation that no display string participates in retry authority
