### PR TITLE
fix(install): materialize payload file providers for transaction authority

### DIFF
--- a/apps/conary/src/commands/adopt/packages.rs
+++ b/apps/conary/src/commands/adopt/packages.rs
@@ -550,9 +550,9 @@ fn collect_planned_package(
 
     if conflicts.is_empty() {
         validate_package_files(identity.native.name(), &files)?;
-        super::provides::extend_materialized_file_provides(
+        conary_core::repository::dependency_model::extend_materialized_file_provides(
             &mut provides,
-            &identity.native,
+            identity.native.source_package_format(),
             files.iter().filter_map(|file| {
                 std::fs::symlink_metadata(&file.0)
                     .ok()

--- a/apps/conary/src/commands/adopt/provides.rs
+++ b/apps/conary/src/commands/adopt/provides.rs
@@ -7,12 +7,8 @@ use conary_core::db::models::ProvideEntry;
 use conary_core::packages::{
     InstalledPackageIdentity, SystemPackageManager, dpkg_query, pacman_query, rpm_query,
 };
-use conary_core::repository::dependency_model::{
-    CapabilityProvenance, ProvideArchitectureQualifier, ProvidedCapability,
-    RepositoryCapabilityKind, SourcePackageFormat,
-};
+use conary_core::repository::dependency_model::ProvidedCapability;
 use rusqlite::Connection;
-use std::collections::BTreeSet;
 
 pub(super) fn query_package_provides(
     manager: SystemPackageManager,
@@ -48,57 +44,4 @@ pub(super) fn insert_package_provides(
         identity.version_scheme(),
         provides,
     )
-}
-
-/// Add exact materialized package paths as source-derived file providers.
-///
-/// Native solvers admit file dependencies through package file ownership, not
-/// only through declared `Provides` header fields. Adoption has already
-/// captured those paths from the owning package database and live root, so the
-/// same authority must reach Conary's installed provider index.
-pub(super) fn extend_materialized_file_provides<'a>(
-    provides: &mut Vec<ProvidedCapability>,
-    identity: &InstalledPackageIdentity,
-    paths: impl IntoIterator<Item = &'a str>,
-) -> conary_core::Result<()> {
-    let format = match identity {
-        InstalledPackageIdentity::Rpm { .. } => SourcePackageFormat::Rpm,
-        InstalledPackageIdentity::Dpkg { .. } => SourcePackageFormat::Debian,
-        InstalledPackageIdentity::Pacman { .. } => SourcePackageFormat::Alpm,
-    };
-    let mut existing = provides
-        .iter()
-        .filter(|provide| provide.kind == RepositoryCapabilityKind::File)
-        .map(|provide| provide.name.clone())
-        .collect::<BTreeSet<_>>();
-    let paths = paths.into_iter().collect::<BTreeSet<_>>();
-
-    for path in paths {
-        if path == "/" {
-            continue;
-        }
-        if !path.starts_with('/') {
-            return Err(conary_core::Error::ParseError(format!(
-                "installed package file provider is not an absolute path: {path:?}"
-            )));
-        }
-        if !existing.insert(path.to_string()) {
-            continue;
-        }
-        let provide = ProvidedCapability {
-            kind: RepositoryCapabilityKind::File,
-            name: path.to_string(),
-            version: None,
-            version_relation: None,
-            version_scheme: identity.version_scheme(),
-            architecture_qualifier: ProvideArchitectureQualifier::Implicit,
-            provenance: CapabilityProvenance::SourceDerivedFile {
-                format,
-                source_path: path.to_string(),
-            },
-        };
-        provide.validate()?;
-        provides.push(provide);
-    }
-    Ok(())
 }

--- a/apps/conary/src/commands/adopt/refresh.rs
+++ b/apps/conary/src/commands/adopt/refresh.rs
@@ -335,9 +335,9 @@ pub async fn cmd_adopt_refresh(
                     continue;
                 }
             };
-            super::provides::extend_materialized_file_provides(
+            conary_core::repository::dependency_model::extend_materialized_file_provides(
                 &mut provides,
-                identity,
+                identity.source_package_format(),
                 captured_files.iter().map(|file| file.source.0.as_str()),
             )?;
 

--- a/apps/conary/src/commands/adopt/system.rs
+++ b/apps/conary/src/commands/adopt/system.rs
@@ -442,9 +442,9 @@ pub async fn cmd_adopt_system(
                     continue;
                 }
             };
-        super::provides::extend_materialized_file_provides(
+        conary_core::repository::dependency_model::extend_materialized_file_provides(
             &mut provides,
-            &package.identity,
+            package.identity.source_package_format(),
             captured_files.iter().map(|file| file.source.0.as_str()),
         )?;
 

--- a/apps/conary/src/commands/install/batch/ccs.rs
+++ b/apps/conary/src/commands/install/batch/ccs.rs
@@ -98,6 +98,16 @@ pub(crate) fn prepare_ccs_package_for_batch(
     let native_lifecycle_state =
         NativeLifecycleInstallState::from_bundle(package.manifest().native_lifecycle.as_ref())?;
 
+    // A converted artifact declares only its source header capabilities, so the
+    // payload it is about to install is the only authority for the file
+    // providers that satisfy path dependencies.
+    let mut provides = package.resolution_capabilities()?;
+    conary_core::repository::dependency_model::extend_materialized_file_provides(
+        &mut provides,
+        semantics.source_package_format(),
+        extracted_files.iter().map(|file| file.path.as_str()),
+    )?;
+
     Ok(PreparedPackage {
         name: package.name().to_string(),
         version: package.version().to_string(),
@@ -108,7 +118,7 @@ pub(crate) fn prepare_ccs_package_for_batch(
         description: package.description().map(str::to_string),
         extracted_files,
         requirements: package.requirements().to_vec(),
-        provides: package.resolution_capabilities()?,
+        provides,
         relations: package.relations().to_vec(),
         relation_removals: Vec::new(),
         relation_deconfigurations: Vec::new(),

--- a/apps/conary/src/commands/install/batch/preparation.rs
+++ b/apps/conary/src/commands/install/batch/preparation.rs
@@ -61,6 +61,7 @@ pub fn prepare_package_for_batch(
 
     // Parse package
     let pkg = parse_package(package_path, format)?;
+    let semantics = InstallSemantics::native_package(format);
 
     // Open database
     let conn = open_db(db_path)?;
@@ -69,7 +70,7 @@ pub fn prepare_package_for_batch(
     let (is_upgrade, old_trove) = match check_upgrade_status(
         &conn,
         pkg.as_ref(),
-        &InstallSemantics::native_package(format),
+        &semantics,
         allow_downgrade,
         InstallIntent::PackageChange,
     )? {
@@ -96,16 +97,25 @@ pub fn prepare_package_for_batch(
     let native_lifecycle_state =
         NativeLifecycleInstallState::from_native_package(pkg.as_ref(), format, source_profile_id)?;
 
+    // A native header declares only its own `Provides`; the payload it ships is
+    // the only authority for the file providers that satisfy path dependencies.
+    let mut provides = pkg.resolution_capabilities()?;
+    conary_core::repository::dependency_model::extend_materialized_file_provides(
+        &mut provides,
+        semantics.source_package_format(),
+        extracted_files.iter().map(|file| file.path.as_str()),
+    )?;
+
     Ok(Some(PreparedPackage {
         name: pkg.name().to_string(),
         version: pkg.version().to_string(),
-        semantics: InstallSemantics::native_package(format),
+        semantics,
         package_release: pkg.package_release().map(str::to_string),
         debian_multi_arch: pkg.debian_multi_arch(),
         architecture: pkg.architecture().map(|s| s.to_string()),
         description: pkg.description().map(|s| s.to_string()),
         extracted_files,
-        provides: pkg.resolution_capabilities()?,
+        provides,
         requirements: pkg.requirements().to_vec(),
         relations: pkg.relations().to_vec(),
         relation_removals: Vec::new(),

--- a/apps/conary/src/commands/install/batch/tests.rs
+++ b/apps/conary/src/commands/install/batch/tests.rs
@@ -871,3 +871,188 @@ fn selected_root_batch_conflict_preflight_runs_before_lifecycle() {
         "owned elsewhere"
     );
 }
+
+/// Sign one CCS carrying `paths` as its complete runtime payload.
+///
+/// The manifest declares no capability naming a payload path, which is how a
+/// converted artifact reaches the transaction: source headers own `Provides`,
+/// and the payload alone owns file ownership.
+fn signed_rpm_ccs_package(
+    temp_dir: &std::path::Path,
+    name: &str,
+    paths: &[&str],
+) -> conary_core::ccs::CcsPackage {
+    let signing_key =
+        conary_core::ccs::SigningKeyPair::generate().with_key_id("payload-file-provider");
+    let mut manifest = conary_core::ccs::CcsManifest::new_minimal(name, "1.0.0");
+    manifest.package.version_scheme = conary_core::repository::versioning::VersionScheme::Rpm;
+    manifest.components.default = vec!["runtime".to_string()];
+
+    let mut entries = Vec::new();
+    let mut blobs = HashMap::new();
+    let mut total_size = 0;
+    for path in paths {
+        let content = format!("payload for {path}").into_bytes();
+        let sha256 = conary_core::hash::sha256(&content);
+        total_size += content.len() as u64;
+        entries.push(conary_core::ccs::FileEntry {
+            path: (*path).to_string(),
+            node: payload_node(
+                PayloadNodeKind::Regular {
+                    hardlink_identity: None,
+                },
+                libc::S_IFREG | 0o755,
+            ),
+            content: Some(PayloadContentAuthority {
+                sha256: sha256.clone(),
+                size: content.len() as u64,
+            }),
+            component: "runtime".to_string(),
+            chunks: None,
+        });
+        blobs.insert(sha256, content);
+    }
+
+    let result = conary_core::ccs::BuildResult {
+        manifest,
+        components: HashMap::from([(
+            "runtime".to_string(),
+            conary_core::ccs::ComponentData {
+                name: "runtime".to_string(),
+                files: entries.clone(),
+                hash: "runtime".to_string(),
+                size: total_size,
+            },
+        )]),
+        files: entries.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &entries, blobs,
+        )
+        .unwrap(),
+        total_size,
+        chunked: false,
+        chunk_stats: None,
+    };
+    let package_path = temp_dir.join(format!("{name}.ccs"));
+    conary_core::ccs::builder::write_signed_current_ccs_package(
+        &result,
+        &package_path,
+        &signing_key,
+        false,
+    )
+    .unwrap();
+    let verified = conary_core::ccs::verify::verify_package(
+        &package_path,
+        &conary_core::ccs::TrustPolicy::strict(vec![signing_key.public_key_base64()]),
+    )
+    .unwrap();
+    conary_core::ccs::CcsPackage::from_verified_archive(package_path.to_str().unwrap(), &verified)
+        .unwrap()
+}
+
+fn prepare_signed_ccs_dependency(
+    temp_dir: &std::path::Path,
+    db_path: &std::path::Path,
+    name: &str,
+    paths: &[&str],
+) -> PreparedPackage {
+    let package = signed_rpm_ccs_package(temp_dir, name, paths);
+    prepare_ccs_package_for_batch(
+        &package,
+        db_path.to_str().unwrap(),
+        InstallReason::Dependency,
+        "required by the exact selected transaction",
+        false,
+        InstallIntent::PackageChange,
+        None,
+    )
+    .unwrap()
+}
+
+fn ccs_test_db(temp_dir: &std::path::Path) -> (std::path::PathBuf, rusqlite::Connection) {
+    let db_path = temp_dir.join("conary.db");
+    conary_core::db::init(&db_path).unwrap();
+    let conn = conary_core::db::open(&db_path).unwrap();
+    (db_path, conn)
+}
+
+#[test]
+fn prepared_package_publishes_every_payload_path_as_a_file_provider() {
+    let temp = tempfile::tempdir().unwrap();
+    let (db_path, _conn) = ccs_test_db(temp.path());
+    let paths = ["/usr/bin/sh", "/usr/share/doc/bash/README"];
+
+    let prepared = prepare_signed_ccs_dependency(temp.path(), &db_path, "bash", &paths);
+
+    assert!(
+        !prepared.extracted_files.is_empty(),
+        "the fixture must carry a payload"
+    );
+    for file in &prepared.extracted_files {
+        assert!(
+            prepared.provides.iter().any(|provide| {
+                provide.kind
+                    == conary_core::repository::dependency_model::RepositoryCapabilityKind::File
+                    && provide.name == file.path
+            }),
+            "payload path {} is not published as a file provider: {:?}",
+            file.path,
+            prepared
+                .provides
+                .iter()
+                .map(|provide| provide.name.as_str())
+                .collect::<Vec<_>>()
+        );
+    }
+    assert!(
+        prepared
+            .provides
+            .iter()
+            .any(|provide| provide.name == "bash"),
+        "materialized paths must not displace the exact package self-provider"
+    );
+}
+
+#[test]
+fn payload_file_provider_satisfies_an_exact_path_requirement_and_orders_provider_first() {
+    let temp = tempfile::tempdir().unwrap();
+    let (db_path, conn) = ccs_test_db(temp.path());
+    let dependent_of = |requirement: &str| {
+        let mut dependent =
+            prepared_test_package("systemd-udev", "/usr/lib/udev/rules.d/99.rules", b"rule");
+        dependent.requirements = vec![depends_on(requirement)];
+        dependent
+    };
+
+    // A converted artifact reduced to its declared header capabilities cannot
+    // satisfy the path dependency the solver resolved from repository metadata.
+    let mut declared_only =
+        prepare_signed_ccs_dependency(temp.path(), &db_path, "bash", &["/usr/bin/sh"]);
+    declared_only.provides.retain(|provide| {
+        provide.kind != conary_core::repository::dependency_model::RepositoryCapabilityKind::File
+    });
+    let error = super::ordering::order_packages_for_transaction(
+        &conn,
+        &mut vec![dependent_of("/usr/bin/sh"), declared_only],
+    )
+    .unwrap_err();
+    assert!(
+        error.to_string().contains(
+            "selected package transaction does not satisfy exact depends requirement for systemd-udev"
+        ),
+        "{error:#}"
+    );
+
+    let shell = prepare_signed_ccs_dependency(temp.path(), &db_path, "bash", &["/usr/bin/sh"]);
+    let mut packages = vec![dependent_of("/usr/bin/sh"), shell];
+
+    super::ordering::order_packages_for_transaction(&conn, &mut packages).unwrap();
+
+    assert_eq!(
+        packages
+            .iter()
+            .map(|package| package.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["bash", "systemd-udev"]
+    );
+}

--- a/apps/conary/src/commands/install/semantics.rs
+++ b/apps/conary/src/commands/install/semantics.rs
@@ -38,6 +38,19 @@ impl InstallSemantics {
         }
     }
 
+    /// Exact source format that owns the capabilities this artifact publishes.
+    ///
+    /// A converted CCS keeps the version scheme of the format it was built
+    /// from, so both prepared sources recover their format from the one scheme
+    /// they already carry.
+    pub(super) const fn source_package_format(
+        self,
+    ) -> conary_core::repository::dependency_model::SourcePackageFormat {
+        conary_core::repository::dependency_model::SourcePackageFormat::for_version_scheme(
+            self.version_scheme,
+        )
+    }
+
     pub(super) const fn payload_sharing_policy(self) -> conary_core::payload::PayloadSharingPolicy {
         match self.source {
             PreparedSourceKind::NativePackage {

--- a/crates/conary-core/src/packages/installed_identity.rs
+++ b/crates/conary-core/src/packages/installed_identity.rs
@@ -3,6 +3,7 @@
 //! Typed identity for one exact native package-manager database record.
 
 use crate::error::{Error, Result};
+use crate::repository::dependency_model::SourcePackageFormat;
 use crate::repository::versioning::VersionScheme;
 use serde::{Deserialize, Serialize};
 
@@ -37,13 +38,18 @@ pub enum InstalledPackageIdentity {
 }
 
 impl InstalledPackageIdentity {
+    /// Exact source package format that owns this native identity.
+    pub const fn source_package_format(&self) -> SourcePackageFormat {
+        match self {
+            Self::Rpm { .. } => SourcePackageFormat::Rpm,
+            Self::Dpkg { .. } => SourcePackageFormat::Debian,
+            Self::Pacman { .. } => SourcePackageFormat::Alpm,
+        }
+    }
+
     /// Exact version grammar owned by this native package-manager identity.
     pub const fn version_scheme(&self) -> VersionScheme {
-        match self {
-            Self::Rpm { .. } => VersionScheme::Rpm,
-            Self::Dpkg { .. } => VersionScheme::Debian,
-            Self::Pacman { .. } => VersionScheme::Arch,
-        }
+        self.source_package_format().version_scheme()
     }
 
     pub fn rpm(

--- a/crates/conary-core/src/repository/dependency_model.rs
+++ b/crates/conary-core/src/repository/dependency_model.rs
@@ -16,6 +16,7 @@
 
 use super::versioning::VersionScheme;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 
 /// Source package format that established a signed or persisted capability.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -35,6 +36,21 @@ impl SourcePackageFormat {
             Self::Debian => VersionScheme::Debian,
             Self::Alpm => VersionScheme::Arch,
             Self::Ccs => VersionScheme::Conary,
+        }
+    }
+
+    /// Exact source format that owns package identity under `scheme`.
+    ///
+    /// Inverse of [`Self::version_scheme`]. A capability's provenance format and
+    /// its version scheme are one fact, so a consumer holding either recovers
+    /// the other instead of restating the pairing.
+    #[must_use]
+    pub const fn for_version_scheme(scheme: VersionScheme) -> Self {
+        match scheme {
+            VersionScheme::Rpm => Self::Rpm,
+            VersionScheme::Debian => Self::Debian,
+            VersionScheme::Arch => Self::Alpm,
+            VersionScheme::Conary => Self::Ccs,
         }
     }
 }
@@ -345,6 +361,58 @@ impl ProvidedCapability {
         }
         Ok(())
     }
+}
+
+/// Add exact materialized package paths as source-derived file providers.
+///
+/// Native solvers admit file dependencies through package file ownership, not
+/// only through declared `Provides` header fields. Every consumer holding a
+/// package's exact paths -- adoption reading the owning package database, or a
+/// transaction holding the artifact it is about to install -- must publish that
+/// authority, otherwise a path dependency the solver satisfied from repository
+/// file metadata becomes unsatisfiable against the same package's own facts.
+///
+/// `format` owns the resulting version scheme, so the provenance format and the
+/// capability scheme cannot contradict each other.
+pub fn extend_materialized_file_provides<'a>(
+    provides: &mut Vec<ProvidedCapability>,
+    format: SourcePackageFormat,
+    paths: impl IntoIterator<Item = &'a str>,
+) -> crate::error::Result<()> {
+    let mut existing = provides
+        .iter()
+        .filter(|provide| provide.kind == RepositoryCapabilityKind::File)
+        .map(|provide| provide.name.clone())
+        .collect::<BTreeSet<_>>();
+
+    for path in paths.into_iter().collect::<BTreeSet<_>>() {
+        if path == "/" {
+            continue;
+        }
+        if !path.starts_with('/') {
+            return Err(crate::error::Error::ParseError(format!(
+                "materialized package file provider is not an absolute path: {path:?}"
+            )));
+        }
+        if !existing.insert(path.to_string()) {
+            continue;
+        }
+        let provide = ProvidedCapability {
+            kind: RepositoryCapabilityKind::File,
+            name: path.to_string(),
+            version: None,
+            version_relation: None,
+            version_scheme: format.version_scheme(),
+            architecture_qualifier: ProvideArchitectureQualifier::Implicit,
+            provenance: CapabilityProvenance::SourceDerivedFile {
+                format,
+                source_path: path.to_string(),
+            },
+        };
+        provide.validate()?;
+        provides.push(provide);
+    }
+    Ok(())
 }
 
 impl ProvideVersionRelation {
@@ -896,5 +964,108 @@ mod tests {
         capability.provenance = CapabilityProvenance::AuthorDeclared;
         capability.architecture_qualifier = ProvideArchitectureQualifier::Exact(String::new());
         assert!(capability.validate().is_err());
+    }
+
+    #[test]
+    fn every_materialized_file_provider_validates_under_its_source_format() {
+        for format in [
+            SourcePackageFormat::Rpm,
+            SourcePackageFormat::Debian,
+            SourcePackageFormat::Alpm,
+            SourcePackageFormat::Ccs,
+        ] {
+            let mut provides = Vec::new();
+            extend_materialized_file_provides(
+                &mut provides,
+                format,
+                ["/usr/bin/sh", "/usr/share/doc/tool/README", "/"],
+            )
+            .unwrap();
+
+            assert_eq!(
+                provides
+                    .iter()
+                    .map(|provide| provide.name.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["/usr/bin/sh", "/usr/share/doc/tool/README"],
+                "the root directory is not a file provider"
+            );
+            for provide in &provides {
+                provide.validate().unwrap();
+                assert_eq!(provide.kind, RepositoryCapabilityKind::File);
+                assert_eq!(provide.version_scheme, format.version_scheme());
+                assert_eq!(
+                    provide.provenance,
+                    CapabilityProvenance::SourceDerivedFile {
+                        format,
+                        source_path: provide.name.clone(),
+                    }
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn materialized_file_providers_never_duplicate_a_declared_path() {
+        let mut provides = vec![ProvidedCapability {
+            kind: RepositoryCapabilityKind::File,
+            name: "/usr/bin/sh".to_string(),
+            version: None,
+            version_relation: None,
+            version_scheme: VersionScheme::Rpm,
+            architecture_qualifier: ProvideArchitectureQualifier::Implicit,
+            provenance: CapabilityProvenance::SourceDerivedFile {
+                format: SourcePackageFormat::Rpm,
+                source_path: "/usr/bin/sh".to_string(),
+            },
+        }];
+
+        extend_materialized_file_provides(
+            &mut provides,
+            SourcePackageFormat::Rpm,
+            ["/usr/bin/sh", "/usr/bin/sh", "/usr/bin/bash"],
+        )
+        .unwrap();
+
+        assert_eq!(
+            provides
+                .iter()
+                .map(|provide| provide.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["/usr/bin/sh", "/usr/bin/bash"]
+        );
+    }
+
+    #[test]
+    fn materialized_file_providers_reject_a_relative_payload_path() {
+        let mut provides = Vec::new();
+
+        let error = extend_materialized_file_provides(
+            &mut provides,
+            SourcePackageFormat::Rpm,
+            ["usr/bin/sh"],
+        )
+        .expect_err("a relative payload path has no absolute file-provider identity");
+
+        assert!(
+            error.to_string().contains("absolute path"),
+            "unexpected error: {error}"
+        );
+        assert!(provides.is_empty());
+    }
+
+    #[test]
+    fn source_format_and_version_scheme_recover_each_other() {
+        for format in [
+            SourcePackageFormat::Rpm,
+            SourcePackageFormat::Debian,
+            SourcePackageFormat::Alpm,
+            SourcePackageFormat::Ccs,
+        ] {
+            assert_eq!(
+                SourcePackageFormat::for_version_scheme(format.version_scheme()),
+                format
+            );
+        }
     }
 }


### PR DESCRIPTION
## Problem

The SAT solver and the commit-time transaction validator consult two different provider universes. The solver resolves path dependencies against repository metadata, where primary.xml file entries become file-kind provides; the validator re-derives satisfaction from the prepared artifact's declared capabilities, which lose the file list at conversion. bash declares /bin/sh but owns /usr/bin/sh only as a file, so a correctly solved Fedora transaction (systemd-udev -> /usr/bin/sh) failed at commit:

```
selected package transaction does not satisfy exact depends requirement for systemd-udev: /usr/bin/sh
```

Found by the PR #268 four-suite QEMU wrapper (TGE02, run qemu-pr268-10470355); reproduced without QEMU against a scratch db. The validator and the supported-host scenario were both introduced in the #151 merge, so no tree had ever exercised this path: latent defect, not a regression. Full trace on #283.

## Fix

- `extend_materialized_file_provides` moves from adopt into conary-core (`repository/dependency_model.rs`) as the single owner, keyed on `SourcePackageFormat` so provenance format and version scheme cannot contradict each other. Adopt's local copy is deleted; its three call sites delegate.
- Both batch preparation paths (CCS and native) extend declared provides with file providers materialized from `extracted_files` — the exact payload being installed. The ordering validator reads and the transaction persists the same field, so installed packages satisfy path dependencies for later transactions too.
- `InstalledPackageIdentity::version_scheme` now derives from a new `source_package_format()`, collapsing a mapping stated twice into one owner.

## Verification

- `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean (isolated CARGO_TARGET_DIR)
- `cargo test -p conary`: 1020 passed. `cargo test -p conary-core`: 3342 passed.
- New contract tests fail without the fix, reproducing the exact production error string (negative control), and pass with it: `prepared_package_publishes_every_payload_path_as_a_file_provider`, `payload_file_provider_satisfies_an_exact_path_requirement_and_orders_provider_first`, plus materializer property tests in conary-core.
- Full four-suite QEMU wrapper proof runs on the rebased #268 after this merges (TGE02 is the end-to-end witness).

## Follow-ups (filed)

- #284 model apply --dry-run skips solve and transaction validation
- #285 filelists.xml never read; file deps outside primary.xml filter unsolvable
- Converted CCS artifacts still do not carry file providers in signed authority; the transaction layer compensates. Conversion-side question filed separately.

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfXaawDkA5fFBu3rm9RDfU
