### PR TITLE
fix(remi): bulk-delete R2 orphans in chunk GC

### DIFF
--- a/apps/remi/src/server/chunk_gc.rs
+++ b/apps/remi/src/server/chunk_gc.rs
@@ -361,8 +361,17 @@ pub async fn run_chunk_gc(
         return Ok(result);
     }
 
-    // Step 6: Delete orphans
+    // Step 6: Delete orphans.
+    //
+    // Local unlinks stay one at a time, but R2 orphans are collected here and
+    // removed in one bulk pass below. One HTTP round trip per orphan turned the
+    // first production run's 345,913 R2 orphans into hours of serial deletes.
+    let mut r2_orphans: Vec<String> = Vec::new();
     for hash in &orphans_after_grace {
+        if r2_store.is_some() && r2_set.contains(hash.as_str()) {
+            r2_orphans.push(hash.clone());
+        }
+
         // Delete from local disk
         if local_set.contains(hash.as_str()) {
             let path = chunk_path(objects_dir, hash);
@@ -387,19 +396,24 @@ pub async fn run_chunk_gc(
                 }
             }
         }
+    }
 
-        // Delete from R2
-        if r2_set.contains(hash.as_str())
-            && let Some(ref store) = r2_store
-        {
-            match store.delete_chunk(hash).await {
-                Ok(_) => {
-                    result.r2_deleted += 1;
-                }
-                Err(e) => {
-                    tracing::warn!("Failed to delete R2 chunk {}: {}", hash, e);
-                }
-            }
+    // Bulk-delete the R2 orphans in one pass.
+    if let Some(ref store) = r2_store
+        && !r2_orphans.is_empty()
+    {
+        let outcome = store
+            .delete_chunks(&r2_orphans)
+            .await
+            .context("bulk delete R2 orphan chunks")?;
+        result.r2_deleted += outcome.deleted;
+        if outcome.failed > 0 {
+            tracing::warn!(
+                "Failed to delete {} of {} R2 orphan chunk(s); samples: {:?}",
+                outcome.failed,
+                outcome.attempted,
+                outcome.failure_samples
+            );
         }
     }
 

--- a/apps/remi/src/server/r2.rs
+++ b/apps/remi/src/server/r2.rs
@@ -9,6 +9,13 @@ use anyhow::{Context, Result};
 use s3::Bucket;
 use s3::Region;
 use s3::creds::Credentials;
+use s3::serde_types::{DeleteObjectsResult, ObjectIdentifier};
+
+/// Maximum keys S3/R2 accepts in one `DeleteObjects` request.
+const R2_DELETE_BATCH_SIZE: usize = 1000;
+
+/// Maximum (hash, error) pairs retained from a bulk delete for diagnostics.
+const R2_DELETE_FAILURE_SAMPLES: usize = 10;
 
 /// Configuration for the R2 storage backend
 #[derive(Debug, Clone)]
@@ -32,6 +39,68 @@ impl Default for R2Config {
             region: "auto".to_string(),
         }
     }
+}
+
+/// Aggregate outcome of a bulk chunk delete.
+///
+/// A per-key rejection is recorded rather than propagated so one bad key
+/// cannot abandon the rest of a garbage-collection run.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct R2BatchDeleteOutcome {
+    /// Keys submitted for deletion
+    pub attempted: usize,
+    /// Keys R2 removed (or that were already absent)
+    pub deleted: usize,
+    /// Keys R2 refused, plus keys in a batch whose request failed outright
+    pub failed: usize,
+    /// Up to `R2_DELETE_FAILURE_SAMPLES` (hash, error) pairs for diagnostics
+    pub failure_samples: Vec<(String, String)>,
+}
+
+impl R2BatchDeleteOutcome {
+    fn record_failure(&mut self, hash: &str, error: &str) {
+        self.failed += 1;
+        if self.failure_samples.len() < R2_DELETE_FAILURE_SAMPLES {
+            self.failure_samples
+                .push((hash.to_string(), error.to_string()));
+        }
+    }
+
+    /// Fold a batch whose request succeeded.
+    ///
+    /// S3 reports only the keys it refused; deletion is idempotent, so every
+    /// other key in the batch is gone whether or not it existed. That matches
+    /// what the single-key `delete_chunk` path counts as a delete.
+    fn fold_batch(&mut self, batch: &[String], failures: &[(String, String)]) {
+        for (hash, error) in failures {
+            self.record_failure(hash, error);
+        }
+        self.deleted += batch.len().saturating_sub(failures.len());
+    }
+
+    /// Fold a batch whose request itself failed: none of its keys were removed.
+    fn fold_batch_request_failure(&mut self, batch: &[String], error: &str) {
+        for hash in batch {
+            self.record_failure(hash, error);
+        }
+    }
+}
+
+/// Split chunk hashes into request-sized batches.
+fn delete_batches(hashes: &[String]) -> std::slice::Chunks<'_, String> {
+    hashes.chunks(R2_DELETE_BATCH_SIZE)
+}
+
+/// Convert a bulk-delete response's per-key errors into (hash, error) pairs.
+fn delete_failures(prefix: &str, response: &DeleteObjectsResult) -> Vec<(String, String)> {
+    response
+        .errors
+        .iter()
+        .map(|err| {
+            let hash = err.key.strip_prefix(prefix).unwrap_or(&err.key).to_string();
+            (hash, format!("{}: {}", err.code, err.message))
+        })
+        .collect()
 }
 
 /// Cloudflare R2 object storage backend for CAS chunks
