### PR TITLE
feat(conary-test): emit typed corpus evidence

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -165,6 +165,11 @@ jobs:
           --distro "${{ matrix.distro }}"
           --phase 4
           --suite native-cross-source-lifecycle
+      - name: Verify attributable corpus evidence
+        run: |
+          result="apps/conary/tests/integration/remi/results/${{ matrix.distro }}-phase4.json"
+          bash scripts/check-conary-test-result-gate.sh "$result"
+          bash scripts/check-conary-corpus-result-gate.sh "$result"
 
   native-cross-source-lifecycle-gate:
     name: native-cross-source-lifecycle

--- a/.github/workflows/release-artifact-proof.yml
+++ b/.github/workflows/release-artifact-proof.yml
@@ -168,6 +168,11 @@ jobs:
           --distro "${{ matrix.distro }}"
           --phase 4
           --suite native-cross-source-lifecycle
+      - name: Verify attributable published-binary corpus evidence
+        run: |
+          result="apps/conary/tests/integration/remi/results/${{ matrix.distro }}-phase4.json"
+          bash scripts/check-conary-test-result-gate.sh "$result"
+          bash scripts/check-conary-corpus-result-gate.sh "$result"
 
   release-artifact-proof:
     name: release-artifact-proof

--- a/apps/conary-test/src/cli.rs
+++ b/apps/conary-test/src/cli.rs
@@ -544,8 +544,12 @@ fn run_single_distro(
             let suite = runner
                 .run(&manifest, &backend, &container_id, Some(&container_config))
                 .await?;
+            aggregate_suite.expect_corpus_cases(suite.corpus_expected());
             for result in suite.results {
                 aggregate_suite.record(result);
+            }
+            for case in suite.corpus_cases {
+                aggregate_suite.record_corpus(case);
             }
         }
         aggregate_suite.finish();
@@ -561,7 +565,8 @@ fn run_single_distro(
 
         let has_blocking_results = aggregate_suite.failed() > 0
             || aggregate_suite.skipped() > 0
-            || aggregate_suite.cancelled() > 0;
+            || aggregate_suite.cancelled() > 0
+            || !aggregate_suite.corpus_all_completed();
 
         // Cleanup container.
         let keep_container = std::env::var("CONARY_TEST_KEEP_CONTAINER")
@@ -625,8 +630,12 @@ async fn run_qemu_only_suite(
                 Some(&dummy_config),
             )
             .await?;
+        aggregate_suite.expect_corpus_cases(suite.corpus_expected());
         for result in suite.results {
             aggregate_suite.record(result);
+        }
+        for case in suite.corpus_cases {
+            aggregate_suite.record_corpus(case);
         }
     }
     aggregate_suite.finish();
