### PR TITLE
chore: release remi-v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [remi-v0.11.0] - 2026-08-07
+
+### Added
+- expose chunk GC as a typed admin HTTP surface (#308)
+
+### Fixed
+- make chunk GC runnable at production scale (#304)
+
 ## [remi-v0.10.0] - 2026-08-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4858,7 +4858,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remi"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/apps/remi/Cargo.toml
+++ b/apps/remi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remi"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]


### PR DESCRIPTION
Release prep for remi-v0.11.0 (conventional-commit authority: minor, from feat #308).

Ships since remi-v0.10.0:
- #304 — chunk GC runnable at production scale (grace-period filter no longer exceeds SQLite's host-variable limit at ~1.79M orphan candidates; aggregated dry-run logging; transaction-batched chunk_access cleanup; honest local_bytes_freed accounting). Closes the defect blocking #287's GC step.
- #308 — chunk GC exposed as a typed admin HTTP surface (`POST /v1/admin/chunk-gc`, preview-by-default); MCP tool now adapts the same shared service function.

After merge: tag the merge commit `remi-v0.11.0` and push the tag to trigger release-build → deploy-and-verify (recoverable helper deploy with health + repopulation proof). Post-deploy plan on production: GC dry-run via the new HTTP route, review counts (~1.79M orphan candidates expected), then the real run on operator go — completing #287 closeout.

Refs #287, #303, #307.