### PR TITLE
fix(try): type watcher divergence

### DIFF
--- a/apps/conary/src/commands/try_session/mod.rs
+++ b/apps/conary/src/commands/try_session/mod.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result};
 use conary_core::ccs::verify::TrustPolicy;
 use conary_core::db::models::TrySession;
 use std::path::{Path, PathBuf};
+use thiserror::Error;
 
 mod executor;
 mod install;
@@ -44,6 +45,20 @@ pub(crate) struct TryRefreshRequest<'a> {
     pub(crate) expected_try_generation_id: i64,
     pub(crate) package_path: &'a Path,
     pub(crate) trust_policy: &'a TrustPolicy,
+}
+
+#[derive(Debug, Error)]
+#[error("try watch session {session_id} diverged from watcher-owned state")]
+pub(crate) struct TryRefreshSessionDiverged {
+    session_id: String,
+}
+
+impl TryRefreshSessionDiverged {
+    pub(crate) fn new(session_id: impl Into<String>) -> Self {
+        Self {
+            session_id: session_id.into(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/apps/conary/src/commands/try_session/session.rs
+++ b/apps/conary/src/commands/try_session/session.rs
@@ -22,7 +22,10 @@ use super::namespace::{
 use super::package_verification::load_verified_try_package;
 use super::util::{remove_dir_if_exists, remove_path_if_exists};
 use super::validation::{TryExecutionRoot, validate_try_package_policy};
-use super::{TryRefreshOutcome, TryRefreshRequest, TryStartOutcome, TryStartRequest};
+use super::{
+    TryRefreshOutcome, TryRefreshRequest, TryRefreshSessionDiverged, TryStartOutcome,
+    TryStartRequest,
+};
 use watch_marker::{is_watch_created_try_session, write_try_watch_marker};
 
 pub(crate) fn begin_try_session(request: TryStartRequest<'_>) -> Result<TryStartOutcome> {
@@ -161,25 +164,32 @@ pub(crate) fn refresh_try_session(request: TryRefreshRequest<'_>) -> Result<TryR
     let result = (|| -> Result<TryRefreshOutcome> {
         let live_conn = conary_core::db::open(request.db_path)
             .with_context(|| format!("failed to open Conary DB {}", request.db_path))?;
-        let session = TrySession::find_by_id(&live_conn, request.session_id)?
-            .ok_or_else(|| anyhow::anyhow!("try watch session {} missing", request.session_id))?;
+        let session = TrySession::find_by_id(&live_conn, request.session_id)?.ok_or_else(|| {
+            refresh_session_diverged(request.session_id, "try watch session is missing")
+        })?;
         if session.status != conary_core::db::models::TrySessionStatus::Active {
-            bail!(
-                "try watch session {} changed outside the watcher",
-                request.session_id
-            );
+            return Err(refresh_session_diverged(
+                request.session_id,
+                "try watch session is no longer active",
+            ));
         }
         if session.try_generation_id != Some(request.expected_try_generation_id) {
-            bail!(
-                "try watch session {} changed outside the watcher",
-                request.session_id
-            );
+            return Err(refresh_session_diverged(
+                request.session_id,
+                "try watch session generation no longer matches the watcher",
+            ));
         }
         if session.mode != TrySessionMode::Namespace {
-            bail!("try watch refresh requires a namespace try session");
+            return Err(refresh_session_diverged(
+                request.session_id,
+                "try watch session is no longer a namespace session",
+            ));
         }
         if !is_watch_created_try_session(&session) {
-            bail!("try watch refresh requires a watch-created try session");
+            return Err(refresh_session_diverged(
+                request.session_id,
+                "try watch session no longer has watcher-owned identity",
+            ));
         }
 
         let runtime_root = ConaryRuntimeRoot::from_db_path(PathBuf::from(request.db_path));
@@ -236,8 +246,10 @@ pub(crate) fn refresh_try_session(request: TryRefreshRequest<'_>) -> Result<TryR
         let stable_package_path = work_dir.join("package.ccs");
         let stable_db_path = work_dir.join("conary.db");
         let stable_package_path_string = stable_package_path.to_string_lossy().into_owned();
-        let copied_session = TrySession::find_by_id(&copied_conn, request.session_id)?
-            .ok_or_else(|| anyhow::anyhow!("copied try session {} missing", request.session_id))?;
+        let copied_session =
+            TrySession::find_by_id(&copied_conn, request.session_id)?.ok_or_else(|| {
+                refresh_session_diverged(request.session_id, "copied try watch session is missing")
+            })?;
         if !copied_session.replace_active_try_generation(
             &copied_conn,
             request.expected_try_generation_id,
@@ -245,10 +257,10 @@ pub(crate) fn refresh_try_session(request: TryRefreshRequest<'_>) -> Result<TryR
             &verified.signing_key,
             built.generation_number,
         )? {
-            bail!(
-                "copied try watch session {} changed outside the watcher",
-                request.session_id
-            );
+            return Err(refresh_session_diverged(
+                request.session_id,
+                "copied try watch session generation no longer matches the watcher",
+            ));
         }
 
         let prepared_files = prepare_stable_try_files(
@@ -281,10 +293,10 @@ pub(crate) fn refresh_try_session(request: TryRefreshRequest<'_>) -> Result<TryR
         if !replaced {
             let _ = namespace_switch.restore();
             let _ = file_switch.restore();
-            bail!(
-                "try watch session {} changed outside the watcher",
-                request.session_id
-            );
+            return Err(refresh_session_diverged(
+                request.session_id,
+                "live try watch session generation no longer matches the watcher",
+            ));
         }
 
         refresh_committed = true;
@@ -323,6 +335,10 @@ pub(crate) fn refresh_try_session(request: TryRefreshRequest<'_>) -> Result<TryR
         }
     }
     result
+}
+
+fn refresh_session_diverged(session_id: &str, diagnostic: &'static str) -> anyhow::Error {
+    anyhow::Error::new(TryRefreshSessionDiverged::new(session_id)).context(diagnostic)
 }
 
 fn ensure_staging_db_generation_floor(

--- a/apps/conary/src/commands/try_session/session/tests.rs
+++ b/apps/conary/src/commands/try_session/session/tests.rs
@@ -399,6 +399,24 @@ fn refresh_try_session_updates_generation_after_staging_succeeds() -> anyhow::Re
 }
 
 #[test]
+fn refresh_missing_session_is_typed_divergence_before_package_access() {
+    let fixture = TryRuntimeFixture::new();
+    let unused_package = fixture.root.join("unused.ccs");
+
+    let err = refresh_try_session(TryRefreshRequest {
+        db_path: &fixture.db_path_string,
+        session_id: "missing-watch-session",
+        expected_try_generation_id: 41,
+        package_path: &unused_package,
+        trust_policy: &fixture.trust_policy,
+    })
+    .unwrap_err();
+
+    assert!(err.is::<TryRefreshSessionDiverged>(), "{err:#}");
+    assert!(!unused_package.exists());
+}
+
+#[test]
 fn refresh_try_session_cas_miss_preserves_previous_generation() -> anyhow::Result<()> {
     let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
     let fixture = TryRuntimeFixture::new();
@@ -435,10 +453,7 @@ fn refresh_try_session_cas_miss_preserves_previous_generation() -> anyhow::Resul
     })
     .unwrap_err();
 
-    assert!(
-        err.to_string().contains("changed outside the watcher"),
-        "{err:#}"
-    );
+    assert!(err.is::<TryRefreshSessionDiverged>(), "{err:#}");
     let conn = fixture.open();
     let session = TrySession::find_by_id(&conn, &started.session_id)?.unwrap();
     assert_eq!(session.try_generation_id, Some(started.try_generation_id));

--- a/apps/conary/src/commands/try_session/watch.rs
+++ b/apps/conary/src/commands/try_session/watch.rs
@@ -23,8 +23,8 @@ use super::watch_source::{
     DebounceState, WatchIdentity, WatchSourceSet, compute_watch_identity, resolve_watch_source_set,
 };
 use super::{
-    TryRefreshRequest, TryStartRequest, TryWatchMarkerRequest, begin_try_session,
-    refresh_try_session,
+    TryRefreshRequest, TryRefreshSessionDiverged, TryStartRequest, TryWatchMarkerRequest,
+    begin_try_session, refresh_try_session,
 };
 
 mod reporting;
@@ -852,7 +852,7 @@ async fn run_refresh_loop(
                     output,
                 )?;
                 write_optional_file(&config.failure_file, &message)?;
-                if message.contains("changed outside the watcher") {
+                if refresh_failure_stops_watch(&error) {
                     finish_current_events(
                         events,
                         PackagingCommandStatus::Failed,
@@ -920,6 +920,10 @@ async fn run_refresh_loop(
             );
         }
     }
+}
+
+fn refresh_failure_stops_watch(error: &anyhow::Error) -> bool {
+    error.is::<TryRefreshSessionDiverged>()
 }
 
 async fn run_watch_cook_cancellable(

--- a/apps/conary/src/commands/try_session/watch/tests.rs
+++ b/apps/conary/src/commands/try_session/watch/tests.rs
@@ -126,6 +126,16 @@ fn watched_sources_missing_ignores_recipe_and_auxiliary_files() {
 }
 
 #[test]
+fn refresh_failure_termination_uses_typed_divergence_not_prose() {
+    let divergence = anyhow::Error::new(TryRefreshSessionDiverged::new("try-1"))
+        .context("diagnostic wording can change independently");
+    assert!(refresh_failure_stops_watch(&divergence));
+
+    let diagnostic_prose = anyhow::anyhow!("try watch session changed outside the watcher");
+    assert!(!refresh_failure_stops_watch(&diagnostic_prose));
+}
+
+#[test]
 fn debounce_step_resets_deadline_when_identity_changes_before_ready() {
     let start = Instant::now();
     let mut debounce = DebounceState::new(Duration::from_millis(750));

--- a/docs/roadmaps/development-roadmap.md
+++ b/docs/roadmaps/development-roadmap.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-06
-revision: 13
+revision: 14
 summary: Track Conary's cross-distro package milestone, ordered workstreams, evidence, blockers, and post-milestone horizons
 proof_baseline: "immutable v0.14.0 at fe23a604b64ea6f7cc87fce8298911e2245e027f and production remi-v0.9.5 at 101dba655257f1ff3d1bee689d9c5ac8b2b68cbd; exact asset, deployment, and released-package proof complete"
 current_milestone: first external tester loop
@@ -277,7 +277,8 @@ the stated scope, not whether a workstream happens to be active.
   active.
 - **Issues:** #67 as epic; #109 for persisted status; #257 and #259 for Remi
   acquisition integrity; #261 for exact publish-destination routing; #263 for
-  required source-pin strength; plus one narrow issue per remaining P1 item.
+  required source-pin strength; #265 for typed try-session divergence; plus one
+  narrow issue per remaining P1 item.
 - **Closed ledger items:**
   - PR #61 rejects missing package architecture, separates typed
     `InstallReason` from diagnostic selection prose, and validates trigger


### PR DESCRIPTION
## Primary Issue

Closes #265

Design / Plan / Roadmap: Refs #67 and W6 in `docs/roadmaps/development-roadmap.md`.

## Problem And Outcome

Try-watch termination searched rendered refresh-error text for `changed outside the watcher`. Diagnostic wording therefore decided whether a failed refresh retried or terminated.

After this change, every missing or structurally divergent live/copied watch session carries `TryRefreshSessionDiverged`. Watch mode matches that type through any diagnostic context; rendered text and failure-file content are presentation only.

## Changes

- Add the typed `TryRefreshSessionDiverged` lifecycle error.
- Return it for missing sessions, status/generation/mode/watch-marker drift, and copied/live generation compare-and-swap misses.
- Replace the substring classifier with an `anyhow::Error::is` type check.
- Prove a context-wrapped typed error terminates while identical legacy prose in an untyped error does not.
- Prove a missing session fails as typed divergence before package access.
- Register #265 in the W6 roadmap issue set.

## Scope

- In scope: internal try-refresh error authority and watch termination behavior.
- Out of scope: try-session schema, CLI syntax, package trust, cook behavior, and bootloader identity.

## Ownership / Boundary

- Owning subsystem: Packaging, Try Sessions, And Static Repository Publishing.
- Boundary changed or preserved: refresh-session state owns divergence; watch rendering consumes the type without interpreting prose.
- Persisted state or public surface impact: none. No schema or CLI compatibility surface changes.
- [x] Checked `docs/modules/feature-ownership.md`; the look-here-first path is unchanged.

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly
- [x] No subsystem-map update needed; ownership paths are unchanged
- [x] The change does not cross publish, trust, sync, install, or signing boundaries, so the packaging interaction gate is not triggered
- [x] Primary issue has no acceptance criteria deferred by this PR

```text
- cargo test -p conary --lib commands::try_session
  - 68 passed; 0 failed; 0 ignored
- cargo test -p conary
  - exit 0; full unit, integration, and doc-test suite passed
- cargo clippy --workspace --all-targets -- -D warnings
  - exit 0
- cargo fmt --all --check
  - exit 0
- git diff --check
  - exit 0
- bash scripts/check-doc-truth.sh
  - passed
- bash scripts/test-doc-truth.sh
  - passed
- bash scripts/test-agent-context.sh
  - passed
- bash scripts/agent-context.sh --validate
  - 17 cards passed
- changed Rust path/header/line audit
  - all five touched Rust files retain path headers
  - mod.rs 662, session.rs 975, session/tests.rs 990, watch.rs 995, watch/tests.rs 196
```

## Review And Merge Notes

- Review focus: typed error propagation through `anyhow` context and exhaustive permanent-divergence classification.
- User or developer impact: changing diagnostic wording can no longer alter watch lifecycle behavior.
- Required-check bypass: not used