### PR TITLE
chore: release remi-v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [remi-v0.11.1] - 2026-08-08
+
+### Fixed
+- bulk-delete R2 orphans in chunk GC (#311)
+
 ## [remi-v0.11.0] - 2026-08-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4858,7 +4858,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remi"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/apps/remi/Cargo.toml
+++ b/apps/remi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remi"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]


### PR DESCRIPTION
Release prep for remi-v0.11.1 (conventional-commit authority: patch, from fix #311).

Ships since remi-v0.11.0:
- #311 — chunk GC bulk-deletes R2 orphans via native S3 DeleteObjects (1,000 keys/request). The v0.11.0 GC run measured 345,913 R2 orphans being deleted one HTTP request at a time; this collapses the R2 phase from hours to minutes. Per-key failures surfaced with samples instead of dropped.

After merge: tag `remi-v0.11.1`, push to trigger release-build → deploy-and-verify. Post-deploy: rerun chunk GC via POST /v1/admin/chunk-gc (the in-flight slow GC dies with the service restart; its partial deletions are banked and the rerun is idempotent), then #287 closeout.

Refs #287, #310.