### PR TITLE
chore: release remi-v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [remi-v0.10.0] - 2026-08-07
+
+### Added
+- emit typed corpus evidence (#276)
+- supported-host bootable generation fixture (#137) (#151)
+
+### Fixed
+- bump conversion version for promised-path authority (#298)
+- publish promised paths as signed provider authority (#296)
+- materialize payload file providers for transaction authority (#286)
+- wait for terminal Remi jobs (#279)
+- preserve adopted provider authority (#273)
+- validate captured-root version authority (#270)
+- require explicit pin strength (#264)
+- publish downloaded packages atomically (#260)
+- type acquisition retry failures (#258)
+- add retired schema rebuild path (#256)
+- reject corrupt persisted statuses (#255)
+- preserve source declaration authority (#254)
+- separate package identity from source capabilities (#253)
+- project selected-root /dev/null (#250)
+- require composefs initramfs helper (#251)
+- remove dead metadata signature route (#249)
+
 ## [remi-v0.9.5] - 2026-07-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4858,7 +4858,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remi"
-version = "0.9.5"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/apps/remi/Cargo.toml
+++ b/apps/remi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remi"
-version = "0.9.5"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]


### PR DESCRIPTION
Release-prep commit for remi-v0.10.0, carrying the promised-path reconversion payload: #296 (signed promised-path authority), #297 (promise post-condition), #298 (CONVERSION_VERSION 13 -> 14, the invalidation trigger). Tag is applied to the merge result on main per the established release flow (cf. remi-v0.9.5 / #227), then release-build + deploy-and-verify run on the exact tag. Refs #287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfXaawDkA5fFBu3rm9RDfU