### PR TITLE
fix(source-policy): require explicit pin strength

### DIFF
--- a/crates/conary-core/src/db/current_schema/sql/repository.sql
+++ b/crates/conary-core/src/db/current_schema/sql/repository.sql
@@ -401,7 +401,7 @@ CREATE TABLE distro_pin (
             id INTEGER PRIMARY KEY,
             distro TEXT NOT NULL
                 CHECK(distro IN ('fedora-44', 'ubuntu-26.04', 'arch')),
-            mixing_policy TEXT NOT NULL DEFAULT 'guarded'
+            mixing_policy TEXT NOT NULL
                 CHECK(mixing_policy IN ('strict', 'guarded', 'permissive')),
             created_at TEXT NOT NULL
         );

--- a/crates/conary-core/src/db/models/distro_pin.rs
+++ b/crates/conary-core/src/db/models/distro_pin.rs
@@ -230,6 +230,26 @@ mod tests {
     }
 
     #[test]
+    fn schema_rejects_omitted_mixing_policy() {
+        let (_temp, conn) = create_test_db();
+
+        let error = conn
+            .execute(
+                "INSERT INTO distro_pin (distro, created_at)
+                 VALUES ('arch', datetime('now'))",
+                [],
+            )
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("NOT NULL constraint failed: distro_pin.mixing_policy"),
+            "{error}"
+        );
+    }
+
+    #[test]
     fn schema_rejects_non_catalog_profile_identity() {
         let (_temp, conn) = create_test_db();
 
@@ -286,11 +306,11 @@ mod tests {
     }
 
     #[test]
-    fn test_set_from_source_pin_uses_default_strength() {
+    fn test_set_from_source_pin_preserves_explicit_strength() {
         let (_temp, conn) = create_test_db();
         let pin = SourcePinConfig {
             distro: "arch".to_string(),
-            ..SourcePinConfig::default()
+            strength: DependencyMixingPolicy::Guarded,
         };
 
         DistroPin::set_from_source_pin(&conn, &pin).unwrap();

--- a/crates/conary-core/src/db/schema.rs
+++ b/crates/conary-core/src/db/schema.rs
@@ -12,12 +12,12 @@ use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 use std::path::Path;
 use tracing::info;
 
-/// Revision 25 of the current-only schema epoch.
+/// Revision 26 of the current-only schema epoch.
 ///
-/// Revision 25 retains revision 24's exact source authority and adds fail-closed
-/// constraints for trigger and derived-package persisted states. Earlier
+/// Revision 26 retains revision 25's fail-closed persisted states and requires
+/// every source pin to persist an explicit dependency-mixing policy. Earlier
 /// pre-alpha databases must be rebuilt; no compatibility migration is provided.
-pub const SCHEMA_VERSION: i32 = 25;
+pub const SCHEMA_VERSION: i32 = 26;
 /// Stable identity that distinguishes this epoch from retired schema revisions.
 pub const SCHEMA_EPOCH: &str = "conary-current-v1";
 
@@ -209,6 +209,31 @@ mod tests {
         ensure_current(&conn).unwrap();
         ensure_current(&conn).unwrap();
         assert_eq!(get_schema_version(&conn).unwrap(), SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn revision_25_requires_rebuild_for_revision_26() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE schema_identity (
+                epoch TEXT NOT NULL,
+                revision INTEGER NOT NULL
+            );
+            INSERT INTO schema_identity (epoch, revision)
+                VALUES ('conary-current-v1', 25);
+            CREATE TABLE schema_version (
+                version INTEGER PRIMARY KEY,
+                applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            INSERT INTO schema_version (version) VALUES (25);",
+        )
+        .unwrap();
+
+        let error = ensure_current(&conn).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "Database schema rebuild required: database uses schema epoch conary-current-v1 revision 25; this pre-alpha build supports only schema epoch conary-current-v1 revision 26"
+        );
     }
 
     #[test]

--- a/crates/conary-core/src/model/parser/source_policy.rs
+++ b/crates/conary-core/src/model/parser/source_policy.rs
@@ -14,7 +14,6 @@ pub struct SourcePinConfig {
     pub distro: String,
 
     /// Typed dependency mixing behavior.
-    #[serde(default = "default_pin_strength")]
     pub strength: DependencyMixingPolicy,
 }
 
@@ -22,7 +21,6 @@ pub struct SourcePinConfig {
 #[serde(deny_unknown_fields)]
 struct SourcePinConfigSerde {
     distro: String,
-    #[serde(default = "default_pin_strength")]
     strength: DependencyMixingPolicy,
 }
 
@@ -41,19 +39,6 @@ impl TryFrom<SourcePinConfigSerde> for SourcePinConfig {
             strength: raw.strength,
         })
     }
-}
-
-impl Default for SourcePinConfig {
-    fn default() -> Self {
-        Self {
-            distro: String::new(),
-            strength: default_pin_strength(),
-        }
-    }
-}
-
-const fn default_pin_strength() -> DependencyMixingPolicy {
-    DependencyMixingPolicy::Guarded
 }
 
 /// Convergence intent controls how aggressively the system should migrate

--- a/crates/conary-core/src/model/parser/tests.rs
+++ b/crates/conary-core/src/model/parser/tests.rs
@@ -652,6 +652,21 @@ strength = "hard"
 }
 
 #[test]
