### PR TITLE
fix(ci): stage the static musl conary in lifecycle test images

### DIFF
--- a/.github/actions/build-static-conary/action.yml
+++ b/.github/actions/build-static-conary/action.yml
@@ -1,0 +1,23 @@
+name: build-static-conary
+description: >-
+  Build the static x86_64-unknown-linux-musl Conary artifact that distro test
+  images stage, so no image depends on the runner's glibc or libseccomp.
+runs:
+  using: composite
+  steps:
+    - name: Install musl build dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y musl-tools gperf linux-libc-dev
+    - name: Install the musl Rust target
+      shell: bash
+      run: rustup target add x86_64-unknown-linux-musl
+    - name: Restore the cached static libseccomp
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      with:
+        path: ~/.cache/conary-static-deps
+        key: ${{ runner.os }}-conary-static-deps-v1-${{ hashFiles('scripts/build-static-conary.sh') }}
+    - name: Build the static Conary artifact
+      shell: bash
+      run: bash scripts/build-static-conary.sh

--- a/.github/actions/build-static-conary/action.yml
+++ b/.github/actions/build-static-conary/action.yml
@@ -18,6 +18,9 @@ runs:
       with:
         path: ~/.cache/conary-static-deps
         key: ${{ runner.os }}-conary-static-deps-v1-${{ hashFiles('scripts/build-static-conary.sh') }}
+    - name: Test the kernel-header probe
+      shell: bash
+      run: bash scripts/test-build-static-conary.sh
     - name: Build the static Conary artifact
       shell: bash
       run: bash scripts/build-static-conary.sh

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -152,6 +152,7 @@ jobs:
       - uses: ./.github/actions/setup-rust-workspace
       - name: Require the hosted container runtime
         run: docker info
+      - uses: ./.github/actions/build-static-conary
       - name: Build the lifecycle harness
         run: cargo build -p conary -p conary-test
       - name: Build the ${{ matrix.distro }} test image

--- a/.github/workflows/release-artifact-proof.yml
+++ b/.github/workflows/release-artifact-proof.yml
@@ -151,6 +151,7 @@ jobs:
 
           echo "native_package=${package}" >> "$GITHUB_OUTPUT"
           echo "asset=${asset}" >> "$GITHUB_OUTPUT"
+      - uses: ./.github/actions/build-static-conary
       - name: Build the lifecycle harness
         run: cargo build -p conary -p conary-test
       - name: Install the published native package in the test image

--- a/apps/conary-test/src/config/distro.rs
+++ b/apps/conary-test/src/config/distro.rs
@@ -73,14 +73,22 @@ pub struct DistroConfig {
     pub test_packages: Vec<TestPackage>,
 }
 
-/// Files staged into a distro image build context.
+/// Which Conary binary a distro image build context stages.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum DistroBuildContext {
-    /// Stage the host Conary binary and integration fixtures only.
+    /// Stage the host-built Conary binary and integration fixtures.
+    ///
+    /// The staged binary keeps the host's glibc and `libseccomp.so.2`
+    /// couplings, so it only runs in an image whose userland matches the
+    /// build host.
     Binary,
-    /// Stage the binary, fixtures, and the complete workspace source tree.
-    WorkspaceSource,
+    /// Stage the static `x86_64-unknown-linux-musl` Conary artifact.
+    ///
+    /// Built by `scripts/build-static-conary.sh`, this artifact carries no
+    /// runtime library couplings and therefore runs in any image regardless
+    /// of the build host.
+    StaticBinary,
 }
 
 #[derive(Debug, Clone)]

--- a/apps/conary-test/src/config/tests.rs
+++ b/apps/conary-test/src/config/tests.rs
@@ -373,7 +373,7 @@ test_packages = [{ package = "tree", binary = "/usr/bin/tree" }]
 [distros."ubuntu-26.04"]
 remi_distro = "ubuntu-26.04"
 repo_name = "remi-ubuntu-26.04"
-build_context = "workspace-source"
+build_context = "static-binary"
 test_packages = [{ package = "tree", binary = "/usr/bin/tree" }]
 
 [fixtures]
@@ -403,7 +403,7 @@ ccs_file = "conary-test-fixture-1.0.0-1.ccs"
     );
     assert_eq!(
         config.distros["ubuntu-26.04"].build_context,
-        DistroBuildContext::WorkspaceSource
+        DistroBuildContext::StaticBinary
     );
 
     let fixtures = config.fixtures.as_ref().unwrap();
@@ -485,9 +485,28 @@ repo_name = "custom"
         .expect_err("build context must use the typed contract")
         .to_string();
     assert!(
-        invalid_error.contains("binary") && invalid_error.contains("workspace-source"),
+        invalid_error.contains("binary") && invalid_error.contains("static-binary"),
         "invalid capability should list typed values: {invalid_error}"
     );
+}
+
+/// The shipped integration config is what CI parses, so hold it to the typed
+/// contract directly rather than to a copy of it.
+#[test]
+fn shipped_integration_config_stages_the_static_binary_everywhere() {
+    let config_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../conary/tests/integration/remi/config.toml");
+    let contents = std::fs::read_to_string(&config_path).expect("read integration config");
+    let config: GlobalConfig = toml::from_str(&contents).expect("parse integration config");
+
+    assert!(!config.distros.is_empty(), "config must declare distros");
+    for (distro, distro_config) in &config.distros {
+        assert_eq!(
+            distro_config.build_context,
+            DistroBuildContext::StaticBinary,
+            "{distro} must stage the host-independent static artifact"
+        );
+    }
 }
 
 #[test]

--- a/apps/conary-test/src/container/image.rs
+++ b/apps/conary-test/src/container/image.rs
@@ -10,6 +10,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use super::backend::ContainerBackend;
 use crate::config::DistroBuildContext;
 
