### PR TITLE
fix(remi): publish downloaded packages atomically

### DIFF
--- a/crates/conary-core/src/repository/remi.rs
+++ b/crates/conary-core/src/repository/remi.rs
@@ -677,8 +677,13 @@ impl RemiClient {
         );
         pb.set_message(format!("Downloading {}", filename));
 
-        // Download to file with progress
-        let mut file = std::fs::File::create(&output_path).io_context("create output file")?;
+        // Keep every attempt private until its complete body has been flushed and
+        // validated. The same-directory stage makes the final rename atomic and
+        // lets NamedTempFile clean up stream, local I/O, and validation failures.
+        let mut staged = tempfile::Builder::new()
+            .prefix(".conary-remi-download-")
+            .tempfile_in(output_dir)
+            .io_context("create staged output file")?;
 
         let mut downloaded: u64 = 0;
         let mut response = response;
@@ -688,33 +693,48 @@ impl RemiClient {
             .await
             .map_err(ReadyPackageAcquisitionError::response_stream)?
         {
-            file.write_all(&chunk).io_context("write to output file")?;
+            staged
+                .as_file_mut()
+                .write_all(&chunk)
+                .io_context("write staged output file")?;
 
             downloaded += chunk.len() as u64;
             pb.set_position(downloaded);
         }
 
-        pb.finish_with_message(format!("Downloaded {} ({} bytes)", filename, downloaded));
-        info!("CCS package downloaded: {}", output_path.display());
+        staged
+            .as_file_mut()
+            .flush()
+            .io_context("flush staged output file")?;
 
         // Verify the file is a valid CCS package (gzip-compressed tar)
         // CCS packages are gzipped tar archives, so check for gzip magic bytes
         let mut magic = [0u8; 2];
         {
             use std::io::Read;
-            let mut file = std::fs::File::open(&output_path).io_context("read downloaded file")?;
+            let mut file =
+                std::fs::File::open(staged.path()).io_context("read staged output file")?;
             file.read_exact(&mut magic).io_context("read magic bytes")?;
         }
 
         // Gzip magic: 0x1f 0x8b
         if magic != [0x1f, 0x8b] {
-            // Clean up invalid file
-            let _ = std::fs::remove_file(&output_path);
             return Err(Error::DownloadError(
                 "Downloaded file is not a valid CCS package (expected gzip)".to_string(),
             )
             .into());
         }
+
+        staged.persist(&output_path).map_err(|error| {
+            Error::IoError(format!(
+                "Failed to publish downloaded package at {}: {}",
+                output_path.display(),
+                error.error
+            ))
+        })?;
+
+        pb.finish_with_message(format!("Downloaded {} ({} bytes)", filename, downloaded));
+        info!("CCS package downloaded: {}", output_path.display());
 
         Ok(output_path)
     }

--- a/crates/conary-core/src/repository/remi/tests.rs
+++ b/crates/conary-core/src/repository/remi/tests.rs
@@ -345,6 +345,25 @@ fn download_response(status: &str, body: &[u8]) -> Vec<u8> {
     response
 }
 