@@ -640,7 +649,8 @@ async fn run_qemu_only_suite(
 
     Ok(aggregate_suite.failed() == 0
         && aggregate_suite.skipped() == 0
-        && aggregate_suite.cancelled() == 0)
+        && aggregate_suite.cancelled() == 0
+        && aggregate_suite.corpus_all_completed())
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/conary-test/src/config/corpus.rs
+++ b/apps/conary-test/src/config/corpus.rs
@@ -1,0 +1,178 @@
+// conary-test/src/config/corpus.rs
+
+//! Persisted declarations for attributable just-works corpus cases.
+
+use anyhow::{Result, bail};
+use conary_core::corpus::{ConversionStage, SourceArtifactDigestSource};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::{Component, Path};
+
+/// Exact native source package format exercised by a corpus case.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CorpusSourceFormat {
+    Rpm,
+    Deb,
+    Alpm,
+}
+
+impl CorpusSourceFormat {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Rpm => "rpm",
+            Self::Deb => "deb",
+            Self::Alpm => "alpm",
+        }
+    }
+}
+
+/// Target facts that must accompany every corpus result.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CorpusTargetDef {
+    pub architecture: String,
+    pub init_system: String,
+    pub capabilities: Vec<String>,
+}
+
+/// Manifest-owned authority for one attributable corpus case.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CorpusCaseDef {
+    /// Absolute in-container path of the versioned runtime evidence envelope.
+    pub evidence_path: String,
+    pub source_profile: String,
+    pub source_format: CorpusSourceFormat,
+    pub digest_source: SourceArtifactDigestSource,
+    pub target: CorpusTargetDef,
+    /// Declared journey stages in their canonical execution order.
+    pub stages: Vec<ConversionStage>,
+}
+
+impl CorpusCaseDef {
+    pub fn validate(&self, test_id: &str) -> Result<()> {
+        let context = || format!("test {test_id} corpus declaration");
+        let evidence = Path::new(&self.evidence_path);
+        if !evidence.is_absolute()
+            || evidence
+                .components()
+                .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
+        {
+            bail!(
+                "{}: evidence_path must be an absolute normalized path",
+                context()
+            );
+        }
+        if self.source_profile.trim().is_empty() {
+            bail!("{}: source_profile must not be empty", context());
+        }
+        if self.target.architecture.trim().is_empty()
+            || self.target.init_system.trim().is_empty()
+            || self.target.capabilities.is_empty()
+            || self
+                .target
+                .capabilities
+                .iter()
+                .any(|capability| capability.trim().is_empty())
+        {
+            bail!(
+                "{}: target architecture, init_system, and capabilities are required",
+                context()
+            );
+        }
+        if self.stages.is_empty() {
+            bail!("{}: at least one journey stage is required", context());
+        }
+        if self.stages.iter().copied().collect::<HashSet<_>>().len() != self.stages.len() {
+            bail!("{}: journey stages must be unique", context());
+        }
+        if !self.stages.windows(2).all(|stages| stages[0] < stages[1]) {
+            bail!(
+                "{}: journey stages must follow canonical execution order",
+                context()
+            );
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_case() -> CorpusCaseDef {
+        CorpusCaseDef {
+            evidence_path: "/tmp/conary-corpus-rpm.json".into(),
+            source_profile: "fedora-44".into(),
+            source_format: CorpusSourceFormat::Rpm,
+            digest_source: SourceArtifactDigestSource::FixtureBuildManifest,
+            target: CorpusTargetDef {
+                architecture: "x86_64".into(),
+                init_system: "systemd".into(),
+                capabilities: vec!["native_lifecycle".into()],
+            },
+            stages: vec![
+                ConversionStage::Installation,
+                ConversionStage::Update,
+                ConversionStage::Rollback,
+                ConversionStage::Removal,
+            ],
+        }
+    }
+
+    #[test]
+    fn complete_case_is_valid() {
+        assert!(valid_case().validate("TC01").is_ok());
+    }
+
+    #[test]
+    fn missing_attribution_is_rejected() {
+        let mut case = valid_case();
+        case.source_profile.clear();
+        assert!(case.validate("TC01").is_err());
+
+        let mut case = valid_case();
+        case.target.capabilities.clear();
+        assert!(case.validate("TC01").is_err());
+    }
+
+    #[test]
+    fn missing_digest_source_is_rejected_during_deserialization() {
+        let declaration = r#"
+evidence_path = "/tmp/corpus.json"
+source_profile = "fedora-44"
+source_format = "rpm"
+stages = ["installation"]
+
+[target]
+architecture = "x86_64"
+init_system = "systemd"
+capabilities = ["native_lifecycle"]
+"#;
+        assert!(toml::from_str::<CorpusCaseDef>(declaration).is_err());
+    }
+
+    #[test]
+    fn relative_or_traversing_evidence_path_is_rejected() {
+        for path in ["corpus.json", "/tmp/../corpus.json"] {
+            let mut case = valid_case();
+            case.evidence_path = path.into();
+            assert!(case.validate("TC01").is_err());
+        }
+    }
+
+    #[test]
+    fn duplicate_stages_are_rejected() {
+        let mut case = valid_case();
+        case.stages = vec![ConversionStage::Installation, ConversionStage::Installation];
+        assert!(case.validate("TC01").is_err());
+    }
+
+    #[test]
+    fn out_of_order_stages_are_rejected() {
+        let mut case = valid_case();
+        case.stages = vec![ConversionStage::Rollback, ConversionStage::Update];
+        assert!(case.validate("TC01").is_err());
+    }
+}

--- a/apps/conary-test/src/config/manifest.rs
+++ b/apps/conary-test/src/config/manifest.rs
@@ -59,6 +59,9 @@ pub struct TestDef {
     /// Runtime capabilities required inside the test container.
     #[serde(default)]
     pub requires: Vec<String>,
+    /// Attributable just-works corpus authority for this test.
+    #[serde(default)]
+    pub corpus: Option<super::corpus::CorpusCaseDef>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -436,6 +439,15 @@ impl TestManifest {
     /// Validate all assertions in the manifest for conflicting fields.
     pub fn validate(&self) -> Result<()> {
         for test in &self.test {
+            if let Some(corpus) = &test.corpus {
+                corpus.validate(&test.id)?;
+                if test.resources.is_some() {
+                    bail!(
+                        "test {}: corpus evidence cannot use a resource-scoped disposable container",
+                        test.id
+                    );
+                }
+            }
             for requirement in &test.requires {
                 if requirement != "composefs_runtime" {
                     bail!(

--- a/apps/conary-test/src/config/mod.rs
+++ b/apps/conary-test/src/config/mod.rs
@@ -1,5 +1,6 @@
 // conary-test/src/config/mod.rs
 
+pub mod corpus;
 pub mod distro;
 pub mod manifest;
 
@@ -52,3 +53,4 @@ pub fn validate_unique_test_ids(manifests: &[(PathBuf, TestManifest)]) -> Result
 
 #[cfg(test)]
 mod tests;
+pub use corpus::{CorpusCaseDef, CorpusSourceFormat, CorpusTargetDef};

--- a/apps/conary-test/src/config/tests.rs
+++ b/apps/conary-test/src/config/tests.rs
@@ -54,6 +54,7 @@ fn minimal_manifest_with_id(id: &str) -> TestManifest {
             group: None,
             skip: None,
             requires: Vec::new(),
+            corpus: None,
         }],
         distro_overrides: Default::default(),
     }
@@ -754,22 +755,42 @@ fn focused_native_cross_source_manifest_runs_the_shared_lifecycle_contract() {
 
     let manifest = load_manifest(&path).expect("load focused native lifecycle manifest");
     assert_eq!(manifest.suite.phase, 4);
-    assert_eq!(manifest.test.len(), 1);
-    let test = &manifest.test[0];
-    assert_eq!(test.id, "TNPMX01");
-    assert_eq!(test.fatal, Some(true));
-    assert_eq!(test.skip, None);
-    assert_eq!(test.flaky, None);
+    assert_eq!(manifest.test.len(), 3);
+    for (test, expected_id, expected_profile, expected_format) in [
+        (&manifest.test[0], "TNPMX01R", "fedora-44", "rpm"),
+        (&manifest.test[1], "TNPMX01D", "ubuntu-26.04", "deb"),
+        (&manifest.test[2], "TNPMX01A", "arch", "alpm"),
+    ] {
+        assert_eq!(test.id, expected_id);
+        assert_eq!(test.fatal, Some(false));
+        assert_eq!(test.skip, None);
+        assert_eq!(test.flaky, None);
 
-    let rendered = format!("{test:?}");
-    assert!(
-        rendered.contains("run-cross-source-lifecycle-matrix.sh"),
-        "focused manifest must execute the shared lifecycle contract"
-    );
-    assert!(
-        rendered.contains("${native_lifecycle_oracle_format}"),
-        "focused manifest must pass an explicit typed native-oracle format"
-    );
+        let corpus = test.corpus.as_ref().expect("typed corpus declaration");
+        assert_eq!(corpus.source_profile, expected_profile);
+        assert_eq!(corpus.source_format.as_str(), expected_format);
+        assert_eq!(
+            corpus.digest_source,
+            conary_core::corpus::SourceArtifactDigestSource::FixtureBuildManifest
+        );
+        assert_eq!(corpus.stages.len(), 4);
+
+        let rendered = format!("{test:?}");
+        assert!(
+            rendered.contains("run-cross-source-lifecycle-matrix.sh"),
+            "focused manifest must execute the shared lifecycle contract"
+        );
+        assert!(
+            rendered.contains("${native_lifecycle_oracle_format}"),
+            "focused manifest must pass an explicit typed native-oracle format"
+        );
+        for operation in ["install", "update", "rollback", "remove"] {
+            assert!(
+                test.description.contains(operation),
+                "focused manifest should name {operation} in its contract"
+            );
+        }
+    }
     for (distro, expected_format) in [
         ("fedora44", "rpm"),
         ("ubuntu-26.04", "deb"),
@@ -785,12 +806,6 @@ fn focused_native_cross_source_manifest_runs_the_shared_lifecycle_contract() {
                 .map(String::as_str),
             Some(expected_format),
             "{distro} must select its native lifecycle oracle explicitly"
-        );
-    }
-    for operation in ["install", "update", "rollback", "remove"] {
-        assert!(
-            test.description.contains(operation),
-            "focused manifest should name {operation} in its contract"
         );
     }
 }

--- a/apps/conary-test/src/engine/corpus.rs
+++ b/apps/conary-test/src/engine/corpus.rs
@@ -1,0 +1,441 @@
+// conary-test/src/engine/corpus.rs
+
+//! Projection of typed runtime evidence into just-works corpus results.
+
+use crate::config::corpus::CorpusCaseDef;
+use crate::container::backend::{ContainerBackend, ContainerId};
+use crate::engine::suite::TestStatus;
+use anyhow::{Result, bail};
+use conary_core::corpus::{
+    ConversionFailure, ConversionStage, CorpusCaseResult, CorpusOutcome, SourceArtifactIdentity,
+    SourceProfileIdentity, StageResult, TargetCapabilitySnapshot,
+};
+use serde::Deserialize;
+use std::collections::HashSet;
+
+const EVIDENCE_SCHEMA_VERSION: u32 = 1;
+
+/// Versioned evidence written by the in-container lifecycle fixture.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CorpusRuntimeEvidence {
+    schema_version: u32,
+    source_profile: String,
+    source_format: String,
+    source_artifacts: Vec<SourceArtifactIdentity>,
+    completed_stages: Vec<ConversionStage>,
+    active_stage: Option<ConversionStage>,
+}
+
+/// Concrete owner for malformed, absent, or contradictory evidence.
+struct CorpusEvidenceFailure;
+
+/// Concrete owner for a test command or assertion failure.
+struct CorpusTestExecutionFailure;
+
+pub async fn capture_case(
+    definition: &CorpusCaseDef,
+    test_id: &str,
+    target_profile: &str,
+    status: TestStatus,
+    diagnostic: Option<&str>,
+    backend: &dyn ContainerBackend,
+    container_id: &ContainerId,
+) -> CorpusCaseResult {
+    if matches!(status, TestStatus::Skipped | TestStatus::Cancelled) {
+        return skipped_case(
+            definition,
+            test_id,
+            target_profile,
+            diagnostic.unwrap_or("corpus case did not run"),
+        );
+    }
+
+    let evidence = match backend
+        .copy_from(container_id, &definition.evidence_path)
+        .await
+        .and_then(|bytes| Ok(serde_json::from_slice::<CorpusRuntimeEvidence>(&bytes)?))
+    {
+        Ok(evidence) => evidence,
+        Err(error) => {
+            return evidence_failure_case(
+                definition,
+                test_id,
+                target_profile,
+                Vec::new(),
+                format!("failed to read typed corpus evidence: {error}"),
+            );
+        }
+    };
+
+    if let Err(error) = validate_evidence(definition, status, &evidence) {
+        return evidence_failure_case(
+            definition,
+            test_id,
+            target_profile,
+            evidence.source_artifacts,
+            error.to_string(),
+        );
+    }
+
+    let mut stages = evidence
+        .completed_stages
+        .iter()
+        .copied()
+        .map(StageResult::passed)
+        .collect::<Vec<_>>();
+
+    if status == TestStatus::Failed {
+        let active = evidence
+            .active_stage
+            .expect("validated failed evidence has an active stage");
+        stages.push(StageResult::failed(
+            active,
+            ConversionFailure::internal_for::<CorpusTestExecutionFailure>(
+                diagnostic.unwrap_or("corpus test failed"),
+            ),
+        ));
+        stages.extend(
+            definition.stages[stages.len()..]
+                .iter()
+                .copied()
+                .map(StageResult::not_reached),
+        );
+    }
+
+    CorpusCaseResult::from_stages(
+        test_id,
+        source_profile(definition),
+        evidence.source_artifacts,
+        target_snapshot(definition, target_profile),
+        stages,
+    )
+}
+
+fn validate_evidence(
+    definition: &CorpusCaseDef,
+    status: TestStatus,
+    evidence: &CorpusRuntimeEvidence,
+) -> Result<()> {
+    if evidence.schema_version != EVIDENCE_SCHEMA_VERSION {
+        bail!(
+            "unsupported corpus evidence schema version {}",
+            evidence.schema_version
+        );
+    }
+    if evidence.source_profile != definition.source_profile
+        || evidence.source_format != definition.source_format.as_str()
+    {
+        bail!("runtime source profile or format contradicts the corpus declaration");
+    }
+    if evidence.source_artifacts.is_empty() {
+        bail!("corpus evidence carries no source artifacts");
+    }
+
+    let mut request_roles = HashSet::new();
+    let mut artifact_identities = HashSet::new();
+    for artifact in &evidence.source_artifacts {
+        if !artifact_identities.insert((
+            artifact.role,
+            artifact.name.as_str(),
+            artifact.version.as_str(),
+            artifact.architecture.as_deref(),
+            artifact.digest.as_str(),
+        )) {
+            bail!("corpus evidence repeats an exact source artifact identity");
+        }
+        if matches!(
+            artifact.role,
+            conary_core::corpus::SourceArtifactRole::InstallRequest
+                | conary_core::corpus::SourceArtifactRole::UpdateRequest
+        ) && !request_roles.insert(artifact.role)
+        {
+            bail!(
+                "corpus evidence repeats requested artifact role {:?}",
+                artifact.role
+            );
+        }
+        if artifact.name.trim().is_empty()
+            || artifact.version.trim().is_empty()
+            || artifact.digest.len() != 64
+            || !artifact
+                .digest
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            bail!(
+                "corpus source artifact {:?} lacks exact name, version, or lowercase SHA-256 identity",
+                artifact.role
+            );
+        }
+        if artifact.digest_source != definition.digest_source {
+            bail!("runtime artifact digest source contradicts the corpus declaration");
+        }
+    }
+    if definition.stages.contains(&ConversionStage::Installation)
+        && !request_roles.contains(&conary_core::corpus::SourceArtifactRole::InstallRequest)
+    {
+        bail!("installation journey lacks its requested source artifact");
+    }
+    if definition.stages.contains(&ConversionStage::Update)
+        && !request_roles.contains(&conary_core::corpus::SourceArtifactRole::UpdateRequest)
+    {
+        bail!("update journey lacks its requested source artifact");
+    }
+
+    if !definition.stages.starts_with(&evidence.completed_stages) {
+        bail!("completed corpus stages are not a prefix of the declared journey");
+    }
+
+    match status {
+        TestStatus::Passed => {
+            if evidence.completed_stages != definition.stages || evidence.active_stage.is_some() {
+                bail!("passed corpus test did not complete its exact declared journey");
+            }
+        }
+        TestStatus::Failed => {
+            let expected_active = definition
+                .stages
+                .get(evidence.completed_stages.len())
+                .copied();
+            if evidence.active_stage != expected_active {
+                bail!("failed corpus test does not identify the next declared active stage");
+            }
+        }
+        TestStatus::Skipped | TestStatus::Cancelled => unreachable!("handled before evidence read"),
+    }
+    Ok(())
+}
+
+fn evidence_failure_case(
+    definition: &CorpusCaseDef,
+    test_id: &str,
+    target_profile: &str,
+    source_artifacts: Vec<SourceArtifactIdentity>,
+    detail: String,
+) -> CorpusCaseResult {
+    let failed_stage = definition.stages[0];
+    let mut stages = vec![StageResult::failed(
+        failed_stage,
+        ConversionFailure::internal_for::<CorpusEvidenceFailure>(detail),
+    )];
+    stages.extend(
+        definition.stages[1..]
+            .iter()
+            .copied()
+            .map(StageResult::not_reached),
+    );
+    CorpusCaseResult::from_stages(
+        test_id,
+        source_profile(definition),
+        source_artifacts,
+        target_snapshot(definition, target_profile),
+        stages,
+    )
+}
+
+fn skipped_case(
+    definition: &CorpusCaseDef,
+    test_id: &str,
+    target_profile: &str,
+    reason: &str,
+) -> CorpusCaseResult {
+    let mut case = CorpusCaseResult::from_stages(
+        test_id,
+        source_profile(definition),
+        Vec::new(),
+        target_snapshot(definition, target_profile),
+        definition
+            .stages
+            .iter()
+            .copied()
+            .map(StageResult::not_reached)
+            .collect(),
+    );
+    case.final_outcome = CorpusOutcome::Skipped {
+        reason: reason.to_string(),
+    };
+    case
+}
+
+pub fn case_did_not_run(
+    definition: &CorpusCaseDef,
+    test_id: &str,
+    target_profile: &str,
+    reason: &str,
+) -> CorpusCaseResult {
+    skipped_case(definition, test_id, target_profile, reason)
+}
+
+fn source_profile(definition: &CorpusCaseDef) -> SourceProfileIdentity {
+    SourceProfileIdentity {
+        profile: definition.source_profile.clone(),
+        format: definition.source_format.as_str().to_string(),
+    }
+}
+
+fn target_snapshot(definition: &CorpusCaseDef, target_profile: &str) -> TargetCapabilitySnapshot {
+    TargetCapabilitySnapshot {
+        profile: target_profile.to_string(),
+        architecture: definition.target.architecture.clone(),
+        init_system: definition.target.init_system.clone(),
+        capabilities: definition.target.capabilities.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::corpus::{CorpusSourceFormat, CorpusTargetDef};
+    use conary_core::corpus::{FailureKind, SourceArtifactDigestSource, SourceArtifactRole};
+
+    fn definition() -> CorpusCaseDef {
+        CorpusCaseDef {
+            evidence_path: "/tmp/corpus.json".into(),
+            source_profile: "fedora-44".into(),
+            source_format: CorpusSourceFormat::Rpm,
+            digest_source: SourceArtifactDigestSource::FixtureBuildManifest,
+            target: CorpusTargetDef {
+                architecture: "x86_64".into(),
+                init_system: "systemd".into(),
+                capabilities: vec!["native_lifecycle".into()],
+            },
+            stages: vec![
+                ConversionStage::Installation,
+                ConversionStage::Update,
+                ConversionStage::Rollback,
+                ConversionStage::Removal,
+            ],
+        }
+    }
+
+    fn artifacts() -> Vec<SourceArtifactIdentity> {
+        vec![
+            SourceArtifactIdentity {
+                role: SourceArtifactRole::InstallRequest,
+                digest_source: SourceArtifactDigestSource::FixtureBuildManifest,
+                name: "fixture".into(),
+                version: "1.0-1".into(),
+                architecture: Some("x86_64".into()),
+                digest: "a".repeat(64),
+            },
+            SourceArtifactIdentity {
+                role: SourceArtifactRole::UpdateRequest,
+                digest_source: SourceArtifactDigestSource::FixtureBuildManifest,
+                name: "fixture".into(),
+                version: "2.0-1".into(),
+                architecture: Some("x86_64".into()),
+                digest: "b".repeat(64),
+            },
+        ]
+    }
+
+    #[test]
+    fn passing_evidence_requires_the_complete_declared_journey() {
+        let evidence = CorpusRuntimeEvidence {
+            schema_version: EVIDENCE_SCHEMA_VERSION,
+            source_profile: "fedora-44".into(),
+            source_format: "rpm".into(),
+            source_artifacts: artifacts(),
+            completed_stages: definition().stages,
+            active_stage: None,
+        };
+        assert!(validate_evidence(&definition(), TestStatus::Passed, &evidence).is_ok());
+
+        let incomplete = CorpusRuntimeEvidence {
+            completed_stages: vec![ConversionStage::Installation],
+            ..evidence
+        };
+        assert!(validate_evidence(&definition(), TestStatus::Passed, &incomplete).is_err());
+    }
+
+    #[test]
+    fn failed_evidence_names_the_exact_next_stage() {
+        let evidence = CorpusRuntimeEvidence {
+            schema_version: EVIDENCE_SCHEMA_VERSION,
+            source_profile: "fedora-44".into(),
+            source_format: "rpm".into(),
+            source_artifacts: artifacts(),
+            completed_stages: vec![ConversionStage::Installation],
+            active_stage: Some(ConversionStage::Update),
+        };
+        assert!(validate_evidence(&definition(), TestStatus::Failed, &evidence).is_ok());
+
+        let contradictory = CorpusRuntimeEvidence {
+            active_stage: Some(ConversionStage::Removal),
+            ..evidence
+        };
+        assert!(validate_evidence(&definition(), TestStatus::Failed, &contradictory).is_err());
+    }
+
+    #[test]
+    fn malformed_or_duplicate_artifact_authority_is_rejected() {
+        let mut malformed = artifacts();
+        malformed[1].role = SourceArtifactRole::InstallRequest;
+        malformed[1].digest = "not-a-digest".into();
+        let evidence = CorpusRuntimeEvidence {
+            schema_version: EVIDENCE_SCHEMA_VERSION,
+            source_profile: "fedora-44".into(),
+            source_format: "rpm".into(),
+            source_artifacts: malformed,
+            completed_stages: definition().stages,
+            active_stage: None,
+        };
+        assert!(validate_evidence(&definition(), TestStatus::Passed, &evidence).is_err());
+    }
+
+    #[test]
+    fn runtime_source_identity_cannot_contradict_the_manifest() {
+        let evidence = CorpusRuntimeEvidence {
+            schema_version: EVIDENCE_SCHEMA_VERSION,
+            source_profile: "arch".into(),
+            source_format: "alpm".into(),
+            source_artifacts: artifacts(),
+            completed_stages: definition().stages,
+            active_stage: None,
+        };
+        assert!(validate_evidence(&definition(), TestStatus::Passed, &evidence).is_err());
+    }
+
+    #[test]
+    fn diagnostic_wording_cannot_change_evidence_failure_bucket() {
+        let first = evidence_failure_case(
+            &definition(),
+            "TC01",
+            "fedora44",
+            Vec::new(),
+            "first wording".into(),
+        );
+        let second = evidence_failure_case(
+            &definition(),
+            "TC02",
+            "fedora44",
+            Vec::new(),
+            "unrelated sentence".into(),
+        );
+
+        assert_eq!(
+            first.failure_key(),
+            Some((
+                ConversionStage::Installation,
+                FailureKind::InternalUnclassified
+            ))
+        );
+        assert_eq!(first.failure_key(), second.failure_key());
+        let first_id = match &first.final_outcome {
+            CorpusOutcome::Failed {
+                failure: ConversionFailure::InternalUnclassified { incident_id, .. },
+                ..
+            } => incident_id,
+            other => panic!("unexpected outcome: {other:?}"),
+        };
+        let second_id = match &second.final_outcome {
+            CorpusOutcome::Failed {
+                failure: ConversionFailure::InternalUnclassified { incident_id, .. },
+                ..
+            } => incident_id,
+            other => panic!("unexpected outcome: {other:?}"),
+        };
+        assert_eq!(first_id, second_id);
+    }
+}

--- a/apps/conary-test/src/engine/corpus.rs
+++ b/apps/conary-test/src/engine/corpus.rs
@@ -438,4 +438,19 @@ mod tests {
         };
         assert_eq!(first_id, second_id);
     }
+
+    #[test]
+    fn an_unrun_declared_case_remains_visible_as_skipped() {
+        let case = case_did_not_run(&definition(), "TC01", "fedora44", "suite timeout");
+
+        assert!(matches!(
+            case.final_outcome,
+            CorpusOutcome::Skipped { ref reason } if reason == "suite timeout"
+        ));
+        assert_eq!(case.stage_results.len(), definition().stages.len());
+        assert!(case.stage_results.iter().all(|stage| matches!(
+            &stage.outcome,
+            conary_core::corpus::StageOutcome::NotReached
+        )));
+    }
 }

--- a/apps/conary-test/src/engine/mod.rs
+++ b/apps/conary-test/src/engine/mod.rs
@@ -3,6 +3,7 @@
 pub mod assertions;
 pub mod container_coordinator;
 pub mod container_setup;
+pub mod corpus;
 pub mod executor;
 pub mod mock_server;
 pub mod qemu;

--- a/apps/conary-test/src/engine/runner.rs
+++ b/apps/conary-test/src/engine/runner.rs
@@ -182,6 +182,13 @@ impl TestRunner {
             .await?;
 
         let mut suite = TestSuite::new(&manifest.suite.name, manifest.suite.phase);
+        suite.expect_corpus_cases(
+            manifest
+                .test
+                .iter()
+                .filter(|test| test.corpus.is_some())
+                .count(),
+        );
         suite.status = crate::engine::suite::RunStatus::Running;
 
         // Emit suite-started event.
@@ -217,6 +224,7 @@ impl TestRunner {
                     stderr: None,
                     attempts: Vec::new(),
                 });
+                self.record_unrun_corpus(&mut suite, test_def, "cancelled");
                 continue;
             }
 
@@ -236,6 +244,7 @@ impl TestRunner {
                     stderr: None,
                     attempts: Vec::new(),
                 });
+                self.record_unrun_corpus(&mut suite, test_def, "suite timeout exceeded");
                 continue;
             }
 
@@ -248,11 +257,12 @@ impl TestRunner {
                     name: test_def.name.clone(),
                     status: TestStatus::Skipped,
                     duration_ms: 0,
-                    message: Some(msg),
+                    message: Some(msg.clone()),
                     stdout: None,
                     stderr: None,
                     attempts: Vec::new(),
                 });
