### PR TITLE
fix(convert): bump conversion version for promised-path authority

### DIFF
--- a/crates/conary-core/src/db/models/converted.rs
+++ b/crates/conary-core/src/db/models/converted.rs
@@ -17,9 +17,9 @@ use strum_macros::{AsRefStr, Display, EnumString};
 /// Current conversion algorithm version
 /// Bump this when making changes that require re-conversion of existing packages.
 ///
-/// Revision 13 preserves source-defined strong dependency ordering in signed
-/// CCS authority.
-pub const CONVERSION_VERSION: i32 = 13;
+/// Revision 14 publishes source-promised (%ghost) paths as signed provider
+/// authority, so converted artifacts state their whole path ownership set.
+pub const CONVERSION_VERSION: i32 = 14;
 /// Canonical digest of an empty repository-provide projection.
 pub const EMPTY_REPOSITORY_PROVIDES_DIGEST: &str =
     "sha256:4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945";


### PR DESCRIPTION
One-line invalidation trigger for #296: converted rows carry `conversion_version` (converted.rs:138,185) and `needs_reconversion()` is `!= CONVERSION_VERSION` (converted.rs:334-336) — without the bump, a deployed Remi serves pre-promise artifacts from cache indefinitely. Stale artifacts lazily delete-and-reconvert on the download path (persistence.rs:136-146) and are filtered from index generation until reconverted (index_gen.rs:202-205).

Must ship in the same Remi release as #296. Refs #287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfXaawDkA5fFBu3rm9RDfU