### PR TITLE
feat(remi): expose chunk GC as a typed admin HTTP surface

### DIFF
--- a/apps/remi/src/server/admin_service.rs
+++ b/apps/remi/src/server/admin_service.rs
@@ -241,6 +241,66 @@ fn validate_external_ip(ip: &IpAddr) -> Result<(), ServiceError> {
 }
 
 // ---------------------------------------------------------------------------
+// Chunk garbage collection
+// ---------------------------------------------------------------------------
+
+/// Chunks touched more recently than this are kept even when unreferenced, so
+/// an in-flight conversion cannot lose the chunks it is still writing.
+const CHUNK_GC_GRACE_PERIOD_SECS: u64 = 3600;
+
+/// Outcome of a chunk garbage-collection run.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ChunkGcReport {
+    pub dry_run: bool,
+    pub referenced: usize,
+    pub local_scanned: usize,
+    pub r2_scanned: usize,
+    pub local_deleted: usize,
+    pub r2_deleted: usize,
+    pub local_bytes_freed: u64,
+    pub r2_bytes_freed: u64,
+}
+
+/// Garbage collect chunks that no converted package references.
+///
+/// With `dry_run` set the run only reports what it would remove.  This is the
+/// single implementation behind both the HTTP admin route and the MCP tool.
+pub async fn run_chunk_gc_op(
+    state: &Arc<RwLock<ServerState>>,
+    dry_run: bool,
+) -> Result<ChunkGcReport, ServiceError> {
+    let (db_path, objects_dir, r2_store) = {
+        let state = state.read().await;
+        (
+            state.config.db_path.clone(),
+            state.config.chunk_dir.join("objects"),
+            state.r2_store.clone(),
+        )
+    };
+
+    let result = crate::server::chunk_gc::run_chunk_gc(
+        &db_path,
+        &objects_dir,
+        r2_store,
+        dry_run,
+        CHUNK_GC_GRACE_PERIOD_SECS,
+    )
+    .await
+    .map_err(|e| ServiceError::Internal(e.to_string()))?;
+
+    Ok(ChunkGcReport {
+        dry_run,
+        referenced: result.referenced,
+        local_scanned: result.local_scanned,
+        r2_scanned: result.r2_scanned,
+        local_deleted: result.local_deleted,
+        r2_deleted: result.r2_deleted,
+        local_bytes_freed: result.local_bytes_freed,
+        r2_bytes_freed: result.r2_bytes_freed,
+    })
+}
+
+// ---------------------------------------------------------------------------
 // Token operations
 // ---------------------------------------------------------------------------
 