+fn source_pin_requires_explicit_strength() {
+    let input = r#"
+[model]
+version = 1
+
+[system.pin]
+distro = "arch"
+"#;
+    let error = toml::from_str::<SystemModel>(input)
+        .expect_err("a source pin without typed strength must fail")
+        .to_string();
+    assert!(error.contains("missing field `strength`"), "{error}");
+}
+
+#[test]
 fn unsupported_source_pin_profile_is_rejected() {
     let input = r#"
 [model]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-03
-revision: 39
+last_updated: 2026-08-06
+revision: 40
 summary: Describe workspace architecture, source-authority projections, repository trust, package transactions, lifecycle execution, typed carrier security, generation GC, and service boundaries
 ---
 
@@ -581,6 +581,11 @@ current schema epoch initialized by `crates/conary-core/src/db/schema.rs`.
 The schema itself is split by ownership under
 `crates/conary-core/src/db/current_schema/sql/`: local package-manager state,
 repository/service state, and Remi conversion/administration state.
+
+Schema revision 26 retains revision 25's fail-closed persisted-state
+constraints and requires every persisted source pin to carry an explicit
+`strict`, `guarded`, or `permissive` dependency-mixing policy. Omitting the
+policy never selects one on the operator's behalf.
 
 Databases from retired schema revisions are rejected with an exact recovery
 command. `conary system rebuild-db --discard-state --yes` consolidates the

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-05
-revision: 15
+last_updated: 2026-08-06
+revision: 16
 summary: Document Remi source, sparse sync, signing, canonical-map, repository trust, conversion, publication, and serving authority
 ---
 
@@ -271,10 +271,11 @@ the authenticated source artifact. Public, OCI, index, search, chunk, and
 garbage-collection paths validate that typed artifact instead of filling
 missing fields with guesses or empty values. Architecture and the repository
 provide digest are required constructor and API-view fields, and the current
-schema rejects missing, empty, or malformed values. Schema revision 25 retains
-revision 24's source-authority representation and is a pre-alpha hard cut:
-prior databases are rebuilt and re-ingested from configured repository
-authority rather than migrated. Local conversion tracking is
+schema rejects missing, empty, or malformed values. Schema revision 26 retains
+revision 25's source-authority and fail-closed state constraints while requiring
+an explicit mixing policy for every persisted source pin. It is a pre-alpha
+hard cut: prior databases are rebuilt and re-ingested from configured
+repository authority rather than migrated. Local conversion tracking is
 written only after the CCS install transaction commits.
 
 Ready conversion means the artifact carries a source-independent Conary

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-31
-revision: 24
+last_updated: 2026-08-06
+revision: 25
 summary: Document exact profile-owned source policy, multi-root model authority, Remi CCS package authority, canonical map authority, native repository authority, package identity, full-adoption root continuity, and lifecycle handoff
 ---
 
@@ -68,11 +68,15 @@ Important fields:
 - `convergence`: how aggressively package ownership should move during source
   transitions.
 
-The only mixing values are `strict`, `guarded`, and `permissive`. Model parsing
-rejects unknown profile IDs, profile route aliases, unknown mixing values, and
-unknown source-pin fields. The CLI parses the same typed mixing enum before
-changing state, and the current schema independently constrains both persisted
-profile IDs and mixing values. No invalid value silently becomes a default.
+The only mixing values are `strict`, `guarded`, and `permissive`. A configured
+`[system.pin]` must name both its exact profile and its strength; omission is a
+parse error rather than an implicit `guarded` choice. Model parsing rejects
+unknown profile IDs, profile route aliases, unknown mixing values, and unknown
+source-pin fields. The CLI parses the same typed mixing enum before changing
+state, and the current schema independently requires and constrains both
+persisted profile IDs and mixing values. No omitted or invalid value silently
+becomes a default. Absence of the entire pin remains the distinct supported
+unpinned state.
 
 The removed flat `[system].distro` and `[system].mixing` aliases are rejected;
 write `[system.pin]` directly. The former `profile` and `selection_mode`

--- a/docs/roadmaps/development-roadmap.md
+++ b/docs/roadmaps/development-roadmap.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-04
-revision: 12
+last_updated: 2026-08-06
+revision: 13
 summary: Track Conary's cross-distro package milestone, ordered workstreams, evidence, blockers, and post-milestone horizons
 proof_baseline: "immutable v0.14.0 at fe23a604b64ea6f7cc87fce8298911e2245e027f and production remi-v0.9.5 at 101dba655257f1ff3d1bee689d9c5ac8b2b68cbd; exact asset, deployment, and released-package proof complete"
 current_milestone: first external tester loop
@@ -275,13 +275,23 @@ the stated scope, not whether a workstream happens to be active.
 - **Execution status:** active. #109 closes the trigger-status slice; remaining
   ledger items proceed as narrow issues while the W4 aggregate gate remains
   active.
-- **Issues:** #67 as epic, #109 complete, #261 for exact publish-destination
-  routing, plus one narrow issue per remaining ledger item.
+- **Issues:** #67 as epic; #109 for persisted status; #257 and #259 for Remi
+  acquisition integrity; #261 for exact publish-destination routing; #263 for
+  required source-pin strength; plus one narrow issue per remaining P1 item.
 - **Closed ledger items:**
+  - PR #61 rejects missing package architecture, separates typed
+    `InstallReason` from diagnostic selection prose, and validates trigger
+    patterns before persistence and again on read.
   - #109 replaces trigger and derived-package status defaults with typed row
     corruption, validates every candidate row before mutation planning, and
-    constrains the current schema. Schema revision 25 requires rebuilding
-    earlier disposable databases from authoritative inputs.
+    constrains the current schema. The current revision retains those
+    revision-25 constraints.
+  - #257 carries Remi retry disposition through typed acquisition failures;
+    #259 stages, validates, and atomically publishes downloaded CCS files.
+  - #261 parses CLI and packaging-MCP publish destinations through one exact
+    route contract.
+  - #263 requires an explicit typed dependency-mixing strength in every source
+    pin and advances the current-only schema to revision 26.
 - **Ledger gaps found on audit that #67 does not currently own:**
   - The `sanitize_path` ASCII heuristic is a #67-class invented authority but is
     owned only by #99, and only for ALPM. Cross-reference both.

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-03
-revision: 39
+last_updated: 2026-08-06
+revision: 40
 summary: Define source-independent lifecycle, source-authority handoff, generation activation, and configuration transactions for RPM, Debian, and Arch packages
 ---
 
@@ -600,11 +600,11 @@ commits each package's files, payload claims, requirements, and provides
 atomically under `AdoptedTrack` or `AdoptedFull`; package names and partial
 warning paths are not ownership authority.
 
-Schema revision 25 is a pre-alpha hard cut: it retains revision 24's exact
-provider provenance and source-authority representation, and adds fail-closed
-constraints for trigger and derived-package persisted states. It does not
-migrate earlier databases. Operators rebuild disposable local state from
-authoritative package and repository inputs.
+Schema revision 26 is a pre-alpha hard cut: it retains revision 25's exact
+provider provenance, source-authority representation, and fail-closed trigger
+and derived-package states, and requires an explicit mixing policy for every
+persisted source pin. It does not migrate earlier databases. Operators rebuild
+disposable local state from authoritative package and repository inputs.
 
 A complete unfiltered full-system adoption also performs one exact global
 selected-root capture after every native package capture succeeds. Existing

--- a/docs/specs/source-package-authority.md
+++ b/docs/specs/source-package-authority.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-03
-revision: 3
+last_updated: 2026-08-06
+revision: 4
 summary: Define lossless RPM, Debian, ALPM, and CCS package authority plus explicit consumer projections
 ---
 
@@ -313,21 +313,21 @@ The signed CCS contract and installed database both change intentionally.
 
 - CCS v3 replaces v2; every local, cached, static-repository, and Remi v2
   artifact must be rebuilt or reconverted from authenticated source.
-- SQLite schema revision 25 retains revision 24's source-authority hard cut and
-  replaces the current schema in place with fail-closed trigger and
-  derived-package state constraints.
+- SQLite schema revision 26 retains revision 25's source-authority and
+  fail-closed persisted-state constraints, and requires an explicit mixing
+  policy for every source pin.
   Installed and repository provider rows must distinguish identity-derived
   matches from declared/derived capabilities, and config persistence must
   distinguish source declarations from materialized node and transaction
   state.
-- Existing pre-W5 databases are disposable and must be recreated with
+- Existing pre-revision-26 databases are disposable and must be recreated with
   `conary system init` plus repository resync/reinstallation. No migration,
   compatibility decoder, dual write, or fallback reader is added.
 - Remi conversion records and indexes tied to v2 authority are rebuilt before
   public serving. A mixed v2/v3 serving state is invalid.
 
-The rebuild property is intentional: revision 25 has no migration or dual-read
-path from revision 24 or the retired provider representation.
+The rebuild property is intentional: revision 26 has no migration or dual-read
+path from revision 25 or the retired provider representation.
 
 ## Conformance And Closeout
 


### PR DESCRIPTION
Closes #263
Refs #67

## Problem

Source-pin dependency mixing still had two silent authorities: TOML deserialization defaulted an omitted strength to `guarded`, and SQLite did the same for omitted persisted values. That let incomplete source policy become executable state.

## Change

- require `[system.pin].strength` whenever a source pin exists
- remove the Rust `Default` implementation and serde fallback
- remove the SQLite `guarded` default while retaining the closed enum constraint
- advance the current-only pre-alpha schema to revision 26
- reject revision-25 databases with the existing exact rebuild path
- update source-selection, schema, lifecycle, Remi, and roadmap truth

Absence of the entire source pin remains the distinct supported unpinned state.

## Rebuild impact

Revision 26 is a hard cut. Earlier disposable databases must be rebuilt with:

```text
conary system rebuild-db --discard-state --yes
```

No migration, dual read, or compatibility default is introduced.

## Verification

- `cargo test -p conary-core model::parser` — 39 passed
- `cargo test -p conary-core db::models::distro_pin` — 12 passed
- `cargo test -p conary-core --lib db::schema` — 20 passed
- `cargo test -p conary-core repository::effective_policy` — 6 passed
- `cargo test -p conary --lib commands::distro` — 8 passed
- `cargo test -p conary --lib commands::model` — 33 passed
- `bash scripts/agent-context.sh --feature database-state --run focused` — 6 commands passed
- `bash scripts/agent-context.sh --feature resolution --run focused` — 7 commands passed
- `bash scripts/agent-context.sh --feature resolution --run gate` — 6 commands passed
- `cargo test -p conary-core` — passed (3,327 unit passed, 2 ignored; integration and docs passed)
- `cargo test -p conary` — passed (1,016 unit passed, 2 ignored; integration and docs passed)
- `bash scripts/check-doc-truth.sh`
- `bash scripts/test-doc-truth.sh`
- `bash scripts/test-agent-context.sh`
- `bash scripts/agent-context.sh --validate`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`
