### PR TITLE
fix(adoption): validate captured-root version authority

### DIFF
--- a/apps/conary/src/commands/adopt/system/captured_root.rs
+++ b/apps/conary/src/commands/adopt/system/captured_root.rs
@@ -21,7 +21,9 @@ use rusqlite::Transaction;
 
 use super::{CapturedAdoptionFile, LIVE_ROOT_PACKAGE_NAME};
 
-const CAPTURED_ROOT_VERSION: &str = "snapshot";
+// This is a synthetic identity, not a changing snapshot serial. It still uses
+// Conary's SemVer-owned version scheme and must obey that grammar.
+const CAPTURED_ROOT_VERSION: &str = "0.0.0-captured-root";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct CapturedRootSync {
@@ -531,6 +533,23 @@ mod tests {
             .find(|trove| trove.install_source == InstallSource::CapturedRoot)
             .unwrap();
         let captured_id = captured_trove.id.unwrap();
+        assert_eq!(captured_trove.version, CAPTURED_ROOT_VERSION);
+        conary_core::repository::versioning::validate_repo_version(
+            captured_trove.version_scheme,
+            &captured_trove.version,
+        )
+        .unwrap();
+        let captured_provides = ProvideEntry::find_by_trove(&tx, captured_id).unwrap();
+        assert_eq!(captured_provides.len(), 1);
+        assert_eq!(
+            captured_provides[0].version.as_deref(),
+            Some(CAPTURED_ROOT_VERSION)
+        );
+        conary_core::repository::versioning::validate_repo_version(
+            captured_provides[0].version_scheme,
+            captured_provides[0].version.as_deref().unwrap(),
+        )
+        .unwrap();
         assert_eq!(
             FileEntry::find_by_path(&tx, "/etc/owned-primary")
                 .unwrap()

--- a/apps/conary/src/commands/generation/config_transaction/tests.rs
+++ b/apps/conary/src/commands/generation/config_transaction/tests.rs
@@ -307,7 +307,7 @@ fn capture_update_records_exact_old_current_and_new_artifacts() {
     let cas = CasStore::new(temp.path().join("objects")).unwrap();
     let mut trove = conary_core::db::models::Trove::new(
         "demo".to_string(),
-        "1".to_string(),
+        "1.0.0".to_string(),
         conary_core::db::models::TroveType::Package,
         conary_core::repository::versioning::VersionScheme::Conary,
     );
@@ -416,7 +416,7 @@ fn deb_remove_on_upgrade_is_a_durable_generation_operation() {
     let cas = CasStore::new(temp.path().join("objects")).unwrap();
     let mut trove = conary_core::db::models::Trove::new(
         "demo".to_string(),
-        "1".to_string(),
+        "1.0.0".to_string(),
         conary_core::db::models::TroveType::Package,
         conary_core::repository::versioning::VersionScheme::Conary,
     );

--- a/apps/conary/src/commands/generation/selected_root.rs
+++ b/apps/conary/src/commands/generation/selected_root.rs
@@ -532,7 +532,7 @@ mod tests {
         let hash = cas.store(b"package-a").unwrap();
         let mut trove = Trove::new(
             "package-a".to_string(),
-            "1".to_string(),
+            "1.0.0".to_string(),
             TroveType::Package,
             conary_core::repository::versioning::VersionScheme::Conary,
         );
@@ -780,7 +780,7 @@ mod tests {
         let tx = conn.unchecked_transaction().unwrap();
         let mut trove = Trove::new(
             "serialized-fixture".to_string(),
-            "1".to_string(),
+            "1.0.0".to_string(),
             TroveType::Package,
             conary_core::repository::versioning::VersionScheme::Conary,
         );

--- a/apps/conary/src/commands/install/ccs_removal_hooks.rs
+++ b/apps/conary/src/commands/install/ccs_removal_hooks.rs
@@ -128,7 +128,7 @@ mod tests {
     fn installed_ccs(conn: &Connection, name: &str, script: &str) -> (Trove, i64) {
         let mut trove = Trove::new_with_source(
             name.to_string(),
-            "1".to_string(),
+            "1.0.0".to_string(),
             TroveType::Package,
             InstallSource::File,
             conary_core::repository::versioning::VersionScheme::Conary,

--- a/apps/conary/src/commands/install/ccs_transaction/converted_directory_tests.rs
+++ b/apps/conary/src/commands/install/ccs_transaction/converted_directory_tests.rs
@@ -199,7 +199,7 @@ async fn reloaded_converted_formats_install_with_their_directory_contract() {
             .unwrap();
         let mut anchor_trove = Trove::new(
             format!("{}-anchor", format.as_str()),
-            "1".to_string(),
+            "1.0.0".to_string(),
             TroveType::Package,
             VersionScheme::Conary,
         );

--- a/apps/conary/src/commands/install/config_files/tests.rs
+++ b/apps/conary/src/commands/install/config_files/tests.rs
@@ -142,14 +142,14 @@ fn remove_on_upgrade_requires_and_preserves_prior_debian_identity() {
     let conn = conary_core::db::open(&database_path).unwrap();
     let mut old_trove = conary_core::db::models::Trove::new(
         "demo".to_string(),
-        "1".to_string(),
+        "1.0.0".to_string(),
         conary_core::db::models::TroveType::Package,
         conary_core::repository::versioning::VersionScheme::Conary,
     );
     let old_trove_id = old_trove.insert(&conn).unwrap();
     let mut new_trove = conary_core::db::models::Trove::new(
         "demo".to_string(),
-        "2".to_string(),
+        "2.0.0".to_string(),
         conary_core::db::models::TroveType::Package,
         conary_core::repository::versioning::VersionScheme::Conary,
     );
@@ -197,7 +197,7 @@ fn prepared_arch_conflict_keeps_local_and_writes_pacnew() {
     let conn = conary_core::db::open(&db).unwrap();
     let mut trove = conary_core::db::models::Trove::new(
         "demo".to_string(),
-        "1".to_string(),
+        "1.0.0".to_string(),
         conary_core::db::models::TroveType::Package,
         conary_core::repository::versioning::VersionScheme::Conary,
     );
@@ -262,7 +262,7 @@ fn deb_remove_on_upgrade_removes_pristine_and_saves_modified_conffiles() {
     let conn = conary_core::db::open(&db).unwrap();
     let mut trove = conary_core::db::models::Trove::new(
         "demo".to_string(),
-        "1".to_string(),
+        "1.0.0".to_string(),
         conary_core::db::models::TroveType::Package,
         conary_core::repository::versioning::VersionScheme::Conary,
     );
@@ -337,7 +337,7 @@ fn deb_remove_retains_conffile_state_until_purge() {
     let conn = conary_core::db::open(&db).unwrap();
     let mut trove = conary_core::db::models::Trove::new(
         "demo".to_string(),
-        "1".to_string(),
+        "1.0.0".to_string(),
         conary_core::db::models::TroveType::Package,
         conary_core::repository::versioning::VersionScheme::Conary,
     );
@@ -389,7 +389,7 @@ fn deb_purge_removes_conffile_and_package_manager_backups() {
     let conn = conary_core::db::open(&db).unwrap();
     let mut trove = conary_core::db::models::Trove::new(
         "demo".to_string(),
-        "1".to_string(),
+        "1.0.0".to_string(),
         conary_core::db::models::TroveType::Package,
         conary_core::repository::versioning::VersionScheme::Conary,
     );
@@ -427,7 +427,7 @@ fn deb_purge_plan_deletes_the_exact_rows_captured_before_trove_removal() {
     let conn = conary_core::db::open(&db).unwrap();
     let mut trove = conary_core::db::models::Trove::new(
         "demo".to_string(),
-        "1".to_string(),
+        "1.0.0".to_string(),
         conary_core::db::models::TroveType::Package,
         conary_core::repository::versioning::VersionScheme::Conary,
     );
@@ -467,7 +467,7 @@ fn rpm_ghost_config_is_owned_without_payload_and_erased_without_backup() {
     let conn = conary_core::db::open(&db).unwrap();
     let mut trove = conary_core::db::models::Trove::new(
         "demo".to_string(),
-        "1".to_string(),
+        "1.0.0".to_string(),
         conary_core::db::models::TroveType::Package,
         conary_core::repository::versioning::VersionScheme::Conary,
     );
@@ -495,7 +495,7 @@ fn arch_remove_rotates_existing_pacsaves_before_saving_local_file() {
     let conn = conary_core::db::open(&db).unwrap();
     let mut trove = conary_core::db::models::Trove::new(
         "demo".to_string(),
-        "1".to_string(),
+        "1.0.0".to_string(),
         conary_core::db::models::TroveType::Package,
         conary_core::repository::versioning::VersionScheme::Conary,
     );

--- a/apps/conary/src/commands/install/inner/tests.rs
+++ b/apps/conary/src/commands/install/inner/tests.rs
@@ -172,7 +172,7 @@ fn install_inner_replaces_live_root_owned_overlapping_path() {
 
     let mut live_root = Trove::new_with_source(
         "conary-live-root".to_string(),
-        "2026.05.14".to_string(),
+        "0.0.0-captured-root".to_string(),
         TroveType::Package,
         InstallSource::CapturedRoot,
         conary_core::repository::versioning::VersionScheme::Conary,

--- a/apps/conary/src/commands/install/resolve.rs
+++ b/apps/conary/src/commands/install/resolve.rs
@@ -355,7 +355,7 @@ mod tests {
         let conn = test_db();
         let mut trove = Trove::new(
             "glibc".to_string(),
-            "2.42".to_string(),
+            "2.42.0".to_string(),
             TroveType::Package,
             conary_core::repository::versioning::VersionScheme::Conary,
         );
@@ -363,7 +363,7 @@ mod tests {
         ProvideEntry::new(
             trove_id,
             "glibc".to_string(),
-            Some("2.42".to_string()),
+            Some("2.42.0".to_string()),
             conary_core::repository::versioning::VersionScheme::Conary,
         )
         .insert(&conn)

--- a/apps/conary/src/commands/install/shared_directory/tests.rs
+++ b/apps/conary/src/commands/install/shared_directory/tests.rs
@@ -12,7 +12,7 @@ use std::os::unix::fs::symlink;
 fn insert_trove(conn: &rusqlite::Connection, name: &str) -> i64 {
     Trove::new(
         name.to_string(),
-        "1".to_string(),
+        "1.0.0".to_string(),
         TroveType::Package,
         VersionScheme::Conary,
     )
@@ -818,7 +818,7 @@ fn captured_root_authority_is_typed_and_cannot_be_spoofed_by_package_name() {
 
     let mut captured = Trove::new_with_source(
         "captured-root-authority".to_string(),
-        "1".to_string(),
+        "1.0.0".to_string(),
         TroveType::Package,
         InstallSource::CapturedRoot,
         VersionScheme::Conary,

--- a/apps/conary/src/commands/query/components.rs
+++ b/apps/conary/src/commands/query/components.rs
@@ -192,7 +192,7 @@ mod tests {
         let conn = conary_core::db::open(&db_path).unwrap();
         let mut trove = Trove::new(
             "broken-components".to_string(),
-            "1".to_string(),
+            "1.0.0".to_string(),
             TroveType::Package,
             conary_core::repository::versioning::VersionScheme::Conary,
         );
@@ -231,7 +231,7 @@ mod tests {
         let conn = conary_core::db::open(&db_path).unwrap();
         Trove::new(
             "metadata-only".to_string(),
-            "1".to_string(),
+            "1.0.0".to_string(),
             TroveType::Package,
             conary_core::repository::versioning::VersionScheme::Conary,
         )

--- a/apps/conary/src/commands/remove/payload_ownership.rs
+++ b/apps/conary/src/commands/remove/payload_ownership.rs
@@ -17,7 +17,7 @@ mod tests {
     fn insert_trove(conn: &rusqlite::Connection, name: &str) -> i64 {
         Trove::new(
             name.to_string(),
-            "1".to_string(),
+            "1.0.0".to_string(),
             TroveType::Package,
             VersionScheme::Conary,
         )

--- a/apps/conary/src/commands/system/rollback_restore/tests.rs
+++ b/apps/conary/src/commands/system/rollback_restore/tests.rs
@@ -139,7 +139,7 @@ fn verified_symlink_directory_anchor_policy_round_trips_exactly() {
     .unwrap();
     let mut snapshot = TroveSnapshot::test_package(
         "symlink-anchor",
-        "1",
+        "1.0.0",
         vec![crate::commands::FileSnapshot {
             path: "/lib".to_string(),
             node: symlink_node.clone(),
@@ -213,14 +213,14 @@ fn rollback_reclaims_an_exact_peer_reanchored_symlink_without_unique_path_failur
     let mut conn = conary_core::db::open(&db_path).unwrap();
     let mut symlink_owner = Trove::new(
         "symlink-owner".to_string(),
-        "1".to_string(),
+        "1.0.0".to_string(),
         TroveType::Package,
         VersionScheme::Conary,
     );
     let symlink_owner_id = symlink_owner.insert(&conn).unwrap();
     let mut claimant = Trove::new(
         "directory-claimant".to_string(),
-        "1".to_string(),
+        "1.0.0".to_string(),
         TroveType::Package,
         VersionScheme::Conary,
     );
@@ -304,21 +304,21 @@ fn rollback_restores_a_target_owned_only_by_an_rpm_through_symlink_edge() {
     let mut conn = conary_core::db::open(&db_path).unwrap();
     let mut target_owner = Trove::new(
         "target-owner".to_string(),
-        "1".to_string(),
+        "1.0.0".to_string(),
         TroveType::Package,
         VersionScheme::Conary,
     );
     let target_owner_id = target_owner.insert(&conn).unwrap();
     let mut symlink_owner = Trove::new(
         "symlink-owner".to_string(),
-        "1".to_string(),
+        "1.0.0".to_string(),
         TroveType::Package,
         VersionScheme::Conary,
     );
     let symlink_owner_id = symlink_owner.insert(&conn).unwrap();
     let mut rpm_claimant = Trove::new(
         "rpm-claimant".to_string(),
-        "1".to_string(),
+        "1.0.0".to_string(),
         TroveType::Package,
         VersionScheme::Conary,
     );
@@ -443,12 +443,12 @@ fn cyclic_cross_payload_claims_restore_through_global_anchor_phase() {
             component: None,
         }),
     };
-    let mut package_a = TroveSnapshot::test_package("cycle-a", "1", Vec::new());
+    let mut package_a = TroveSnapshot::test_package("cycle-a", "1.0.0", Vec::new());
     package_a.payload_claims = vec![
         claim("/opt", 0o700, None),
         claim("/usr", 0o755, Some(0o711)),
     ];
-    let mut package_b = TroveSnapshot::test_package("cycle-b", "1", Vec::new());
+    let mut package_b = TroveSnapshot::test_package("cycle-b", "1.0.0", Vec::new());
     package_b.payload_claims = vec![
         claim("/opt", 0o750, Some(0o775)),
         claim("/usr", 0o700, None),
@@ -706,7 +706,7 @@ fn exact_installed_authority_round_trips_and_rejects_broken_relations() {
 
     let mut collection = Trove::new(
         "authority-collection".to_string(),
-        "1".to_string(),
+        "1.0.0".to_string(),
         TroveType::Collection,
         VersionScheme::Conary,
     );
@@ -720,7 +720,7 @@ fn exact_installed_authority_round_trips_and_rejects_broken_relations() {
 
     let mut peer = Trove::new(
         "shared-directory-peer".to_string(),
-        "1".to_string(),
+        "1.0.0".to_string(),
         TroveType::Package,
         VersionScheme::Conary,
     );

--- a/apps/conary/src/commands/system/tests/rollback.rs
+++ b/apps/conary/src/commands/system/tests/rollback.rs
@@ -267,7 +267,7 @@ fn record_additive_changeset_with_system_authority(
     changeset
         .update_status(conn, ChangesetStatus::Applied)
         .unwrap();
-    insert_test_trove(conn, changeset_id, fixture, "1.0", &[]);
+    insert_test_trove(conn, changeset_id, fixture, "1.0.0", &[]);
     changeset_id
 }
 
@@ -340,7 +340,7 @@ async fn additive_rollback_restores_unaffected_config_runtime_projection() {
 
     let mut peer = Trove::new(
         "config-runtime-peer".to_string(),
-        "1.0".to_string(),
+        "1.0.0".to_string(),
         TroveType::Package,
         conary_core::repository::versioning::VersionScheme::Conary,
     );
@@ -450,7 +450,7 @@ async fn rollback_without_v5_authority_fails_closed_and_remains_retryable() {
     changeset
         .update_status(&conn, ChangesetStatus::Applied)
         .unwrap();
-    let trove_id = insert_test_trove(&conn, changeset_id, "rollback-rpm-fixture", "1.0-1", &[]);
+    let trove_id = insert_test_trove(&conn, changeset_id, "rollback-rpm-fixture", "1.0.1", &[]);
     set_trove_rpm_provenance(&conn, trove_id);
     drop(conn);
 
@@ -500,7 +500,13 @@ async fn rollback_with_retired_metadata_schema_fails_closed_and_remains_retryabl
     changeset
         .update_status(&conn, ChangesetStatus::Applied)
         .unwrap();
-    let trove_id = insert_test_trove(&conn, changeset_id, "retired-metadata-fixture", "1.0", &[]);
+    let trove_id = insert_test_trove(
+        &conn,
+        changeset_id,
+        "retired-metadata-fixture",
+        "1.0.0",
+        &[],
+    );
     drop(conn);
 
     for _ in 0..2 {
@@ -579,7 +585,7 @@ async fn rollback_snapshot_restores_exact_prior_typed_rpm_authority() {
     changeset
         .update_status(&conn, ChangesetStatus::Applied)
         .unwrap();
-    let trove_id = insert_test_trove(&conn, changeset_id, "rollback-rpm-fixture", "1.0-1", &[]);
+    let trove_id = insert_test_trove(&conn, changeset_id, "rollback-rpm-fixture", "1.0.1", &[]);
     set_trove_rpm_provenance(&conn, trove_id);
     let bundle = rollback_typed_rpm_bundle();
     let mut installed =
@@ -894,7 +900,7 @@ fn rollback_snapshot_restores_exact_ccs_remove_hook() {
     let mut conn = conary_core::db::open(&db_path).unwrap();
     let mut changeset = Changeset::new("Restore CCS hook fixture".to_string());
     let changeset_id = changeset.insert(&conn).unwrap();
-    let mut snapshot = TroveSnapshot::test_package("ccs-hook-fixture", "1", Vec::new());
+    let mut snapshot = TroveSnapshot::test_package("ccs-hook-fixture", "1.0.0", Vec::new());
     snapshot.ccs_remove_hook = Some(crate::commands::CcsRemoveHookSnapshot {
         script: "echo removing\n".to_string(),
         reversible: Some(true),

--- a/apps/conary/src/commands/system/tests/rollback/directories.rs
+++ b/apps/conary/src/commands/system/tests/rollback/directories.rs
@@ -107,7 +107,7 @@ async fn assert_additive_shared_directory_rollback(
 
     let mut anchor = Trove::new(
         format!("{fixture}-anchor"),
-        "1.0".to_string(),
+        "1.0.0".to_string(),
         TroveType::Package,
         conary_core::repository::versioning::VersionScheme::Conary,
     );
@@ -118,7 +118,7 @@ async fn assert_additive_shared_directory_rollback(
     let claim_owner_id = if symlink_anchor {
         let mut claim_owner = Trove::new(
             format!("{fixture}-claim-owner"),
-            "1.0".to_string(),
+            "1.0.0".to_string(),
             TroveType::Package,
             conary_core::repository::versioning::VersionScheme::Conary,
         );
@@ -218,7 +218,7 @@ async fn assert_additive_shared_directory_rollback(
 
     let mut added_ids = Vec::new();
     for (name, mode) in additions {
-        let trove_id = insert_test_trove(&conn, changeset_id, name, "1.0", &[]);
+        let trove_id = insert_test_trove(&conn, changeset_id, name, "1.0.0", &[]);
         added_ids.push(trove_id);
         let mut incoming = FileEntry::new(
             path.to_string(),

--- a/apps/conary/src/commands/system/tests/rollback/generation.rs
+++ b/apps/conary/src/commands/system/tests/rollback/generation.rs
@@ -165,7 +165,7 @@ async fn rollback_generation_excludes_forward_activation_request() {
             .unwrap(),
         1
     );
-    insert_test_trove(&conn, changeset_id, "activation-fixture", "1.0", &[]);
+    insert_test_trove(&conn, changeset_id, "activation-fixture", "1.0.0", &[]);
     drop(conn);
 
     cmd_rollback(changeset_id, &db_path_str).await.unwrap();

--- a/apps/conary/tests/batch_install.rs
+++ b/apps/conary/tests/batch_install.rs
@@ -178,7 +178,7 @@ fn test_batch_install_file_tracking() {
         // Package 1 with 2 files
         let mut pkg1 = Trove::new(
             "lib-a".to_string(),
-            "1.0".to_string(),
+            "1.0.0".to_string(),
             TroveType::Package,
             conary_core::repository::versioning::VersionScheme::Conary,
         );
@@ -192,7 +192,7 @@ fn test_batch_install_file_tracking() {
         // Package 2 with 3 files
         let mut pkg2 = Trove::new(
             "lib-b".to_string(),
-            "2.0".to_string(),
+            "2.0.0".to_string(),
             TroveType::Package,
             conary_core::repository::versioning::VersionScheme::Conary,
         );
@@ -240,7 +240,7 @@ fn test_batch_preserves_dependency_reasons() {
         // Dependency with "Required by" reason
         let mut dep = Trove::new(
             "libfoo".to_string(),
-            "1.0".to_string(),
+            "1.0.0".to_string(),
             TroveType::Package,
             conary_core::repository::versioning::VersionScheme::Conary,
         );
@@ -252,7 +252,7 @@ fn test_batch_preserves_dependency_reasons() {
         // Main package with explicit reason
         let mut app = Trove::new(
             "myapp".to_string(),
-            "2.0".to_string(),
+            "2.0.0".to_string(),
             TroveType::Package,
             conary_core::repository::versioning::VersionScheme::Conary,
         );

--- a/apps/conary/tests/features/collections.rs
+++ b/apps/conary/tests/features/collections.rs
@@ -17,7 +17,7 @@ fn test_collection_management() {
         // Create a collection
         let mut collection = Trove::new(
             "dev-tools".to_string(),
-            "1.0".to_string(),
+            "1.0.0".to_string(),
             TroveType::Collection,
             conary_core::repository::versioning::VersionScheme::Conary,
         );
@@ -85,7 +85,7 @@ fn test_collection_operations() {
     db::transaction(&mut conn, |tx| {
         let mut collection = Trove::new(
             "webstack".to_string(),
-            "1.0".to_string(),
+            "1.0.0".to_string(),
             TroveType::Collection,
             conary_core::repository::versioning::VersionScheme::Conary,
         );

--- a/apps/conary/tests/query.rs
+++ b/apps/conary/tests/query.rs
@@ -33,7 +33,7 @@ fn test_query_packages() {
     for (name, version) in [
         ("nginx", "1.21.0"),
         ("redis", "6.2.0"),
-        ("postgres", "14.0"),
+        ("postgres", "14.0.0"),
     ] {
         db::transaction(&mut conn, |tx| {
             let mut changeset = Changeset::new(format!("Install {}-{}", name, version));

--- a/apps/remi/src/server/handlers/models.rs
+++ b/apps/remi/src/server/handlers/models.rs
@@ -820,7 +820,7 @@ mod tests {
         // Create two collections
         let mut t1 = Trove::new(
             "group-base".to_string(),
-            "1.0".to_string(),
+            "1.0.0".to_string(),
             TroveType::Collection,
             conary_core::repository::versioning::VersionScheme::Conary,
         );
@@ -831,7 +831,7 @@ mod tests {
 
         let mut t2 = Trove::new(
             "group-dev".to_string(),
-            "2.0".to_string(),
+            "2.0.0".to_string(),
             TroveType::Collection,
             conary_core::repository::versioning::VersionScheme::Conary,
         );

--- a/apps/remi/src/server/prewarm.rs
+++ b/apps/remi/src/server/prewarm.rs
@@ -526,7 +526,7 @@ mod tests {
 
         let mut trove = Trove::new(
             "pkg".to_string(),
-            "1.0".to_string(),
+            "1.0.0".to_string(),
             TroveType::Package,
             conary_core::repository::versioning::VersionScheme::Conary,
         );

--- a/crates/conary-core/src/db/models/converted/tests.rs
+++ b/crates/conary-core/src/db/models/converted/tests.rs
@@ -45,7 +45,7 @@ fn installed_package(
 ) -> ConvertedPackage {
     let mut trove = Trove::new(
         format!("installed-{}", conn.last_insert_rowid()),
-        "1".to_string(),
+        "1.0.0".to_string(),
         TroveType::Package,
         crate::repository::versioning::VersionScheme::Conary,
     );

--- a/crates/conary-core/src/db/models/distro_pin.rs
+++ b/crates/conary-core/src/db/models/distro_pin.rs
@@ -350,7 +350,7 @@ mod tests {
         let (_temp, conn) = create_test_db();
         let mut trove = Trove::new(
             "catalog-match".to_string(),
-            "1.0".to_string(),
+            "1.0.0".to_string(),
             TroveType::Package,
             crate::repository::versioning::VersionScheme::Conary,
         );

--- a/crates/conary-core/src/db/models/installed_ccs_remove_hook.rs
+++ b/crates/conary-core/src/db/models/installed_ccs_remove_hook.rs
@@ -72,7 +72,7 @@ mod tests {
         let (_temp, conn) = create_test_db();
         let trove_id = Trove::new(
             "fixture".to_string(),
-            "1".to_string(),
+            "1.0.0".to_string(),
             TroveType::Package,
             crate::repository::versioning::VersionScheme::Conary,
         )

--- a/crates/conary-core/src/db/models/installed_file_capability.rs
+++ b/crates/conary-core/src/db/models/installed_file_capability.rs
@@ -191,7 +191,7 @@ mod tests {
     fn fixture_trove(conn: &rusqlite::Connection) -> i64 {
         let mut trove = Trove::new(
             "capability-fixture".to_string(),
-            "1.0-1".to_string(),
+            "1.0.0".to_string(),
             TroveType::Package,
             crate::repository::versioning::VersionScheme::Conary,
         );

--- a/crates/conary-core/src/db/models/installed_native_lifecycle_bundle.rs
+++ b/crates/conary-core/src/db/models/installed_native_lifecycle_bundle.rs
@@ -264,7 +264,7 @@ mod tests {
     fn fixture_trove(conn: &rusqlite::Connection) -> i64 {
         let mut trove = Trove::new(
             "native-lifecycle-fixture".to_string(),
-            "1.0-1".to_string(),
+            "1.0.0".to_string(),
             TroveType::Package,
             crate::repository::versioning::VersionScheme::Conary,
         );

--- a/crates/conary-core/src/db/models/installed_requirement_group.rs
+++ b/crates/conary-core/src/db/models/installed_requirement_group.rs
@@ -191,7 +191,7 @@ mod tests {
         let (_temp, conn) = create_test_db();
         let mut trove = Trove::new(
             "new-libssl".to_string(),
-            "3.0-1".to_string(),
+            "3.0.1".to_string(),
             TroveType::Package,
             crate::repository::versioning::VersionScheme::Conary,
         );

--- a/crates/conary-core/src/db/models/package_payload_ownership/tests.rs
+++ b/crates/conary-core/src/db/models/package_payload_ownership/tests.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeMap;
 fn insert_trove(conn: &Connection, name: &str) -> i64 {
     Trove::new(
         name.to_string(),
-        "1".to_string(),
+        "1.0.0".to_string(),
         TroveType::Package,
         VersionScheme::Conary,
     )

--- a/crates/conary-core/src/db/models/payload_claim/sharing_tests.rs
+++ b/crates/conary-core/src/db/models/payload_claim/sharing_tests.rs
@@ -11,7 +11,7 @@ use crate::repository::versioning::VersionScheme;
 fn insert_trove(conn: &Connection, name: &str) -> i64 {
     Trove::new(
         name.to_string(),
-        "1".to_string(),
+        "1.0.0".to_string(),
         TroveType::Package,
         VersionScheme::Conary,
     )

--- a/crates/conary-core/src/db/models/payload_claim/tests.rs
+++ b/crates/conary-core/src/db/models/payload_claim/tests.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeMap;
 fn insert_trove(conn: &Connection, name: &str) -> i64 {
     Trove::new(
         name.to_string(),
-        "1".to_string(),
+        "1.0.0".to_string(),
         TroveType::Package,
         VersionScheme::Conary,
     )

--- a/crates/conary-core/src/db/models/provide_entry.rs
+++ b/crates/conary-core/src/db/models/provide_entry.rs
@@ -11,7 +11,7 @@ use crate::repository::dependency_model::{
     CapabilityProvenance, ProvideArchitectureQualifier, ProvideVersionRelation,
     RepositoryCapabilityKind,
 };
-use crate::repository::versioning::VersionScheme;
+use crate::repository::versioning::{VersionScheme, validate_repo_version};
 use rusqlite::{Connection, OptionalExtension, Row, params};
 
 use super::repository::version_scheme_from_row;
@@ -119,6 +119,7 @@ impl ProvideEntry {
 
     /// Insert this provide into the database
     pub fn insert(&mut self, conn: &Connection) -> Result<i64> {
+        self.validate_version()?;
         conn.execute(
             "INSERT INTO provides (
                 trove_id, capability, version, version_relation, kind, version_scheme,
@@ -144,6 +145,7 @@ impl ProvideEntry {
 
     /// Insert or ignore if already exists (for idempotent imports)
     pub fn insert_or_ignore(&mut self, conn: &Connection) -> Result<i64> {
+        self.validate_version()?;
         conn.execute(
             "INSERT OR IGNORE INTO provides (
                 trove_id, capability, version, version_relation, kind, version_scheme,
@@ -185,6 +187,18 @@ impl ProvideEntry {
 
         self.id = Some(id);
         Ok(id)
+    }
+
+    fn validate_version(&self) -> Result<()> {
+        let Some(version) = self.version.as_deref() else {
+            return Ok(());
+        };
+        validate_repo_version(self.version_scheme, version).map_err(|error| {
+            crate::error::Error::ConfigError(format!(
+                "provide {} has a version outside its declared grammar: {error}",
+                self.capability
+            ))
+        })
     }
 
     /// Find a provide by capability name
@@ -654,6 +668,36 @@ mod tests {
         assert_eq!(found.kind, RepositoryCapabilityKind::Generic);
         assert_eq!(found.version, Some("0.04".to_string()));
         assert_eq!(found.provenance, CapabilityProvenance::AuthorDeclared);
+    }
+
+    #[test]
+    fn writes_reject_versions_outside_declared_scheme() {
+        for insert_or_ignore in [false, true] {
+            let conn = setup_test_db();
+            let mut provide = ProvideEntry::new(
+                1,
+                "captured-root".to_string(),
+                Some("snapshot".to_string()),
+                VersionScheme::Conary,
+            );
+
+            let error = if insert_or_ignore {
+                provide.insert_or_ignore(&conn).unwrap_err()
+            } else {
+                provide.insert(&conn).unwrap_err()
+            };
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("invalid conary version 'snapshot'"),
+                "{error}"
+            );
+            let count: i64 = conn
+                .query_row("SELECT COUNT(*) FROM provides", [], |row| row.get(0))
+                .unwrap();
+            assert_eq!(count, 0);
+        }
     }
 
     #[test]

--- a/crates/conary-core/src/db/models/state.rs
+++ b/crates/conary-core/src/db/models/state.rs
@@ -727,7 +727,7 @@ mod tests {
 
         let mut trove = crate::db::models::Trove::new(
             "pkg-a".to_string(),
-            "1.0".to_string(),
+            "1.0.0".to_string(),
             crate::db::models::TroveType::Package,
             crate::repository::versioning::VersionScheme::Conary,
         );

--- a/crates/conary-core/src/db/models/trove.rs
+++ b/crates/conary-core/src/db/models/trove.rs
@@ -13,6 +13,8 @@ use strum_macros::{AsRefStr, Display, EnumString};
 
 use super::repository::version_scheme_from_row;
 
+mod identity;
+
 /// Type of trove (package, component, or collection)
 #[derive(Debug, Clone, PartialEq, Eq, AsRefStr, Display, EnumString, Serialize, Deserialize)]
 #[strum(serialize_all = "lowercase")]
@@ -231,87 +233,7 @@ impl Trove {
     }
 
     fn validated_native_identity_json(&self) -> Result<Option<String>> {
-        if let Some(release) = self.package_release.as_deref() {
-            crate::repository::versioning::validate_package_release(release).map_err(|error| {
-                Error::ConfigError(format!(
-                    "{} {} has invalid signed CCS release: {error}",
-                    self.name, self.version
-                ))
-            })?;
-        }
-        match (self.version_scheme, self.debian_multi_arch) {
-            (VersionScheme::Debian, Some(_))
-            | (VersionScheme::Conary | VersionScheme::Rpm | VersionScheme::Arch, None) => {}
-            (VersionScheme::Debian, None) => {
-                return Err(Error::ConfigError(format!(
-                    "{} {} has Debian version authority without exact Multi-Arch metadata",
-                    self.name, self.version
-                )));
-            }
-            (_, Some(_)) => {
-                return Err(Error::ConfigError(format!(
-                    "{} {} carries Debian Multi-Arch metadata under the {} version scheme",
-                    self.name,
-                    self.version,
-                    self.version_scheme.as_str()
-                )));
-            }
-        }
-        let native_source = matches!(
-            self.install_source,
-            InstallSource::AdoptedTrack | InstallSource::AdoptedFull | InstallSource::Taken
-        );
-        match (&self.native_package_identity, native_source) {
-            (Some(identity), true) => {
-                identity.validate()?;
-                if identity.version_scheme() != self.version_scheme {
-                    return Err(Error::ConfigError(format!(
-                        "{} {} native package identity uses {} versioning, not the trove's {} scheme",
-                        self.name,
-                        self.version,
-                        identity.version_scheme().as_str(),
-                        self.version_scheme.as_str()
-                    )));
-                }
-                if identity.name() != self.name {
-                    return Err(Error::ConfigError(format!(
-                        "{} {} native package identity names {}, not the owning trove",
-                        self.name,
-                        self.version,
-                        identity.name()
-                    )));
-                }
-                if identity.version() != self.version {
-                    return Err(Error::ConfigError(format!(
-                        "{} {} native package identity has canonical version {}",
-                        self.name,
-                        self.version,
-                        identity.version()
-                    )));
-                }
-                if Some(identity.architecture()) != self.architecture.as_deref() {
-                    return Err(Error::ConfigError(format!(
-                        "{} {} native package identity architecture {} does not match trove architecture {:?}",
-                        self.name,
-                        self.version,
-                        identity.architecture(),
-                        self.architecture
-                    )));
-                }
-                serde_json::to_string(identity)
-                    .map(Some)
-                    .map_err(Into::into)
-            }
-            (None, false) => Ok(None),
-            (None, true) => Err(Error::ConfigError(format!(
-                "{} {} uses install source {} without an exact native package identity",
-                self.name, self.version, self.install_source
-            ))),
-            (Some(_), false) => Err(Error::ConfigError(format!(
-                "{} {} uses install source {} but carries a native package identity",
-                self.name, self.version, self.install_source
-            ))),
-        }
+        identity::validated_native_identity_json(self)
     }
 
     /// Find a trove by ID
@@ -864,11 +786,30 @@ mod tests {
     }
 
     #[test]
+    fn insert_rejects_version_outside_declared_scheme() {
+        let (_dir, conn) = setup_test_db();
+        let mut trove = Trove::new(
+            "captured-root".to_string(),
+            "snapshot".to_string(),
+            TroveType::Package,
+            VersionScheme::Conary,
+        );
+
+        let error = trove.insert(&conn).unwrap_err().to_string();
+
+        assert!(
+            error.contains("invalid conary version 'snapshot'"),
+            "{error}"
+        );
+        assert!(Trove::list_all(&conn).unwrap().is_empty());
+    }
+
+    #[test]
     fn database_decode_rejects_unknown_installed_version_scheme() {
         let (_dir, conn) = setup_test_db();
         let mut trove = Trove::new(
             "bash".to_string(),
-            "5.2.37-1".to_string(),
+            "5.2.37".to_string(),
             TroveType::Package,
             VersionScheme::Conary,
         );

--- a/crates/conary-core/src/db/models/trove/identity.rs
+++ b/crates/conary-core/src/db/models/trove/identity.rs
@@ -1,0 +1,100 @@
+// conary-core/src/db/models/trove/identity.rs
+
+//! Persistence-boundary validation for exact trove identity authority.
+
+use crate::error::{Error, Result};
+use crate::repository::versioning::{
+    VersionScheme, validate_package_release, validate_repo_version,
+};
+
+use super::{InstallSource, Trove};
+
+pub(super) fn validated_native_identity_json(trove: &Trove) -> Result<Option<String>> {
+    validate_repo_version(trove.version_scheme, &trove.version).map_err(|error| {
+        Error::ConfigError(format!(
+            "{} has a version outside its declared grammar: {error}",
+            trove.name
+        ))
+    })?;
+    if let Some(release) = trove.package_release.as_deref() {
+        validate_package_release(release).map_err(|error| {
+            Error::ConfigError(format!(
+                "{} {} has invalid signed CCS release: {error}",
+                trove.name, trove.version
+            ))
+        })?;
+    }
+    match (trove.version_scheme, trove.debian_multi_arch) {
+        (VersionScheme::Debian, Some(_))
+        | (VersionScheme::Conary | VersionScheme::Rpm | VersionScheme::Arch, None) => {}
+        (VersionScheme::Debian, None) => {
+            return Err(Error::ConfigError(format!(
+                "{} {} has Debian version authority without exact Multi-Arch metadata",
+                trove.name, trove.version
+            )));
+        }
+        (_, Some(_)) => {
+            return Err(Error::ConfigError(format!(
+                "{} {} carries Debian Multi-Arch metadata under the {} version scheme",
+                trove.name,
+                trove.version,
+                trove.version_scheme.as_str()
+            )));
+        }
+    }
+    let native_source = matches!(
+        trove.install_source,
+        InstallSource::AdoptedTrack | InstallSource::AdoptedFull | InstallSource::Taken
+    );
+    match (&trove.native_package_identity, native_source) {
+        (Some(identity), true) => {
+            identity.validate()?;
+            if identity.version_scheme() != trove.version_scheme {
+                return Err(Error::ConfigError(format!(
+                    "{} {} native package identity uses {} versioning, not the trove's {} scheme",
+                    trove.name,
+                    trove.version,
+                    identity.version_scheme().as_str(),
+                    trove.version_scheme.as_str()
+                )));
+            }
+            if identity.name() != trove.name {
+                return Err(Error::ConfigError(format!(
+                    "{} {} native package identity names {}, not the owning trove",
+                    trove.name,
+                    trove.version,
+                    identity.name()
+                )));
+            }
+            if identity.version() != trove.version {
+                return Err(Error::ConfigError(format!(
+                    "{} {} native package identity has canonical version {}",
+                    trove.name,
+                    trove.version,
+                    identity.version()
+                )));
+            }
+            if Some(identity.architecture()) != trove.architecture.as_deref() {
+                return Err(Error::ConfigError(format!(
+                    "{} {} native package identity architecture {} does not match trove architecture {:?}",
+                    trove.name,
+                    trove.version,
+                    identity.architecture(),
+                    trove.architecture
+                )));
+            }
+            serde_json::to_string(identity)
+                .map(Some)
+                .map_err(Into::into)
+        }
+        (None, false) => Ok(None),
+        (None, true) => Err(Error::ConfigError(format!(
+            "{} {} uses install source {} without an exact native package identity",
+            trove.name, trove.version, trove.install_source
+        ))),
+        (Some(_), false) => Err(Error::ConfigError(format!(
+            "{} {} uses install source {} but carries a native package identity",
+            trove.name, trove.version, trove.install_source
+        ))),
+    }
+}

--- a/crates/conary-core/src/generation/builder/runtime_inputs.rs
+++ b/crates/conary-core/src/generation/builder/runtime_inputs.rs
@@ -406,7 +406,7 @@ mod tests {
     fn trove(id: i64, name: &str, source: InstallSource) -> Trove {
         let mut trove = Trove::new_with_source(
             name.to_string(),
-            "1.0-1".to_string(),
+            "1.0.0".to_string(),
             TroveType::Package,
             source,
             crate::repository::versioning::VersionScheme::Conary,
@@ -869,7 +869,7 @@ mod tests {
         let anchor_trove_id = anchor_trove.insert(&conn).unwrap();
         let mut claimant_trove = Trove::new_with_source(
             "repository-claimant".to_string(),
-            "1".to_string(),
+            "1.0.0".to_string(),
             TroveType::Package,
             InstallSource::Repository,
             crate::repository::versioning::VersionScheme::Conary,

--- a/crates/conary-core/src/model/replatform/execution_tests.rs
+++ b/crates/conary-core/src/model/replatform/execution_tests.rs
@@ -526,7 +526,7 @@ fn test_replatform_execution_plan_accepts_tracked_capability_provider_for_target
 
     let mut provider_trove = Trove::new_with_source(
         "file-libs".to_string(),
-        "5.45".to_string(),
+        "5.45.0".to_string(),
         TroveType::Package,
         InstallSource::Repository,
         crate::repository::versioning::VersionScheme::Conary,

--- a/crates/conary-core/src/model/replatform/snapshot_tests.rs
+++ b/crates/conary-core/src/model/replatform/snapshot_tests.rs
@@ -76,7 +76,7 @@ fn test_visible_realignment_candidates_counts_same_name_target_impls() {
 
     let mut trove = Trove::new_with_source(
         "vim".to_string(),
-        "1.0".to_string(),
+        "1.0.0".to_string(),
         TroveType::Package,
         InstallSource::Repository,
         crate::repository::versioning::VersionScheme::Conary,
@@ -154,7 +154,7 @@ fn test_source_policy_replatform_snapshot_combines_estimate_and_candidates() {
 
     let mut trove = Trove::new_with_source(
         "vim".to_string(),
-        "1.0".to_string(),
+        "1.0.0".to_string(),
         TroveType::Package,
         InstallSource::Repository,
         crate::repository::versioning::VersionScheme::Conary,
@@ -235,7 +235,7 @@ fn test_source_policy_replatform_snapshot_uses_native_repo_version_ordering() {
 
     let mut installed = Trove::new_with_source(
         "demo".to_string(),
-        "0.9".to_string(),
+        "0.9.0".to_string(),
         TroveType::Package,
         InstallSource::Repository,
         crate::repository::versioning::VersionScheme::Conary,
@@ -306,7 +306,7 @@ fn test_source_policy_replatform_snapshot_uses_shared_selector_priority_ordering
 
     let mut installed = Trove::new_with_source(
         "demo".to_string(),
-        "0.9".to_string(),
+        "0.9.0".to_string(),
         TroveType::Package,
         InstallSource::Repository,
         crate::repository::versioning::VersionScheme::Conary,

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-04
-revision: 61
+last_updated: 2026-08-06
+revision: 62
 summary: Route typed database rebuilds, lossless source authority, exact Remi signing, selected-root mutation, rollback lineage, canonical-map authority, carrier security, generation GC, release authority, and subsystem proof through current feature owners.
 ---
 
@@ -218,6 +218,10 @@ commands.
   `crates/conary-core/src/generation/builder/runtime_inputs.rs`. `CapturedRoot`
   preserves continuity state only; package anchors and claims remain the
   install/update/remove ownership authority.
+- Trove version, release, Debian Multi-Arch, and exact native-identity
+  persistence validation is owned by
+  `crates/conary-core/src/db/models/trove/identity.rs`; `trove.rs` remains the
+  public model and CRUD hub.
 - Single-package adoption preview and apply share the planner in
   `apps/conary/src/commands/adopt/packages.rs`; preview stops before every
   SQLite, checkpoint, CAS, native-PM, hook, generation, and live-root write.

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-04
-revision: 64
+last_updated: 2026-08-06
+revision: 65
 summary: Route feature ownership through typed database rebuilds, exact Remi signing, streaming package payloads, serialized selected-root mutation, typed rollback lineage, exact lifecycle, canonical-map authority, carrier security, generation GC, exact release authority, and current canonical docs
 ---
 
@@ -57,6 +57,8 @@ supplied them.
 `apps/conary/src/commands/system/rebuild_database.rs`;
 `crates/conary-core/src/db/current_schema/`;
 `crates/conary-core/src/db/models/persisted_value.rs`;
+`crates/conary-core/src/db/models/trove/identity.rs`;
+`crates/conary-core/src/db/models/provide_entry.rs`;
 `crates/conary-core/src/db/models/trigger.rs`;
 `crates/conary-core/src/db/models/trigger_engine.rs`;
 `crates/conary-core/src/db/models/derived.rs`;
@@ -72,12 +74,15 @@ that persists a typed state.
 `apps/conary/src/commands/system/rebuild_database.rs`;
 `crates/conary-core/src/db/models/mod.rs`;
 `crates/conary-core/src/db/models/persisted_value.rs`;
+`crates/conary-core/src/db/models/trove/identity.rs`;
 `crates/conary-core/src/db/models/trigger.rs`;
 `crates/conary-core/src/db/models/trigger_engine.rs`;
 `crates/conary-core/src/db/models/derived.rs`.
 
 **Focused proof:** `cargo test -p conary-core --lib db::schema`;
 `cargo test -p conary-core --lib db::rebuild`;
+`cargo test -p conary-core --lib db::models::trove::tests`;
+`cargo test -p conary-core --lib db::models::provide_entry::tests`;
 `cargo test -p conary-core --lib db::models::trigger`;
 `cargo test -p conary-core --lib db::models::derived`;
 `cargo test -p conary --lib commands::system`;

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-06
-revision: 25
+revision: 26
 summary: Document exact profile-owned source policy, multi-root model authority, Remi CCS package authority, canonical map authority, native repository authority, package identity, full-adoption root continuity, and lifecycle handoff
 ---
 
@@ -480,6 +480,13 @@ partition without accumulating another captured-root owner. Track-only native
 troves are privately CAS-backed and promoted to `AdoptedFull` in the same
 full-adoption transaction.
 
+The synthetic trove uses the fixed Conary-authored identity
+`conary-live-root=0.0.0-captured-root`; both its trove version and exact package
+provide are validated under Conary's SemVer grammar before persistence.
+Pre-alpha databases containing the retired invalid `snapshot` version are
+disposable authority: rebuild the database and repeat full adoption. There is
+no compatibility adapter for that contradictory typed state.
+
 Package filters and `--explicit-only` deliberately do not assert whole-root
 continuity: they adopt only their requested native package scope. If any exact
 native query, payload capture, or package persistence fails, full-system
@@ -600,6 +607,9 @@ state requires an explicit scoped install, update, or replatform operation.
 - `apps/conary/src/commands/adopt/system.rs` and
   `adopt/system/captured_root.rs` for complete system adoption, track-to-full
   promotion, and exact package-versus-captured-root partitioning
+- `crates/conary-core/src/db/models/trove/identity.rs` for version, release,
+  Debian Multi-Arch, and exact native-identity validation at trove persistence
+  and decode boundaries
 - `crates/conary-core/src/generation/root_manifest/scan.rs` for finite
   selected-root capture and normalized runtime exclusions
 - `crates/conary-core/src/generation/builder/runtime_inputs.rs` for installed

--- a/docs/roadmaps/development-roadmap.md
+++ b/docs/roadmaps/development-roadmap.md
@@ -277,8 +277,9 @@ the stated scope, not whether a workstream happens to be active.
   active.
 - **Issues:** #67 as epic; #109 for persisted status; #257 and #259 for Remi
   acquisition integrity; #261 for exact publish-destination routing; #263 for
-  required source-pin strength; #265 for typed try-session divergence; plus one
-  narrow issue per remaining P1 item.
+  required source-pin strength; #265 for typed try-session divergence; #267 for
+  exact GRUB executable/output identity; and #269 for captured-root version
+  authority.
 - **Closed ledger items:**
   - PR #61 rejects missing package architecture, separates typed
     `InstallReason` from diagnostic selection prose, and validates trigger
@@ -293,6 +294,8 @@ the stated scope, not whether a workstream happens to be active.
     route contract.
   - #263 requires an explicit typed dependency-mixing strength in every source
     pin and advances the current-only schema to revision 26.
+  - #265 carries try-session divergence as a typed error through watch-mode
+    context instead of classifying diagnostic prose.
 - **Ledger gaps found on audit that #67 does not currently own:**
   - The `sanitize_path` ASCII heuristic is a #67-class invented authority but is
     owned only by #99, and only for ALPM. Cross-reference both.


### PR DESCRIPTION
## Problem

Full-system adoption assigned the synthetic captured-root authority the literal Conary version `snapshot`. That value contradicts the declared SemVer grammar and caused the external-tester QEMU flow to fail when dependency resolution later read the installed authority.

## Changes

- use the fixed Conary-authored identity `conary-live-root=0.0.0-captured-root`
- validate trove and provide versions against their declared grammar before persistence
- move trove persistence identity validation into the focused `trove/identity.rs` owner, leaving the model hub as thin CRUD wiring
- repair synthetic Conary test fixtures that the new write boundary correctly rejected, including the Remi fixtures exposed by hosted workspace coverage
- document the pre-alpha rebuild/re-adopt hard cut and update subsystem/feature routing

## Verification

- `cargo test -p conary-core`
- `cargo test -p conary`
- `cargo test -p remi`
- `bash scripts/agent-context.sh --feature adopt --run focused`
- `bash scripts/agent-context.sh --feature database-state --run focused`
- `cargo run -p conary-test -- list`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `bash scripts/test-agent-context.sh`
- `bash scripts/test-doc-truth.sh`
- `bash scripts/check-doc-truth.sh`

The downstream QEMU interaction gate will be rerun after this repair is integrated into #268.

Closes #269
Refs #267