+                self.record_unrun_corpus(&mut suite, test_def, &msg);
                 continue;
             }
 
@@ -272,6 +282,7 @@ impl TestRunner {
                     stderr: None,
                     attempts: Vec::new(),
                 });
+                self.record_unrun_corpus(&mut suite, test_def, &msg);
                 if let Some((run_id, ref tx)) = event_tx {
                     let _ = tx.send(TestEvent::TestSkipped {
                         run_id,
@@ -301,6 +312,7 @@ impl TestRunner {
                     stderr: None,
                     attempts: Vec::new(),
                 });
+                self.record_unrun_corpus(&mut suite, test_def, &msg);
                 if let Some((run_id, ref tx)) = event_tx {
                     let _ = tx.send(TestEvent::TestSkipped {
                         run_id,
@@ -367,6 +379,20 @@ impl TestRunner {
                 attempts: Vec::new(),
             });
 
+            if let Some(corpus) = &test_def.corpus {
+                let corpus_result = crate::engine::corpus::capture_case(
+                    corpus,
+                    &test_def.id,
+                    &self.distro,
+                    status,
+                    message.as_deref(),
+                    backend,
+                    container_id,
+                )
+                .await;
+                suite.record_corpus(corpus_result);
+            }
+
             // Push result to Remi if streaming is configured.
             if let Some(ctx) = remi_ctx {
                 let push_data = build_push_result(
@@ -429,6 +455,17 @@ impl TestRunner {
         }
 
         Ok(suite)
+    }
+
+    fn record_unrun_corpus(&self, suite: &mut TestSuite, test_def: &TestDef, reason: &str) {
+        if let Some(corpus) = &test_def.corpus {
+            suite.record_corpus(crate::engine::corpus::case_did_not_run(
+                corpus,
+                &test_def.id,
+                &self.distro,
+                reason,
+            ));
+        }
     }
 
     async fn run_setup_steps(

--- a/apps/conary-test/src/engine/runner/tests.rs
+++ b/apps/conary-test/src/engine/runner/tests.rs
@@ -137,6 +137,7 @@ async fn test_runner_passes_on_success() {
         group: None,
         skip: None,
         requires: Vec::new(),
+        corpus: None,
     }]);
 
     let mut runner = TestRunner::new(test_config(), "fedora44".to_string());
@@ -194,6 +195,7 @@ async fn suite_setup_executes_before_tests() {
             group: None,
             skip: None,
             requires: Vec::new(),
+            corpus: None,
         }],
         distro_overrides: HashMap::new(),
     };
@@ -234,6 +236,7 @@ async fn test_runner_fails_on_bad_exit_code() {
         group: None,
         skip: None,
         requires: Vec::new(),
+        corpus: None,
     }]);
 
     let mut runner = TestRunner::new(test_config(), "fedora44".to_string());
