### PR TITLE
fix(packaging): parse publish targets exactly

### DIFF
--- a/apps/conary/src/commands/packaging_mcp/service.rs
+++ b/apps/conary/src/commands/packaging_mcp/service.rs
@@ -21,7 +21,7 @@ use conary_core::repository::static_repo::publish_context::{
 };
 
 use super::super::publish::{
-    StaticArtifactPublishServiceInput, publish_static_artifact_form_service,
+    PublishDestination, StaticArtifactPublishServiceInput, publish_static_artifact_form_service,
 };
 use super::projection::{AgentProjectionMode, project_packaging_output};
 use super::publish_plan::{PublishPlanMaterial, PublishPlanRegistry, stage_artifact_private};
@@ -167,27 +167,46 @@ impl PackagingAgentService {
 
     pub(crate) fn plan_publish(&self, input: PublishPlanInput) -> Result<PlanResult> {
         let operation = "conary.packaging.publish.plan";
-        let target_route = classify_publish_target(&input.target);
-        if matches!(target_route, PublishTargetRoute::RemiRelease) {
-            return Ok(failed_plan_result(
-                operation,
-                OperationStatus::Unavailable,
-                "Remi publish apply is not available through M3b packaging MCP",
-                AgentErrorKind::RemoteUnavailable,
-                "M3b does not resolve bearer tokens or apply Remi publishes",
-            )
-            .with_data(route_data(&input, "remi_release", "remi")));
-        }
-        if matches!(target_route, PublishTargetRoute::UnsupportedHttp) {
-            return Ok(failed_plan_result(
-                operation,
-                OperationStatus::Failed,
-                "HTTP static publish targets are not supported by M3b packaging MCP",
-                AgentErrorKind::NotSupported,
-                "M3b only plans local static artifact-form publish targets",
-            )
-            .with_data(route_data(&input, "unsupported_http", "artifact_static")));
-        }
+        let destination = match PublishDestination::parse(&input.target) {
+            Ok(PublishDestination::RemiRelease(destination)) => {
+                return Ok(failed_plan_result(
+                    operation,
+                    OperationStatus::Unavailable,
+                    "Remi publish apply is not available through M3b packaging MCP",
+                    AgentErrorKind::RemoteUnavailable,
+                    format!(
+                        "M3b does not resolve bearer tokens or apply Remi publishes for route '{}'",
+                        destination.route_slug()
+                    ),
+                )
+                .with_data(route_data(&input, "remi_release", "remi")));
+            }
+            Ok(PublishDestination::UnsupportedHttp(_)) => {
+                return Ok(failed_plan_result(
+                    operation,
+                    OperationStatus::Failed,
+                    "HTTP static publish targets are not supported by M3b packaging MCP",
+                    AgentErrorKind::NotSupported,
+                    "M3b only plans local static artifact-form publish targets",
+                )
+                .with_data(route_data(
+                    &input,
+                    "unsupported_http",
+                    "artifact_static",
+                )));
+            }
+            Ok(PublishDestination::StaticLocal(destination)) => destination,
+            Err(error) => {
+                return Ok(failed_plan_result(
+                    operation,
+                    OperationStatus::Failed,
+                    "Publish target could not be parsed",
+                    AgentErrorKind::ValidationFailed,
+                    error.to_string(),
+                )
+                .with_data(route_data(&input, "invalid", "artifact_static")));
+            }
+        };
 
         let source = Path::new(&input.artifact_or_project_path);
         let mode = match input.mode {
@@ -221,19 +240,6 @@ impl PackagingAgentService {
                     operation,
                     OperationStatus::Failed,
                     "Artifact publish planning needs a regular local CCS artifact",
-                    AgentErrorKind::ValidationFailed,
-                    error.to_string(),
-                )
-                .with_data(route_data(&input, "static_local", mode)));
-            }
-        };
-        let destination = match RepoLocation::parse(&input.target) {
-            Ok(destination) => destination,
-            Err(error) => {
-                return Ok(failed_plan_result(
-                    operation,
-                    OperationStatus::Failed,
-                    "Static publish target could not be parsed",
                     AgentErrorKind::ValidationFailed,
                     error.to_string(),
                 )
@@ -417,8 +423,16 @@ impl PackagingAgentService {
             ));
         }
 
-        let destination = match RepoLocation::parse(&material.normalized_static_target) {
-            Ok(destination) => destination,
+        let destination = match PublishDestination::parse(&material.normalized_static_target) {
+            Ok(PublishDestination::StaticLocal(destination)) => destination,
+            Ok(_) => {
+                return Ok(failed_apply_result(
+                    operation,
+                    "Static publish target changed route during apply",
+                    AgentErrorKind::UnsafeWithoutConfirmation,
+                    "confirmed local static target no longer parses as a local static destination",
+                ));
+            }
             Err(error) => {
                 return Ok(failed_apply_result(
                     operation,
@@ -496,7 +510,7 @@ impl PackagingAgentService {
         let operation_id = super::super::operation_records::new_operation_id("publish");
         let output = match publish_static_artifact_form_service(StaticArtifactPublishServiceInput {
             artifact_path: staged.path().to_path_buf(),
-            target: material.normalized_static_target.clone(),
+            destination,
             key_dir: material
                 .key_dir_path_when_supplied
                 .as_deref()
@@ -701,25 +715,6 @@ fn read_regular_file_identity(path: &Path) -> Result<FileIdentity> {
         digest,
         size: metadata.len(),
     })
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PublishTargetRoute {
-    StaticLocal,
-    RemiRelease,
-    UnsupportedHttp,
-}
-
-fn classify_publish_target(target: &str) -> PublishTargetRoute {
-    if target.starts_with("http://") || target.starts_with("https://") {
-        if target.contains("/v1/admin/releases/") {
-            PublishTargetRoute::RemiRelease
-        } else {
-            PublishTargetRoute::UnsupportedHttp
-        }
-    } else {
-        PublishTargetRoute::StaticLocal
-    }
 }
 
 fn route_data(

--- a/apps/conary/src/commands/packaging_mcp/service/tests.rs
+++ b/apps/conary/src/commands/packaging_mcp/service/tests.rs
@@ -219,6 +219,61 @@ fn publish_plan_remi_target_is_explicitly_unavailable_without_token_resolution()
 }
 
 #[test]
+fn publish_plan_does_not_route_unrelated_release_substring_to_remi() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let artifact = temp.path().join("pkg.ccs");
+    let key_dir = temp.path().join("keys");
+    std::fs::write(&artifact, b"not-a-real-package").unwrap();
+    let service = PackagingAgentService::with_operations_dir(temp.path().join("ops"));
+
+    let plan = service
+        .plan_publish(PublishPlanInput {
+            artifact_or_project_path: artifact.display().to_string(),
+            target: "https://remi.example.invalid/prefix/v1/admin/releases/fedora".to_string(),
+            recipe: None,
+            key_dir: Some(key_dir.display().to_string()),
+            state_file: None,
+            mode: PublishModeInput::ArtifactStatic,
+        })
+        .unwrap();
+
+    assert_eq!(plan.envelope.status, OperationStatus::Failed);
+    assert_eq!(
+        plan.envelope.error.unwrap().kind,
+        AgentErrorKind::NotSupported
+    );
+    assert_eq!(plan.data["route"], "unsupported_http");
+    assert!(!key_dir.exists());
+}
+
+#[test]
+fn publish_plan_rejects_non_path_url_authority_before_artifact_reads() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let key_dir = temp.path().join("keys");
+    let service = PackagingAgentService::with_operations_dir(temp.path().join("ops"));
+
+    let plan = service
+        .plan_publish(PublishPlanInput {
+            artifact_or_project_path: temp.path().join("missing.ccs").display().to_string(),
+            target: "https://remi.example.invalid/v1/admin/releases/fedora?dry-run=true"
+                .to_string(),
+            recipe: None,
+            key_dir: Some(key_dir.display().to_string()),
+            state_file: None,
+            mode: PublishModeInput::ArtifactStatic,
+        })
+        .unwrap();
+
+    assert_eq!(plan.envelope.status, OperationStatus::Failed);
+    assert_eq!(
+        plan.envelope.error.unwrap().kind,
+        AgentErrorKind::ValidationFailed
+    );
+    assert_eq!(plan.data["route"], "invalid");
+    assert!(!key_dir.exists());
+}
+
+#[test]
 fn publish_plan_rejects_symlink_and_non_regular_artifacts() {
     let temp = tempfile::TempDir::new().unwrap();
     let dir_artifact = temp.path().join("dir-artifact");

--- a/apps/conary/src/commands/publish.rs
+++ b/apps/conary/src/commands/publish.rs
@@ -3,6 +3,7 @@
 //! Publish command - build a recipe project and publish it to a static repo.
 
 mod artifact;
+mod target;
 
 use artifact::publish_artifact_form;
 pub(crate) use artifact::publish_static_artifact_form_service;
@@ -10,6 +11,7 @@ use std::env;
 use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+pub(crate) use target::{PublishDestination, RemiReleaseDestination};
 
 use anyhow::{Context, Result, bail};
 use conary_core::ccs::manifest::ManifestProvenance;
@@ -56,7 +58,7 @@ pub struct PublishOptions {
 
 pub(crate) struct StaticArtifactPublishServiceInput {
     pub artifact_path: PathBuf,
-    pub target: String,
+    pub destination: RepoLocation,
     pub key_dir: Option<PathBuf>,
     pub state_file: Option<PathBuf>,
     pub refresh: bool,
@@ -166,7 +168,7 @@ async fn run_project_form_publish(
     let destination = RepoLocation::parse(&options.what)
         .with_context(|| format!("parse static repo destination {}", options.what))?;
     ensure_static_local_publish_destination(&destination)?;
-    let repo_name = derive_repo_name(&options.what)?;
+    let repo_name = derive_repo_name(&destination, &options.what)?;
     let key_dir = resolve_key_dir(options.key_dir.as_deref(), &repo_name)?;
     let state_file = options
         .state_file
@@ -359,33 +361,8 @@ fn ensure_static_local_publish_destination(destination: &RepoLocation) -> Result
     Ok(())
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PublishTargetRoute {
-    StaticLocal,
-    RemiRelease,
-}
-
-fn classify_publish_target(target: &str) -> Result<PublishTargetRoute> {
-    if target.starts_with("http://") || target.starts_with("https://") {
-        if target.contains("/v1/admin/releases/") {
-            return Ok(PublishTargetRoute::RemiRelease);
-        }
-        bail!(
-            "HTTP(S) publish targets must use the Remi release endpoint /v1/admin/releases/{{distro}}"
-        );
-    }
-    Ok(PublishTargetRoute::StaticLocal)
-}
-
-#[cfg(test)]
-fn classify_publish_target_for_tests(target: &str) -> Result<PublishTargetRoute> {
-    classify_publish_target(target)
-}
-
-fn derive_repo_name(destination: &str) -> Result<String> {
-    let location = RepoLocation::parse(destination)
-        .with_context(|| format!("parse static repo destination {}", destination))?;
-    let repo_name = match location {
+fn derive_repo_name(destination: &RepoLocation, display: &str) -> Result<String> {
+    let repo_name = match destination {
         RepoLocation::File { root } => root.file_name().map(|name| name.to_owned()),
         RepoLocation::Http { base } => base
             .rsplit('/')
@@ -396,7 +373,7 @@ fn derive_repo_name(destination: &str) -> Result<String> {
     let repo_name = repo_name
         .and_then(|name| name.into_string().ok())
         .filter(|name| !name.trim().is_empty())
-        .with_context(|| format!("derive static repo name from destination {destination}"))?;
+        .with_context(|| format!("derive static repo name from destination {display}"))?;
 
     Ok(repo_name)
 }
@@ -474,7 +451,9 @@ mod tests {
         let fixture = ArtifactPublishFixture::without_attestation();
         let output = publish_static_artifact_form_service(StaticArtifactPublishServiceInput {
             artifact_path: fixture.package_path.clone(),
-            target: fixture.repo_dir.display().to_string(),
+            destination: RepoLocation::File {
+                root: fixture.repo_dir.clone(),
+            },
             key_dir: Some(fixture.key_dir.clone()),
             state_file: Some(fixture.state_file.clone()),
             refresh: false,
@@ -581,6 +560,42 @@ install = "mkdir -p %(destdir)s/usr/share/publish-json"
             serde_json::from_slice(&output).expect("valid remi unsupported json");
         assert_eq!(value["status"], "failed");
         assert_eq!(value["diagnostics"][0]["code"], "publish-json-unsupported");
+    }
+
+    #[tokio::test]
+    async fn unrelated_release_path_substring_fails_before_publish_side_effects() {
+        let temp = tempfile::tempdir().unwrap();
+        let key_dir = temp.path().join("keys");
+        let mut output = Vec::new();
+
+        let error = cmd_publish_with_output(
+            PublishOptions {
+                what: temp.path().join("missing.ccs").display().to_string(),
+                target: Some(
+                    "https://remi.example.invalid/prefix/v1/admin/releases/fedora".to_string(),
+                ),
+                recipe: None,
+                key_dir: Some(key_dir.display().to_string()),
+                state_file: None,
+                refresh: false,
+                rotate_publish_key: false,
+                rotate_root_key: false,
+                yes: true,
+                json: false,
+            },
+            &mut output,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("must use the exact Remi release endpoint"),
+            "{error:#}"
+        );
+        assert!(!key_dir.exists());
+        assert!(output.is_empty());
     }
 
     #[test]
@@ -705,26 +720,6 @@ install = "mkdir -p %(destdir)s/usr/share/publish-local && printf hi > %(destdir
     }
 
     #[test]
-    fn http_publish_target_routes_to_remi_release_path() {
-        let route = classify_publish_target_for_tests(
-            "https://remi.example.invalid/v1/admin/releases/test",
-        )
-        .unwrap();
-
-        assert_eq!(route, PublishTargetRoute::RemiRelease);
-    }
-
-    #[test]
-    fn remi_release_publish_target_routes_to_release_endpoint() {
-        let route = classify_publish_target_for_tests(
-            "https://remi.example.invalid/v1/admin/releases/test",
-        )
-        .unwrap();
-
-        assert_eq!(route, PublishTargetRoute::RemiRelease);
-    }
-
-    #[test]
     fn static_local_guard_still_rejects_http_static_path() {
         let destination = RepoLocation::parse("https://repo.example.invalid/static").unwrap();
         let error = ensure_static_local_publish_destination(&destination).unwrap_err();
@@ -738,9 +733,11 @@ install = "mkdir -p %(destdir)s/usr/share/publish-local && printf hi > %(destdir
 
     #[test]
     fn repo_name_is_derived_from_destination_tail() {
-        assert_eq!(derive_repo_name("./repo").unwrap(), "repo");
+        let local = RepoLocation::parse("./repo").unwrap();
+        assert_eq!(derive_repo_name(&local, "./repo").unwrap(), "repo");
+        let http = RepoLocation::parse("https://example.invalid/static/acme").unwrap();
         assert_eq!(
-            derive_repo_name("https://example.invalid/static/acme").unwrap(),
+            derive_repo_name(&http, "https://example.invalid/static/acme").unwrap(),
             "acme"
         );
     }

--- a/apps/conary/src/commands/publish/artifact.rs
+++ b/apps/conary/src/commands/publish/artifact.rs
@@ -10,11 +10,11 @@ pub(super) async fn publish_artifact_form(
     writer: &mut impl Write,
 ) -> Result<()> {
     let operation_id = publish_operation_id();
-    match classify_publish_target(target)? {
-        PublishTargetRoute::StaticLocal => {
-            publish_static_artifact_form(options, target, writer, operation_id).await
+    match PublishDestination::parse(target)? {
+        PublishDestination::StaticLocal(destination) => {
+            publish_static_artifact_form(options, target, destination, writer, operation_id).await
         }
-        PublishTargetRoute::RemiRelease if options.json => {
+        PublishDestination::RemiRelease(_) if options.json => {
             let message = "Remi publish JSON output is not supported in M3a";
             let output = publish_failure_output(
                 &operation_id,
@@ -25,20 +25,28 @@ pub(super) async fn publish_artifact_form(
             super::super::diagnostics::write_packaging_record_if_possible(&output);
             bail!("{message}")
         }
-        PublishTargetRoute::RemiRelease => publish_remi_artifact_form(options, target).await,
+        PublishDestination::RemiRelease(destination) => {
+            publish_remi_artifact_form(options, &destination).await
+        }
+        PublishDestination::UnsupportedHttp(destination) => bail!(
+            "HTTP(S) publish target '{}' must use the exact Remi release endpoint /v1/admin/releases/{{route}}",
+            destination
+        ),
     }
 }
 
 async fn publish_static_artifact_form(
     options: PublishOptions,
     target: &str,
+    destination: RepoLocation,
     writer: &mut impl Write,
     operation_id: String,
 ) -> Result<()> {
     let json = options.json;
+    let repo_name = derive_repo_name(&destination, target)?;
     let input = StaticArtifactPublishServiceInput {
         artifact_path: PathBuf::from(&options.what),
-        target: target.to_string(),
+        destination,
         key_dir: options.key_dir.as_deref().map(PathBuf::from),
         state_file: options.state_file.as_deref().map(PathBuf::from),
         refresh: options.refresh,
@@ -57,7 +65,6 @@ async fn publish_static_artifact_form(
     if json {
         super::super::diagnostics::write_packaging_output(&output, true, writer)?;
     } else {
-        let repo_name = derive_repo_name(target)?;
         writeln!(
             writer,
             "Published attested artifact to static repo: {repo_name}"
@@ -75,10 +82,13 @@ pub(crate) async fn publish_static_artifact_form_service(
     input: StaticArtifactPublishServiceInput,
 ) -> Result<PackagingCommandOutput> {
     let artifact_path = input.artifact_path;
-    let destination = RepoLocation::parse(&input.target)
-        .with_context(|| format!("parse publish target {}", input.target))?;
+    let destination = input.destination;
     ensure_static_local_publish_destination(&destination)?;
-    let repo_name = derive_repo_name(&input.target)?;
+    let display_target = match &destination {
+        RepoLocation::File { root } => root.display().to_string(),
+        RepoLocation::Http { base } => base.clone(),
+    };
+    let repo_name = derive_repo_name(&destination, &display_target)?;
     let key_dir = match input.key_dir {
         Some(key_dir) => key_dir,
         None => resolve_key_dir(None, &repo_name)?,
@@ -146,7 +156,10 @@ fn publish_key_id_from_output(output: &PackagingCommandOutput) -> Option<&str> {
         .find_map(|message| message.strip_prefix("Publish key ID: "))
 }
 
-async fn publish_remi_artifact_form(options: PublishOptions, target: &str) -> Result<()> {
+async fn publish_remi_artifact_form(
+    options: PublishOptions,
+    destination: &RemiReleaseDestination,
+) -> Result<()> {
     let artifact_path = PathBuf::from(&options.what);
     let key_dir = options.key_dir.as_deref().context(
         "Remi artifact publication requires --key-dir so the artifact signer can be authenticated before upload",
@@ -160,12 +173,15 @@ async fn publish_remi_artifact_form(options: PublishOptions, target: &str) -> Re
     let bearer_token = resolve_remi_publish_bearer_token()?;
     publish_to_remi(RemiPublishOptions {
         artifact_path: &artifact_path,
-        target_url: target,
+        target_url: destination.endpoint(),
         bearer_token: &bearer_token,
         trust_policy: &trust_policy,
     })
     .await?;
 
-    println!("Published attested artifact to Remi release endpoint: {target}");
+    println!(
+        "Published attested artifact to Remi release endpoint: {}",
+        destination.endpoint()
+    );
     Ok(())
 }

--- a/apps/conary/src/commands/publish/target.rs
+++ b/apps/conary/src/commands/publish/target.rs
@@ -1,0 +1,176 @@
+// apps/conary/src/commands/publish/target.rs
+
+//! Exact publication-destination parsing shared by the CLI and agent service.
+
+use anyhow::{Result, bail};
+use conary_core::repository::static_repo::RepoLocation;
+use url::{ParseError, Url};
+
+const REMI_RELEASE_ROUTE_PREFIX: [&str; 3] = ["v1", "admin", "releases"];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PublishDestination {
+    StaticLocal(RepoLocation),
+    RemiRelease(RemiReleaseDestination),
+    UnsupportedHttp(Url),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RemiReleaseDestination {
+    endpoint: Url,
+    route_slug: String,
+}
+
+impl PublishDestination {
+    pub(crate) fn parse(input: &str) -> Result<Self> {
+        match Url::parse(input) {
+            Ok(url) => match url.scheme() {
+                "http" | "https" => parse_http_destination(url),
+                "file" => {
+                    reject_non_path_url_authority(&url)?;
+                    Ok(Self::StaticLocal(RepoLocation::parse(input)?))
+                }
+                scheme => bail!(
+                    "publish destination scheme '{scheme}' is unsupported; use http://, https://, file://, or a local path"
+                ),
+            },
+            Err(ParseError::RelativeUrlWithoutBase) => {
+                Ok(Self::StaticLocal(RepoLocation::parse(input)?))
+            }
+            Err(error) => bail!("invalid publish destination URL '{input}': {error}"),
+        }
+    }
+}
+
+impl RemiReleaseDestination {
+    pub(crate) fn endpoint(&self) -> &str {
+        self.endpoint.as_str()
+    }
+
+    pub(crate) fn route_slug(&self) -> &str {
+        &self.route_slug
+    }
+}
+
+fn parse_http_destination(url: Url) -> Result<PublishDestination> {
+    reject_non_path_url_authority(&url)?;
+
+    let segments = url
+        .path_segments()
+        .ok_or_else(|| anyhow::anyhow!("publish destination URL must have a hierarchical path"))?
+        .collect::<Vec<_>>();
+    if segments.len() == 4
+        && segments[..3] == REMI_RELEASE_ROUTE_PREFIX
+        && is_canonical_route_slug(segments[3])
+    {
+        return Ok(PublishDestination::RemiRelease(RemiReleaseDestination {
+            route_slug: segments[3].to_string(),
+            endpoint: url,
+        }));
+    }
+
+    Ok(PublishDestination::UnsupportedHttp(url))
+}
+
+fn reject_non_path_url_authority(url: &Url) -> Result<()> {
+    if !url.username().is_empty() || url.password().is_some() {
+        bail!("publish destination URL must not contain user information");
+    }
+    if url.query().is_some() {
+        bail!("publish destination URL must not contain a query string");
+    }
+    if url.fragment().is_some() {
+        bail!("publish destination URL must not contain a fragment");
+    }
+    Ok(())
+}
+
+fn is_canonical_route_slug(segment: &str) -> bool {
+    let mut bytes = segment.bytes();
+    bytes
+        .next()
+        .is_some_and(|byte| byte.is_ascii_alphanumeric())
+        && bytes
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_remi_release_route_is_typed() {
+        let destination =
+            PublishDestination::parse("https://remi.example.invalid/v1/admin/releases/fedora")
+                .unwrap();
+
+        let PublishDestination::RemiRelease(release) = destination else {
+            panic!("exact Remi release route was not recognized");
+        };
+        assert_eq!(release.route_slug(), "fedora");
+        assert_eq!(
+            release.endpoint(),
+            "https://remi.example.invalid/v1/admin/releases/fedora"
+        );
+    }
+
+    #[test]
+    fn http_scheme_is_parsed_case_insensitively() {
+        let destination =
+            PublishDestination::parse("HTTPS://remi.example.invalid/v1/admin/releases/arch")
+                .unwrap();
+
+        assert!(matches!(destination, PublishDestination::RemiRelease(_)));
+    }
+
+    #[test]
+    fn unrelated_release_substrings_never_select_remi() {
+        for target in [
+            "https://example.invalid/prefix/v1/admin/releases/fedora",
+            "https://example.invalid/v1/admin/releases/fedora/suffix",
+            "https://example.invalid/v1/admin/releases/",
+            "https://example.invalid/v1/admin/releases/fedora/",
+            "https://example.invalid/v1/admin/releases/fedora%2Fextra",
+            "https://example.invalid/static?next=/v1/admin/releases/fedora",
+        ] {
+            let destination = PublishDestination::parse(target);
+            assert!(
+                !matches!(destination, Ok(PublishDestination::RemiRelease(_))),
+                "{target} selected the Remi mutation route"
+            );
+        }
+    }
+
+    #[test]
+    fn remi_release_route_rejects_non_path_url_authority() {
+        for target in [
+            "https://user@example.invalid/v1/admin/releases/fedora",
+            "https://example.invalid/v1/admin/releases/fedora?dry-run=true",
+            "https://example.invalid/v1/admin/releases/fedora#fragment",
+        ] {
+            assert!(PublishDestination::parse(target).is_err(), "{target}");
+        }
+    }
+
+    #[test]
+    fn local_and_file_destinations_remain_static() {
+        for target in ["./repo", "/srv/conary/repo", "file:///srv/conary/repo"] {
+            assert!(matches!(
+                PublishDestination::parse(target).unwrap(),
+                PublishDestination::StaticLocal(_)
+            ));
+        }
+    }
+
+    #[test]
+    fn malformed_and_unsupported_urls_fail_closed() {
+        for target in [
+            "https://[",
+            "ssh://example.invalid/repo",
+            "file:///srv/conary/repo?mode=publish",
+            "file:///srv/conary/repo#fragment",
+        ] {
+            assert!(PublishDestination::parse(target).is_err(), "{target}");
+        }
+    }
+}

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -929,7 +929,8 @@ Artifact-form `conary publish <pkg.ccs> <target>` must pass
 `publish_gate.rs` checks for package signatures, TOML integrity, attestation
 authority, output identity, command-risk evidence, and foreign-boundary hashes
 before static publication or Remi release upload. The artifact-form CLI and
-service boundary lives in `apps/conary/src/commands/publish/artifact.rs`.
+service boundary lives in `apps/conary/src/commands/publish/artifact.rs`; exact
+CLI/MCP destination parsing lives in `apps/conary/src/commands/publish/target.rs`.
 Destination inspection and attestation preparation live in
 `publish_context.rs`; key staging, recovery, promotion, and package-key
 projection live in `publish_context/key_management.rs`. Never parse static `index.json` or

--- a/docs/modules/recipe.md
+++ b/docs/modules/recipe.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-25
-revision: 6
+last_updated: 2026-08-05
+revision: 7
 summary: Explicit recipe scaffolding, parsing, hermetic cook, Kitchen execution, and source provenance
 ---
 
@@ -131,10 +131,17 @@ rejects the removed generated-recipe/inference identity instead of migrating
 it. Discard and rebuild any local artifacts carrying that superseded shape.
 
 Project-form `conary publish <target>` uses the same hermetic Kitchen path and
-then publishes the cooked CCS package to a static repository. It remains
-pre-M2b: the CCS manifest can carry unsigned M2a hermetic evidence, but there
-is no signed build-attestation envelope yet and artifact-form
-`conary publish <pkg.ccs> <target>` still rejects.
+then attaches the signed build-attestation envelope before publishing the
+cooked CCS package to a static repository. Artifact-form
+`conary publish <pkg.ccs> <target>` accepts only a current signed artifact that
+passes the shared release publish gate and the destination's trust policy.
+
+Artifact-form destination routing is owned once by
+`apps/conary/src/commands/publish/target.rs`. The CLI and packaging agent
+service consume the same parsed type: local paths and `file://` select static
+publication, while only the exact HTTP(S) route
+`/v1/admin/releases/{route}` selects Remi release upload. URL substrings and
+diagnostic text are not publication authority.
 
 ## Architecture Context
 

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-30
-revision: 14
+last_updated: 2026-08-05
+revision: 15
 summary: Document Remi source, sparse sync, signing, canonical-map, repository trust, conversion, publication, and serving authority
 ---
 
@@ -231,6 +231,13 @@ structurally. The route selects a repository feed, never a destination
 compatibility policy. Unsupported route slugs fail before storage or artifact
 verification. Package rows, native rows, chunks, and TUF targets are published
 only after the gate, structural lifecycle validation, and metadata commit pass.
+
+Client-side publication routing is parsed once by
+`apps/conary/src/commands/publish/target.rs` and shared by the CLI and
+packaging agent service. Only an exact hierarchical HTTP(S)
+`/v1/admin/releases/{route}` path, without user information, a query, or a
+fragment, selects this authenticated mutation path. A matching substring in
+another URL is not route authority.
 
 The route/staging wrapper lives in `apps/remi/src/server/release_publish.rs`.
 Native CCS verification, artifact promotion, metadata persistence, supersede

--- a/docs/roadmaps/development-roadmap.md
+++ b/docs/roadmaps/development-roadmap.md
@@ -275,7 +275,8 @@ the stated scope, not whether a workstream happens to be active.
 - **Execution status:** active. #109 closes the trigger-status slice; remaining
   ledger items proceed as narrow issues while the W4 aggregate gate remains
   active.
-- **Issues:** #67 as epic, #109 complete, plus one narrow issue per remaining ledger item.
+- **Issues:** #67 as epic, #109 complete, #261 for exact publish-destination
+  routing, plus one narrow issue per remaining ledger item.
 - **Closed ledger items:**
   - #109 replaces trigger and derived-package status defaults with typed row
     corruption, validates every candidate row before mutation planning, and


### PR DESCRIPTION
## Primary Issue

Closes #261

Design / Plan / Roadmap: Refs #67; W6 external-readiness audit in `docs/roadmaps/development-roadmap.md`.

## Problem And Outcome

Publish destination selection was duplicated between the CLI and packaging MCP service and depended on string prefix/substring checks. A URL containing `/v1/admin/releases/` anywhere could be classified as an authenticated Remi mutation route.

After merge, one typed parser owns this decision. Local paths and `file://` destinations remain static repositories; only an exact hierarchical HTTP(S) path `/v1/admin/releases/{route}` selects Remi. User information, queries, fragments, malformed URLs, unrelated HTTP paths, and unsupported schemes fail closed before artifact, token, network, or key-directory side effects.

## Changes

- Add a shared typed `PublishDestination` parser and typed `RemiReleaseDestination`.
- Remove the CLI and MCP heuristic classifiers.
- Pass parsed static destinations through the service boundary instead of reparsing strings.
- Add CLI, parser, and agent-contract regressions for exact routing and early failure.
- Update recipe, Remi, ownership, and W6 roadmap truth.

## Scope

- In scope: artifact-form publish destination parsing and routing in CLI and packaging MCP.
- Out of scope: Remi token support in packaging MCP, project-form MCP publication, server route behavior, persisted schemas.

## Ownership / Boundary

- Owning subsystem: Packaging, Try Sessions, And Static Repository Publishing.
- Boundary changed or preserved: one shared typed CLI/MCP route boundary replaces duplicated string heuristics.
- Persisted state or public surface impact: no schema change; invalid/ambiguous publish URLs now fail earlier and consistently.
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code
- [x] Updated subsystem docs or maps when the "look here first" path changed
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs

```text
- cargo test -p conary --lib commands::publish
- cargo test -p conary --lib commands::packaging_mcp
- cargo test -p conary --test packaging_m2a
- cargo test -p conary --test packaging_m3a
- bash scripts/agent-context.sh --feature packaging --run focused
- bash scripts/agent-context.sh --feature packaging --run gate
- bash scripts/check-doc-truth.sh
- bash scripts/test-doc-truth.sh
- bash scripts/test-agent-context.sh
- bash scripts/agent-context.sh --validate
- cargo fmt --check
- git diff --check
```

Observed results: all commands passed. The focused feature proof completed all 19 commands; the interaction gate completed all 4 commands, including full `conary-core` and `conary` tests, manifest inventory, and workspace Clippy with warnings denied.

## Review And Merge Notes

- Review focus: URL normalization and exact route recognition; preservation of local and `file://` static publication; failure before side effects.
- User or developer impact: publication routing is deterministic across CLI and agent entrypoints, so a misleading URL substring cannot select the Remi mutation path.
- Required-check bypass: not used