@@ -132,6 +201,37 @@ impl R2Store {
 
         // S3/R2 returns 204 for successful delete, 404 if not found
         Ok(response.status_code() < 300)
+    }
+
+    /// Delete many chunks from R2 using the S3 multi-object delete API.
+    ///
+    /// Keys are sent in batches of at most `R2_DELETE_BATCH_SIZE`. Neither a
+    /// per-key rejection nor a failed batch request aborts the remaining
+    /// batches; both are reported through the returned outcome.
+    pub async fn delete_chunks(&self, hashes: &[String]) -> Result<R2BatchDeleteOutcome> {
+        let mut outcome = R2BatchDeleteOutcome {
+            attempted: hashes.len(),
+            ..Default::default()
+        };
+
+        for batch in delete_batches(hashes) {
+            let objects: Vec<ObjectIdentifier> = batch
+                .iter()
+                .map(|hash| ObjectIdentifier::new(self.chunk_key(hash)))
+                .collect();
+
+            match self.bucket.delete_objects(objects).await {
+                Ok(response) => {
+                    let failures = delete_failures(&self.prefix, &response);
+                    outcome.fold_batch(batch, &failures);
+                }
+                Err(e) => {
+                    outcome.fold_batch_request_failure(batch, &e.to_string());
+                }
+            }
+        }
+
+        Ok(outcome)
     }
 
     /// Generate a presigned GET URL for a chunk
@@ -254,6 +354,164 @@ mod tests {
         }
 
         assert_eq!(hashes, vec!["abc123def456", "xyz789"]);
