### PR TITLE
fix(repository): wait for terminal Remi jobs

### DIFF
--- a/crates/conary-core/src/repository/remi.rs
+++ b/crates/conary-core/src/repository/remi.rs
@@ -34,13 +34,10 @@ mod async_client;
 pub use async_client::AsyncRemiClient;
 mod protocol;
 use protocol::RemiClientCore;
-pub use protocol::{ChunkRef, ConversionAccepted, JobStatus, PackageManifest};
+pub use protocol::{ChunkRef, ConversionAccepted, ConversionJobState, JobStatus, PackageManifest};
 
 /// Default timeout for initial request (30 seconds)
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
-
-/// Default timeout for polling (5 minutes max wait)
-const POLL_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Poll interval (2 seconds)
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
@@ -123,7 +120,7 @@ impl RemiClient {
     /// Request a package from the Remi
     ///
     /// Returns the manifest when the package is ready. If conversion is needed,
-    /// this will poll automatically until complete or timeout.
+    /// this polls until Remi reports a terminal job state or the caller cancels.
     pub async fn get_package(
         &self,
         distro: &str,
@@ -209,7 +206,6 @@ impl RemiClient {
     /// refused) with exponential backoff. 4xx errors fail immediately.
     async fn poll_for_completion(&self, job_id: &str) -> Result<PackageManifest> {
         let url = self.core.job_url(job_id);
-        let start = std::time::Instant::now();
         let max_transient_retries: u32 = 3;
 
         // Create a spinner for visual feedback
@@ -225,15 +221,6 @@ impl RemiClient {
         let mut consecutive_transient_failures: u32 = 0;
 
         loop {
-            // Check timeout
-            if start.elapsed() > POLL_TIMEOUT {
-                spinner.finish_with_message("Conversion timed out");
-                return Err(Error::TimeoutError(format!(
-                    "Conversion job {} timed out after {:?}",
-                    job_id, POLL_TIMEOUT
-                )));
-            }
-
             // Poll job status
             let response = match self.client.get(&url).send().await {
                 Ok(resp) => resp,
@@ -296,10 +283,11 @@ impl RemiClient {
             // Successful response -- reset transient failure counter
             consecutive_transient_failures = 0;
 
-            let status: JobStatus = response.json().await.parse_context("job status")?;
+            let body = response.text().await.download_context(&url)?;
+            let status: JobStatus = serde_json::from_str(&body).parse_context("job status")?;
 
-            match status.status.as_str() {
-                "ready" => {
+            match status.poll_decision() {
+                protocol::JobPollDecision::Ready => {
                     spinner.finish_with_message("Conversion complete");
                     info!("Conversion complete for job {}", job_id);
 
@@ -327,15 +315,14 @@ impl RemiClient {
                     let manifest = response.json().await.parse_context("manifest")?;
                     return Ok(manifest);
                 }
-                "failed" => {
+                protocol::JobPollDecision::Failed(error_msg) => {
                     spinner.finish_with_message("Conversion failed");
-                    let error_msg = status.error.unwrap_or_else(|| "Unknown error".to_string());
                     return Err(Error::DownloadError(format!(
                         "Conversion failed: {}",
                         error_msg
                     )));
                 }
-                "converting" | "queued" => {
+                protocol::JobPollDecision::Wait => {
                     // Still in progress - update spinner and continue polling
                     if let Some(progress) = status.progress {
                         spinner.set_message(format!(
@@ -343,14 +330,7 @@ impl RemiClient {
                             status.package, progress
                         ));
                     }
-                    tokio::time::sleep(POLL_INTERVAL).await;
-                }
-                other => {
-                    spinner.finish_with_message("Conversion protocol error");
-                    return Err(Error::DownloadError(format!(
-                        "Remi returned unsupported conversion status {other} for {}/{}",
-                        status.distro, status.package
-                    )));
+                    self.core.wait_for_next_poll().await;
                 }
             }
         }

--- a/crates/conary-core/src/repository/remi/async_client.rs
+++ b/crates/conary-core/src/repository/remi/async_client.rs
@@ -68,7 +68,7 @@ impl AsyncRemiClient {
     /// Request a package manifest from the Remi
     ///
     /// Returns the manifest when the package is ready. If conversion is needed,
-    /// this will poll automatically until complete or timeout.
+    /// this polls until Remi reports a terminal job state or the caller cancels.
     pub async fn get_package(
         &self,
         distro: &str,
@@ -119,16 +119,7 @@ impl AsyncRemiClient {
     /// Poll for job completion (async version)
     async fn poll_for_completion_async(&self, job_id: &str) -> Result<PackageManifest> {
         let url = self.core.job_url(job_id);
-        let start = std::time::Instant::now();
-
         loop {
-            if start.elapsed() > POLL_TIMEOUT {
-                return Err(Error::TimeoutError(format!(
-                    "Conversion job {} timed out after {:?}",
-                    job_id, POLL_TIMEOUT
-                )));
-            }
-
             let response = self
                 .http_client
                 .get(&url)
@@ -143,10 +134,11 @@ impl AsyncRemiClient {
                 )));
             }
 
-            let status: JobStatus = response.json().await.parse_context("job status")?;
+            let body = response.text().await.download_context(&url)?;
+            let status: JobStatus = serde_json::from_str(&body).parse_context("job status")?;
 
-            match status.status.as_str() {
-                "ready" => {
+            match status.poll_decision() {
+                protocol::JobPollDecision::Ready => {
                     info!("Conversion complete for job {}", job_id);
                     if let Some(manifest) = status.manifest {
                         return Ok(manifest);
@@ -160,24 +152,17 @@ impl AsyncRemiClient {
                     ))
                     .await;
                 }
-                "failed" => {
-                    let error_msg = status.error.unwrap_or_else(|| "Unknown error".to_string());
+                protocol::JobPollDecision::Failed(error_msg) => {
                     return Err(Error::DownloadError(format!(
                         "Conversion failed: {}",
                         error_msg
                     )));
                 }
-                "converting" | "queued" => {
+                protocol::JobPollDecision::Wait => {
                     if let Some(progress) = status.progress {
                         debug!("Converting {} ({}%)...", status.package, progress);
                     }
-                    tokio::time::sleep(POLL_INTERVAL).await;
-                }
-                other => {
-                    return Err(Error::DownloadError(format!(
-                        "Remi returned unsupported conversion status {other} for {}/{}",
-                        status.distro, status.package
-                    )));
+                    self.core.wait_for_next_poll().await;
                 }
             }
         }

--- a/crates/conary-core/src/repository/remi/protocol.rs
+++ b/crates/conary-core/src/repository/remi/protocol.rs
@@ -15,7 +15,7 @@ pub struct ConversionAccepted {
 #[derive(Debug, Deserialize)]
 pub struct JobStatus {
     pub job_id: String,
-    pub status: String,
+    pub status: ConversionJobState,
     pub distro: String,
     pub package: String,
     pub version: Option<String>,
@@ -23,6 +23,35 @@ pub struct JobStatus {
     pub progress: Option<u8>,
     pub error: Option<String>,
     pub manifest: Option<PackageManifest>,
+}
+
+/// Exact lifecycle states published by Remi's job-status endpoint.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ConversionJobState {
+    Pending,
+    Converting,
+    Ready,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum JobPollDecision<'a> {
+    Wait,
+    Ready,
+    Failed(&'a str),
+}
+
+impl JobStatus {
+    pub(super) fn poll_decision(&self) -> JobPollDecision<'_> {
+        match self.status {
+            ConversionJobState::Pending | ConversionJobState::Converting => JobPollDecision::Wait,
+            ConversionJobState::Ready => JobPollDecision::Ready,
+            ConversionJobState::Failed => {
+                JobPollDecision::Failed(self.error.as_deref().unwrap_or("Unknown error"))
+            }
+        }
+    }
 }
 
 /// Package manifest with chunk list
@@ -51,6 +80,7 @@ pub struct ChunkRef {
 /// duplicating these operations.
 pub(super) struct RemiClientCore {
     pub(super) base_url: String,
+    pub(super) poll_interval: Duration,
 }
 
 impl RemiClientCore {
@@ -59,7 +89,12 @@ impl RemiClientCore {
         crate::repository::client::validate_url_scheme(base_url)?;
         Ok(Self {
             base_url: base_url.trim_end_matches('/').to_string(),
+            poll_interval: POLL_INTERVAL,
         })
+    }
+
+    pub(super) async fn wait_for_next_poll(&self) {
+        tokio::time::sleep(self.poll_interval).await;
     }
 
     /// Construct a package URL with optional version and architecture query parameters.

--- a/crates/conary-core/src/repository/remi/tests.rs
+++ b/crates/conary-core/src/repository/remi/tests.rs
@@ -26,8 +26,36 @@ fn test_conversion_accepted_parsing() {
 fn test_job_status_parsing() {
     let json = r#"{"job_id":"1","status":"ready","distro":"arch","package":"gzip","version":null,"progress":null,"error":null,"manifest":null}"#;
     let status: JobStatus = serde_json::from_str(json).unwrap();
-    assert_eq!(status.status, "ready");
+    assert_eq!(status.status, ConversionJobState::Ready);
     assert_eq!(status.package, "gzip");
+}
+
+#[test]
+fn every_remi_job_state_has_one_shared_poll_decision() {
+    let cases = [
+        ("pending", protocol::JobPollDecision::Wait),
+        ("converting", protocol::JobPollDecision::Wait),
+        ("ready", protocol::JobPollDecision::Ready),
+        (
+            "failed",
+            protocol::JobPollDecision::Failed("conversion failed"),
+        ),
+    ];
+
+    for (wire_state, expected) in cases {
+        let json = format!(
+            r#"{{"job_id":"1","status":"{wire_state}","distro":"fedora","package":"kernel-core","version":null,"architecture":"x86_64","progress":null,"error":"conversion failed","manifest":null}}"#
+        );
+        let status: JobStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(status.poll_decision(), expected);
+    }
+
+    let unsupported = r#"{"job_id":"1","status":"blocked","distro":"fedora","package":"kernel-core","version":null,"architecture":"x86_64","progress":null,"error":null,"manifest":null}"#;
+    let error = serde_json::from_str::<JobStatus>(unsupported).unwrap_err();
+    assert!(
+        error.to_string().contains("unknown variant `blocked`"),
+        "{error}"
+    );
 }
 
 #[test]
@@ -288,7 +316,79 @@ async fn get_package_rejects_retired_job_status() {
         .unwrap_err();
     let message = err.to_string();
 
-    assert!(message.contains("unsupported conversion status blocked"));
+    assert!(message.contains("unknown variant `blocked`"), "{message}");
+}
+
+const POLLS_BEYOND_FORMER_FIVE_MINUTE_CUTOFF: usize = 152;
+
+async fn spawn_active_job_server(active_polls: usize) -> (String, tokio::task::JoinHandle<()>) {
+    use tokio::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+        let accepted =
+            r#"{"status":"queued","job_id":"55","poll_url":"/v1/jobs/55","eta_seconds":null}"#;
+        write_json_response(&listener, "202 Accepted", accepted).await;
+
+        for poll in 0..active_polls {
+            let state = if poll % 2 == 0 {
+                "pending"
+            } else {
+                "converting"
+            };
+            let active = format!(
+                r#"{{"job_id":"55","status":"{state}","distro":"fedora","package":"kernel-modules-core","version":"6.19.10-300.fc44","architecture":"x86_64","progress":null,"error":null,"manifest":null}}"#
+            );
+            write_json_response(&listener, "200 OK", &active).await;
+        }
+
+        let ready = r#"{
+            "job_id":"55",
+            "status":"ready",
+            "distro":"fedora",
+            "package":"kernel-modules-core",
+            "version":"6.19.10-300.fc44",
+            "architecture":"x86_64",
+            "progress":100,
+            "error":null,
+            "manifest":{
+                "name":"kernel-modules-core",
+                "version":"6.19.10-300.fc44",
+                "distro":"fedora",
+                "chunks":[],
+                "total_size":0,
+                "content_hash":"sha256:test"
+            }
+        }"#;
+        write_json_response(&listener, "200 OK", ready).await;
+    });
+
+    (base_url, server)
+}
+
+#[tokio::test]
+async fn both_clients_wait_past_the_former_five_minute_poll_cycle_count() {
+    let (base_url, server) = spawn_active_job_server(POLLS_BEYOND_FORMER_FIVE_MINUTE_CUTOFF).await;
+    let mut client = RemiClient::new(&base_url).unwrap();
+    client.core.poll_interval = Duration::from_millis(1);
+    let manifest = client
+        .get_package("fedora", "kernel-modules-core", None, Some("x86_64"))
+        .await
+        .unwrap();
+    assert_eq!(manifest.name, "kernel-modules-core");
+    server.await.unwrap();
+
+    let (base_url, server) = spawn_active_job_server(POLLS_BEYOND_FORMER_FIVE_MINUTE_CUTOFF).await;
+    let cache = tempfile::tempdir().unwrap();
+    let mut client = AsyncRemiClient::new(&base_url, cache.path()).unwrap();
+    client.core.poll_interval = Duration::from_millis(1);
+    let manifest = client
+        .get_package("fedora", "kernel-modules-core", None, Some("x86_64"))
+        .await
+        .unwrap();
+    assert_eq!(manifest.name, "kernel-modules-core");
+    server.await.unwrap();
 }
 
 async fn write_json_response(listener: &tokio::net::TcpListener, status: &str, body: &str) {

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-06
-revision: 26
+revision: 27
 summary: Document exact profile-owned source policy, multi-root model authority, Remi CCS package authority, canonical map authority, native repository authority, package identity, full-adoption root continuity, and lifecycle handoff
 ---
 
@@ -129,6 +129,11 @@ source-identity aliases. Native repository sync writes the repository's exact
 profile into every package row and rejects a missing or conflicting profile.
 The superseded
 `data/distros.toml` catalog was deleted in M4d.
+
+An accepted Remi conversion remains server-owned work until the typed job
+status reaches `ready` or `failed`. The client continues to observe `pending`
+and `converting` jobs; it does not turn elapsed wall time into conversion
+failure. Cancellation and complete-operation deadlines belong to the caller.
 
 ## Remi CCS Package Authority
 


### PR DESCRIPTION
## Problem

Conary assigned an arbitrary five-minute failure deadline to active Remi conversion jobs. PR #268's exact-head Group O gate exposed the defect when job 55 for `kernel-modules-core-6.19.10-300.fc44.x86_64` reached `ready` only after the client had returned `Timeout`.

## Changes

- remove the duplicated fixed poll timeout from both Remi clients
- model the exact Remi job states as a typed wire enum
- share one wait/ready/failed decision contract across the regular and async clients
- admit the server's real `pending` state and fail closed on retired/unknown states
- retain caller cancellation as the complete-operation deadline authority
- preserve exact JSON protocol diagnostics
- document the ownership boundary in the source-selection module

## Verification

All commands passed at exact head `ff0b9816f59f5ffeaac9663938a0253566f3612c`.

Focused regression:

- `cargo test -p conary-core repository::remi` — 42 passed, 0 failed
  - both clients observed 152 active poll cycles, more than the former five-minute production cycle count, before accepting `ready`
  - every server job state maps through one shared typed decision contract

Resolution feature-card proof:

- `cargo test -p conary-core repository::trust`
- `cargo test -p conary-core repository::parsers`
- `cargo test -p conary-core repository::download`
- `cargo test -p conary-core repository::sync`
- `cargo test -p conary-core repository`
- `cargo test -p conary-core resolver`
- `cargo test -p conary-core transaction::package_relations`

Interaction gate:

- `cargo test -p conary --lib commands::repo` — 33 passed
- `cargo test -p conary --lib cli::tests` — 67 passed
- `cargo test -p remi repository_manifest` — 4 passed
- `cargo test -p conary --lib commands::install` — 192 passed, 1 intentional network proof ignored
- `cargo test -p conary --test conversion_integration` — 16 passed, 1 external-fixture proof ignored
- `cargo test -p remi conversion` — 78 passed

Repository gates:

- `cargo fmt --check`
- `bash scripts/check-doc-truth.sh`
- `bash scripts/test-doc-truth.sh`
- `bash scripts/test-agent-context.sh`
- `cargo clippy --workspace --all-targets -- -D warnings`

PR #268's exact four-suite QEMU wrapper will be rerun only after this fix is integrated into its exact head. Issue #278 remains open until that cold-acquisition acceptance proof completes.

Refs #278
Refs #267
Refs #277
