### PR TITLE
fix(ccs): publish promised paths as signed provider authority

### DIFF
--- a/apps/conary/src/commands/install/batch/tests.rs
+++ b/apps/conary/src/commands/install/batch/tests.rs
@@ -1056,3 +1056,58 @@ fn payload_file_provider_satisfies_an_exact_path_requirement_and_orders_provider
         vec!["bash", "systemd-udev"]
     );
 }
+
+#[test]
+fn a_promised_path_witnesses_a_dependency_the_provider_ships_no_content_for() {
+    let (_temp, conn) = empty_test_db();
+    let dependent_of = |requirement: &str| {
+        let mut dependent = prepared_test_package("krb5-libs", "/usr/lib64/libkrb5.so.3", b"krb5");
+        dependent.requirements = vec![depends_on(requirement)];
+        dependent
+    };
+    let promised = "/etc/crypto-policies/back-ends/krb5.config";
+
+    // Before the package publishes its promise, nothing in the transaction can
+    // witness a path the provider owns but never ships.
+    let mut without_promise = vec![
+        dependent_of(promised),
+        prepared_test_package(
+            "crypto-policies",
+            "/usr/share/crypto-policies/DEFAULT",
+            b"policy",
+        ),
+    ];
+    let error =
+        super::ordering::order_packages_for_transaction(&conn, &mut without_promise).unwrap_err();
+    assert!(
+        error.to_string().contains(
+            "selected package transaction does not satisfy exact depends requirement for krb5-libs"
+        ),
+        "{error:#}"
+    );
+
+    let mut provider = prepared_test_package(
+        "crypto-policies",
+        "/usr/share/crypto-policies/DEFAULT",
+        b"policy",
+    );
+    provider.install_reason = InstallReason::Dependency;
+    provider.provides.push(
+        conary_core::repository::dependency_model::ProvidedCapability::promised_path(
+            conary_core::repository::dependency_model::SourcePackageFormat::Rpm,
+            promised,
+        ),
+    );
+    let mut packages = vec![dependent_of(promised), provider];
+
+    super::ordering::order_packages_for_transaction(&conn, &mut packages).unwrap();
+
+    assert_eq!(
+        packages
+            .iter()
+            .map(|package| package.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["crypto-policies", "krb5-libs"],
+        "the package that promises the path must be ordered before its dependent"
+    );
+}

--- a/crates/conary-core/src/ccs/v3/validation.rs
+++ b/crates/conary-core/src/ccs/v3/validation.rs
@@ -645,6 +645,55 @@ mod tests {
     }
 
     #[test]
+    fn signed_authority_accepts_a_promised_path_the_package_does_not_ship() {
+        let mut authority = AuthorityDocumentV3::package_for_tests("crypto-policies");
+        authority.identity.version_scheme = VersionScheme::Rpm;
+        authority.identity.version = "20251128-3".to_string();
+        authority.provided_capabilities =
+            vec![promised_capability_v3("/etc/example/back-end.config")];
+
+        validate_authority(&authority).unwrap();
+    }
+
+    #[test]
+    fn signed_authority_refuses_a_promised_path_that_is_also_payload_content() {
+        let mut authority = AuthorityDocumentV3::package_for_tests("contradiction");
+        authority.identity.version_scheme = VersionScheme::Rpm;
+        authority.identity.version = "1-1".to_string();
+        // package_for_tests signs /usr/bin/hello as payload content.
+        authority.provided_capabilities = vec![promised_capability_v3("/usr/bin/hello")];
+
+        let error = validate_authority(&authority).unwrap_err();
+        assert!(
+            error.diagnostics.iter().any(|diagnostic| {
+                diagnostic
+                    .message
+                    .contains("is also signed payload content")
+            }),
+            "{:?}",
+            error.diagnostics
+        );
+    }
+
+    fn promised_capability_v3(path: &str) -> ProvidedCapabilityV3 {
+        ProvidedCapabilityV3 {
+            kind: DependencyKindV3::File,
+            name: path.to_string(),
+            provider_version: None,
+            version_relation: None,
+            version_scheme: VersionScheme::Rpm,
+            architecture_qualifier: ProvideArchitectureQualifier::Implicit,
+            provenance:
+                crate::repository::dependency_model::CapabilityProvenance::SourcePromisedPath {
+                    format: crate::repository::dependency_model::SourcePackageFormat::Rpm,
+                    source_path: path.to_string(),
+                },
+            target: None,
+            component: None,
+        }
+    }
+
+    #[test]
     fn capability_list_rejects_a_second_exact_identity_origin() {
         let mut authority = AuthorityDocumentV3::package_for_tests("identity-spoof");
         authority.provided_capabilities = vec![ProvidedCapabilityV3 {

--- a/crates/conary-core/src/ccs/v3/validation/identity.rs
+++ b/crates/conary-core/src/ccs/v3/validation/identity.rs
@@ -85,6 +85,14 @@ pub(super) fn validate_capabilities(
     authority: &AuthorityDocumentV3,
     diagnostics: &mut Vec<V3Diagnostic>,
 ) {
+    let signed_paths = match &authority.kind {
+        crate::ccs::v3::schema::PackageKindV3::Package(data) => data
+            .files
+            .iter()
+            .map(|file| file.path.as_str())
+            .collect::<std::collections::BTreeSet<_>>(),
+        _ => std::collections::BTreeSet::new(),
+    };
     for (index, entry) in authority.provided_capabilities.iter().enumerate() {
         let field = format!("capabilities[{index}]");
         if entry.target.is_some() || entry.component.is_some() {
@@ -124,8 +132,21 @@ pub(super) fn validate_capabilities(
             diagnostics.push(V3Diagnostic::error(
                 V3DiagnosticCode::KindContractViolation,
                 format!("invalid provided capability authority: {error}"),
-                Some(field),
+                Some(field.clone()),
                 "encode a complete provider record accepted by the shared capability grammar",
+            ));
+        }
+        // A promise says a path will be created; signed payload says it already
+        // has content. One artifact cannot claim both about one path.
+        if !projected.witnesses_installed_content() && signed_paths.contains(entry.name.as_str()) {
+            diagnostics.push(V3Diagnostic::error(
+                V3DiagnosticCode::KindContractViolation,
+                format!(
+                    "promised path '{}' is also signed payload content",
+                    entry.name
+                ),
+                Some(field),
+                "publish a path either as signed payload or as a promised path, never as both",
             ));
         }
     }

--- a/crates/conary-core/src/packages/rpm.rs
+++ b/crates/conary-core/src/packages/rpm.rs
@@ -450,6 +450,7 @@ impl PackageFormat for RpmPackage {
         // Extract exact native lifecycle entries and config-file policy.
         let native_scriptlet_abi = Self::extract_native_scriptlet_abi(&pkg)?;
         let config = authority::parse_config_declarations(&pkg)?;
+        let promised_paths = authority::parse_promised_paths(&pkg)?;
 
         debug!(
             "Parsed RPM: {} version {} ({} files, {} dependencies, {} native lifecycle entries, {} config files)",
@@ -470,6 +471,7 @@ impl PackageFormat for RpmPackage {
             architecture: architecture.clone().expect("RPM architecture is required"),
             provides,
             config,
+            promised_paths,
         };
 
         Ok(Self {

--- a/crates/conary-core/src/packages/rpm/authority.rs
+++ b/crates/conary-core/src/packages/rpm/authority.rs
@@ -29,6 +29,17 @@ pub struct RpmDeclaredCapability {
     pub architecture_qualifier: ProvideArchitectureQualifier,
 }
 
+/// A header path the package owns without shipping content for it (`%ghost`).
+///
+/// RPM keeps these in the file table and satisfies file dependencies from them,
+/// but excludes them from the payload, so they are the package's promise that
+/// its own lifecycle will create the path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RpmPromisedPath {
+    pub header_index: u32,
+    pub path: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RpmPackageAuthority {
     pub name: String,
@@ -39,6 +50,30 @@ pub struct RpmPackageAuthority {
     pub architecture: String,
     pub provides: Vec<RpmDeclaredCapability>,
     pub config: Vec<RpmConfigDeclaration>,
+    pub promised_paths: Vec<RpmPromisedPath>,
+}
+
+pub(super) fn parse_promised_paths(package: &rpm::Package) -> crate::Result<Vec<RpmPromisedPath>> {
+    use rpm::FileFlags;
+
+    package
+        .metadata
+        .get_file_entries()
+        .map_err(|error| {
+            crate::Error::ParseError(format!("Failed to read RPM file metadata: {error}"))
+        })?
+        .into_iter()
+        .enumerate()
+        .filter(|(_, entry)| entry.flags().contains(FileFlags::GHOST))
+        .map(|(header_index, entry)| {
+            Ok(RpmPromisedPath {
+                header_index: u32::try_from(header_index).map_err(|_| {
+                    crate::Error::ParseError("RPM file record index exceeds u32".to_string())
+                })?,
+                path: entry.path().to_string_lossy().to_string(),
+            })
+        })
+        .collect()
 }
 
 pub(super) fn parse_config_declarations(

--- a/crates/conary-core/src/packages/rpm/tests.rs
+++ b/crates/conary-core/src/packages/rpm/tests.rs
@@ -17,6 +17,7 @@ fn package_for_test(name: &str, version: &str) -> RpmPackage {
             architecture: "x86_64".to_string(),
             provides: Vec::new(),
             config: Vec::new(),
+            promised_paths: Vec::new(),
         },
         description: None,
         files: Vec::new(),

--- a/crates/conary-core/src/packages/source_authority.rs
+++ b/crates/conary-core/src/packages/source_authority.rs
@@ -144,22 +144,33 @@ impl SourcePackageAuthority {
                 Ok(capability)
             };
         match self {
-            Self::Rpm(value) => value
-                .provides
-                .iter()
-                .map(|entry| {
-                    project(
-                        SourcePackageFormat::Rpm,
-                        VersionScheme::Rpm,
-                        entry.header_index,
-                        entry.kind,
-                        &entry.name,
-                        &entry.version,
-                        entry.version_relation,
-                        &entry.architecture_qualifier,
-                    )
-                })
-                .collect(),
+            Self::Rpm(value) => {
+                let mut capabilities = value
+                    .provides
+                    .iter()
+                    .map(|entry| {
+                        project(
+                            SourcePackageFormat::Rpm,
+                            VersionScheme::Rpm,
+                            entry.header_index,
+                            entry.kind,
+                            &entry.name,
+                            &entry.version,
+                            entry.version_relation,
+                            &entry.architecture_qualifier,
+                        )
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                // RPM satisfies a file dependency from its header file table,
+                // which includes paths the package only promises to create.
+                // Debian and Arch have no equivalent declaration.
+                crate::repository::dependency_model::extend_promised_path_provides(
+                    &mut capabilities,
+                    SourcePackageFormat::Rpm,
+                    value.promised_paths.iter().map(|entry| entry.path.as_str()),
+                )?;
+                Ok(capabilities)
+            }
             Self::Debian(value) => value
                 .provides
                 .iter()
@@ -306,6 +317,7 @@ mod tests {
                     ),
                 }],
                 config: Vec::new(),
+                promised_paths: Vec::new(),
             }),
             SourcePackageAuthority::Debian(DebianPackageAuthority {
                 name: "runtime".to_string(),
@@ -384,6 +396,102 @@ mod tests {
                     format: expected.1,
                     record_index: expected.2,
                 }
+            );
+        }
+    }
+
+    fn rpm_authority_with_promised_paths(paths: &[&str]) -> SourcePackageAuthority {
+        SourcePackageAuthority::Rpm(RpmPackageAuthority {
+            name: "crypto-policies".to_string(),
+            epoch: None,
+            version_component: "20251128".to_string(),
+            release: "3".to_string(),
+            evr: "20251128-3".to_string(),
+            architecture: "noarch".to_string(),
+            provides: Vec::new(),
+            config: Vec::new(),
+            promised_paths: paths
+                .iter()
+                .enumerate()
+                .map(
+                    |(index, path)| crate::packages::rpm::authority::RpmPromisedPath {
+                        header_index: index as u32,
+                        path: (*path).to_string(),
+                    },
+                )
+                .collect(),
+        })
+    }
+
+    #[test]
+    fn rpm_publishes_every_ghost_header_path_as_a_promised_capability() {
+        let authority =
+            rpm_authority_with_promised_paths(&["/etc/crypto-policies/back-ends/krb5.config"]);
+
+        let capabilities = authority.declared_capabilities().unwrap();
+
+        assert_eq!(capabilities.len(), 1);
+        let promised = &capabilities[0];
+        assert!(promised.is_promised_path());
+        assert!(!promised.witnesses_installed_content());
+        assert_eq!(promised.kind, RepositoryCapabilityKind::File);
+        assert_eq!(promised.name, "/etc/crypto-policies/back-ends/krb5.config");
+        assert_eq!(promised.version, None);
+        assert_eq!(promised.version_scheme, VersionScheme::Rpm);
+        promised.validate().unwrap();
+    }
+
+    #[test]
+    fn a_promised_path_never_displaces_the_exact_package_identity() {
+        let authority =
+            rpm_authority_with_promised_paths(&["/etc/crypto-policies/back-ends/krb5.config"]);
+
+        let capabilities = authority.resolution_capabilities().unwrap();
+
+        assert_eq!(
+            capabilities
+                .iter()
+                .filter(|capability| capability.provenance == CapabilityProvenance::ExactIdentity)
+                .count(),
+            1
+        );
+        assert!(
+            capabilities
+                .iter()
+                .any(ProvidedCapability::is_promised_path)
+        );
+    }
+
+    #[test]
+    fn only_rpm_declares_promised_paths() {
+        // Debian and Arch have no %ghost equivalent, so no source authority
+        // other than RPM may publish a promise.
+        for authority in [
+            SourcePackageAuthority::Debian(DebianPackageAuthority {
+                name: "tool".to_string(),
+                epoch: None,
+                source_version: "1.0-1".to_string(),
+                version: "1.0-1".to_string(),
+                architecture: "amd64".to_string(),
+                multi_arch: DebianMultiArch::No,
+                provides: Vec::new(),
+                config: Vec::new(),
+            }),
+            SourcePackageAuthority::Alpm(AlpmPackageAuthority {
+                name: "tool".to_string(),
+                version: "1.0-1".to_string(),
+                architecture: "x86_64".to_string(),
+                package_type: None,
+                provides: Vec::new(),
+                config: Vec::new(),
+            }),
+        ] {
+            assert!(
+                !authority
+                    .declared_capabilities()
+                    .unwrap()
+                    .iter()
+                    .any(ProvidedCapability::is_promised_path)
             );
         }
     }

--- a/crates/conary-core/src/repository/dependency_model.rs
+++ b/crates/conary-core/src/repository/dependency_model.rs
@@ -16,7 +16,7 @@
 
 use super::versioning::VersionScheme;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Source package format that established a signed or persisted capability.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -67,6 +67,17 @@ pub enum CapabilityProvenance {
         record_index: u32,
     },
     SourceDerivedFile {
+        format: SourcePackageFormat,
+        source_path: String,
+    },
+    /// A path the source package owns but ships no content for, materialized by
+    /// its own lifecycle (RPM `%ghost`).
+    ///
+    /// Deliberately distinct from [`Self::SourceDerivedFile`]: native solvers
+    /// admit a promised path as a dependency provider, but no consumer may read
+    /// content through it. Keeping it a separate variant forces every match to
+    /// decide, instead of letting a promise pass silently as a shipped file.
+    SourcePromisedPath {
         format: SourcePackageFormat,
         source_path: String,
     },
@@ -342,6 +353,7 @@ impl ProvidedCapability {
             }
             CapabilityProvenance::SourceDeclared { format, .. }
             | CapabilityProvenance::SourceDerivedFile { format, .. }
+            | CapabilityProvenance::SourcePromisedPath { format, .. }
                 if format.version_scheme() != self.version_scheme =>
             {
                 return Err(crate::error::Error::ParseError(format!(
@@ -357,9 +369,81 @@ impl ProvidedCapability {
                         .to_string(),
                 ));
             }
+            CapabilityProvenance::SourcePromisedPath { source_path, .. }
+                if self.kind != RepositoryCapabilityKind::File
+                    || !source_path.starts_with('/')
+                    || source_path != &self.name =>
+            {
+                return Err(crate::error::Error::ParseError(format!(
+                    "promised path capability '{}' requires a file kind and a matching absolute source path",
+                    self.name
+                )));
+            }
+            // A promise states that a path will exist, never what it contains.
+            CapabilityProvenance::SourcePromisedPath { .. } if self.version.is_some() => {
+                return Err(crate::error::Error::ParseError(format!(
+                    "promised path capability '{}' cannot carry a provider version",
+                    self.name
+                )));
+            }
             _ => {}
         }
         Ok(())
+    }
+
+    /// Exact source-derived provider for a path the package ships.
+    #[must_use]
+    pub fn payload_file(format: SourcePackageFormat, path: &str) -> Self {
+        Self {
+            kind: RepositoryCapabilityKind::File,
+            name: path.to_string(),
+            version: None,
+            version_relation: None,
+            version_scheme: format.version_scheme(),
+            architecture_qualifier: ProvideArchitectureQualifier::Implicit,
+            provenance: CapabilityProvenance::SourceDerivedFile {
+                format,
+                source_path: path.to_string(),
+            },
+        }
+    }
+
+    /// Exact provider for a path the package owns but materializes at install
+    /// time rather than shipping.
+    #[must_use]
+    pub fn promised_path(format: SourcePackageFormat, path: &str) -> Self {
+        Self {
+            kind: RepositoryCapabilityKind::File,
+            name: path.to_string(),
+            version: None,
+            version_relation: None,
+            version_scheme: format.version_scheme(),
+            architecture_qualifier: ProvideArchitectureQualifier::Implicit,
+            provenance: CapabilityProvenance::SourcePromisedPath {
+                format,
+                source_path: path.to_string(),
+            },
+        }
+    }
+
+    /// Whether this capability is a promise that a path will exist rather than
+    /// a statement that the package ships it.
+    #[must_use]
+    pub const fn is_promised_path(&self) -> bool {
+        matches!(
+            self.provenance,
+            CapabilityProvenance::SourcePromisedPath { .. }
+        )
+    }
+
+    /// Whether a consumer may read installed content through this capability.
+    ///
+    /// Dependency resolution asks only whether a provider exists, so it must
+    /// not call this. Any check that reads, hashes, or verifies the file behind
+    /// a capability must, because a promised path has no content to read.
+    #[must_use]
+    pub const fn witnesses_installed_content(&self) -> bool {
+        !self.is_promised_path()
     }
 }
 
@@ -379,11 +463,33 @@ pub fn extend_materialized_file_provides<'a>(
     format: SourcePackageFormat,
     paths: impl IntoIterator<Item = &'a str>,
 ) -> crate::error::Result<()> {
+    extend_path_ownership(provides, format, paths, false)
+}
+
+/// Add the paths a package owns but materializes at install time.
+///
+/// The promise is what makes a native file dependency solvable against a
+/// package that ships no content for the path. It never states that content
+/// exists; see [`ProvidedCapability::witnesses_installed_content`].
+pub fn extend_promised_path_provides<'a>(
+    provides: &mut Vec<ProvidedCapability>,
+    format: SourcePackageFormat,
+    paths: impl IntoIterator<Item = &'a str>,
+) -> crate::error::Result<()> {
+    extend_path_ownership(provides, format, paths, true)
+}
+
+fn extend_path_ownership<'a>(
+    provides: &mut Vec<ProvidedCapability>,
+    format: SourcePackageFormat,
+    paths: impl IntoIterator<Item = &'a str>,
+    promised: bool,
+) -> crate::error::Result<()> {
     let mut existing = provides
         .iter()
         .filter(|provide| provide.kind == RepositoryCapabilityKind::File)
-        .map(|provide| provide.name.clone())
-        .collect::<BTreeSet<_>>();
+        .map(|provide| (provide.name.clone(), provide.is_promised_path()))
+        .collect::<BTreeMap<_, _>>();
 
     for path in paths.into_iter().collect::<BTreeSet<_>>() {
         if path == "/" {
@@ -394,20 +500,21 @@ pub fn extend_materialized_file_provides<'a>(
                 "materialized package file provider is not an absolute path: {path:?}"
             )));
         }
-        if !existing.insert(path.to_string()) {
-            continue;
+        match existing.insert(path.to_string(), promised) {
+            // Shipping a path and promising to create it are contradictory
+            // claims about the same path, so one package can only make one.
+            Some(previous) if previous != promised => {
+                return Err(crate::error::Error::ParseError(format!(
+                    "package path {path:?} is declared both as shipped payload and as a promised path"
+                )));
+            }
+            Some(_) => continue,
+            None => {}
         }
-        let provide = ProvidedCapability {
-            kind: RepositoryCapabilityKind::File,
-            name: path.to_string(),
-            version: None,
-            version_relation: None,
-            version_scheme: format.version_scheme(),
-            architecture_qualifier: ProvideArchitectureQualifier::Implicit,
-            provenance: CapabilityProvenance::SourceDerivedFile {
-                format,
-                source_path: path.to_string(),
-            },
+        let provide = if promised {
+            ProvidedCapability::promised_path(format, path)
+        } else {
+            ProvidedCapability::payload_file(format, path)
         };
         provide.validate()?;
         provides.push(provide);
@@ -1052,6 +1159,93 @@ mod tests {
             "unexpected error: {error}"
         );
         assert!(provides.is_empty());
+    }
+
+    #[test]
+    fn a_promised_path_is_a_provider_but_never_content() {
+        let promised = ProvidedCapability::promised_path(
+            SourcePackageFormat::Rpm,
+            "/etc/crypto-policies/back-ends/krb5.config",
+        );
+        promised.validate().unwrap();
+
+        assert!(promised.is_promised_path());
+        assert!(!promised.witnesses_installed_content());
+        assert_eq!(promised.kind, RepositoryCapabilityKind::File);
+        assert_eq!(promised.version_scheme, VersionScheme::Rpm);
+
+        let shipped = ProvidedCapability::payload_file(SourcePackageFormat::Rpm, "/usr/bin/sh");
+        shipped.validate().unwrap();
+        assert!(!shipped.is_promised_path());
+        assert!(shipped.witnesses_installed_content());
+    }
+
+    #[test]
+    fn a_promised_path_cannot_claim_content_semantics() {
+        let mut promised =
+            ProvidedCapability::promised_path(SourcePackageFormat::Rpm, "/etc/tool/generated.conf");
+
+        promised.version = Some("1".to_string());
+        promised.version_relation = Some(ProvideVersionRelation::Equal);
+        assert!(promised.validate().is_err(), "a promise carries no version");
+
+        let mut wrong_kind =
+            ProvidedCapability::promised_path(SourcePackageFormat::Rpm, "/etc/tool/generated.conf");
+        wrong_kind.kind = RepositoryCapabilityKind::Generic;
+        assert!(wrong_kind.validate().is_err(), "a promise is a file path");
+
+        let mut relative =
+            ProvidedCapability::promised_path(SourcePackageFormat::Rpm, "etc/tool/generated.conf");
+        relative.name = "etc/tool/generated.conf".to_string();
+        assert!(
+            relative.validate().is_err(),
+            "a promise is an absolute path"
+        );
+    }
+
+    #[test]
+    fn one_package_cannot_both_ship_and_promise_a_path() {
+        let mut provides = Vec::new();
+        extend_promised_path_provides(
+            &mut provides,
+            SourcePackageFormat::Rpm,
+            ["/etc/pam.d/system-auth"],
+        )
+        .unwrap();
+
+        let error = extend_materialized_file_provides(
+            &mut provides,
+            SourcePackageFormat::Rpm,
+            ["/etc/pam.d/system-auth"],
+        )
+        .expect_err("shipping a promised path contradicts the promise");
+        assert!(
+            error.to_string().contains("shipped payload"),
+            "unexpected error: {error}"
+        );
+
+        // The reverse order is the same contradiction.
+        let mut shipped = Vec::new();
+        extend_materialized_file_provides(&mut shipped, SourcePackageFormat::Rpm, ["/usr/bin/sh"])
+            .unwrap();
+        assert!(
+            extend_promised_path_provides(&mut shipped, SourcePackageFormat::Rpm, ["/usr/bin/sh"])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn repeating_the_same_ownership_claim_is_not_a_contradiction() {
+        let mut provides = Vec::new();
+        for _ in 0..2 {
+            extend_promised_path_provides(
+                &mut provides,
+                SourcePackageFormat::Rpm,
+                ["/etc/pam.d/system-auth"],
+            )
+            .unwrap();
+        }
+        assert_eq!(provides.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

RPM satisfies file dependencies from its header file table, which includes %ghost paths — paths a package owns but materializes through its own lifecycle instead of shipping. Conversion discarded the ghost table, so a converted CCS stated only half its path ownership; #286's payload-derived witnesses structurally could not see promises, and TGE02 failed at commit:

```
selected package transaction does not satisfy exact depends requirement for krb5-libs: /etc/crypto-policies/back-ends/krb5.config
```

Design approved on #291: a package's dependency-relevant fact is its whole path ownership set, payload plus promise, stated in the artifact's signed authority — one witness universe for solver and validator.

## Fix

- RpmPackageAuthority retains the header ghost table (RpmPromisedPath); declared_capabilities() projects promises for RPM through the single flow point feeding signed conversion, native install, and adoption. Debian/Arch emit nothing.
- New CapabilityProvenance::SourcePromisedPath variant (not a discriminant field — a new variant forces every match site to decide; a field would let promises silently pass as shipped files).
- Dependency resolution admits promises; witnesses_installed_content() refuses them for any content reader; signed v3 validation rejects an artifact claiming one path as both promise and payload.
- Pre-alpha hard cut: prior artifacts keep validating but carry no promises — the Remi corpus must be reconverted (#287), which is why this is Refs #291 not Closes.

## Verification

- fmt --check and clippy --workspace --all-targets -D warnings clean (isolated target dir); re-verified after rebase onto 9570ac56.
- cargo test -p conary-core: 3351 passed. cargo test -p conary: 1021 passed. 10 new tests across source_authority, dependency_model, v3 validation, and install/batch — including a dependency-witness test carrying its own inline negative control (without the promise, ordering fails with the exact production error string) and a content-refusal negative control (removing the v3 collision check flips its test red).

## Field evidence chain

#283 (payload half, fixed by #286) -> this PR (promise half) -> #287 (reconversion) -> #293 (promises verified kept after lifecycle execution). Converted-artifact reads from Remi confirm crypto-policies materializes its own symlinks via embedded Lua (executed against the target root) and authselect-libs %posttrans selects the default profile — so with this fix plus reconversion, the supported-host fixture's enumerated at-risk edges close.

Refs #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfXaawDkA5fFBu3rm9RDfU