+    }
+
+    fn hashes(range: std::ops::Range<usize>) -> Vec<String> {
+        range.map(|i| format!("hash-{i:06}")).collect()
+    }
+
+    #[test]
+    fn delete_batches_never_exceed_the_s3_request_limit() {
+        let keys = hashes(0..2500);
+        let batches: Vec<&[String]> = delete_batches(&keys).collect();
+
+        assert_eq!(batches.len(), 3);
+        assert_eq!(batches[0].len(), R2_DELETE_BATCH_SIZE);
+        assert_eq!(batches[1].len(), R2_DELETE_BATCH_SIZE);
+        // Final partial batch carries the remainder.
+        assert_eq!(batches[2].len(), 500);
+        assert_eq!(batches[0][0], "hash-000000");
+        assert_eq!(batches[2][499], "hash-002499");
+
+        let total: usize = batches.iter().map(|b| b.len()).sum();
+        assert_eq!(total, keys.len());
+    }
+
+    #[test]
+    fn delete_batches_are_empty_for_no_keys() {
+        assert_eq!(delete_batches(&[]).count(), 0);
+    }
+
+    #[test]
+    fn delete_batches_send_an_exact_multiple_without_a_trailing_batch() {
+        let keys = hashes(0..R2_DELETE_BATCH_SIZE * 2);
+        let batches: Vec<&[String]> = delete_batches(&keys).collect();
+        assert_eq!(batches.len(), 2);
+        assert!(batches.iter().all(|b| b.len() == R2_DELETE_BATCH_SIZE));
+    }
+
+    fn delete_error(key: &str, code: &str) -> s3::serde_types::DeleteError {
+        s3::serde_types::DeleteError {
+            key: key.to_string(),
+            code: code.to_string(),
+            message: "denied".to_string(),
+            version_id: None,
+        }
+    }
+
+    #[test]
+    fn delete_failures_strip_the_chunk_prefix() {
+        let response = DeleteObjectsResult {
+            deleted: Vec::new(),
+            errors: vec![
+                delete_error("chunks/abc123", "AccessDenied"),
+                // A key outside the prefix is reported verbatim.
+                delete_error("other/def456", "InternalError"),
+            ],
+        };
+
+        let failures = delete_failures("chunks/", &response);
+        assert_eq!(
+            failures,
+            vec![
+                ("abc123".to_string(), "AccessDenied: denied".to_string()),
+                (
+                    "other/def456".to_string(),
+                    "InternalError: denied".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn outcome_counts_unreported_keys_in_a_batch_as_deleted() {
+        let batch = hashes(0..5);
+        let mut outcome = R2BatchDeleteOutcome {
+            attempted: batch.len(),
+            ..Default::default()
+        };
+
+        outcome.fold_batch(
+            &batch,
+            &[(
+                "hash-000002".to_string(),
+                "AccessDenied: denied".to_string(),
+            )],
+        );
+
+        assert_eq!(outcome.attempted, 5);
+        assert_eq!(outcome.deleted, 4);
+        assert_eq!(outcome.failed, 1);
+        assert_eq!(
+            outcome.failure_samples,
+            vec![(
+                "hash-000002".to_string(),
+                "AccessDenied: denied".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn outcome_accumulates_across_batches() {
+        let first = hashes(0..3);
+        let second = hashes(3..6);
+        let mut outcome = R2BatchDeleteOutcome {
+            attempted: 6,
+            ..Default::default()
+        };
+
+        outcome.fold_batch(&first, &[]);
+        // A failed request loses its whole batch but not the earlier one.
+        outcome.fold_batch_request_failure(&second, "connection reset");
+
+        assert_eq!(outcome.deleted, 3);
+        assert_eq!(outcome.failed, 3);
+        assert_eq!(outcome.failure_samples.len(), 3);
+        assert!(
+            outcome
+                .failure_samples
+                .iter()
+                .all(|(_, error)| error == "connection reset")
+        );
+    }
+
+    #[test]
+    fn outcome_caps_failure_samples_but_keeps_counting() {
+        let batch = hashes(0..250);
+        let mut outcome = R2BatchDeleteOutcome {
+            attempted: batch.len(),
+            ..Default::default()
+        };
+
+        outcome.fold_batch_request_failure(&batch, "timeout");
+
+        assert_eq!(outcome.deleted, 0);
+        assert_eq!(outcome.failed, 250);
+        assert_eq!(outcome.failure_samples.len(), R2_DELETE_FAILURE_SAMPLES);
+        // Samples are the first failures seen, not a random subset.
+        assert_eq!(outcome.failure_samples[0].0, "hash-000000");
+        assert_eq!(outcome.failure_samples[9].0, "hash-000009");
+    }
+
+    #[test]
+    fn outcome_does_not_underflow_when_a_server_over_reports_errors() {
+        let batch = hashes(0..2);
+        let mut outcome = R2BatchDeleteOutcome {
+            attempted: batch.len(),
+            ..Default::default()
+        };
+
+        outcome.fold_batch(
+            &batch,
+            &[
+                ("hash-000000".to_string(), "e".to_string()),
+                ("hash-000001".to_string(), "e".to_string()),
+                ("hash-000099".to_string(), "e".to_string()),
+            ],
+        );
+
+        assert_eq!(outcome.deleted, 0);
+        assert_eq!(outcome.failed, 3);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`run_chunk_gc` deleted R2 orphans one HTTP request per chunk. First production GC (2026-08-08): 345,913 R2 orphans → the R2 phase alone stretched the run to hours. #310 has the full evidence.

## Fix

- `R2Store::delete_chunks(&[String]) -> R2BatchDeleteOutcome` using the vendored rust-s3's native S3 `DeleteObjects` — one request per 1,000 keys (~346 requests for the production set). Self-chunked rather than crate-batched because the crate returns Err on the first failed batch, which would abandon the remainder; we record that batch's keys as failures and continue.
- Outcome reports attempted/deleted/failed with up to 10 (hash, error) samples; deleted = batch minus refusals (S3 reports only refused keys; absent-key deletes are idempotent successes, matching the old path's `<300 == deleted` semantics, `saturating_sub`-guarded and tested).
- GC Step 6: local unlink loop unchanged; R2-resident orphans collected during it and bulk-deleted after. Failure count + samples logged at warn. Dry-run untouched.
- Deliberate behavior change: an orphan whose local unlink fails is still deleted from R2 — its `chunk_access` row was already removed regardless, so the three deletion domains stay consistent; the leftover local file is re-collected next run.

## Verification (run, real output)

`cargo test -p remi`: 612 lib / 5 bin / 3 cli_help passed, 0 failed (8 new `server::r2::tests`, all 20 existing chunk_gc/handler tests unchanged). Clippy `-D warnings` clean, fmt clean. Independent re-run by reviewer matched.

## Found, filed separately

`GcResult.r2_bytes_freed` is never assigned anywhere — the report field is always 0 despite being exposed on both admin surfaces (see follow-up issue).

Closes #310. Refs #287.