--- a/apps/remi/src/server/handlers/admin/chunk_gc.rs
+++ b/apps/remi/src/server/handlers/admin/chunk_gc.rs
@@ -1,0 +1,184 @@
+// apps/remi/src/server/handlers/admin/chunk_gc.rs
+//! Chunk garbage-collection handler for the external admin API.
+
+use axum::Json;
+use axum::extract::State;
+use axum::response::{IntoResponse, Response};
+use serde::Deserialize;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use crate::server::ServerState;
+use crate::server::admin_service;
+use crate::server::auth::{Scope, TokenScopes, json_error};
+
+use super::check_scope;
+
+/// Request body for `POST /v1/admin/chunk-gc`.
+#[derive(Debug, Default, Deserialize)]
+pub struct ChunkGcRequest {
+    pub dry_run: Option<bool>,
+}
+
+impl ChunkGcRequest {
+    /// Deletion requires an explicit `dry_run: false`; anything else previews.
+    fn dry_run(&self) -> bool {
+        self.dry_run.unwrap_or(true)
+    }
+}
+
+/// POST /v1/admin/chunk-gc
+///
+/// Delete chunks that no converted package references. An omitted body, or a
+/// body without `dry_run`, previews the run instead of deleting.
+pub async fn chunk_gc(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    scopes: Option<axum::Extension<TokenScopes>>,
+    body: Option<Json<ChunkGcRequest>>,
+) -> Response {
+    if let Some(err) = check_scope(&scopes, Scope::Admin) {
+        return err;
+    }
+
+    let dry_run = body
+        .map_or_else(ChunkGcRequest::default, |Json(body)| body)
+        .dry_run();
+
+    match admin_service::run_chunk_gc_op(&state, dry_run).await {
+        Ok(report) => Json(report).into_response(),
+        Err(e) => {
+            tracing::error!("Chunk garbage collection failed: {e}");
+            json_error(500, "Failed to garbage-collect chunks", "INTERNAL_ERROR")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    use super::super::test_helpers::{rebuild_app, test_app};
+
+    #[test]
+    fn omitted_body_previews() {
+        assert!(ChunkGcRequest::default().dry_run());
+    }
+
+    #[test]
+    fn omitted_dry_run_field_previews() {
+        let request: ChunkGcRequest = serde_json::from_str("{}").unwrap();
+        assert!(request.dry_run());
+    }
+
+    #[test]
+    fn explicit_dry_run_false_deletes() {
+        let request: ChunkGcRequest = serde_json::from_str(r#"{"dry_run": false}"#).unwrap();
+        assert!(!request.dry_run());
+    }
+
+    #[tokio::test]
+    async fn chunk_gc_route_rejects_token_without_admin_scope() {
+        let (_app, db_path) = test_app().await;
+
+        let reader_token = "chunk-gc-reader-token-67890";
+        let hash = crate::server::auth::hash_token(reader_token);
+        {
+            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            conary_core::db::models::admin_token::create(
+                &conn,
+                "chunk-gc-reader",
+                &hash,
+                "repos:read",
+            )
+            .unwrap();
+        }
+
+        let response = rebuild_app(&db_path)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/admin/chunk-gc")
+                    .header("Authorization", format!("Bearer {reader_token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn chunk_gc_route_requires_authentication() {
+        let (app, _db_path) = test_app().await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/admin/chunk-gc")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn chunk_gc_route_defaults_to_dry_run_without_a_body() {
+        let (app, _db_path) = test_app().await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/admin/chunk-gc")
+                    .header("Authorization", "Bearer test-admin-token-12345")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let report: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(report["dry_run"], true);
+        assert_eq!(report["local_deleted"], 0);
+    }
+
+    #[tokio::test]
+    async fn chunk_gc_route_honors_explicit_dry_run_false() {
+        let (app, _db_path) = test_app().await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/admin/chunk-gc")
+                    .header("Authorization", "Bearer test-admin-token-12345")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(r#"{"dry_run": false}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let report: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(report["dry_run"], false);
+        assert_eq!(report["local_scanned"], 0);
+    }
+}

--- a/apps/remi/src/server/handlers/admin/mod.rs
+++ b/apps/remi/src/server/handlers/admin/mod.rs
@@ -3,6 +3,7 @@
 
 mod artifacts;
 mod audit;
+mod chunk_gc;
 mod events;
 mod federation;
 mod repos;
@@ -11,6 +12,7 @@ mod tokens;
 
 pub use artifacts::*;
 pub use audit::*;
+pub use chunk_gc::*;
 pub use events::*;
 pub use federation::*;
 pub use repos::*;

--- a/apps/remi/src/server/handlers/openapi.rs
+++ b/apps/remi/src/server/handlers/openapi.rs
@@ -395,6 +395,23 @@ pub async fn openapi_spec() -> Response {
                     "responses": { "200": { "description": "Configuration updated" }, "400": { "description": "Invalid configuration" }, "401": { "description": "Invalid or missing token" } }
                 }
             },
+            "/v1/admin/chunk-gc": {
+                "post": {
+                    "operationId": "chunkGarbageCollect",
+                    "summary": "Garbage collect orphaned chunks",
+                    "description": "Deletes chunks that no converted package references, from local disk and R2. An omitted body, or a body without dry_run, previews the run without deleting. Requires admin scope.",
+                    "tags": ["admin"],
+                    "security": [{ "bearerAuth": [] }],
+                    "requestBody": {
+                        "required": false,
+                        "content": { "application/json": { "schema": {
+                            "type": "object",
+                            "properties": { "dry_run": { "type": "boolean", "default": true, "description": "Preview only; set false to delete." } }
+                        }}}
+                    },
+                    "responses": { "200": { "description": "Chunk garbage collection report" }, "400": { "description": "Invalid request body" }, "401": { "description": "Invalid or missing token" }, "403": { "description": "Insufficient scope" } }
+                }
+            },
             "/v1/admin/test-runs/gc": {
                 "delete": {
                     "operationId": "testRunGarbageCollect",
@@ -668,6 +685,7 @@ mod tests {
             ("/v1/admin/federation/peers/{id}", &["delete"][..]),
             ("/v1/admin/federation/peers/{id}/health", &["get"][..]),
             ("/v1/admin/federation/config", &["get", "put"][..]),
+            ("/v1/admin/chunk-gc", &["post"][..]),
             ("/v1/admin/test-runs/gc", &["delete"][..]),
             ("/v1/admin/test-health", &["get"][..]),
             ("/v1/admin/test-runs", &["get", "post"][..]),

--- a/apps/remi/src/server/mcp.rs
+++ b/apps/remi/src/server/mcp.rs
@@ -29,7 +29,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 
 use crate::server::ServerState;
-use crate::server::admin_service::{self, AddPeerInput, ServiceError};
+use crate::server::admin_service::{self, AddPeerInput, ChunkGcReport, ServiceError};
 
 /// Map a [`ServiceError`] to the appropriate [`McpError`] variant.
 ///
@@ -43,6 +43,15 @@ fn service_err_to_mcp(e: ServiceError) -> McpError {
         ServiceError::Conflict(msg) => McpError::invalid_request(msg, None),
         ServiceError::Internal(msg) => McpError::internal_error(msg, None),
     }
+}
+
+/// Render a [`ChunkGcReport`] as the `chunk_gc` tool's output object.
+///
+/// Going through [`serde_json::Value`] keeps the tool's established key order,
+/// which is independent of the report struct's field order.
+fn chunk_gc_tool_output(report: &ChunkGcReport) -> Result<serde_json::Value, McpError> {
+    serde_json::to_value(report)
+        .map_err(|e| McpError::internal_error(format!("Serialization error: {e}"), None))
 }
 
 /// MCP server instance that wraps Remi admin operations as tools.
@@ -597,34 +606,12 @@ impl RemiMcpServer {
         Parameters(params): Parameters<ChunkGcParams>,
     ) -> Result<CallToolResult, McpError> {
         let dry_run = params.dry_run.unwrap_or(true);
-        let grace_period_secs: u64 = 3600; // 1 hour grace period
 
-        let state = self.state.read().await;
-        let db_path = state.config.db_path.clone();
-        let objects_dir = state.config.chunk_dir.join("objects");
-        let r2_store = state.r2_store.clone();
-        drop(state);
+        let report = admin_service::run_chunk_gc_op(&self.state, dry_run)
+            .await
+            .map_err(service_err_to_mcp)?;
 
-        let gc_result = crate::server::chunk_gc::run_chunk_gc(
-            &db_path,
-            &objects_dir,
-            r2_store,
-            dry_run,
-            grace_period_secs,
-        )
-        .await
-        .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-        let text = to_json_text(&serde_json::json!({
-            "dry_run": dry_run,
-            "referenced": gc_result.referenced,
-            "local_scanned": gc_result.local_scanned,
-            "r2_scanned": gc_result.r2_scanned,
-            "local_deleted": gc_result.local_deleted,
-            "r2_deleted": gc_result.r2_deleted,
-            "local_bytes_freed": gc_result.local_bytes_freed,
-            "r2_bytes_freed": gc_result.r2_bytes_freed,
-        }))?;
+        let text = to_json_text(&chunk_gc_tool_output(&report)?)?;
         Ok(CallToolResult::success(vec![Content::text(text)]))
     }
 
@@ -751,6 +738,35 @@ mod tests {
 
         let info = server.get_info();
         assert_eq!(info.server_info.name, "remi-mcp");
+    }
+
+    #[test]
+    fn chunk_gc_tool_output_matches_the_published_report_object() {
+        let report = ChunkGcReport {
+            dry_run: true,
+            referenced: 1,
+            local_scanned: 2,
+            r2_scanned: 3,
+            local_deleted: 4,
+            r2_deleted: 5,
+            local_bytes_freed: 6,
+            r2_bytes_freed: 7,
+        };
+
+        let rendered = to_json_text(&chunk_gc_tool_output(&report).unwrap()).unwrap();
+        let expected = to_json_text(&serde_json::json!({
+            "dry_run": true,
+            "referenced": 1,
+            "local_scanned": 2,
+            "r2_scanned": 3,
+            "local_deleted": 4,
+            "r2_deleted": 5,
+            "local_bytes_freed": 6,
+            "r2_bytes_freed": 7,
+        }))
+        .unwrap();
+
+        assert_eq!(rendered, expected);
     }
 
     #[test]

--- a/apps/remi/src/server/routes/admin.rs
+++ b/apps/remi/src/server/routes/admin.rs
@@ -92,6 +92,7 @@ pub fn create_external_admin_router(
             post(admin_handlers::sync_repo),
         )
         .route("/v1/admin/refresh", post(admin_handlers::refresh_repos))
+        .route("/v1/admin/chunk-gc", post(admin_handlers::chunk_gc))
         .route(
             "/v1/admin/federation/peers",
             get(admin_handlers::list_peers),

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -422,3 +422,17 @@ local experiments unless you intentionally want to warm a real Remi cache.
 The former scan-only corpus tokenizer was removed because line splitting and
 manual command lists duplicated the formal shell/parser pipeline and produced
 non-authoritative evidence that required ongoing heuristic maintenance.
+
+## Chunk Garbage Collection
+
+`apps/remi/src/server/chunk_gc.rs` owns the referenced-set computation and the
+local/R2 deletion pass. `admin_service::run_chunk_gc_op` is the single caller:
+it resolves the database path, chunk objects directory, and optional R2 store
+from server state, applies the one-hour grace period that protects chunks of
+in-flight conversions, and returns the typed report.
+
+Two surfaces call that one function, so neither can drift from the other. The
+MCP tool `chunk_gc` is the agent surface, and `POST /v1/admin/chunk-gc` on the
+external admin router is the operator surface; both require the `admin` scope.
+Deletion requires an explicit `dry_run: false`, so an omitted body, an omitted
+field, or an absent MCP parameter previews the run instead of deleting.


### PR DESCRIPTION
## Problem

`chunk_gc` is MCP-only — the single caller of `run_chunk_gc` is the MCP tool. Per AGENTS.md, MCP is an adapter over the agent contract, never the sole authority for an essential operation. Felt concretely on 2026-08-07: running GC required hand-rolled stateful JSON-RPC when an authenticated curl should have sufficed.

## Fix

One shared implementation, two callers:

- `admin_service::run_chunk_gc_op(state, dry_run)` → typed `ChunkGcReport` (eight fields, unchanged shape); grace period is a named constant (`CHUNK_GC_GRACE_PERIOD_SECS = 3600`).
- New `POST /v1/admin/chunk-gc` on the **external admin router** (bearer token, `Scope::Admin`). Omitted body or omitted `dry_run` field previews; deletion requires explicit `{"dry_run": false}`.
- MCP `chunk_gc` tool rewired to the shared function; params, defaults, description, and serialized output are unchanged (byte-identity pinned by `chunk_gc_tool_output_matches_the_published_report_object`).
- OpenAPI path entry + `docs/modules/remi.md` "Chunk Garbage Collection" section (single owner, two surfaces, preview-by-default).

`apps/remi/src/server/chunk_gc.rs` untouched — #304 owned that file this cycle.

## Verification (run, real output)

- `cargo test -p remi` — 600 lib / 5 bin / 3 cli_help passed, 0 failed. New: 7 handler tests (401 unauthenticated, 403 wrong scope, 200 + `dry_run:true` with no body, explicit `dry_run:false` honored, 3 default-logic units) + 1 MCP output-identity test.
- `cargo clippy -p remi --all-targets -- -D warnings` clean; `cargo fmt --check` clean; `scripts/check-doc-truth.sh` passed.

## Known edge (accepted, documented)

axum's `Option<Json<T>>` yields the 400 extractor error for `Content-Type: application/json` with an empty body; plain `POST` with no body (the operator curl path) gets the preview default and is covered by test. Switch to a `Bytes` parse helper if this ever bites.

Closes #307. Refs #306 (decide-point 1 executed), #287 (GC closeout unblocked outside MCP).