+fn truncated_download_response(body: &[u8]) -> Vec<u8> {
+    let mut response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Disposition: attachment; filename=\"qemu-img.ccs\"\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len() + 2
+    )
+    .into_bytes();
+    response.extend_from_slice(body);
+    response
+}
+
+fn output_filenames(output_dir: &Path) -> Vec<String> {
+    let mut filenames = std::fs::read_dir(output_dir)
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    filenames.sort();
+    filenames
+}
+
 async fn fetch_test_package(base_url: &str, output_dir: &Path) -> Result<PathBuf> {
     RemiClient::new(base_url)?
         .fetch_package(
@@ -444,7 +463,10 @@ async fn fetch_package_does_not_retry_local_output_failure() {
         .unwrap_err();
 
     assert_eq!(attempts.load(Ordering::SeqCst), 1);
-    assert!(error.to_string().contains("create output file"), "{error}");
+    assert!(
+        error.to_string().contains("create staged output file"),
+        "{error}"
+    );
 }
 
 #[tokio::test]
@@ -528,6 +550,89 @@ async fn fetch_package_retries_transient_body_stream_failure() {
 
     assert_eq!(attempts.load(Ordering::SeqCst), 2);
     assert_eq!(std::fs::read(path).unwrap(), [0x1f, 0x8b]);
+    assert_eq!(output_filenames(output.path()), ["qemu-img.ccs"]);
+}
+
+#[tokio::test]
+async fn exhausted_stream_retries_leave_no_partial_artifact() {
+    use std::sync::atomic::Ordering;
+
+    let truncated = truncated_download_response(&[0x1f, 0x8b]);
+    let (base_url, attempts) = spawn_download_server(vec![
+        Some(truncated.clone()),
+        Some(truncated.clone()),
+        Some(truncated),
+    ])
+    .await;
+    let output = tempfile::tempdir().unwrap();
+
+    let error = fetch_test_package(&base_url, output.path())
+        .await
+        .unwrap_err();
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    assert!(error.to_string().contains("response stream"), "{error}");
+    assert!(output_filenames(output.path()).is_empty());
+}
+
+#[tokio::test]
+async fn exhausted_stream_retries_preserve_existing_destination() {
+    let truncated = truncated_download_response(&[0x1f, 0x8b]);
+    let (base_url, _) = spawn_download_server(vec![
+        Some(truncated.clone()),
+        Some(truncated.clone()),
+        Some(truncated),
+    ])
+    .await;
+    let output = tempfile::tempdir().unwrap();
+    let destination = output.path().join("qemu-img.ccs");
+    std::fs::write(&destination, b"existing verified package").unwrap();
+
+    fetch_test_package(&base_url, output.path())
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        std::fs::read(destination).unwrap(),
+        b"existing verified package"
+    );
+    assert_eq!(output_filenames(output.path()), ["qemu-img.ccs"]);
+}
+
+#[tokio::test]
+async fn invalid_body_preserves_existing_destination_and_removes_stage() {
+    let (base_url, _) =
+        spawn_download_server(vec![Some(download_response("200 OK", b"not-gzip"))]).await;
+    let output = tempfile::tempdir().unwrap();
+    let destination = output.path().join("qemu-img.ccs");
+    std::fs::write(&destination, b"existing verified package").unwrap();
+
+    fetch_test_package(&base_url, output.path())
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        std::fs::read(destination).unwrap(),
+        b"existing verified package"
+    );
+    assert_eq!(output_filenames(output.path()), ["qemu-img.ccs"]);
+}
+
+#[tokio::test]
+async fn valid_body_atomically_replaces_existing_destination() {
+    let (base_url, _) =
+        spawn_download_server(vec![Some(download_response("200 OK", &[0x1f, 0x8b]))]).await;
+    let output = tempfile::tempdir().unwrap();
+    let destination = output.path().join("qemu-img.ccs");
+    std::fs::write(&destination, b"existing verified package").unwrap();
+
+    let path = fetch_test_package(&base_url, output.path())
+        .await
+        .expect("valid staged package should replace the destination");
+
+    assert_eq!(path, destination);
+    assert_eq!(std::fs::read(path).unwrap(), [0x1f, 0x8b]);
+    assert_eq!(output_filenames(output.path()), ["qemu-img.ccs"]);
 }
 
 mod async_tests {


### PR DESCRIPTION
## Primary Issue

Closes #259

Design / Plan / Roadmap: W6 Authority Audit Closure; #67 audit epic

## Problem And Outcome

The ready-package client created or truncated the caller-visible CCS destination before consuming the response stream. A truncated final retry could therefore leave partial bytes at the final pathname, and an invalid or failed replacement could destroy a previously valid package.

After this change, each response is written to a unique private file in the destination directory. The client flushes and validates the complete staged body before atomically renaming it over the final pathname. Stream, local I/O, and validation failures drop the stage without changing any existing destination.

## Changes

- stage each ready-package response in a same-directory `NamedTempFile`
- flush and validate gzip authority against the staged file
- publish only by same-filesystem atomic rename after validation
- retain typed retry disposition from #257 without diagnostic-text classification
- add filesystem-boundary regressions for exhausted partial streams, existing destinations, invalid bodies, successful replacement, and stage cleanup

## Scope

- In scope: Remi ready-package acquisition and caller-visible CCS filesystem publication
- Out of scope: retry classification, server publication, CCS archive validation beyond the existing gzip-body contract, persisted schemas, and public protocol changes

## Ownership / Boundary

- Owning subsystem: repository resolution / Remi package acquisition
- Boundary changed or preserved: filesystem publication now occurs only after a complete validated response; typed retry authority is preserved
- Persisted state or public surface impact: none
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code
- [x] Updated subsystem docs or maps when the "look here first" path changed (not applicable; ownership paths did not change)
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs (none)

```text
- cargo test -p conary-core repository::remi::tests -- --nocapture
- cargo test -p conary-core repository -- --nocapture
- cargo test -p conary-core
- cargo test -p remi
- bash scripts/agent-context.sh --feature resolution --run focused
- bash scripts/agent-context.sh --feature resolution --run gate
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --check
- bash scripts/check-doc-truth.sh
- bash scripts/agent-context.sh --validate
- git diff --check
```

Observed results: Remi client 32/32, repository 551/551, conary-core 3,324 passed with 2 documented fixture-dependent ignores, Remi 600/600 across its targets, all 7 focused commands, all 6 interaction commands, strict Clippy, formatting, docs truth, ownership validation, and diff checks passed. The new exhausted-stream regression failed against the pre-fix implementation because it found a partial final artifact.

## Review And Merge Notes

- Review focus: same-directory staging cleanup on every error path and overwrite-only-after-validation semantics
- User or developer impact: failed Remi downloads no longer expose partial CCS files or destroy an existing valid destination
- Required-check bypass: not used
