### PR TITLE
fix(install): fail a transaction that breaks a promised path

### DIFF
--- a/apps/conary/src/commands/install/batch/execution.rs
+++ b/apps/conary/src/commands/install/batch/execution.rs
@@ -16,6 +16,48 @@ use conary_core::scriptlet::ExecutionMode;
 use std::collections::BTreeSet;
 use std::path::Path;
 
+/// Prove every promised path the transaction admitted was actually created.
+///
+/// A promised path is a dependency witness precisely because the owning
+/// package's lifecycle creates it, so the transaction only stays honest if that
+/// happened. RPM's warning-only slots let a scriptlet fail, or silently do
+/// nothing, while still reporting success, which is why this runs for every
+/// promise regardless of the entry's criticality and after the whole native
+/// lifecycle has had its chance -- including post-transaction slots.
+///
+/// A path is materialized when it exists, symlinks included: the promise is
+/// that the path exists, never what its content resolves to.
+pub(super) fn verify_promised_paths_materialized(
+    packages: &[PreparedPackage],
+    selected_root: &Path,
+) -> Result<()> {
+    for package in packages {
+        for promise in package
+            .provides
+            .iter()
+            .filter(|provide| provide.is_promised_path())
+        {
+            let target = crate::commands::live_root::target_path(selected_root, &promise.name)
+                .with_context(|| {
+                    format!(
+                        "promised path {} declared by {} is not addressable in the target root",
+                        promise.name, package.name
+                    )
+                })?;
+            if std::fs::symlink_metadata(&target).is_err() {
+                anyhow::bail!(
+                    "package {}-{} did not materialize promised path {} during its native lifecycle \
+                     (checked after the post-transaction stage)",
+                    package.name,
+                    package.version,
+                    promise.name
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
 struct GraphExecutionInputs {
     final_incoming_paths: BTreeSet<String>,
     finalization_troves: Vec<Option<i64>>,
@@ -76,6 +118,7 @@ impl BatchInstaller<'_> {
                 &graph_inputs,
                 &retained_upgrade_trove_ids,
             )?;
+            verify_promised_paths_materialized(packages, &selected_root)?;
             let mut activation_requests = native_transaction.take_activation_requests();
             for (package, executor) in packages.iter().zip(ccs_hook_executors.iter()) {
                 let (Some(ccs), Some(executor)) = (package.ccs.as_ref(), executor.as_ref()) else {

--- a/apps/conary/src/commands/install/batch/tests.rs
+++ b/apps/conary/src/commands/install/batch/tests.rs
@@ -1111,3 +1111,70 @@ fn a_promised_path_witnesses_a_dependency_the_provider_ships_no_content_for() {
         "the package that promises the path must be ordered before its dependent"
     );
 }
+
+fn promised(path: &str) -> conary_core::repository::dependency_model::ProvidedCapability {
+    conary_core::repository::dependency_model::ProvidedCapability::promised_path(
+        conary_core::repository::dependency_model::SourcePackageFormat::Rpm,
+        path,
+    )
+}
+
+#[test]
+fn a_transaction_fails_when_a_declared_promised_path_is_never_materialized() {
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let db_path = temp.path().join("conary.db");
+    std::fs::create_dir_all(temp.path().join("root")).unwrap();
+    conary_core::db::init(&db_path).unwrap();
+    crate::commands::test_helpers::seed_test_bootable_runtime(&db_path);
+    let db_path_string = db_path.to_string_lossy().into_owned();
+
+    let mut package =
+        prepared_test_package("promise-breaker", "/usr/bin/promise-breaker", b"payload");
+    // Declared as a dependency witness, but no lifecycle ever creates it.
+    package
+        .provides
+        .push(promised("/etc/promise-breaker/generated.conf"));
+    let installer = BatchInstaller::new(&db_path_string, SandboxMode::Always);
+
+    let error = installer.install_batch(vec![package]).unwrap_err();
+
+    let message = format!("{error:#}");
+    assert!(
+        message.contains("did not materialize promised path /etc/promise-breaker/generated.conf"),
+        "{message}"
+    );
+    assert!(message.contains("promise-breaker"), "{message}");
+}
+
+#[test]
+fn a_promised_path_present_in_the_assembled_root_satisfies_the_post_condition() {
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let db_path = temp.path().join("conary.db");
+    std::fs::create_dir_all(temp.path().join("root")).unwrap();
+    conary_core::db::init(&db_path).unwrap();
+    crate::commands::test_helpers::seed_test_bootable_runtime(&db_path);
+    let db_path_string = db_path.to_string_lossy().into_owned();
+
+    // The post-condition asks whether the path exists in the assembled root,
+    // not who produced it, so a path another batch member ships satisfies it.
+    let mut promiser = prepared_test_package("promiser", "/usr/bin/promiser", b"payload");
+    promiser
+        .provides
+        .push(promised("/usr/share/promised/marker.conf"));
+    let producer = prepared_test_package(
+        "producer",
+        "/usr/share/promised/marker.conf",
+        b"materialized",
+    );
+    let installer = BatchInstaller::new(&db_path_string, SandboxMode::Always);
+
+    installer.install_batch(vec![producer, promiser]).unwrap();
+
+    let conn = conary_core::db::open(&db_path).unwrap();
+    assert_eq!(
+        conary_core::db::models::Changeset::list_all(&conn).unwrap()[0].status,
+        ChangesetStatus::Applied
+    );
+}


### PR DESCRIPTION
## Problem

A promised (ghost) path is a dependency witness precisely because the owning package's lifecycle creates it — but RPM's warning-only lifecycle slots let a scriptlet fail, or silently do nothing, while the transaction records success. The promise then satisfies the validator and the missing path surfaces hours later as a boot/SSH failure with no diagnosis. crypto-policies' embedded-Lua %post and authselect-libs' %posttrans are both warning-only.

## Fix

After the complete native lifecycle graph (including post-transaction slots), every SourcePromisedPath declared by any batch member must exist in the selected root — symlink_metadata existence, symlinks included, content unread (content witnessing is already refused by witnesses_installed_content). Otherwise the transaction fails naming package, version, and path. Runs for every promise regardless of the declaring entry's criticality; a path materialized by any batch member satisfies the post-condition (it is a property of the assembled root).

## Verification

- fmt --check, clippy --workspace --all-targets -D warnings clean (isolated target dir); focused batch tests re-verified after rebase onto 185bdb7f.
- cargo test -p conary: 1023 passed; conary-core: 3352 passed.
- Negative control: with the post-condition call removed, the failure test prints the exact silent success this issue exists to kill ('Batch installed 1 package(s) successfully: promise-breaker...'); restored and re-verified.

Depends on #296 (merged). With #287's reconversion this makes the authselect edge safe to run: either the wrapper passes or it fails fast with a typed diagnosis.

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfXaawDkA5fFBu3rm9RDfU