@@ -282,6 +285,7 @@ async fn test_runner_skips_on_dep_failure() {
             group: None,
             skip: None,
             requires: Vec::new(),
+            corpus: None,
         },
         TestDef {
             id: "T02".to_string(),
@@ -298,6 +302,7 @@ async fn test_runner_skips_on_dep_failure() {
             group: None,
             skip: None,
             requires: Vec::new(),
+            corpus: None,
         },
     ]);
 
@@ -339,6 +344,7 @@ async fn test_runner_skips_when_composefs_runtime_requirement_is_missing() {
         group: None,
         skip: None,
         requires: vec!["composefs_runtime".to_string()],
+        corpus: None,
     }]);
 
     let mut runner = TestRunner::new(test_config(), "fedora44".to_string());
@@ -397,6 +403,7 @@ async fn test_runner_kill_after_log() {
         group: None,
         skip: None,
         requires: Vec::new(),
+        corpus: None,
     }]);
 
     let mut runner = TestRunner::new(test_config(), "fedora44".to_string());
@@ -465,6 +472,7 @@ async fn test_runner_flaky_majority_pass() {
         group: None,
         skip: None,
         requires: Vec::new(),
+        corpus: None,
     }]);
 
     let mut runner = TestRunner::new(test_config(), "fedora44".to_string());
@@ -522,6 +530,7 @@ async fn test_runner_flaky_majority_fail() {
         group: None,
         skip: None,
         requires: Vec::new(),
+        corpus: None,
     }]);
 
     let mut runner = TestRunner::new(test_config(), "fedora44".to_string());
@@ -600,6 +609,7 @@ async fn test_resource_scoped_flaky_retries_use_fresh_container() {
             group: None,
             skip: None,
             requires: Vec::new(),
+            corpus: None,
         }],
         distro_overrides: HashMap::new(),
     };

--- a/apps/conary-test/src/engine/runner/tests/controls.rs
+++ b/apps/conary-test/src/engine/runner/tests/controls.rs
@@ -160,6 +160,7 @@ async fn test_runner_qemu_boot_step_skips_when_tooling_missing() {
         group: None,
         skip: None,
         requires: Vec::new(),
+        corpus: None,
     }]);
 
     let mut runner = TestRunner::new(test_config(), "fedora44".to_string());
@@ -260,6 +261,7 @@ async fn test_cancel_flag_stops_runner() {
             group: None,
             skip: None,
             requires: Vec::new(),
+            corpus: None,
         },
         TestDef {
             id: "T02".to_string(),
@@ -276,6 +278,7 @@ async fn test_cancel_flag_stops_runner() {
             group: None,
             skip: None,
             requires: Vec::new(),
+            corpus: None,
         },
     ]);
 
@@ -331,6 +334,7 @@ async fn test_suite_timeout_cancels_remaining() {
                 group: None,
                 skip: None,
                 requires: Vec::new(),
+                corpus: None,
             },
             TestDef {
                 id: "T02".to_string(),
@@ -347,6 +351,7 @@ async fn test_suite_timeout_cancels_remaining() {
                 group: None,
                 skip: None,
                 requires: Vec::new(),
+                corpus: None,
             },
         ],
         distro_overrides: HashMap::new(),
@@ -408,6 +413,7 @@ async fn test_step_timeout_overrides_test_timeout() {
         group: None,
         skip: None,
         requires: Vec::new(),
+        corpus: None,
     }]);
 
     let mut runner = TestRunner::new(test_config(), "fedora44".to_string());
@@ -452,6 +458,7 @@ async fn test_concurrent_runs_independent() {
         group: None,
         skip: None,
         requires: Vec::new(),
+        corpus: None,
     }]);
 
     let manifest_b = make_manifest(vec![TestDef {
@@ -472,6 +479,7 @@ async fn test_concurrent_runs_independent() {
         group: None,
         skip: None,
         requires: Vec::new(),
+        corpus: None,
     }]);
 
     let (suite_a, suite_b) = tokio::join!(

--- a/apps/conary-test/src/engine/suite.rs
+++ b/apps/conary-test/src/engine/suite.rs
@@ -69,6 +69,10 @@ pub struct TestSuite {
     pub phase: u32,
     pub status: RunStatus,
     pub results: Vec<TestResult>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub corpus_cases: Vec<conary_core::corpus::CorpusCaseResult>,
+    #[serde(skip)]
+    corpus_expected: usize,
     pub started_at: DateTime<Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub finished_at: Option<DateTime<Utc>>,
@@ -83,6 +87,8 @@ impl TestSuite {
             phase,
             status: RunStatus::Pending,
             results: Vec::new(),
+            corpus_cases: Vec::new(),
+            corpus_expected: 0,
             started_at: Utc::now(),
             finished_at: None,
             unsuccessful_ids: HashSet::new(),
@@ -94,6 +100,18 @@ impl TestSuite {
             self.unsuccessful_ids.insert(result.id.clone());
         }
         self.results.push(result);
+    }
+
+    pub fn record_corpus(&mut self, result: conary_core::corpus::CorpusCaseResult) {
+        self.corpus_cases.push(result);
+    }
+
+    pub fn expect_corpus_cases(&mut self, count: usize) {
+        self.corpus_expected += count;
+    }
+
+    pub fn corpus_expected(&self) -> usize {
+        self.corpus_expected
     }
 
     pub fn has_failed(&self, id: &str) -> bool {
@@ -137,6 +155,11 @@ impl TestSuite {
 
     pub fn total(&self) -> usize {
         self.results.len()
+    }
+
+    pub fn corpus_all_completed(&self) -> bool {
+        self.corpus_cases.len() == self.corpus_expected
+            && conary_core::corpus::aggregate_cases(&self.corpus_cases).all_completed()
     }
 
     pub fn finish(&mut self) {

--- a/apps/conary-test/src/report/corpus.rs
+++ b/apps/conary-test/src/report/corpus.rs
@@ -1,0 +1,27 @@
+// conary-test/src/report/corpus.rs
+
+//! Fail-closed JSON envelope for attributable just-works corpus evidence.
+
+use conary_core::corpus::{CorpusAggregate, CorpusCaseResult, aggregate_cases};
+use serde::Serialize;
+
+pub const CORPUS_REPORT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Serialize)]
+pub struct CorpusReport<'a> {
+    pub schema_version: u32,
+    pub expected_cases: usize,
+    pub aggregate: CorpusAggregate,
+    pub cases: &'a [CorpusCaseResult],
+}
+
+impl<'a> CorpusReport<'a> {
+    pub fn from_cases(cases: &'a [CorpusCaseResult], expected_cases: usize) -> Option<Self> {
+        (expected_cases > 0 || !cases.is_empty()).then(|| Self {
+            schema_version: CORPUS_REPORT_SCHEMA_VERSION,
+            expected_cases,
+            aggregate: aggregate_cases(cases),
+            cases,
+        })
+    }
+}

--- a/apps/conary-test/src/report/json.rs
+++ b/apps/conary-test/src/report/json.rs
@@ -12,6 +12,8 @@ struct JsonReport<'a> {
     status: &'a str,
     summary: Summary,
     results: &'a [crate::engine::suite::TestResult],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    corpus: Option<crate::report::corpus::CorpusReport<'a>>,
 }
 
 #[derive(Serialize)]
@@ -44,6 +46,10 @@ pub fn to_json_value(suite: &TestSuite) -> Result<serde_json::Value> {
             cancelled: suite.cancelled(),
         },
         results: &suite.results,
+        corpus: crate::report::corpus::CorpusReport::from_cases(
+            &suite.corpus_cases,
+            suite.corpus_expected(),
+        ),
     };
     Ok(serde_json::to_value(report)?)
 }
