### PR TITLE
fix(install): verify only witness-used promised paths

### DIFF
--- a/apps/conary/src/commands/install/batch.rs
+++ b/apps/conary/src/commands/install/batch.rs
@@ -285,7 +285,7 @@ impl<'a> BatchInstaller<'a> {
 
         // Open database connection
         let mut conn = open_db(self.db_path)?;
-        ordering::order_packages_for_transaction(&conn, &mut packages)?;
+        let witnessed_promises = ordering::order_packages_for_transaction(&conn, &mut packages)?;
         self.plan_package_relations_for_batch(&conn, &mut packages)?;
         // Build transaction description
         let tx_description = if package_count == 1 {
@@ -416,6 +416,7 @@ impl<'a> BatchInstaller<'a> {
             &mut selected_root,
             rollback_root,
             &mut ccs_hook_executors,
+            &witnessed_promises,
         );
         let (_changeset_id, trove_ids, _retained_upgrade_trove_ids) = transaction_result?;
 

--- a/apps/conary/src/commands/install/batch/execution.rs
+++ b/apps/conary/src/commands/install/batch/execution.rs
@@ -16,43 +16,47 @@ use conary_core::scriptlet::ExecutionMode;
 use std::collections::BTreeSet;
 use std::path::Path;
 
-/// Prove every promised path the transaction admitted was actually created.
+/// Prove every promised path the transaction *relied on* was actually created.
 ///
-/// A promised path is a dependency witness precisely because the owning
-/// package's lifecycle creates it, so the transaction only stays honest if that
-/// happened. RPM's warning-only slots let a scriptlet fail, or silently do
-/// nothing, while still reporting success, which is why this runs for every
-/// promise regardless of the entry's criticality and after the whole native
-/// lifecycle has had its chance -- including post-transaction slots.
+/// RPM's `%ghost` marks a path the package owns if present -- `rpm-spec.5`
+/// describes it as a file "not to be included in the package", used "when the
+/// attributes of the file are important while the contents is not (e.g. a log
+/// file)". It is not a claim that the package creates the path, and many
+/// promises (`/etc/fstab`, log files, generated certificate links) are
+/// legitimately absent after a fresh transaction. Verifying every declared
+/// promise therefore asserts something the source never said.
+///
+/// So this verifies exactly the promises a dependency edge was certified
+/// against, as computed by the ordering validator: the transaction proves its
+/// own reasoning and nothing beyond it. It still runs regardless of the
+/// declaring lifecycle entry's criticality, because RPM's warning-only slots
+/// let a scriptlet fail, or silently do nothing, while reporting success -- and
+/// it runs after the whole native graph, including post-transaction slots.
 ///
 /// A path is materialized when it exists, symlinks included: the promise is
 /// that the path exists, never what its content resolves to.
 pub(super) fn verify_promised_paths_materialized(
-    packages: &[PreparedPackage],
+    witnessed: &[super::ordering::WitnessedPromise],
     selected_root: &Path,
 ) -> Result<()> {
-    for package in packages {
-        for promise in package
-            .provides
-            .iter()
-            .filter(|provide| provide.is_promised_path())
-        {
-            let target = crate::commands::live_root::target_path(selected_root, &promise.name)
-                .with_context(|| {
-                    format!(
-                        "promised path {} declared by {} is not addressable in the target root",
-                        promise.name, package.name
-                    )
-                })?;
-            if std::fs::symlink_metadata(&target).is_err() {
-                anyhow::bail!(
-                    "package {}-{} did not materialize promised path {} during its native lifecycle \
-                     (checked after the post-transaction stage)",
-                    package.name,
-                    package.version,
-                    promise.name
-                );
-            }
+    for promise in witnessed {
+        let target = crate::commands::live_root::target_path(selected_root, &promise.path)
+            .with_context(|| {
+                format!(
+                    "promised path {} declared by {} is not addressable in the target root",
+                    promise.path, promise.provider
+                )
+            })?;
+        if std::fs::symlink_metadata(&target).is_err() {
+            anyhow::bail!(
+                "package {}-{} did not materialize promised path {} during its native lifecycle \
+                 (checked after the post-transaction stage); {} depends on it through {}",
+                promise.provider,
+                promise.provider_version,
+                promise.path,
+                promise.dependent,
+                promise.requirement
+            );
         }
     }
     Ok(())
@@ -80,6 +84,7 @@ impl BatchInstaller<'_> {
         selected: &mut crate::commands::generation::selected_root::SelectedRootSession,
         rollback_root: conary_core::generation::root_manifest::CapturedSelectedRoot,
         ccs_hook_executors: &mut [Option<conary_core::ccs::HookExecutor>],
+        witnessed_promises: &[super::ordering::WitnessedPromise],
     ) -> Result<(i64, Vec<i64>, Vec<i64>)> {
         let graph_inputs = self.prepare_graph_execution(conn, packages)?;
         let runtime_root = conary_core::runtime_root::ConaryRuntimeRoot::from_db_path(
@@ -118,7 +123,7 @@ impl BatchInstaller<'_> {
                 &graph_inputs,
                 &retained_upgrade_trove_ids,
             )?;
-            verify_promised_paths_materialized(packages, &selected_root)?;
+            verify_promised_paths_materialized(witnessed_promises, &selected_root)?;
             let mut activation_requests = native_transaction.take_activation_requests();
             for (package, executor) in packages.iter().zip(ccs_hook_executors.iter()) {
                 let (Some(ccs), Some(executor)) = (package.ccs.as_ref(), executor.as_ref()) else {

--- a/apps/conary/src/commands/install/batch/ordering.rs
+++ b/apps/conary/src/commands/install/batch/ordering.rs
@@ -7,12 +7,29 @@ use conary_core::repository::dependency_model::RepositoryRequirementKind;
 use conary_core::resolver::identity::{PackageIdentity, ProvidedCapability};
 use std::collections::{BTreeMap, BTreeSet};
 
+/// A promised path the transaction actually leaned on to satisfy a dependency.
+///
+/// RPM's `%ghost` means the package owns the path *if present*; it never says
+/// the package creates it, and paths like `/etc/fstab` or a log file are
+/// legitimately absent after a fresh transaction. So the only promises worth
+/// verifying are the ones a dependency edge was certified against: the
+/// transaction checks its own reasoning and claims nothing beyond it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct WitnessedPromise {
+    pub(super) provider: String,
+    pub(super) provider_version: String,
+    pub(super) path: String,
+    pub(super) dependent: String,
+    pub(super) requirement: String,
+}
+
 pub(super) fn order_packages_for_transaction(
     conn: &Connection,
     packages: &mut Vec<PreparedPackage>,
-) -> Result<()> {
+) -> Result<Vec<WitnessedPromise>> {
+    let mut witnessed_promises = Vec::new();
     if packages.len() < 2 {
-        return Ok(());
+        return Ok(witnessed_promises);
     }
 
     let native_architecture = conary_core::repository::registry::detect_system_arch();
@@ -116,6 +133,58 @@ pub(super) fn order_packages_for_transaction(
                     selected_witnesses.remove(position);
                 }
             }
+            // A retained witness may hold the edge up through a promised path.
+            // Drop each promise in turn: if the edge falls, the transaction
+            // relied on that path existing and must later prove it does.
+            for provider_index in &selected_witnesses {
+                for promise in packages[*provider_index]
+                    .provides
+                    .iter()
+                    .filter(|provide| provide.is_promised_path())
+                {
+                    let mut without_promise = installed.clone();
+                    without_promise.push(selected[dependent_index].clone());
+                    for index in &selected_witnesses {
+                        let mut identity = selected[*index].clone();
+                        if index == provider_index {
+                            identity.provided_capabilities.retain(|capability| {
+                                !(capability.is_promised_path() && capability.name == promise.name)
+                            });
+                        }
+                        without_promise.push(identity);
+                    }
+                    if expression_satisfied(
+                        requirement,
+                        package.semantics.version_scheme,
+                        depending_architecture,
+                        &native_architecture,
+                        &without_promise,
+                    )? {
+                        continue;
+                    }
+                    let provider = &packages[*provider_index];
+                    let witnessed = WitnessedPromise {
+                        provider: provider.name.clone(),
+                        provider_version: provider.version.clone(),
+                        path: promise.name.clone(),
+                        dependent: package.name.clone(),
+                        requirement: requirement
+                            .native_text
+                            .as_deref()
+                            .unwrap_or("<typed expression>")
+                            .to_string(),
+                    };
+                    if !witnessed_promises
+                        .iter()
+                        .any(|existing: &WitnessedPromise| {
+                            existing.provider == witnessed.provider
+                                && existing.path == witnessed.path
+                        })
+                    {
+                        witnessed_promises.push(witnessed);
+                    }
+                }
+            }
             for provider_index in selected_witnesses {
                 edges[provider_index].insert(dependent_index);
                 if requirement.kind == RepositoryRequirementKind::PreDepends {
@@ -132,7 +201,7 @@ pub(super) fn order_packages_for_transaction(
             .into_iter()
             .map(|index| slots[index].take().expect("package order repeats an index")),
     );
-    Ok(())
+    Ok(witnessed_promises)
 }
 
 fn expression_satisfied(

--- a/apps/conary/src/commands/install/batch/tests.rs
+++ b/apps/conary/src/commands/install/batch/tests.rs
@@ -1120,7 +1120,7 @@ fn promised(path: &str) -> conary_core::repository::dependency_model::ProvidedCa
 }
 
 #[test]
-fn a_transaction_fails_when_a_declared_promised_path_is_never_materialized() {
+fn a_transaction_fails_when_a_witness_used_promised_path_is_never_materialized() {
     let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
     let temp = tempfile::tempdir().unwrap();
     let db_path = temp.path().join("conary.db");
@@ -1128,27 +1128,42 @@ fn a_transaction_fails_when_a_declared_promised_path_is_never_materialized() {
     conary_core::db::init(&db_path).unwrap();
     crate::commands::test_helpers::seed_test_bootable_runtime(&db_path);
     let db_path_string = db_path.to_string_lossy().into_owned();
+    let promised_path = "/etc/crypto-policies/back-ends/krb5.config";
 
-    let mut package =
-        prepared_test_package("promise-breaker", "/usr/bin/promise-breaker", b"payload");
-    // Declared as a dependency witness, but no lifecycle ever creates it.
-    package
-        .provides
-        .push(promised("/etc/promise-breaker/generated.conf"));
+    // The dependent is satisfied only through the promise, so the transaction
+    // certified an edge against a path that must then exist.
+    let mut provider = prepared_test_package(
+        "crypto-policies",
+        "/usr/share/crypto-policies/DEFAULT/krb5.txt",
+        b"policy",
+    );
+    provider.install_reason = InstallReason::Dependency;
+    provider.provides.push(promised(promised_path));
+    let mut dependent = prepared_test_package("krb5-libs", "/usr/lib64/libkrb5.so.3", b"krb5");
+    dependent.requirements = vec![depends_on(promised_path)];
     let installer = BatchInstaller::new(&db_path_string, SandboxMode::Always);
 
-    let error = installer.install_batch(vec![package]).unwrap_err();
+    let error = installer
+        .install_batch(vec![dependent, provider])
+        .unwrap_err();
 
     let message = format!("{error:#}");
     assert!(
-        message.contains("did not materialize promised path /etc/promise-breaker/generated.conf"),
+        message.contains(&format!(
+            "did not materialize promised path {promised_path}"
+        )),
         "{message}"
     );
-    assert!(message.contains("promise-breaker"), "{message}");
+    assert!(message.contains("crypto-policies"), "{message}");
+    // The diagnostic must name the edge that relied on the promise.
+    assert!(
+        message.contains("krb5-libs depends on it through"),
+        "{message}"
+    );
 }
 
 #[test]
-fn a_promised_path_present_in_the_assembled_root_satisfies_the_post_condition() {
+fn an_unused_promised_path_never_fails_the_transaction() {
     let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
     let temp = tempfile::tempdir().unwrap();
     let db_path = temp.path().join("conary.db");
@@ -1156,21 +1171,51 @@ fn a_promised_path_present_in_the_assembled_root_satisfies_the_post_condition() 
     conary_core::db::init(&db_path).unwrap();
     crate::commands::test_helpers::seed_test_bootable_runtime(&db_path);
     let db_path_string = db_path.to_string_lossy().into_owned();
+
+    // The real case this pins: Fedora's setup package owns /etc/fstab as a
+    // %ghost and never creates it -- an OS installer does. Nothing in the
+    // transaction depends on it, so the transaction has nothing to prove.
+    let mut setup = prepared_test_package("setup", "/etc/profile", b"profile");
+    setup.provides.push(promised("/etc/fstab"));
+    setup.provides.push(promised("/run/motd"));
+    // setup is a retained witness for a real edge, so the promises are in
+    // scope for consideration -- they are simply not what holds the edge up.
+    let mut other = prepared_test_package("filesystem", "/usr/bin/filesystem-marker", b"marker");
+    other.requirements = vec![depends_on("setup")];
+    let installer = BatchInstaller::new(&db_path_string, SandboxMode::Always);
+
+    installer.install_batch(vec![setup, other]).unwrap();
+
+    let conn = conary_core::db::open(&db_path).unwrap();
+    assert_eq!(
+        conary_core::db::models::Changeset::list_all(&conn).unwrap()[0].status,
+        ChangesetStatus::Applied
+    );
+}
+
+#[test]
+fn a_witness_used_promise_already_present_satisfies_the_post_condition() {
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let db_path = temp.path().join("conary.db");
+    std::fs::create_dir_all(temp.path().join("root")).unwrap();
+    conary_core::db::init(&db_path).unwrap();
+    crate::commands::test_helpers::seed_test_bootable_runtime(&db_path);
+    let db_path_string = db_path.to_string_lossy().into_owned();
+    let promised_path = "/usr/share/promised/marker.conf";
 
     // The post-condition asks whether the path exists in the assembled root,
     // not who produced it, so a path another batch member ships satisfies it.
     let mut promiser = prepared_test_package("promiser", "/usr/bin/promiser", b"payload");
-    promiser
-        .provides
-        .push(promised("/usr/share/promised/marker.conf"));
-    let producer = prepared_test_package(
-        "producer",
-        "/usr/share/promised/marker.conf",
-        b"materialized",
-    );
+    promiser.provides.push(promised(promised_path));
+    let producer = prepared_test_package("producer", promised_path, b"materialized");
+    let mut dependent = prepared_test_package("dependent", "/usr/bin/dependent", b"dependent");
+    dependent.requirements = vec![depends_on(promised_path)];
     let installer = BatchInstaller::new(&db_path_string, SandboxMode::Always);
 
-    installer.install_batch(vec![producer, promiser]).unwrap();
+    installer
+        .install_batch(vec![dependent, producer, promiser])
+        .unwrap();
 
     let conn = conary_core::db::open(&db_path).unwrap();
     assert_eq!(


### PR DESCRIPTION
## Problem

The #293 post-condition verified every declared promised path after lifecycle execution. RPM's %ghost semantic (rpm-spec.5) is 'owned if present' — it never claims the package creates the path. Run qemu-pr268-ea553855 failed TGE02 on setup's /etc/fstab, an honest never-materialized-at-install ghost. Census over the fixture closure: 837 promised paths in 15 packages; exactly 2 relied on by the transaction; 486+ runtime-generated paths the old rule would fail on every run (ca-certificates alone: 736 trust-store hash links made by update-ca-trust).

## Fix (decision on #300)

Verify only promises the transaction actually relied on. After the ordering validator's witness minimization, drop each retained witness's promises one at a time and re-evaluate the edge with the same expression evaluator that certified it — a promise whose removal breaks the edge is recorded as WitnessedPromise (provider, version, path, dependent, requirement) and must exist after the post-transaction stage, criticality-independent. The typed error now names the relying edge. Reliance is decided from exact transaction data; no materializer heuristics anywhere.

## Verification

- fmt/clippy -D warnings clean; cargo test -p conary 1024 passed, -p conary-core 3352 passed (isolated target dir).
- Negative controls both directions: (1) with the post-condition removed, the witness-used failure test goes red; (2) with the pre-#300 unscoped rule restored, the setup/fstab regression test reproduces run 3's exact production error string. Both restored and re-verified.
- The setup regression test was strengthened after its first version proved vacuous (no edges in scope) — caught by its own negative control.

Residual (out of scope, filed): #301 — installed packages' promises satisfying later transactions are not re-verified.

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfXaawDkA5fFBu3rm9RDfU