+#[derive(Debug)]
 struct StagedBuildContext {
     root: PathBuf,
     dockerfile: PathBuf,
@@ -244,6 +245,24 @@ fn stage_native_package(root: &Path, artifact: NativePackageArtifact<'_>) -> Res
     Ok(())
 }
 
+/// Pick the Conary binary an image receives.
+///
+/// The static choice fails closed rather than falling back to the host build:
+/// a host binary that happens to run in one image and dies at the dynamic
+/// linker in another is the exact failure this capability removes.
+fn resolve_stage_source(
+    build_context: DistroBuildContext,
+    host_binary: &Path,
+    target_dir: &Path,
+) -> Result<PathBuf> {
+    match build_context {
+        DistroBuildContext::Binary => Ok(host_binary.to_path_buf()),
+        DistroBuildContext::StaticBinary => {
+            crate::static_binary::static_conary_binary_in(target_dir)
+        }
+    }
+}
+
 fn stage_build_context(
     containerfile: &Path,
     distro: &str,
@@ -289,10 +308,18 @@ fn stage_build_context(
             .with_context(|| format!("failed to copy {}", arch_pkgbuild.display()))?;
     }
 
-    let binary = crate::paths::find_host_conary_binary(&project_root)?;
+    // Fixture packages are built by running Conary on this host, so that step
+    // always uses the host binary. What gets staged into the image is a
+    // separate, typed choice: the image's userland is not the host's.
+    let host_binary = crate::paths::find_host_conary_binary(&project_root)?;
+    let stage_source = resolve_stage_source(
+        build_context,
+        &host_binary,
+        &crate::static_binary::static_target_dir(&project_root),
+    )?;
     let staged_binary = root.join("conary");
-    fs::copy(&binary, &staged_binary)
-        .with_context(|| format!("failed to stage host conary binary {}", binary.display()))?;
+    fs::copy(&stage_source, &staged_binary)
+        .with_context(|| format!("failed to stage conary binary {}", stage_source.display()))?;
 
     // Strip debug symbols to shrink the tar context sent over the container
     // socket. A debug build can be 300MB+; stripped it drops to ~70MB, which
@@ -305,15 +332,7 @@ fn stage_build_context(
         stage_native_package(&root, artifact)?;
     }
 
-    ensure_phase2_fixture_outputs(&root.join("fixtures"), &binary)?;
-
-    if build_context == DistroBuildContext::WorkspaceSource {
-        copy_dir_filtered(
-            &project_root,
-            &root.join("source"),
-            &[".git", "target", ".jj", ".direnv"],
-        )?;
-    }
+    ensure_phase2_fixture_outputs(&root.join("fixtures"), &host_binary)?;
 
     Ok(StagedBuildContext {
         dockerfile: root.join("containers").join(dockerfile_name),
@@ -402,7 +421,8 @@ async fn build_distro_image_inner(
 #[cfg(test)]
 mod tests {
     use super::{
-        NativePackageArtifact, find_project_root, stage_build_context, stage_native_package,
+        NativePackageArtifact, find_project_root, resolve_stage_source, stage_build_context,
+        stage_native_package,
     };
     use crate::config::DistroBuildContext;
     use conary_core::repository::supported_profiles::ProfilePackageFormat;
@@ -651,82 +671,80 @@ printf 'fixture\n' > "$output/$file"
         fs::remove_dir_all(workspace_root).expect("cleanup workspace root");
     }
 
+    /// Which binary reaches the image is a typed decision, and the static
+    /// choice fails closed rather than quietly staging the host build.
     #[test]
-    fn workspace_source_staging_is_controlled_by_typed_capability() {
-        let unique = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system time before unix epoch")
-            .as_nanos();
-        let project_root =
-            std::env::temp_dir().join(format!("conary-test-source-context-{unique}"));
-        let remi_root = project_root.join("apps/conary/tests/integration/remi");
-        let containerfile = remi_root.join("containers/Containerfile.custom");
+    fn staged_binary_is_selected_by_typed_capability() {
+        let target_dir = tempfile::tempdir().expect("create temp target directory");
+        let host_binary = Path::new("/workspace/target/debug/conary");
 
-        fs::create_dir_all(remi_root.join("containers")).expect("create containers");
-        fs::create_dir_all(project_root.join("crates/example/src")).expect("create source");
-        fs::write(
-            project_root.join("Cargo.toml"),
-            "[workspace]\nmembers = []\n",
-        )
-        .expect("write workspace manifest");
-        fs::write(
-            project_root.join("crates/example/src/lib.rs"),
-            "pub fn example() {}\n",
-        )
-        .expect("write source file");
-        fs::write(project_root.join("conary"), "binary").expect("write binary");
-        fs::write(&containerfile, "FROM scratch\n").expect("write containerfile");
-        fs::write(remi_root.join("config.toml"), "[paths]\n").expect("write config");
-
-        let source_staged = stage_build_context(
-            &containerfile,
-            "not-an-ubuntu-name",
-            DistroBuildContext::WorkspaceSource,
-            None,
-        )
-        .expect("stage workspace source context");
-        assert!(
-            source_staged
-                .root
-                .join("source/crates/example/src/lib.rs")
-                .is_file()
+        assert_eq!(
+            resolve_stage_source(DistroBuildContext::Binary, host_binary, target_dir.path())
+                .expect("host staging needs no static artifact"),
+            host_binary,
+            "the binary capability must stage the host build"
         );
-        drop(source_staged);
 
-        let binary_staged = stage_build_context(
-            &containerfile,
-            "ubuntu-name-does-not-matter",
-            DistroBuildContext::Binary,
-            None,
+        let error = resolve_stage_source(
+            DistroBuildContext::StaticBinary,
+            host_binary,
+            target_dir.path(),
         )
-        .expect("stage binary context");
-        assert!(!binary_staged.root.join("source").exists());
-        drop(binary_staged);
+        .expect_err("a missing static artifact must not fall back to the host binary");
+        assert!(
+            error
+                .to_string()
+                .contains("static conary artifact not found"),
+            "unexpected message: {error}"
+        );
 
-        fs::remove_dir_all(project_root).expect("cleanup project root");
+        let artifact = crate::static_binary::static_conary_binary_path_in(target_dir.path());
+        fs::create_dir_all(artifact.parent().expect("artifact parent"))
+            .expect("create musl profile directory");
+        fs::write(
+            &artifact,
+            crate::static_binary::synthetic_elf(&[crate::static_binary::PT_LOAD]),
+        )
+        .expect("write static artifact");
+
+        assert_eq!(
+            resolve_stage_source(
+                DistroBuildContext::StaticBinary,
+                host_binary,
+                target_dir.path()
+            )
+            .expect("static staging must accept a static artifact"),
+            artifact,
+            "the static capability must stage the musl artifact"
+        );
     }
 
+    /// Every image now receives an already-built binary. Prove no Containerfile
+    /// still expects a staged workspace to compile from.
     #[test]
-    fn ubuntu_source_builder_proves_pinned_rust_and_native_crypto_tools() {
+    fn containerfiles_install_a_staged_binary_without_building_from_source() {
         let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-        let containerfile = manifest_dir
-            .join("../conary/tests/integration/remi/containers/Containerfile.ubuntu-26.04");
-        let contents = fs::read_to_string(&containerfile).expect("read ubuntu containerfile");
-
-        assert!(
-            contents.contains("cmake"),
-            "Ubuntu source-build image must install cmake for aws-lc-sys"
-        );
-        assert!(
-            contents.contains("--output \"$installer\"")
-                && contents.contains("--default-toolchain 1.96.0")
-                && contents.contains("/root/.cargo/bin/cargo --version"),
-            "Ubuntu source-build image must download, pin, and prove Rust explicitly"
-        );
-        assert!(
-            !contents.contains("https://sh.rustup.rs |"),
-            "Ubuntu source-build image must not hide rustup download failures in a pipeline"
-        );
+        let containers = manifest_dir.join("../conary/tests/integration/remi/containers");
+        for file in [
+            "Containerfile.fedora44",
+            "Containerfile.ubuntu-26.04",
+            "Containerfile.arch",
+        ] {
+            let contents =
+                fs::read_to_string(containers.join(file)).expect("read distro containerfile");
+            assert!(
+                contents.contains("install -m 755 /tmp/install/conary /usr/bin/conary"),
+                "{file} must install the staged binary"
+            );
+            assert!(
+                !contents.contains("source/"),
+                "{file} must not stage the workspace source tree"
+            );
+            assert!(
+                !contents.contains("cargo build"),
+                "{file} must not build Conary from source"
+            );
+        }
     }
 
     #[test]

--- a/apps/conary-test/src/lib.rs
+++ b/apps/conary-test/src/lib.rs
@@ -11,6 +11,7 @@ pub mod error_taxonomy;
 pub mod paths;
 pub mod report;
 pub mod server;
+pub(crate) mod static_binary;
 pub mod suite_inventory;
 
 #[cfg(test)]

--- a/apps/conary-test/src/static_binary.rs
+++ b/apps/conary-test/src/static_binary.rs
@@ -1,0 +1,315 @@
+// conary-test/src/static_binary.rs
+
+//! The statically linked `conary` artifact staged into foreign userlands.
+//!
+//! A distro test image is a frozen userland that rarely matches the build
+//! host. Staging the host-built `conary` couples the image to the host's
+//! glibc and to a matching `libseccomp.so.2`, which is why the Ubuntu image
+//! used to compile Conary from source inside the container instead. A static
+//! musl build removes both couplings, so one artifact runs in every image.
+//!
+//! `scripts/build-static-conary.sh` owns producing that artifact. This module
+//! owns finding it and refusing anything that is not actually static.
+
+use anyhow::{Context, Result, bail};
+use std::ffi::OsString;
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+/// Target triple `scripts/build-static-conary.sh` builds.
+pub(crate) const STATIC_TARGET_TRIPLE: &str = "x86_64-unknown-linux-musl";
+
+/// Cargo profile directory `scripts/build-static-conary.sh` builds into.
+pub(crate) const STATIC_PROFILE_DIR: &str = "debug";
+
+/// Builder for the static artifact, relative to the workspace root.
+pub(crate) const STATIC_BUILD_SCRIPT: &str = "scripts/build-static-conary.sh";
+
+const ELF_MAGIC: [u8; 4] = [0x7f, b'E', b'L', b'F'];
+const ELF_CLASS_64: u8 = 2;
+const ELF_DATA_LSB: u8 = 1;
+const ELF_HEADER_LEN: usize = 64;
+const E_PHOFF_OFFSET: usize = 0x20;
+const E_PHENTSIZE_OFFSET: usize = 0x36;
+const E_PHNUM_OFFSET: usize = 0x38;
+const PT_INTERP: u32 = 3;
+const PN_XNUM: u16 = 0xffff;
+
+/// Resolve the static `conary` artifact under `target_dir`.
+///
+/// Fails closed: a missing artifact names the builder rather than falling back
+/// to the host binary, because a silent fallback reintroduces exactly the
+/// glibc coupling this staging path exists to remove.
+pub(crate) fn static_conary_binary_in(target_dir: &Path) -> Result<PathBuf> {
+    let binary = static_conary_binary_path_in(target_dir);
+    if !binary.is_file() {
+        bail!(
+            "static conary artifact not found at {}\n\
+             Build it with: bash {}",
+            binary.display(),
+            STATIC_BUILD_SCRIPT
+        );
+    }
+    ensure_statically_linked(&binary)?;
+    Ok(binary)
+}
+
+/// Where `scripts/build-static-conary.sh` leaves the artifact.
+pub(crate) fn static_conary_binary_path_in(target_dir: &Path) -> PathBuf {
+    target_dir
+        .join(STATIC_TARGET_TRIPLE)
+        .join(STATIC_PROFILE_DIR)
+        .join("conary")
+}
+
+/// The Cargo target directory the build script writes into.
+///
+/// The script resolves it as `${CARGO_TARGET_DIR:-$repo_root/target}`; keep
+/// both in agreement, or staging looks in a directory nothing builds into.
+pub(crate) fn static_target_dir(project_root: &Path) -> PathBuf {
+    target_dir_from(project_root, std::env::var_os("CARGO_TARGET_DIR"))
+}
+
+fn target_dir_from(project_root: &Path, cargo_target_dir: Option<OsString>) -> PathBuf {
+    match cargo_target_dir {
+        Some(dir) if !dir.is_empty() => PathBuf::from(dir),
+        _ => project_root.join("target"),
+    }
+}
+
+/// Reject any ELF that asks a dynamic loader for its libraries.
+///
+/// A fully static binary carries no `PT_INTERP` segment, whether it is linked
+/// `ET_EXEC` or as a static PIE. Checking the program headers directly proves
+/// the property that matters inside a foreign userland, without shelling out
+/// to `file` or `ldd`.
+fn ensure_statically_linked(path: &Path) -> Result<()> {
+    let mut file =
+        File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+
+    let mut header = [0u8; ELF_HEADER_LEN];
+    file.read_exact(&mut header)
+        .with_context(|| format!("{} is too small to be a 64-bit ELF binary", path.display()))?;
+
+    if header[..4] != ELF_MAGIC {
+        bail!("{} is not an ELF binary", path.display());
+    }
+    if header[4] != ELF_CLASS_64 || header[5] != ELF_DATA_LSB {
+        bail!(
+            "{} is not a little-endian 64-bit ELF binary",
+            path.display()
+        );
+    }
+
+    let e_phoff = u64::from_le_bytes(
+        header[E_PHOFF_OFFSET..E_PHOFF_OFFSET + 8]
+            .try_into()
+            .expect("8 bytes"),
+    );
+    let e_phentsize = u16::from_le_bytes(
+        header[E_PHENTSIZE_OFFSET..E_PHENTSIZE_OFFSET + 2]
+            .try_into()
+            .expect("2 bytes"),
+    );
+    let e_phnum = u16::from_le_bytes(
+        header[E_PHNUM_OFFSET..E_PHNUM_OFFSET + 2]
+            .try_into()
+            .expect("2 bytes"),
+    );
+
+    if e_phnum == PN_XNUM {
+        bail!(
+            "{} stores its program header count in the section table (PN_XNUM); \
+             static linkage cannot be proven",
+            path.display()
+        );
+    }
+    if e_phnum == 0 || u64::from(e_phentsize) < 4 {
+        bail!(
+            "{} has no usable program headers; static linkage cannot be proven",
+            path.display()
+        );
+    }
+
+    for index in 0..u64::from(e_phnum) {
+        let offset = e_phoff + index * u64::from(e_phentsize);
+        file.seek(SeekFrom::Start(offset)).with_context(|| {
+            format!(
+                "failed to seek to program header {index} of {}",
+                path.display()
+            )
+        })?;
+        let mut p_type = [0u8; 4];
+        file.read_exact(&mut p_type).with_context(|| {
+            format!(
+                "failed to read program header {index} of {}",
+                path.display()
+            )
+        })?;
+        if u32::from_le_bytes(p_type) == PT_INTERP {
+            bail!(
+                "{} is dynamically linked (it requests a program interpreter)\n\
+                 A dynamically linked binary reintroduces the host glibc coupling that \
+                 static staging exists to remove; rebuild it with: bash {}",
+                path.display(),
+                STATIC_BUILD_SCRIPT
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Minimal ELF64 image carrying program headers of the given types.
+///
+/// Shared with the container staging tests so they can exercise the artifact
+/// contract without a real musl build.
+#[cfg(test)]
+pub(crate) fn synthetic_elf(program_header_types: &[u32]) -> Vec<u8> {
+    let entry_size: u16 = 56;
+    let mut image = vec![0u8; ELF_HEADER_LEN];
+    image[..4].copy_from_slice(&ELF_MAGIC);
+    image[4] = ELF_CLASS_64;
+    image[5] = ELF_DATA_LSB;
+    image[E_PHOFF_OFFSET..E_PHOFF_OFFSET + 8]
+        .copy_from_slice(&(ELF_HEADER_LEN as u64).to_le_bytes());
+    image[E_PHENTSIZE_OFFSET..E_PHENTSIZE_OFFSET + 2].copy_from_slice(&entry_size.to_le_bytes());
+    image[E_PHNUM_OFFSET..E_PHNUM_OFFSET + 2]
+        .copy_from_slice(&(program_header_types.len() as u16).to_le_bytes());
+
+    for p_type in program_header_types {
+        let mut entry = vec![0u8; entry_size as usize];
+        entry[..4].copy_from_slice(&p_type.to_le_bytes());
+        image.extend_from_slice(&entry);
+    }
+    image
+}
+
+/// `PT_LOAD`, the program header type a static binary does carry.
+#[cfg(test)]
+pub(crate) const PT_LOAD: u32 = 1;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn workspace_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .canonicalize()
+            .expect("canonicalize workspace root")
+    }
+
+    /// The script and this module both encode where the artifact lands. Prove
+    /// they agree instead of discovering a rename at image-build time.
+    #[test]
+    fn static_artifact_path_matches_the_build_script_convention() {
+        let script = workspace_root().join(STATIC_BUILD_SCRIPT);
+        let contents = fs::read_to_string(&script).expect("read static build script");
+
+        assert!(
+            contents.contains(&format!("TARGET=\"{STATIC_TARGET_TRIPLE}\"")),
+            "{} must build {STATIC_TARGET_TRIPLE}",
+            script.display()
+        );
+        assert!(
+            contents.contains("target_dir=\"${CARGO_TARGET_DIR:-$repo_root/target}\""),
+            "{} must resolve its target directory the way this module does",
+            script.display()
+        );
+        assert!(
+            contents.contains(&format!(
+                "binary=\"$target_dir/$TARGET/{STATIC_PROFILE_DIR}/conary\""
+            )),
+            "{} must leave the artifact in the {STATIC_PROFILE_DIR} profile directory",
+            script.display()
+        );
+    }
+
+    #[test]
+    fn static_artifact_path_follows_the_target_directory() {
+        let target_dir = Path::new("/workspace/conary/target");
+        assert_eq!(
+            static_conary_binary_path_in(target_dir),
+            target_dir
+                .join(STATIC_TARGET_TRIPLE)
+                .join(STATIC_PROFILE_DIR)
+                .join("conary")
+        );
+    }
+
+    #[test]
+    fn target_directory_honours_the_cargo_override() {
+        let project_root = Path::new("/workspace/conary");
+        assert_eq!(
+            target_dir_from(project_root, None),
+            project_root.join("target"),
+            "an unset override must use the workspace target directory"
+        );
+        assert_eq!(
+            target_dir_from(project_root, Some(OsString::from("/shared/target"))),
+            Path::new("/shared/target"),
+            "CARGO_TARGET_DIR must win, as it does for the build script"
+        );
+        assert_eq!(
+            target_dir_from(project_root, Some(OsString::new())),
+            project_root.join("target"),
+            "an empty override is not a target directory"
+        );
+    }
+
+    #[test]
+    fn missing_static_artifact_names_the_builder() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let error = static_conary_binary_in(directory.path())
+            .expect_err("a missing static artifact must fail closed");
+        let message = error.to_string();
+
+        assert!(
+            message.contains("static conary artifact not found"),
+            "unexpected message: {message}"
+        );
+        assert!(
+            message.contains(STATIC_BUILD_SCRIPT),
+            "the failure must name the builder: {message}"
+        );
+    }
+
+    #[test]
+    fn dynamically_linked_artifact_is_rejected() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let binary = directory.path().join("conary");
+        fs::write(&binary, synthetic_elf(&[PT_LOAD, PT_INTERP, 2])).expect("write dynamic elf");
+
+        let error =
+            ensure_statically_linked(&binary).expect_err("a PT_INTERP binary must be rejected");
+        assert!(
+            error.to_string().contains("dynamically linked"),
+            "unexpected message: {error}"
+        );
+    }
+
+    #[test]
+    fn statically_linked_artifact_is_accepted() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let binary = directory.path().join("conary");
+        fs::write(&binary, synthetic_elf(&[PT_LOAD, 6, 2])).expect("write static elf");
+
+        ensure_statically_linked(&binary).expect("a binary without PT_INTERP must be accepted");
+    }
+
+    #[test]
+    fn non_elf_artifact_is_rejected() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let binary = directory.path().join("conary");
+        fs::write(&binary, vec![b'#'; ELF_HEADER_LEN]).expect("write script");
+
+        let error = ensure_statically_linked(&binary).expect_err("a non-ELF file must be rejected");
+        assert!(
+            error.to_string().contains("is not an ELF binary"),
+            "unexpected message: {error}"
+        );
+    }
+}

--- a/apps/conary/tests/integration/remi/config.toml
+++ b/apps/conary/tests/integration/remi/config.toml
@@ -19,10 +19,14 @@ results_dir = "/results"
 fixture_dir = "/opt/remi-tests/fixtures"
 
 # Distro-specific settings. Key = DISTRO env var value.
+#
+# Every distro stages the one host-independent artifact from
+# scripts/build-static-conary.sh; Ubuntu's userland mismatch with the build host
+# was the forcing case that used to make it compile in-container (issue #313).
 [distros.fedora44]
 remi_distro = "fedora-44"
 repo_name = "remi-fedora-44"
-build_context = "binary"
+build_context = "static-binary"
 test_packages = [
     { package = "which", binary = "/usr/bin/which" },
     { package = "tree", binary = "/usr/bin/tree" },
@@ -32,7 +36,7 @@ test_packages = [
 [distros."ubuntu-26.04"]
 remi_distro = "ubuntu-26.04"
 repo_name = "remi-ubuntu-26.04"
-build_context = "workspace-source"
+build_context = "static-binary"
 test_packages = [
     { package = "patch", binary = "/usr/bin/patch" },
     { package = "nano", binary = "/usr/bin/nano" },
@@ -42,7 +46,7 @@ test_packages = [
 [distros.arch]
 remi_distro = "arch"
 repo_name = "remi-arch"
-build_context = "binary"
+build_context = "static-binary"
 test_packages = [
     { package = "which", binary = "/usr/bin/which" },
     { package = "tree", binary = "/usr/bin/tree" },

--- a/apps/conary/tests/integration/remi/containers/Containerfile.arch
+++ b/apps/conary/tests/integration/remi/containers/Containerfile.arch
@@ -2,8 +2,8 @@
 # Arch Linux container for Remi integration testing
 #
 # Modes:
-#   binary  - copies pre-built binary (Arch rolling glibc is compatible)
-#   package - installs from pkg.tar.zst via pacman
+#   binary  (default) - copies the pre-built static binary directly
+#   package           - installs from pkg.tar.zst via pacman
 
 FROM docker.io/library/archlinux:latest
 

--- a/apps/conary/tests/integration/remi/containers/Containerfile.fedora44
+++ b/apps/conary/tests/integration/remi/containers/Containerfile.fedora44
@@ -2,7 +2,7 @@
 # Minimal Fedora 44 container for Remi integration testing
 #
 # Modes:
-#   binary  (default) - copies pre-built binary directly
+#   binary  (default) - copies the pre-built static binary directly
 #   package           - installs from RPM via dnf
 
 FROM registry.fedoraproject.org/fedora:44

--- a/apps/conary/tests/integration/remi/containers/Containerfile.ubuntu-26.04
+++ b/apps/conary/tests/integration/remi/containers/Containerfile.ubuntu-26.04
@@ -2,44 +2,13 @@
 # Ubuntu 26.04 LTS container for Remi integration testing
 #
 # Modes:
-#   binary  - builds from source in-container (avoids OpenSSL ABI mismatch)
-#   package - installs from DEB via apt
+#   binary  (default) - copies the pre-built static binary directly
+#   package           - installs from DEB via apt
+#
+# The staged binary is the static musl artifact from
+# scripts/build-static-conary.sh, so this image no longer compiles Conary from
+# source to escape the host's glibc and OpenSSL ABI.
 
-# -- Builder stage: compile from source (binary mode only) -----------------
-# In package mode, source/ contains only a placeholder; the build is skipped.
-FROM docker.io/library/ubuntu:26.04 AS builder
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential cmake pkg-config libssl-dev libseccomp-dev curl ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install the pinned Rust toolchain without a pipeline that can hide a failed
-# download behind a successful empty shell invocation.
-RUN set -eu; \
-    installer=/tmp/rustup-init.sh; \
-    curl --proto '=https' --tlsv1.2 \
-        --fail --show-error --silent --location \
-        --retry 5 --retry-all-errors \
-        --output "$installer" \
-        https://sh.rustup.rs; \
-    sh "$installer" -y --default-toolchain 1.96.0 --profile minimal; \
-    rm -f "$installer"; \
-    /root/.cargo/bin/cargo --version; \
-    /root/.cargo/bin/rustc --version
-ENV PATH="/root/.cargo/bin:${PATH}"
-
-ARG INSTALL_MODE=binary
-
-# Copy source and build (only in binary mode; package mode has placeholder)
-COPY source/ /build/
-WORKDIR /build
-RUN if [ "$INSTALL_MODE" = "binary" ] && [ -f Cargo.toml ]; then \
-        cargo build --release -p conary 2>&1 && strip target/release/conary; \
-    else \
-        mkdir -p target/release && touch target/release/conary; \
-    fi
-
-# -- Runtime stage ----------------------------------------------------------
 FROM docker.io/library/ubuntu:26.04
 
 ARG INSTALL_MODE=binary
@@ -48,17 +17,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl diffutils libseccomp2 passwd python3 sqlite3 \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy all conary* files from build context (package mode)
+# Copy all conary* files from build context (binary or package)
 COPY conary* /tmp/install/
 
-# Copy built binary from builder stage (only meaningful in binary mode)
-COPY --from=builder /build/target/release/conary /tmp/install/conary-built
-
-# Install: exact staged DEB package or built binary from source
+# Install: exact staged DEB package or raw binary
 RUN if [ "$INSTALL_MODE" = "package" ] && [ -f /tmp/install/conary-release.deb ]; then \
         apt-get update && apt-get install -y /tmp/install/conary-release.deb && rm -rf /var/lib/apt/lists/*; \
-    elif [ "$INSTALL_MODE" = "binary" ] && [ -f /tmp/install/conary-built ] && [ -s /tmp/install/conary-built ]; then \
-        install -m 755 /tmp/install/conary-built /usr/bin/conary; \
     elif [ -f /tmp/install/conary ]; then \
         install -m 755 /tmp/install/conary /usr/bin/conary; \
     else \

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -171,13 +171,15 @@ FAT/ext4 mkfs tools, and composefs inspection tools as needed). Group P uses the
 same source fixture and provisions ISO helper packages through Conary when
 `xorriso`/`mtools` are absent before it assembles the generation.
 
-A step with `stage_conary = true` copies the host-built `conary` into the guest,
-which couples the guest to the build host's glibc and to a matching
-`libseccomp.so.2`. `scripts/build-static-conary.sh` removes that coupling: it
-builds a static libseccomp for musl once, caches it, and produces a
-statically linked `conary` for `x86_64-unknown-linux-musl` that runs on any
-guest. Point the harness at it with `CONARY_HOST_BIN`. The build is debug
-profile and the binary is a test-staging artifact, not a release artifact.
+A step with `stage_conary = true` copies a `conary` into the guest. A host-built
+binary would couple the guest to the build host's glibc and to a matching
+`libseccomp.so.2`, so the harness stages the artifact from
+`scripts/build-static-conary.sh` instead: it builds a static libseccomp for musl
+once, caches it, and produces a statically linked `conary` for
+`x86_64-unknown-linux-musl` that runs on any guest. `CONARY_HOST_BIN` overrides
+that default to stage a specific binary. The build is debug profile and the
+binary is a test-staging artifact, not a release artifact. Distro container
+images stage the same artifact through `build_context = "static-binary"`.
 
 `scripts/build-qemu-guest-image.sh` builds such an image from a pinned official
 Fedora Cloud Base qcow2 plus provisioning, and `bash
@@ -668,14 +670,26 @@ FORGE_HOST=peter@replacement.example ./scripts/deploy-forge.sh --group control_p
 
 | Distro | Container | Base | `build_context` |
 |--------|-----------|------|-----------------|
-| `fedora44` | `Containerfile.fedora44` | Fedora 44 | `binary` |
-| `ubuntu-26.04` | `Containerfile.ubuntu-26.04` | Ubuntu 26.04 LTS | `workspace-source` |
-| `arch` | `Containerfile.arch` | Arch Linux (rolling) | `binary` |
+| `fedora44` | `Containerfile.fedora44` | Fedora 44 | `static-binary` |
+| `ubuntu-26.04` | `Containerfile.ubuntu-26.04` | Ubuntu 26.04 LTS | `static-binary` |
+| `arch` | `Containerfile.arch` | Arch Linux (rolling) | `static-binary` |
 
-`build_context` is a required typed distro capability in `config.toml`.
-`binary` stages the built Conary binary and fixtures; `workspace-source` also
-stages the workspace for a container-native build. Distro names do not select
-this behavior.
+`build_context` is a required typed distro capability in `config.toml` that
+selects which Conary binary an image receives. Distro names do not select this
+behavior.
+
+- `static-binary` stages the static `x86_64-unknown-linux-musl` artifact from
+  `scripts/build-static-conary.sh`. It carries no glibc or `libseccomp.so.2`
+  coupling, so one artifact runs in every image. Build it before
+  `images build`; staging fails closed when it is missing or not actually
+  static.
+- `binary` stages the host-built Conary binary. It only runs in an image whose
+  userland matches the build host.
+
+Every distro uses `static-binary`. Ubuntu was the forcing case: its container
+userland does not match the build host, which is why that image used to compile
+Conary from source in a builder stage and made its CI leg roughly three times
+slower than the others.
 
 ## Test Structure
 
@@ -986,7 +1000,7 @@ Current JSON semantics:
 
 1. Create `apps/conary/tests/integration/remi/containers/Containerfile.<name>`
 2. Add `[distros.<name>]` to `config.toml` with an explicit typed
-   `build_context = "binary"` or `build_context = "workspace-source"`
+   `build_context = "static-binary"` or `build_context = "binary"`
 3. Add to CI workflow matrices
 
 ## Troubleshooting

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -1331,6 +1331,8 @@ matrix job in `.github/workflows/pr-gate.yml`.
 `apps/conary/tests/fixtures/*`;
 `apps/conary/tests/integration/remi/containers/*`;
 `apps/conary/tests/integration/remi/manifests/*`;
+`scripts/build-static-conary.sh`;
+`.github/actions/build-static-conary/action.yml`;
 `.github/workflows/pr-gate.yml`.
 
 **Focused proof:** `cargo run -p conary-test -- list`;
@@ -1343,7 +1345,8 @@ matrix job in `.github/workflows/pr-gate.yml`.
 `cargo run -p conary-test -- run --suite phase3-active-generation-handoff --distro fedora44 --phase 3`;
 run `cargo run -p conary-test -- run --suite native-cross-source-lifecycle --distro <distro> --phase 4`
 for each configured distro when native conversion/lifecycle behavior or image
-build-context staging changes.
+build-context staging changes. Image staging needs the static artifact first:
+`bash scripts/build-static-conary.sh`.
 
 **Docs to update:** `docs/INTEGRATION-TESTING.md`;
 `docs/modules/test-fixtures.md`; affected feature cards.
@@ -1352,8 +1355,10 @@ build-context staging changes.
 need parser proof and migration or defaulting decisions. Suite names in
 `--suite` arguments use the manifest filename stem, such as
 `phase4-native-pm-parity`, not the human-readable title shown by
-`cargo run -p conary-test -- list`. Distro image source staging is selected by
-the typed `build_context` field, never by matching the distro key. Corpus cases
+`cargo run -p conary-test -- list`. Which Conary binary a distro image stages is
+selected by the typed `build_context` field, never by matching the distro key,
+and the static choice fails closed rather than falling back to the host build.
+Corpus cases
 must carry versioned runtime evidence with exact role-tagged artifact digests,
 typed digest authority, target capabilities, and canonically ordered stage
 checkpoints; report aggregation uses typed stage/failure discriminants and

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -1332,6 +1332,7 @@ matrix job in `.github/workflows/pr-gate.yml`.
 `apps/conary/tests/integration/remi/containers/*`;
 `apps/conary/tests/integration/remi/manifests/*`;
 `scripts/build-static-conary.sh`;
+`scripts/kernel-header-roots.sh`;
 `.github/actions/build-static-conary/action.yml`;
 `.github/workflows/pr-gate.yml`.
 
@@ -1341,12 +1342,12 @@ matrix job in `.github/workflows/pr-gate.yml`.
 `cargo test -p conary-test focused_native_cross_source_manifest_runs_the_shared_lifecycle_contract`;
 `cargo test -p conary-test native_cross_source_`.
 
-**Interaction gate:** `cargo run -p conary-test -- run --suite phase4-native-pm-parity --distro fedora44 --phase 4`;
+**Interaction gate:** `bash scripts/build-static-conary.sh`;
+`cargo run -p conary-test -- run --suite phase4-native-pm-parity --distro fedora44 --phase 4`;
 `cargo run -p conary-test -- run --suite phase3-active-generation-handoff --distro fedora44 --phase 3`;
 run `cargo run -p conary-test -- run --suite native-cross-source-lifecycle --distro <distro> --phase 4`
 for each configured distro when native conversion/lifecycle behavior or image
-build-context staging changes. Image staging needs the static artifact first:
-`bash scripts/build-static-conary.sh`.
+build-context staging changes.
 
 **Docs to update:** `docs/INTEGRATION-TESTING.md`;
 `docs/modules/test-fixtures.md`; affected feature cards.
@@ -1356,9 +1357,10 @@ need parser proof and migration or defaulting decisions. Suite names in
 `--suite` arguments use the manifest filename stem, such as
 `phase4-native-pm-parity`, not the human-readable title shown by
 `cargo run -p conary-test -- list`. Which Conary binary a distro image stages is
-selected by the typed `build_context` field, never by matching the distro key,
-and the static choice fails closed rather than falling back to the host build.
-Corpus cases
+selected by the typed `build_context` field, never by matching the distro key.
+The static choice fails closed rather than falling back to the host build, so an
+image build requires `scripts/build-static-conary.sh` to have produced its
+artifact first. Corpus cases
 must carry versioned runtime evidence with exact role-tagged artifact digests,
 typed digest authority, target capabilities, and canonically ordered stage
 checkpoints; report aggregation uses typed stage/failure discriminants and

--- a/scripts/build-static-conary.sh
+++ b/scripts/build-static-conary.sh
@@ -35,8 +35,9 @@ Options:
   --help             Show this help text
 
 Host requirements: a Rust toolchain with the x86_64-unknown-linux-musl target
-(`rustup target add x86_64-unknown-linux-musl`), `musl-gcc`, Linux kernel
-headers under /usr/include, plus curl, tar, make, and gperf.
+(`rustup target add x86_64-unknown-linux-musl`), `musl-gcc`, the Linux kernel
+UAPI headers (linux-libc-dev, kernel-headers, or linux-api-headers), plus
+curl, tar, make, and gperf.
 
 Debug profile only. Conary is pre-alpha and this binary is a test-staging
 artifact, not a release artifact.
@@ -97,8 +98,23 @@ fi
 # headers (linux/audit.h, asm/unistd.h), which are not part of musl. -idirafter
 # adds them at the end of the search path so they are found without shadowing
 # any musl header of the same name.
-[[ -d /usr/include/linux && -d /usr/include/asm ]] ||
-    fail "Linux kernel headers not found under /usr/include; libseccomp cannot be built for musl without them"
+#
+# Distributions disagree on where those headers live: Arch and Fedora keep them
+# in /usr/include, while Debian and Ubuntu ship linux-libc-dev under the
+# multiarch directory. Probe for the headers themselves rather than assuming a
+# layout, so this works on a developer workstation and on a CI runner alike.
+KERNEL_HEADER_DIR=""
+KERNEL_HEADER_CANDIDATES=("/usr/include" "/usr/include/$(uname -m)-linux-gnu")
+for candidate in "${KERNEL_HEADER_CANDIDATES[@]}"; do
+    if [[ -f "$candidate/linux/audit.h" && -f "$candidate/asm/unistd.h" ]]; then
+        KERNEL_HEADER_DIR="$candidate"
+        break
+    fi
+done
+[[ -n "$KERNEL_HEADER_DIR" ]] || fail "Linux kernel UAPI headers (linux/audit.h and asm/unistd.h) were not found in ${KERNEL_HEADER_CANDIDATES[*]}
+libseccomp cannot be built for musl without them; install your distribution's
+kernel header package (linux-libc-dev on Debian/Ubuntu, kernel-headers on
+Fedora, linux-api-headers on Arch)."
 
 PREFIX="$CACHE_DIR/libseccomp-$LIBSECCOMP_VERSION-musl"
 if [[ "$REBUILD_DEPS" == "yes" ]]; then
@@ -128,7 +144,7 @@ The cached download has been removed; re-run to fetch it again."
     tar xzf "$tarball" -C "$BUILD_DIR"
     (
         cd "$BUILD_DIR/libseccomp-$LIBSECCOMP_VERSION"
-        CC=musl-gcc CFLAGS="-O2 -idirafter /usr/include" \
+        CC=musl-gcc CFLAGS="-O2 -idirafter $KERNEL_HEADER_DIR" \
             ./configure --prefix="$PREFIX" --enable-static --disable-shared
         make -j"$(nproc)"
         make install
@@ -148,7 +164,7 @@ log "building conary for $TARGET"
     LIBSECCOMP_LIB_PATH="$PREFIX/lib" \
     LIBSECCOMP_LINK_TYPE=static \
     CC_x86_64_unknown_linux_musl=musl-gcc \
-    CFLAGS_x86_64_unknown_linux_musl="-idirafter /usr/include" \
+    CFLAGS_x86_64_unknown_linux_musl="-idirafter $KERNEL_HEADER_DIR" \
         cargo build -p conary --target "$TARGET"
 )
 

--- a/scripts/build-static-conary.sh
+++ b/scripts/build-static-conary.sh
@@ -14,6 +14,9 @@ set -euo pipefail
 # libseccomp for musl once and caches it, then points the crate at it through
 # the two environment variables its build script reads.
 
+# shellcheck source=scripts/kernel-header-roots.sh
+source "$(dirname "${BASH_SOURCE[0]}")/kernel-header-roots.sh"
+
 LIBSECCOMP_VERSION="2.6.0"
 LIBSECCOMP_SHA256="83b6085232d1588c379dc9b9cae47bb37407cf262e6e74993c61ba72d2a784dc"
 LIBSECCOMP_URL="https://github.com/seccomp/libseccomp/releases/download/v${LIBSECCOMP_VERSION}/libseccomp-${LIBSECCOMP_VERSION}.tar.gz"
@@ -94,27 +97,17 @@ if ! rustup target list --installed 2>/dev/null | grep -qx "$TARGET"; then
     fail "target $TARGET is not installed; run: rustup target add $TARGET"
 fi
 
-# musl-gcc compiles with musl's headers only. libseccomp needs the Linux UAPI
-# headers (linux/audit.h, asm/unistd.h), which are not part of musl. -idirafter
-# adds them at the end of the search path so they are found without shadowing
-# any musl header of the same name.
-#
-# Distributions disagree on where those headers live: Arch and Fedora keep them
-# in /usr/include, while Debian and Ubuntu ship linux-libc-dev under the
-# multiarch directory. Probe for the headers themselves rather than assuming a
-# layout, so this works on a developer workstation and on a CI runner alike.
-KERNEL_HEADER_DIR=""
-KERNEL_HEADER_CANDIDATES=("/usr/include" "/usr/include/$(uname -m)-linux-gnu")
-for candidate in "${KERNEL_HEADER_CANDIDATES[@]}"; do
-    if [[ -f "$candidate/linux/audit.h" && -f "$candidate/asm/unistd.h" ]]; then
-        KERNEL_HEADER_DIR="$candidate"
-        break
-    fi
-done
-[[ -n "$KERNEL_HEADER_DIR" ]] || fail "Linux kernel UAPI headers (linux/audit.h and asm/unistd.h) were not found in ${KERNEL_HEADER_CANDIDATES[*]}
-libseccomp cannot be built for musl without them; install your distribution's
-kernel header package (linux-libc-dev on Debian/Ubuntu, kernel-headers on
-Fedora, linux-api-headers on Arch)."
+# musl-gcc compiles with musl's headers only, and libseccomp needs the Linux
+# UAPI headers, which are not part of musl. Where those headers live, and
+# whether they even live together, is distribution-specific; the probe owns
+# that knowledge and returns every directory that has to be searched.
+mapfile -t KERNEL_HEADER_CANDIDATES < <(kernel_header_candidates)
+if ! kernel_header_root_lines="$(kernel_header_roots "${KERNEL_HEADER_CANDIDATES[@]}")"; then
+    exit 1
+fi
+mapfile -t KERNEL_HEADER_ROOTS <<< "$kernel_header_root_lines"
+KERNEL_HEADER_FLAGS="$(kernel_header_include_flags "${KERNEL_HEADER_ROOTS[@]}")"
+log "kernel UAPI headers: ${KERNEL_HEADER_ROOTS[*]}"
 
 PREFIX="$CACHE_DIR/libseccomp-$LIBSECCOMP_VERSION-musl"
 if [[ "$REBUILD_DEPS" == "yes" ]]; then
@@ -144,7 +137,7 @@ The cached download has been removed; re-run to fetch it again."
     tar xzf "$tarball" -C "$BUILD_DIR"
     (
         cd "$BUILD_DIR/libseccomp-$LIBSECCOMP_VERSION"
-        CC=musl-gcc CFLAGS="-O2 -idirafter $KERNEL_HEADER_DIR" \
+        CC=musl-gcc CFLAGS="-O2 $KERNEL_HEADER_FLAGS" \
             ./configure --prefix="$PREFIX" --enable-static --disable-shared
         make -j"$(nproc)"
         make install
@@ -164,7 +157,7 @@ log "building conary for $TARGET"
     LIBSECCOMP_LIB_PATH="$PREFIX/lib" \
     LIBSECCOMP_LINK_TYPE=static \
     CC_x86_64_unknown_linux_musl=musl-gcc \
-    CFLAGS_x86_64_unknown_linux_musl="-idirafter $KERNEL_HEADER_DIR" \
+    CFLAGS_x86_64_unknown_linux_musl="$KERNEL_HEADER_FLAGS" \
         cargo build -p conary --target "$TARGET"
 )
 

--- a/scripts/kernel-header-roots.sh
+++ b/scripts/kernel-header-roots.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# scripts/kernel-header-roots.sh
+#
+# Locate the Linux UAPI headers that libseccomp needs when it is compiled
+# against musl, which supplies no kernel headers of its own.
+#
+# This file is meant to be sourced. Running it directly prints the roots
+# resolved for this host, which is the fastest way to diagnose a static build
+# that failed its header preflight.
+#
+# Distributions disagree about where these headers live, and they do not even
+# keep them in one place. Arch and Fedora put both under /usr/include. Debian
+# and Ubuntu ship linux/ under /usr/include but the architecture-specific asm/
+# only under the multiarch directory, so no single root holds both. Each
+# header is therefore located on its own and every distinct directory that
+# supplied one is returned, in candidate order.
+
+KERNEL_HEADERS_REQUIRED=("linux/audit.h" "asm/unistd.h")
+
+# The directories searched, most exact first.
+kernel_header_candidates() {
+    printf '%s\n' "/usr/include" "/usr/include/$(uname -m)-linux-gnu"
+}
+
+# Usage: kernel_header_roots CANDIDATE_DIR...
+#
+# Prints one include root per line, deduplicated and in candidate order.
+# Returns 1 and explains which header was missing from where when any required
+# header cannot be found at all.
+kernel_header_roots() {
+    local candidates=("$@")
+    local header candidate entry found
+    local -a resolved=()
+    local -a missing=()
+    local -a roots=()
+
+    if [[ ${#candidates[@]} -eq 0 ]]; then
+        echo "error: kernel_header_roots needs at least one candidate directory" >&2
+        return 1
+    fi
+
+    for header in "${KERNEL_HEADERS_REQUIRED[@]}"; do
+        found=""
+        for candidate in "${candidates[@]}"; do
+            if [[ -f "$candidate/$header" ]]; then
+                found="$candidate"
+                break
+            fi
+        done
+        if [[ -n "$found" ]]; then
+            resolved+=("$header=$found")
+        else
+            missing+=("$header")
+        fi
+    done
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        {
+            echo "error: required Linux UAPI headers are missing"
+            for header in "${missing[@]}"; do
+                printf '  %s not found under any of: %s\n' "$header" "${candidates[*]}"
+            done
+            for entry in ${resolved[@]+"${resolved[@]}"}; do
+                printf '  %s found under %s\n' "${entry%%=*}" "${entry#*=}"
+            done
+            echo "libseccomp cannot be built for musl without them; install your"
+            echo "distribution's kernel header package (linux-libc-dev on Debian/Ubuntu,"
+            echo "kernel-headers on Fedora, linux-api-headers on Arch)."
+        } >&2
+        return 1
+    fi
+
+    # Emit in candidate order, so the most exact directory comes first, and
+    # only once even when it supplied several headers.
+    for candidate in "${candidates[@]}"; do
+        for entry in "${resolved[@]}"; do
+            if [[ "${entry#*=}" == "$candidate" ]]; then
+                roots+=("$candidate")
+                break
+            fi
+        done
+    done
+
+    printf '%s\n' "${roots[@]}"
+}
+
+# Usage: kernel_header_include_flags ROOT...
+#
+# Renders one -idirafter per root. -idirafter appends to the end of the search
+# path, so these directories are consulted only after musl's own headers and
+# cannot shadow them.
+kernel_header_include_flags() {
+    local root flags=""
+    for root in "$@"; do
+        flags="${flags:+$flags }-idirafter $root"
+    done
+    printf '%s\n' "$flags"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    set -euo pipefail
+    mapfile -t _candidates < <(kernel_header_candidates)
+    mapfile -t _roots < <(kernel_header_roots "${_candidates[@]}")
+    printf 'roots: %s\n' "${_roots[*]}"
+    printf 'flags: %s\n' "$(kernel_header_include_flags "${_roots[@]}")"
+fi

--- a/scripts/test-build-static-conary.sh
+++ b/scripts/test-build-static-conary.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# scripts/test-build-static-conary.sh
+set -euo pipefail
+
+# Fast, hermetic checks for the kernel-header probe that
+# scripts/build-static-conary.sh depends on. The probe decides which include
+# roots reach the musl compiler, and getting it wrong fails the static build
+# before a single object is compiled -- which is exactly what happened on
+# Ubuntu runners, where linux/ and asm/ do not share a root.
+#
+# These tests never compile anything. The slow proof is a real static build.
+
+repo_root="$(git rev-parse --show-toplevel)"
+build_script="$repo_root/scripts/build-static-conary.sh"
+probe="$repo_root/scripts/kernel-header-roots.sh"
+
+fail() {
+    printf 'FAIL: %s\n' "$1" >&2
+    exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+bash -n "$build_script" || fail "build-static-conary.sh has a syntax error"
+bash -n "$probe" || fail "kernel-header-roots.sh has a syntax error"
+
+# shellcheck source=scripts/kernel-header-roots.sh
+source "$probe"
+
+# Build a fake header tree. Each argument is "<root>:<header>".
+make_tree() {
+    local name="$1"
+    shift
+    local spec root header
+    for spec in "$@"; do
+        root="$tmp/$name/${spec%%:*}"
+        header="${spec#*:}"
+        mkdir -p "$root/$(dirname "$header")"
+        : > "$root/$header"
+    done
+}
+
+candidates_for() {
+    printf '%s\n' "$tmp/$1/usr/include" "$tmp/$1/usr/include/x86_64-linux-gnu"
+}
+
+roots_for() {
+    local name="$1"
+    local -a candidates
+    mapfile -t candidates < <(candidates_for "$name")
+    kernel_header_roots "${candidates[@]}"
+}
+
+# Render the flags for a newline-separated list of roots.
+flags_for() {
+    local -a roots
+    mapfile -t roots <<< "$1"
+    kernel_header_include_flags "${roots[@]}"
+}
+
+# --- Arch and Fedora: both headers under one root -> one flag, as before ---
+make_tree together \
+    "usr/include:linux/audit.h" \
+    "usr/include:asm/unistd.h"
+actual="$(roots_for together)"
+expected="$tmp/together/usr/include"
+[[ "$actual" == "$expected" ]] ||
+    fail "a single shared root should resolve to itself, got: $actual"
+flags="$(flags_for "$actual")"
+[[ "$flags" == "-idirafter $expected" ]] ||
+    fail "a single root should render one -idirafter, got: $flags"
+
+# --- Debian and Ubuntu: linux/ exact, asm/ multiarch only -> two roots ---
+make_tree split \
+    "usr/include:linux/audit.h" \
+    "usr/include/x86_64-linux-gnu:asm/unistd.h"
+actual="$(roots_for split)"
+expected="$(printf '%s\n%s' "$tmp/split/usr/include" "$tmp/split/usr/include/x86_64-linux-gnu")"
+[[ "$actual" == "$expected" ]] ||
+    fail "split headers should resolve to both roots, exact first, got: $actual"
+flags="$(flags_for "$actual")"
+[[ "$flags" == "-idirafter $tmp/split/usr/include -idirafter $tmp/split/usr/include/x86_64-linux-gnu" ]] ||
+    fail "split headers should render one -idirafter per root, got: $flags"
+
+# --- Reversed split: candidate order still wins over discovery order ---
+make_tree reversed \
+    "usr/include:asm/unistd.h" \
+    "usr/include/x86_64-linux-gnu:linux/audit.h"
+actual="$(roots_for reversed)"
+expected="$(printf '%s\n%s' "$tmp/reversed/usr/include" "$tmp/reversed/usr/include/x86_64-linux-gnu")"
+[[ "$actual" == "$expected" ]] ||
+    fail "roots must be emitted in candidate order, got: $actual"
+
+# --- Everything multiarch: one root, and not the empty exact directory ---
+make_tree multiarch \
+    "usr/include/x86_64-linux-gnu:linux/audit.h" \
+    "usr/include/x86_64-linux-gnu:asm/unistd.h"
+actual="$(roots_for multiarch)"
+expected="$tmp/multiarch/usr/include/x86_64-linux-gnu"
+[[ "$actual" == "$expected" ]] ||
+    fail "multiarch-only headers should resolve to the multiarch root, got: $actual"
+
+# --- A missing header fails closed and says which one, and from where ---
+make_tree partial "usr/include:linux/audit.h"
+if roots_for partial > "$tmp/out" 2> "$tmp/err"; then
+    fail "a missing header must not resolve"
+fi
+grep -q 'asm/unistd.h not found under any of:' "$tmp/err" ||
+    fail "the failure must name the missing header: $(cat "$tmp/err")"
+grep -q 'linux/audit.h found under' "$tmp/err" ||
+    fail "the failure should report what it did find: $(cat "$tmp/err")"
+grep -q 'linux-libc-dev' "$tmp/err" ||
+    fail "the failure should name the package that supplies the headers"
+
+make_tree empty "usr/include:unrelated.h"
+if roots_for empty > "$tmp/out" 2> "$tmp/err"; then
+    fail "an empty header tree must not resolve"
+fi
+for header in 'linux/audit.h' 'asm/unistd.h'; do
+    grep -q "$header not found under any of:" "$tmp/err" ||
+        fail "the failure must name every missing header, missing $header"
+done
+
+if kernel_header_roots > "$tmp/out" 2> "$tmp/err"; then
+    fail "no candidate directories must not resolve"
+fi
+
+# --- The build script consumes the probe rather than its own copy ---
+grep -q 'source "$(dirname "${BASH_SOURCE\[0\]}")/kernel-header-roots.sh"' "$build_script" ||
+    fail "build-static-conary.sh must source the shared probe"
+for needle in \
+    'CFLAGS="-O2 $KERNEL_HEADER_FLAGS"' \
+    'CFLAGS_x86_64_unknown_linux_musl="$KERNEL_HEADER_FLAGS"'; do
+    grep -qF "$needle" "$build_script" ||
+        fail "build-static-conary.sh must pass the resolved flags: $needle"
+done
+if grep -q 'KERNEL_HEADER_DIR' "$build_script"; then
+    fail "build-static-conary.sh still uses the single-root variable"
+fi
+
+# --- Running the probe directly reports this host, for diagnosis ---
+bash "$probe" > "$tmp/host.out" 2> "$tmp/host.err" ||
+    fail "the probe should resolve on this host: $(cat "$tmp/host.err")"
+grep -q '^roots: /' "$tmp/host.out" || fail "direct execution should print roots"
+grep -q '^flags: -idirafter /' "$tmp/host.out" || fail "direct execution should print flags"
+
+echo "build-static-conary tests passed."


### PR DESCRIPTION
## Problem

The ubuntu-26.04 `native-cross-source-lifecycle` leg was the matrix's only `workspace-source` build context — a cold in-container cargo build every run: ~21-22 min vs ~7 min for fedora44/arch, setting the gate cadence for every PR (#313 has the timing evidence and the ~13 pipeline-hours/week cost).

## Fix

Adopt the QEMU lane's host-independence artifact for containers: `scripts/build-static-conary.sh`'s fully static musl conary.

- **`DistroBuildContext::StaticBinary`** (`"static-binary"`): stages `<target-dir>/x86_64-unknown-linux-musl/debug/conary`. Fails closed — missing artifact errors with the builder command; a present artifact is validated in-process by parsing ELF64 program headers and rejecting any `PT_INTERP` segment (the actual static-linkage property, not a `file`/`ldd` proxy). No host-binary fallback, no env override.
- **All three distros** flip to `static-binary`: one host-independent artifact, three legs. **`WorkspaceSource` is deleted** (staging source-copy + ubuntu Containerfile builder stage included) — its last user left, so the second authority dies per the pre-alpha hard-cut rule. `Binary` (host) remains for local iteration and test fixtures.
- **CI:** pinned composite action `.github/actions/build-static-conary` (musl-tools, gperf, linux-libc-dev, rustup target, libseccomp cache keyed on the script hash, run script) added to pr-gate and release-artifact-proof (the latter's `images build --native-package` uses the same staging path).
- **Script fix found en route:** the preflight required headers at `/usr/include/{linux,asm}` only; ubuntu-latest ships them under the multiarch dir, so it would have failed before compiling. Now probes both and names per-distro packages on failure. Verified by a full `--rebuild-deps` run.
- Contract tests: script↔Rust convention agreement (target triple, target-dir expression, output path) and the real shipped config.toml parsed in test. Docs updated; doc-truth, action-pin, and release-matrix gates pass.

## Verification (run, real output)

- `bash scripts/build-static-conary.sh` twice (second with `--rebuild-deps`): `static-pie linked ... statically linked`, `conary 0.14.0` runs.
- `cargo test -p conary-test`: 385 + 18 passed, 0 failed (11 new/changed tests incl. the two contract tests). Workspace clippy `-D warnings` clean, fmt clean. Independent reviewer re-run matched.
- **Not runnable locally:** the container image build (no docker/podman on the dev host) — this PR's own lifecycle matrix is the integration proof, and its ubuntu leg duration is the acceptance test grading itself.

## Watch on first CI run

Every leg now cross-compiles the dependency tree for musl in addition to the host build — fedora/arch legs get individually slower while ubuntu drops ~14 min; the gate waits on the slowest leg so net wall-clock should still fall substantially. If the musl build cost annoys, caching `target/x86_64-unknown-linux-musl` is the follow-up.

Closes #313.