@@ -59,6 +65,10 @@ pub fn write_json_report(suite: &TestSuite, path: &Path) -> Result<()> {
 mod tests {
     use super::*;
     use crate::engine::suite::{TestResult, TestStatus, TestSuite};
+    use conary_core::corpus::{
+        ConversionStage, CorpusCaseResult, SourceArtifactDigestSource, SourceArtifactIdentity,
+        SourceArtifactRole, SourceProfileIdentity, StageResult, TargetCapabilitySnapshot,
+    };
 
     #[test]
     fn test_json_report_format() {
@@ -88,5 +98,59 @@ mod tests {
         assert_eq!(parsed["summary"]["cancelled"], 0);
         assert_eq!(parsed["results"][0]["id"], "T01");
         assert_eq!(parsed["results"][0]["status"], "passed");
+        assert!(parsed.get("corpus").is_none());
+    }
+
+    #[test]
+    fn corpus_report_is_attributable_and_fail_closed() {
+        let mut suite = TestSuite::new("corpus", 4);
+        suite.expect_corpus_cases(1);
+        suite.record_corpus(CorpusCaseResult::from_stages(
+            "TC-RPM-FEDORA",
+            SourceProfileIdentity {
+                profile: "fedora-44".into(),
+                format: "rpm".into(),
+            },
+            vec![SourceArtifactIdentity {
+                role: SourceArtifactRole::InstallRequest,
+                digest_source: SourceArtifactDigestSource::FixtureBuildManifest,
+                name: "fixture".into(),
+                version: "1.0-1".into(),
+                architecture: Some("x86_64".into()),
+                digest: "a".repeat(64),
+            }],
+            TargetCapabilitySnapshot {
+                profile: "fedora44".into(),
+                architecture: "x86_64".into(),
+                init_system: "systemd".into(),
+                capabilities: vec!["native_lifecycle".into()],
+            },
+            vec![StageResult::passed(ConversionStage::Installation)],
+        ));
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(&to_json_report(&suite).unwrap()).unwrap();
+        assert_eq!(parsed["corpus"]["schema_version"], 1);
+        assert_eq!(parsed["corpus"]["expected_cases"], 1);
+        assert_eq!(parsed["corpus"]["aggregate"]["cases"], 1);
+        assert_eq!(parsed["corpus"]["aggregate"]["completed"], 1);
+        assert_eq!(parsed["corpus"]["cases"][0]["case_id"], "TC-RPM-FEDORA");
+        assert_eq!(
+            parsed["corpus"]["cases"][0]["source_artifacts"][0]["role"],
+            "install_request"
+        );
+        assert!(suite.corpus_all_completed());
+    }
+
+    #[test]
+    fn missing_declared_corpus_case_is_published_and_blocks_success() {
+        let mut suite = TestSuite::new("corpus", 4);
+        suite.expect_corpus_cases(1);
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(&to_json_report(&suite).unwrap()).unwrap();
+        assert_eq!(parsed["corpus"]["expected_cases"], 1);
+        assert_eq!(parsed["corpus"]["aggregate"]["cases"], 0);
+        assert!(!suite.corpus_all_completed());
     }
 }

--- a/apps/conary-test/src/report/mod.rs
+++ b/apps/conary-test/src/report/mod.rs
@@ -1,5 +1,6 @@
 // conary-test/src/report/mod.rs
 
+pub mod corpus;
 pub mod json;
 pub mod stream;
 

--- a/apps/conary/tests/fixtures/native/run-cross-source-lifecycle-matrix.sh
+++ b/apps/conary/tests/fixtures/native/run-cross-source-lifecycle-matrix.sh
@@ -60,7 +60,15 @@ done
 
 declare -A v1_packages
 declare -A v2_packages
-for source_format in "${all_source_formats[@]}"; do
+declare -A v1_digests
+declare -A v2_digests
+build_formats=("${native_format}")
+for source_format in "${source_formats[@]}"; do
+  if [[ "${source_format}" != "${native_format}" ]]; then
+    build_formats+=("${source_format}")
+  fi
+done
+for source_format in "${build_formats[@]}"; do
   v1_output="${packages_root}/${source_format}/v1"
   v2_output="${packages_root}/${source_format}/v2"
   mkdir -p "${v1_output}" "${v2_output}"
@@ -73,9 +81,11 @@ for source_format in "${all_source_formats[@]}"; do
   # shellcheck disable=SC1090
   source "${v1_output}/native-fixture.env"
   v1_packages["${source_format}"]="${NATIVE_PKG_FILE}"
+  v1_digests["${source_format}"]="${NATIVE_PKG_SHA256}"
   # shellcheck disable=SC1090
   source "${v2_output}/native-fixture.env"
   v2_packages["${source_format}"]="${NATIVE_PKG_FILE}"
+  v2_digests["${source_format}"]="${NATIVE_PKG_SHA256}"
 done
 
 "${capture_native_oracle}" \
@@ -87,6 +97,49 @@ done
 
 declare -a masked_manager_paths=()
 declare -a masked_manager_backups=()
+declare -a corpus_completed_stages=()
+corpus_active_stage=""
+corpus_evidence_path="${CONARY_CORPUS_EVIDENCE_PATH:-}"
+corpus_source_format=""
+corpus_source_profile=""
+corpus_package_format=""
+corpus_architecture=""
+corpus_v1_version=""
+corpus_v2_version=""
+
+write_corpus_evidence() {
+  [[ -n "${corpus_evidence_path}" && -n "${corpus_source_format}" ]] || return 0
+
+  local completed_json=""
+  local separator=""
+  local stage
+  for stage in "${corpus_completed_stages[@]}"; do
+    completed_json+="${separator}\"${stage}\""
+    separator=","
+  done
+
+  local active_json="null"
+  if [[ -n "${corpus_active_stage}" ]]; then
+    active_json="\"${corpus_active_stage}\""
+  fi
+
+  local evidence_tmp="${corpus_evidence_path}.tmp"
+  printf '%s\n' \
+    "{\"schema_version\":1,\"source_profile\":\"${corpus_source_profile}\",\"source_format\":\"${corpus_package_format}\",\"source_artifacts\":[{\"role\":\"install_request\",\"digest_source\":\"fixture_build_manifest\",\"name\":\"${package_name}\",\"version\":\"${corpus_v1_version}\",\"architecture\":\"${corpus_architecture}\",\"digest\":\"${v1_digests[${corpus_source_format}]}\"},{\"role\":\"update_request\",\"digest_source\":\"fixture_build_manifest\",\"name\":\"${package_name}\",\"version\":\"${corpus_v2_version}\",\"architecture\":\"${corpus_architecture}\",\"digest\":\"${v2_digests[${corpus_source_format}]}\"}],\"completed_stages\":[${completed_json}],\"active_stage\":${active_json}}" \
+    > "${evidence_tmp}"
+  mv "${evidence_tmp}" "${corpus_evidence_path}"
+}
+
+begin_corpus_stage() {
+  corpus_active_stage="$1"
+  write_corpus_evidence
+}
+
+complete_corpus_stage() {
+  corpus_completed_stages+=("$1")
+  corpus_active_stage=""
+  write_corpus_evidence
+}
 
 restore_native_managers() {
   local index
@@ -95,10 +148,17 @@ restore_native_managers() {
   done
 }
 
+finalize_case() {
+  local evidence_status=0
+  write_corpus_evidence || evidence_status=$?
+  restore_native_managers
+  return "${evidence_status}"
+}
+
 # PATH shims catch normal delegation. Replacing every native-manager executable
 # present in the target image also catches an absolute-path bypass. The trap
 # restores the ephemeral test image even when a later parity assertion fails.
-trap restore_native_managers EXIT
+trap finalize_case EXIT
 mkdir -p "${work}/native-manager-backups"
 for pm in rpm rpmdb rpmbuild dpkg dpkg-query dpkg-deb apt apt-get pacman makepkg; do
   manager_path="$(command -v "${pm}" 2>/dev/null || true)"
@@ -144,20 +204,40 @@ for source_format in "${source_formats[@]}"; do
       version_scheme="rpm"
       v1_version="1.0.0-1"
       v2_version="1.0.1-1"
+      source_architecture="x86_64"
+      package_format="rpm"
       ;;
     deb)
       source_profile="ubuntu-26.04"
       version_scheme="debian"
       v1_version="1.0.0-1"
       v2_version="1.0.1-1"
+      source_architecture="amd64"
+      package_format="deb"
       ;;
     arch)
       source_profile="arch"
       version_scheme="arch"
       v1_version="1.0.0-1"
       v2_version="1.0.1-1"
+      source_architecture="x86_64"
+      package_format="alpm"
       ;;
   esac
+
+  if [[ -n "${corpus_evidence_path}" ]]; then
+    if [[ "${#source_formats[@]}" -ne 1 ]]; then
+      echo "Corpus evidence requires one explicit source format" >&2
+      exit 64
+    fi
+    rm -f "${corpus_evidence_path}" "${corpus_evidence_path}.tmp"
+    corpus_source_format="${source_format}"
+    corpus_source_profile="${source_profile}"
+    corpus_package_format="${package_format}"
+    corpus_architecture="${source_architecture}"
+    corpus_v1_version="${v1_version}"
+    corpus_v2_version="${v2_version}"
+  fi
 
   conary_env=(
     env
@@ -171,6 +251,7 @@ for source_format in "${source_formats[@]}"; do
   "${conary_env[@]}" "${conary_bin}" system init --db-path "${db}"
   CONARY_BIN="${conary_bin}" "${prepare_selected_root}" "${db}" "${case_root}"
 
+  begin_corpus_stage installation
   "${matrix_env[@]}" "${conary_bin}" install "${v1_package}" \
     --convert-to-ccs \
     --db-path "${db}" \
@@ -187,7 +268,9 @@ for source_format in "${source_formats[@]}"; do
     --expect-sha256 "/usr/bin/conary-native-lifecycle-parity=33851600497e6d83b4f9fd754f20e900fc32c167a1caee9c97203fab7233a7bd" \
     --expect-sha256 "/usr/share/conary-native-lifecycle-parity/payload-version=2d27fbdf4e8ca207afbfa388ca9172fbcc6c70e534af2476b3b704f87debadcf"
   assert_trace "${case_root}" "${source_format}" install
+  complete_corpus_stage installation
 
+  begin_corpus_stage update
   "${matrix_env[@]}" "${conary_bin}" install "${v2_package}" \
     --convert-to-ccs \
     --db-path "${db}" \
@@ -204,6 +287,7 @@ for source_format in "${source_formats[@]}"; do
     --expect-sha256 "/usr/bin/conary-native-lifecycle-parity=56a8ad4c2941515f4bab2c737b40b1a51d1dcdfeeb9bc53adb76b97fcffcc420" \
     --expect-sha256 "/usr/share/conary-native-lifecycle-parity/payload-version=81db67b6a5702b9b68f0016f061c409bf3fb16d062fc854d1b424bb4e9c28c56"
   assert_trace "${case_root}" "${source_format}" upgrade
+  complete_corpus_stage update
 
   upgrade_changeset="$(
     sqlite3 "${db}" \
@@ -215,6 +299,7 @@ for source_format in "${source_formats[@]}"; do
       exit 1
       ;;
   esac
+  begin_corpus_stage rollback
   "${matrix_env[@]}" "${conary_bin}" system state rollback "${upgrade_changeset}" \
     --db-path "${db}" \
     --yes
@@ -227,7 +312,9 @@ for source_format in "${source_formats[@]}"; do
     --expect-sha256 "/usr/bin/conary-native-lifecycle-parity=33851600497e6d83b4f9fd754f20e900fc32c167a1caee9c97203fab7233a7bd" \
     --expect-sha256 "/usr/share/conary-native-lifecycle-parity/payload-version=2d27fbdf4e8ca207afbfa388ca9172fbcc6c70e534af2476b3b704f87debadcf"
   assert_trace "${case_root}" "${source_format}" install
+  complete_corpus_stage rollback
 
+  begin_corpus_stage removal
   "${matrix_env[@]}" "${conary_bin}" remove "${package_name}" \
     --db-path "${db}" \
     --purge \
@@ -242,6 +329,7 @@ for source_format in "${source_formats[@]}"; do
     --absent "/usr/bin/conary-native-lifecycle-parity" \
     --absent "/usr/share/conary-native-lifecycle-parity/payload-version"
   assert_trace "${case_root}" "${source_format}" remove
+  complete_corpus_stage removal
 done
 
 test ! -e "${native_pm_called}"

--- a/apps/conary/tests/integration/remi/manifests/native-cross-source-lifecycle.toml
+++ b/apps/conary/tests/integration/remi/manifests/native-cross-source-lifecycle.toml
@@ -5,7 +5,7 @@
 [suite]
 name = "Native Cross-Source Lifecycle"
 phase = 4
-timeout = 1800
+timeout = 3600
 
 [distro_overrides.fedora44]
 native_lifecycle_oracle_format = "rpm"
@@ -17,15 +17,79 @@ native_lifecycle_oracle_format = "deb"
 native_lifecycle_oracle_format = "arch"
 
 [[test]]
-id = "TNPMX01"
-name = "cross_source_install_update_rollback_remove"
-description = "RPM, Debian, and Arch install, update, rollback, and remove traces match native package-manager authority across every target without runtime delegation"
+id = "TNPMX01R"
+name = "rpm_source_install_update_rollback_remove"
+description = "RPM install, update, rollback, and remove traces match native package-manager authority on this target without runtime delegation"
 timeout = 1500
-fatal = true
+fatal = false
 group = "native-cross-source-lifecycle"
 
+[test.corpus]
+evidence_path = "/tmp/conary-corpus-rpm.json"
+source_profile = "fedora-44"
+source_format = "rpm"
+digest_source = "fixture_build_manifest"
+stages = ["installation", "update", "rollback", "removal"]
+
+[test.corpus.target]
+architecture = "x86_64"
+init_system = "systemd"
+capabilities = ["native_lifecycle", "selected_root_generation"]
+
 [[test.step]]
-run = "CONARY_BIN=${CONARY_BIN} /opt/remi-tests/fixtures/native/run-cross-source-lifecycle-matrix.sh ${native_lifecycle_oracle_format}"
+run = "CONARY_CORPUS_EVIDENCE_PATH=/tmp/conary-corpus-rpm.json CONARY_BIN=${CONARY_BIN} /opt/remi-tests/fixtures/native/run-cross-source-lifecycle-matrix.sh ${native_lifecycle_oracle_format} rpm"
+
+[test.step.assert]
+exit_code = 0
+
+[[test]]
+id = "TNPMX01D"
+name = "debian_source_install_update_rollback_remove"
+description = "Debian install, update, rollback, and remove traces match native package-manager authority on this target without runtime delegation"
+timeout = 1500
+fatal = false
+group = "native-cross-source-lifecycle"
+
+[test.corpus]
+evidence_path = "/tmp/conary-corpus-deb.json"
+source_profile = "ubuntu-26.04"
+source_format = "deb"
+digest_source = "fixture_build_manifest"
+stages = ["installation", "update", "rollback", "removal"]
+
+[test.corpus.target]
+architecture = "x86_64"
+init_system = "systemd"
+capabilities = ["native_lifecycle", "selected_root_generation"]
+
+[[test.step]]
+run = "CONARY_CORPUS_EVIDENCE_PATH=/tmp/conary-corpus-deb.json CONARY_BIN=${CONARY_BIN} /opt/remi-tests/fixtures/native/run-cross-source-lifecycle-matrix.sh ${native_lifecycle_oracle_format} deb"
+
+[test.step.assert]
+exit_code = 0
+
+[[test]]
+id = "TNPMX01A"
+name = "arch_source_install_update_rollback_remove"
+description = "Arch install, update, rollback, and remove traces match native package-manager authority on this target without runtime delegation"
+timeout = 1500
+fatal = false
+group = "native-cross-source-lifecycle"
+
+[test.corpus]
+evidence_path = "/tmp/conary-corpus-arch.json"
+source_profile = "arch"
+source_format = "alpm"
+digest_source = "fixture_build_manifest"
+stages = ["installation", "update", "rollback", "removal"]
+
+[test.corpus.target]
+architecture = "x86_64"
+init_system = "systemd"
+capabilities = ["native_lifecycle", "selected_root_generation"]
+
+[[test.step]]
+run = "CONARY_CORPUS_EVIDENCE_PATH=/tmp/conary-corpus-arch.json CONARY_BIN=${CONARY_BIN} /opt/remi-tests/fixtures/native/run-cross-source-lifecycle-matrix.sh ${native_lifecycle_oracle_format} arch"
 
 [test.step.assert]
 exit_code = 0

--- a/crates/conary-core/src/corpus/aggregate.rs
+++ b/crates/conary-core/src/corpus/aggregate.rs
@@ -145,16 +145,19 @@ mod tests {
 
     fn case_failing_with(stage: ConversionStage, failure: ConversionFailure) -> CorpusCaseResult {
         CorpusCaseResult::from_stages(
+            "arch-on-fedora",
             SourceProfileIdentity {
                 profile: "arch".into(),
                 format: "alpm".into(),
             },
-            SourceArtifactIdentity {
+            vec![SourceArtifactIdentity {
+                role: super::super::SourceArtifactRole::InstallRequest,
+                digest_source: super::super::SourceArtifactDigestSource::FixtureBuildManifest,
                 name: "btop".into(),
                 version: "1.4.0-1".into(),
                 architecture: Some("x86_64".into()),
                 digest: "d3983ae27b3e6e470bc33fd060a29c2e9a4a0c5a363ea76a07dd4ce300709c9c".into(),
-            },
+            }],
             TargetCapabilitySnapshot {
                 profile: "fedora-44".into(),
                 architecture: "x86_64".into(),
@@ -167,16 +170,19 @@ mod tests {
 
     fn passing_case() -> CorpusCaseResult {
         CorpusCaseResult::from_stages(
+            "arch-on-fedora",
             SourceProfileIdentity {
                 profile: "arch".into(),
                 format: "alpm".into(),
             },
-            SourceArtifactIdentity {
+            vec![SourceArtifactIdentity {
+                role: super::super::SourceArtifactRole::InstallRequest,
+                digest_source: super::super::SourceArtifactDigestSource::FixtureBuildManifest,
                 name: "curl".into(),
                 version: "8.0.0-1".into(),
                 architecture: Some("x86_64".into()),
                 digest: "abc".into(),
-            },
+            }],
             TargetCapabilitySnapshot {
                 profile: "fedora-44".into(),
                 architecture: "x86_64".into(),

--- a/crates/conary-core/src/corpus/failure.rs
+++ b/crates/conary-core/src/corpus/failure.rs
@@ -98,6 +98,18 @@ impl FailureKind {
 }
 
 impl ConversionFailure {
+    /// Record an unclassified failure by its concrete typed owner.
+    ///
+    /// This is for callers whose error type lives outside `conary-core`. The
+    /// incident identity is derived from the Rust type name; human diagnostic
+    /// text never participates in classification.
+    pub fn internal_for<T: 'static>(detail: impl Into<String>) -> Self {
+        ConversionFailure::InternalUnclassified {
+            incident_id: incident_id_for(&[std::any::type_name::<T>()]),
+            detail: detail.into(),
+        }
+    }
+
     pub fn kind(&self) -> FailureKind {
         match self {
             ConversionFailure::Trust { .. } => FailureKind::Trust,

--- a/crates/conary-core/src/corpus/mod.rs
+++ b/crates/conary-core/src/corpus/mod.rs
@@ -18,7 +18,7 @@
 mod aggregate;
 mod failure;
 
-pub use aggregate::{FailureTally, StageTally, aggregate_cases};
+pub use aggregate::{CorpusAggregate, FailureTally, StageTally, aggregate_cases};
 pub use failure::{ConversionFailure, FailureKind};
 
 use serde::{Deserialize, Serialize};
@@ -42,8 +42,8 @@ pub enum ConversionStage {
     TransactionPreflight,
     Installation,
     Update,
-    Removal,
     Rollback,
+    Removal,
 }
 
 impl ConversionStage {
@@ -61,8 +61,8 @@ impl ConversionStage {
             ConversionStage::TransactionPreflight => "transaction_preflight",
             ConversionStage::Installation => "installation",
             ConversionStage::Update => "update",
-            ConversionStage::Removal => "removal",
             ConversionStage::Rollback => "rollback",
+            ConversionStage::Removal => "removal",
         }
     }
 
@@ -80,8 +80,8 @@ impl ConversionStage {
         ConversionStage::TransactionPreflight,
         ConversionStage::Installation,
         ConversionStage::Update,
-        ConversionStage::Removal,
         ConversionStage::Rollback,
+        ConversionStage::Removal,
     ];
 }
 
@@ -96,12 +96,40 @@ pub struct SourceProfileIdentity {
 
 /// The exact artifact under test, pinned by digest.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SourceArtifactIdentity {
+    /// How this artifact participates in the declared journey.
+    pub role: SourceArtifactRole,
+    /// Typed authority from which the exact artifact digest was obtained.
+    pub digest_source: SourceArtifactDigestSource,
     pub name: String,
     pub version: String,
     pub architecture: Option<String>,
     /// SHA-256 of the source artifact. A result without this is not evidence.
     pub digest: String,
+}
+
+/// The lifecycle role of one exact source artifact.
+///
+/// A case may consume more than one artifact: an install followed by an update
+/// must identify both inputs rather than attributing the complete journey to
+/// the first package digest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceArtifactRole {
+    InstallRequest,
+    InstallDependency,
+    UpdateRequest,
+    UpdateDependency,
+}
+
+/// Authority that produced an artifact's pinned digest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceArtifactDigestSource {
+    /// The fixture builder's versioned output manifest, computed from the
+    /// completed native package bytes.
+    FixtureBuildManifest,
 }
 
 /// Typed host capabilities the case ran against.
@@ -192,8 +220,10 @@ pub enum CorpusOutcome {
 /// One corpus case: an exact artifact against an exact target.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CorpusCaseResult {
+    /// Stable manifest-owned identity for this case.
+    pub case_id: String,
     pub source_profile: SourceProfileIdentity,
-    pub source_artifact: SourceArtifactIdentity,
+    pub source_artifacts: Vec<SourceArtifactIdentity>,
     pub target_profile: TargetCapabilitySnapshot,
     pub stage_results: Vec<StageResult>,
     pub final_outcome: CorpusOutcome,
@@ -206,8 +236,9 @@ impl CorpusCaseResult {
     /// in separately, so a result cannot claim success while carrying a failed
     /// stage.
     pub fn from_stages(
+        case_id: impl Into<String>,
         source_profile: SourceProfileIdentity,
-        source_artifact: SourceArtifactIdentity,
+        source_artifacts: Vec<SourceArtifactIdentity>,
         target_profile: TargetCapabilitySnapshot,
         stage_results: Vec<StageResult>,
     ) -> Self {
@@ -222,8 +253,9 @@ impl CorpusCaseResult {
             .unwrap_or(CorpusOutcome::Completed);
 
         Self {
+            case_id: case_id.into(),
             source_profile,
-            source_artifact,
+            source_artifacts,
             target_profile,
             stage_results,
             final_outcome,
@@ -256,6 +288,8 @@ mod tests {
 
     fn artifact() -> SourceArtifactIdentity {
         SourceArtifactIdentity {
+            role: SourceArtifactRole::InstallRequest,
+            digest_source: SourceArtifactDigestSource::FixtureBuildManifest,
             name: "2ping".into(),
             version: "4.5.1-24.fc44".into(),
             architecture: Some("noarch".into()),
@@ -280,7 +314,13 @@ mod tests {
             StageResult::passed(ConversionStage::Installation),
         ];
 
-        let case = CorpusCaseResult::from_stages(profile(), artifact(), target(), stages);
+        let case = CorpusCaseResult::from_stages(
+            "rpm-on-fedora",
+            profile(),
+            vec![artifact()],
+            target(),
+            stages,
+        );
 
         assert!(case.completed());
         assert_eq!(case.failure_key(), None);
@@ -301,7 +341,13 @@ mod tests {
             StageResult::not_reached(ConversionStage::Installation),
         ];
 
-        let case = CorpusCaseResult::from_stages(profile(), artifact(), target(), stages);
+        let case = CorpusCaseResult::from_stages(
+            "rpm-on-fedora",
+            profile(),
+            vec![artifact()],
+            target(),
+            stages,
+        );
 
         assert!(!case.completed());
         assert_eq!(
@@ -327,7 +373,13 @@ mod tests {
             ),
         ];
 
-        let case = CorpusCaseResult::from_stages(profile(), artifact(), target(), stages);
+        let case = CorpusCaseResult::from_stages(
+            "rpm-on-fedora",
+            profile(),
+            vec![artifact()],
+            target(),
+            stages,
+        );
 
         assert_eq!(
             case.failure_key(),
@@ -357,13 +409,15 @@ mod tests {
     fn stages_order_by_execution_sequence() {
         assert!(ConversionStage::RepositoryAuthentication < ConversionStage::NativeParse);
         assert!(ConversionStage::Installation < ConversionStage::Rollback);
+        assert!(ConversionStage::Rollback < ConversionStage::Removal);
     }
 
     #[test]
     fn a_case_round_trips_through_serde() {
         let case = CorpusCaseResult::from_stages(
+            "rpm-on-fedora",
             profile(),
-            artifact(),
+            vec![artifact()],
             target(),
             vec![StageResult::failed(
                 ConversionStage::NativeParse,

--- a/crates/conary-core/src/corpus/mod.rs
+++ b/crates/conary-core/src/corpus/mod.rs
@@ -242,15 +242,24 @@ impl CorpusCaseResult {
         target_profile: TargetCapabilitySnapshot,
         stage_results: Vec<StageResult>,
     ) -> Self {
-        let final_outcome = stage_results
-            .iter()
-            .find_map(|result| {
-                result.failure().map(|failure| CorpusOutcome::Failed {
-                    stage: result.stage,
-                    failure: failure.clone(),
-                })
+        let first_failure = stage_results.iter().find_map(|result| {
+            result.failure().map(|failure| CorpusOutcome::Failed {
+                stage: result.stage,
+                failure: failure.clone(),
             })
-            .unwrap_or(CorpusOutcome::Completed);
+        });
+        let final_outcome = first_failure.unwrap_or_else(|| {
+            if stage_results
+                .iter()
+                .any(|result| matches!(&result.outcome, StageOutcome::NotReached))
+            {
+                CorpusOutcome::Skipped {
+                    reason: "one or more declared stages were not reached".into(),
+                }
+            } else {
+                CorpusOutcome::Completed
+            }
+        });
 
         Self {
             case_id: case_id.into(),
@@ -324,6 +333,20 @@ mod tests {
 
         assert!(case.completed());
         assert_eq!(case.failure_key(), None);
+    }
+
+    #[test]
+    fn a_case_with_unreached_stages_cannot_complete() {
+        let case = CorpusCaseResult::from_stages(
+            "rpm-on-fedora",
+            profile(),
+            vec![artifact()],
+            target(),
+            vec![StageResult::not_reached(ConversionStage::Installation)],
+        );
+
+        assert!(!case.completed());
+        assert!(matches!(case.final_outcome, CorpusOutcome::Skipped { .. }));
     }
 
     /// A result must not be able to claim success while carrying a failed

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -547,8 +547,17 @@ Corpus coverage boundaries (not product support exemptions):
 - dependency installation from the generated local corpus package; this suite
   records dependency metadata and installs with `--no-deps`
 
-The focused `native-cross-source-lifecycle` manifest contains one fatal,
-non-flaky test that executes the same shared lifecycle helper as `TNPM02X`.
+The focused `native-cross-source-lifecycle` manifest contains three non-flaky
+corpus cases, one for each exact source format. A failed case does not suppress
+the remaining source-format evidence. Each case executes
+the same shared lifecycle helper as `TNPM02X`, writes a versioned evidence
+envelope carrying both install and update artifact digests, the typed fixture
+build-manifest authority that produced them, and stage checkpoints. It is
+projected by `conary-test` into a typed
+`CorpusCaseResult`. The suite JSON carries the typed aggregate beside the
+ordinary test results and records the manifest-declared case count; a missing,
+malformed, skipped, failed, or unclassified corpus case makes the command fail
+even if generic command output happened to look successful.
 The `pr-gate` workflow builds each configured distro image first and then runs
 that focused manifest across `fedora44`, `ubuntu-26.04`, and `arch`. Together,
 the required lanes authenticate all three checked-in source-ABI traces and run
@@ -567,7 +576,8 @@ filename, and makes the image install that package through `dnf`, `apt`, or
 digest before the installed `/usr/bin/conary` runs all three source formats.
 Source-built PR evidence is not a substitute for this published-byte lane.
 
-Each full parity run must pass `scripts/check-conary-test-result-gate.sh`,
+Each full parity run must pass `scripts/check-conary-test-result-gate.sh` and
+`scripts/check-conary-corpus-result-gate.sh`,
 which requires zero failed, skipped, and cancelled results before the matrix
 can count as limited-preview release evidence. The `conary-test run` command also exits
 unsuccessfully for skipped or cancelled results. Distro images rebuild by
@@ -741,7 +751,7 @@ Adversarial and stress tests.
 
 ### Phase 4: Feature Validation
 
-Phase 4 currently contains 153 tests across eight manifests. It validates the
+Phase 4 currently contains 155 tests across eight manifests. It validates the
 active, user-facing command surface and checks that claimed features still match
 the current binary. Where a flow is intentionally preview-only or not yet
 implemented, the manifest asserts that it fails cleanly with an explicit
@@ -755,7 +765,7 @@ message rather than pretending it is production-ready.
 | D | T221-T255 plus suffix IDs | 38 | Provenance, capability, trust, system ops, federation, automation |
 | E | T256-T277 plus suffix IDs | 24 | Cross-distro compatibility overlay: native package parity, distro policy, replatform, and takeover |
 | Native package-manager parity | TNPM01-TNPM18 plus TNPM02X | 19 | Cross-distro native PM parity and daily-driver corpus |
-| Native cross-source lifecycle | TNPMX01 | 1 | Native-oracle install/update/rollback/remove trace parity on every target image |
+| Native cross-source lifecycle | TNPMX01R, TNPMX01D, TNPMX01A | 3 | Attributable native-oracle install/update/rollback/remove corpus evidence on every target image |
 | Security advisory pipeline | TSEC01-TSEC07 | 7 | Trusted advisory ingestion and security update proof |
 
 Phase 4 is intentionally mixed:

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -1353,7 +1353,11 @@ need parser proof and migration or defaulting decisions. Suite names in
 `--suite` arguments use the manifest filename stem, such as
 `phase4-native-pm-parity`, not the human-readable title shown by
 `cargo run -p conary-test -- list`. Distro image source staging is selected by
-the typed `build_context` field, never by matching the distro key.
+the typed `build_context` field, never by matching the distro key. Corpus cases
+must carry versioned runtime evidence with exact role-tagged artifact digests,
+typed digest authority, target capabilities, and canonically ordered stage
+checkpoints; report aggregation uses typed stage/failure discriminants and
+never diagnostic text. The declared and emitted case counts must agree.
 
 ## Agent/MCP Operation Surfaces
 

--- a/docs/modules/test-fixtures.md
+++ b/docs/modules/test-fixtures.md
@@ -369,9 +369,14 @@ Each fixture family should record:
 
 ### conary-test-remi-manifests
 
-- **Owner:** Integration harness: `apps/conary-test/src/config/` and
+- **Owner:** Integration harness: `apps/conary-test/src/config/`,
+  `apps/conary-test/src/engine/corpus.rs`, `apps/conary-test/src/report/`, and
   `apps/conary-test/src/suite_inventory.rs`.
-- **Purpose:** Declarative Remi and package-manager integration suites.
+- **Purpose:** Declarative Remi and package-manager integration suites. Corpus
+  tests declare exact source/target/stage and artifact-digest authority,
+  consume a versioned runtime evidence file, and emit `CorpusCaseResult` plus
+  typed aggregation with an exact declared-case count; generic stdout and
+  error messages remain diagnostics only.
 - **Fixture sources:** `apps/conary/tests/integration/remi/manifests/`;
   `apps/conary/tests/integration/remi/containers/`;
   `apps/conary/tests/fixtures/conary-test-fixture/`;

--- a/docs/roadmaps/development-roadmap.md
+++ b/docs/roadmaps/development-roadmap.md
@@ -333,8 +333,10 @@ the stated scope, not whether a workstream happens to be active.
   trust, runtime, and failure each require declared coverage, and every fixture
   is selected for its recorded properties.
 - **Typed result:** the runner emits a per-case record carrying source profile,
-  source artifact identity, target capability snapshot, per-stage results, and
-  a typed outcome. Failures aggregate by stage and failure enum. Aggregating by
+  role-tagged source artifact identities for install and update, the typed
+  authority that produced each digest, target capability snapshot, per-stage
+  results, and a typed outcome. Declared and emitted case counts must agree.
+  Failures aggregate by stage and failure enum. Aggregating by
   error-message text is prohibited. Remi's current prewarm result keeps failed
   identity plus a string error, which is adequate for logs and inadequate as
   roadmap authority.

--- a/scripts/check-conary-corpus-result-gate.sh
+++ b/scripts/check-conary-corpus-result-gate.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <result.json> [<result.json> ...]" >&2
+  exit 64
+fi
+
+for result in "$@"; do
+  if [[ ! -f "$result" ]]; then
+    echo "missing corpus result file: $result" >&2
+    exit 1
+  fi
+
+  python3 - "$result" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+data = json.loads(path.read_text())
+corpus = data.get("corpus") if isinstance(data, dict) else None
+if not isinstance(corpus, dict) or corpus.get("schema_version") != 1:
+    print(f"{path}: corpus gate failed: missing schema version 1 corpus object", file=sys.stderr)
+    sys.exit(1)
+
+aggregate = corpus.get("aggregate")
+cases = corpus.get("cases")
+expected_cases = corpus.get("expected_cases")
+if (
+    not isinstance(expected_cases, int)
+    or expected_cases <= 0
+    or not isinstance(aggregate, dict)
+    or not isinstance(cases, list)
+    or not cases
+):
+    print(f"{path}: corpus gate failed: expected count, aggregate, and non-empty cases are required", file=sys.stderr)
+    sys.exit(1)
+
+required_counts = ["cases", "completed", "failed", "skipped", "unclassified"]
+for key in required_counts:
+    if not isinstance(aggregate.get(key), int) or aggregate[key] < 0:
+        print(f"{path}: corpus gate failed: aggregate.{key} must be a non-negative integer", file=sys.stderr)
+        sys.exit(1)
+
+if aggregate["cases"] != len(cases) or expected_cases != len(cases):
+    print(f"{path}: corpus gate failed: declared, aggregate, and emitted case counts disagree", file=sys.stderr)
+    sys.exit(1)
+if (
+    aggregate["completed"] != len(cases)
+    or aggregate["failed"] != 0
+    or aggregate["skipped"] != 0
+    or aggregate["unclassified"] != 0
+    or aggregate.get("stages") != []
+):
+    print(
+        f"{path}: corpus gate failed: completed={aggregate['completed']} "
+        f"failed={aggregate['failed']} skipped={aggregate['skipped']} "
+        f"unclassified={aggregate['unclassified']}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+digest_pattern = re.compile(r"^[0-9a-f]{64}$")
+case_ids = set()
+for case in cases:
+    if not isinstance(case, dict):
+        print(f"{path}: corpus gate failed: case must be an object", file=sys.stderr)
+        sys.exit(1)
+    case_id = case.get("case_id")
+    if not isinstance(case_id, str) or not case_id or case_id in case_ids:
+        print(f"{path}: corpus gate failed: case IDs must be non-empty and unique", file=sys.stderr)
+        sys.exit(1)
+    case_ids.add(case_id)
+
+    source = case.get("source_profile")
+    target = case.get("target_profile")
+    artifacts = case.get("source_artifacts")
+    stages = case.get("stage_results")
+    if (
+        not isinstance(source, dict)
+        or not source.get("profile")
+        or not source.get("format")
+        or not isinstance(target, dict)
+        or not target.get("profile")
+        or not target.get("architecture")
+        or not target.get("init_system")
+        or not isinstance(target.get("capabilities"), list)
+        or not target["capabilities"]
+        or not isinstance(artifacts, list)
+        or not artifacts
+        or not isinstance(stages, list)
+        or not stages
+    ):
+        print(f"{path}: corpus gate failed: {case_id} lacks attributable authority", file=sys.stderr)
+        sys.exit(1)
+
+    request_roles = set()
+    artifact_identities = set()
+    for artifact in artifacts:
+        role = artifact.get("role") if isinstance(artifact, dict) else None
+        if (
+            role not in {
+                "install_request",
+                "install_dependency",
+                "update_request",
+                "update_dependency",
+            }
+            or artifact.get("digest_source") != "fixture_build_manifest"
+            or not artifact.get("name")
+            or not artifact.get("version")
+            or not digest_pattern.fullmatch(str(artifact.get("digest", "")))
+        ):
+            print(f"{path}: corpus gate failed: {case_id} has invalid artifact authority", file=sys.stderr)
+            sys.exit(1)
+        identity = (
+            role,
+            artifact["name"],
+            artifact["version"],
+            artifact.get("architecture"),
+            artifact["digest"],
+        )
+        if identity in artifact_identities:
+            print(f"{path}: corpus gate failed: {case_id} repeats an exact artifact", file=sys.stderr)
+            sys.exit(1)
+        artifact_identities.add(identity)
+        if role in {"install_request", "update_request"}:
+            if role in request_roles:
+                print(f"{path}: corpus gate failed: {case_id} repeats a requested artifact role", file=sys.stderr)
+                sys.exit(1)
+            request_roles.add(role)
+
+    stage_names = {stage.get("stage") for stage in stages if isinstance(stage, dict)}
+    if "installation" in stage_names and "install_request" not in request_roles:
+        print(f"{path}: corpus gate failed: {case_id} lacks its install request", file=sys.stderr)
+        sys.exit(1)
+    if "update" in stage_names and "update_request" not in request_roles:
+        print(f"{path}: corpus gate failed: {case_id} lacks its update request", file=sys.stderr)
+        sys.exit(1)
+
+    if any(stage.get("outcome") != "passed" for stage in stages if isinstance(stage, dict)) \
+       or any(not isinstance(stage, dict) for stage in stages):
+        print(f"{path}: corpus gate failed: {case_id} has a non-passing stage", file=sys.stderr)
+        sys.exit(1)
+    if case.get("final_outcome") != {"outcome": "completed"}:
+        print(f"{path}: corpus gate failed: {case_id} did not complete", file=sys.stderr)
+        sys.exit(1)
+
+print(f"{path}: corpus ok ({len(cases)} cases)")
+PY
+done

--- a/scripts/test-conary-corpus-result-gate.sh
+++ b/scripts/test-conary-corpus-result-gate.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(mktemp -d)"
+cleanup() {
+  find "${root}" -depth -mindepth 1 -delete
+  rmdir "${root}"
+}
+trap cleanup EXIT
+gate="scripts/check-conary-corpus-result-gate.sh"
+
+write_result() {
+  local path="$1"
+  local digest="$2"
+  local completed="$3"
+  local failed="$4"
+  local outcome="$5"
+  printf '%s\n' "{\"corpus\":{\"schema_version\":1,\"expected_cases\":1,\"aggregate\":{\"cases\":1,\"completed\":${completed},\"failed\":${failed},\"skipped\":0,\"stages\":[],\"unclassified\":0},\"cases\":[{\"case_id\":\"rpm-fedora\",\"source_profile\":{\"profile\":\"fedora-44\",\"format\":\"rpm\"},\"source_artifacts\":[{\"role\":\"install_request\",\"digest_source\":\"fixture_build_manifest\",\"name\":\"fixture\",\"version\":\"1-1\",\"architecture\":\"x86_64\",\"digest\":\"${digest}\"}],\"target_profile\":{\"profile\":\"fedora44\",\"architecture\":\"x86_64\",\"init_system\":\"systemd\",\"capabilities\":[\"native_lifecycle\"]},\"stage_results\":[{\"stage\":\"installation\",\"outcome\":\"${outcome}\"}],\"final_outcome\":{\"outcome\":\"completed\"}}]}}" > "${path}"
+}
+
+write_result "${root}/passing.json" "$(printf 'a%.0s' {1..64})" 1 0 passed
+"${gate}" "${root}/passing.json"
+
+write_result "${root}/bad-digest.json" "short" 1 0 passed
+if "${gate}" "${root}/bad-digest.json" >/dev/null 2>&1; then
+  echo "bad digest unexpectedly passed corpus gate" >&2
+  exit 1
+fi
+
+write_result "${root}/failed.json" "$(printf 'b%.0s' {1..64})" 0 1 failed
+if "${gate}" "${root}/failed.json" >/dev/null 2>&1; then
+  echo "failed case unexpectedly passed corpus gate" >&2
+  exit 1
+fi
+
+sed 's/"expected_cases":1/"expected_cases":2/' \
+  "${root}/passing.json" > "${root}/missing-case.json"
+if "${gate}" "${root}/missing-case.json" >/dev/null 2>&1; then
+  echo "missing emitted case unexpectedly passed corpus gate" >&2
+  exit 1
+fi
+
+printf '%s\n' '{"summary":{"total":1,"passed":1,"failed":0,"skipped":0,"cancelled":0},"results":[{"status":"passed"}]}' > "${root}/missing.json"
+if "${gate}" "${root}/missing.json" >/dev/null 2>&1; then
+  echo "missing corpus unexpectedly passed corpus gate" >&2
+  exit 1
+fi
+
+echo "corpus result gate tests passed"


### PR DESCRIPTION
## Problem

The W7 corpus vocabulary had no execution or report path: the three source formats collapsed into one shell result, artifact digests and target facts were not attributable per case, and a missing case could not fail closed.

## Change

- add a typed corpus declaration with exact source profile/format, fixture-build digest authority, target capabilities, and canonically ordered stages
- split RPM, Debian, and ALPM into independent non-fatal cases on every supported target
- publish role-tagged install/update artifact identities, typed stage outcomes, final outcomes, aggregates, and declared-versus-emitted case counts beside generic JSON
- reject incomplete stage sequences instead of allowing unreached stages to appear completed
- classify failures from typed status/evidence authority, never stdout or diagnostic wording
- require the generic and corpus JSON gates in PR and release-artifact lifecycle lanes
- update the owning integration, fixture, feature-card, and roadmap truth

## Verification

- `cargo test -p conary-core corpus::` (29 passed)
- `cargo test -p conary-test` (372 passed, 1 ignored; CLI 18 passed)
- `bash scripts/agent-context.sh --feature conary-test --run focused` (5 commands passed)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `bash scripts/check-doc-truth.sh`
- `bash scripts/test-agent-context.sh`
- `bash scripts/test-conary-corpus-result-gate.sh`
- exact-head PR gate run `31088739293`: all 15 checks passed on `47d43ba2077cb5589be9d69415980186906c48fa`
  - Fedora 44 typed 3-case corpus: 6m54s
  - Arch typed 3-case corpus: 6m49s
  - Ubuntu 26.04 typed 3-case corpus: 23m14s

The PR remains draft until PR #268 lands; it will be rebased and the exact three-target proof rerun against the resulting main before review and merge.

Closes #274
Refs #110
Refs #48