### PR TITLE
fix(remi): close the GC/conversion race and report R2 bytes honestly

### DIFF
--- a/apps/remi/src/server/chunk_gc.rs
+++ b/apps/remi/src/server/chunk_gc.rs
@@ -8,7 +8,7 @@
 //! configurable grace period to avoid removing chunks that are still
 //! being written by in-flight conversions.
 
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -30,9 +30,17 @@ pub struct GcResult {
     pub local_deleted: usize,
     /// Number of chunks deleted from R2
     pub r2_deleted: usize,
-    /// Bytes freed on local disk
+    /// Bytes freed on local disk, measured by stat before each unlink.
+    ///
+    /// A dry run cannot measure this without stat-ing every candidate, so it
+    /// reports 0 here and only counts chunks.
     pub local_bytes_freed: u64,
-    /// Bytes freed in R2 (estimated from chunk_access size_bytes)
+    /// Bytes freed in R2, estimated from `chunk_access.size_bytes`.
+    ///
+    /// R2 object sizes are not in the listing this GC uses, so the recorded
+    /// chunk size is the estimate on both paths. It costs one `chunk_access`
+    /// scan either way, so a dry run reports the same estimate for the chunks
+    /// it would have deleted.
     pub r2_bytes_freed: u64,
 }
 
@@ -215,6 +223,72 @@ fn filter_recently_accessed(
     Ok(collected)
 }
 
+/// Hashes whose bytes count as freed from R2: everything submitted to the bulk
+/// delete except the keys R2 refused.
+///
+/// Deletion is idempotent, so a key R2 did not report as an error is gone
+/// whether or not the object existed -- the same rule `R2BatchDeleteOutcome`
+/// counts by.
+fn r2_freed_hashes(submitted: &[String], failed: &BTreeSet<String>) -> HashSet<String> {
+    submitted
+        .iter()
+        .filter(|hash| !failed.contains(*hash))
+        .cloned()
+        .collect()
+}
+
+/// Sum the recorded `chunk_access.size_bytes` of `hashes`.
+///
+/// The table is streamed once and filtered in memory rather than bound one host
+/// variable per hash: a production orphan set is an order of magnitude past
+/// SQLite's ~32,766 parameter limit, the same wall the grace query hit. Cost is
+/// one scan of `chunk_access` however many hashes are being priced, and the
+/// running total is a single integer.
+///
+/// A hash with no `chunk_access` row contributes nothing; its size was never
+/// recorded, so the result is an underestimate rather than a guess.
+fn sum_chunk_access_bytes(conn: &Connection, hashes: &HashSet<String>) -> Result<u64> {
+    if hashes.is_empty() {
+        return Ok(0);
+    }
+
+    let mut stmt = conn
+        .prepare("SELECT hash, size_bytes FROM chunk_access")
+        .context("prepare chunk_access size query")?;
+    let mut rows = stmt.query([]).context("query chunk_access sizes")?;
+
+    let mut total = 0u64;
+    while let Some(row) = rows.next().context("read chunk_access size row")? {
+        let hash: String = row.get(0).context("read chunk_access size row hash")?;
+        if !hashes.contains(&hash) {
+            continue;
+        }
+        let size: i64 = row.get(1).context("read chunk_access size row size")?;
+        total += u64::try_from(size).unwrap_or(0);
+    }
+
+    Ok(total)
+}
+
+/// Estimate the R2 bytes represented by `hashes` from the `chunk_access` table.
+///
+/// Callers must run this before `chunk_access` rows are deleted: the sizes only
+/// exist while the rows do.
+async fn estimate_r2_bytes_freed(db_path: &Path, hashes: HashSet<String>) -> Result<u64> {
+    if hashes.is_empty() {
+        return Ok(0);
+    }
+
+    let db_path = db_path.to_path_buf();
+    tokio::task::spawn_blocking(move || -> Result<u64> {
+        let conn = crate::server::open_runtime_db(&db_path)?;
+        sum_chunk_access_bytes(&conn, &hashes)
+    })
+    .await
+    .context("spawn_blocking for R2 freed-bytes estimate")?
+    .context("R2 freed-bytes estimate")
+}
+
 /// Delete `chunk_access` rows for `hashes` in batched explicit transactions.
 ///
 /// Returns the number of rows actually removed. A per-row failure warns and
@@ -256,7 +330,9 @@ fn delete_chunk_access_rows(conn: &mut Connection, hashes: &[String]) -> Result<
 /// 3. Identifies orphans (stored but not referenced).
 /// 4. Applies a grace period: chunks with `last_accessed` newer than `now - grace_period_secs`
 ///    are kept even if unreferenced, to avoid removing chunks for in-flight conversions.
-/// 5. Deletes orphans from local disk, R2, and the `chunk_access` table.
+/// 5. Deletes orphans from local disk, R2, and the `chunk_access` table, in
+///    that order: the R2 freed-bytes estimate reads `chunk_access.size_bytes`,
+///    which only exists until the row cleanup runs.
 /// 6. In `dry_run` mode, logs what would be deleted without making changes.
 pub async fn run_chunk_gc(
     db_path: &Path,
@@ -331,16 +407,30 @@ pub async fn run_chunk_gc(
         .context("spawn_blocking for grace period check")?
         .context("grace period check")?;
 
+    // The keys the bulk delete below submits. Built once so a dry run reports
+    // exactly the set a real run would remove, rather than a second expression
+    // that has to be kept in step with it.
+    let r2_orphans: Vec<String> = if r2_store.is_some() {
+        orphans_after_grace
+            .iter()
+            .filter(|h| r2_set.contains(h.as_str()))
+            .cloned()
+            .collect()
+    } else {
+        Vec::new()
+    };
+
     if dry_run {
         // Populate counts for reporting even in dry-run
         result.local_deleted = orphans_after_grace
             .iter()
             .filter(|h| local_set.contains(h.as_str()))
             .count();
-        result.r2_deleted = orphans_after_grace
-            .iter()
-            .filter(|h| r2_set.contains(h.as_str()))
-            .count();
+        result.r2_deleted = r2_orphans.len();
+        // Nothing has been refused yet, so a dry run prices every submitted key.
+        result.r2_bytes_freed =
+            estimate_r2_bytes_freed(db_path, r2_freed_hashes(&r2_orphans, &BTreeSet::new()))
+                .await?;
 
         // Summarize rather than logging a line per orphan: a production store
         // has millions of them.
@@ -363,15 +453,10 @@ pub async fn run_chunk_gc(
 
     // Step 6: Delete orphans.
     //
-    // Local unlinks stay one at a time, but R2 orphans are collected here and
+    // Local unlinks stay one at a time, but the R2 orphans collected above are
     // removed in one bulk pass below. One HTTP round trip per orphan turned the
     // first production run's 345,913 R2 orphans into hours of serial deletes.
-    let mut r2_orphans: Vec<String> = Vec::new();
     for hash in &orphans_after_grace {
-        if r2_store.is_some() && r2_set.contains(hash.as_str()) {
-            r2_orphans.push(hash.clone());
-        }
-
         // Delete from local disk
         if local_set.contains(hash.as_str()) {
             let path = chunk_path(objects_dir, hash);
@@ -407,14 +492,23 @@ pub async fn run_chunk_gc(
             .await
             .context("bulk delete R2 orphan chunks")?;
         result.r2_deleted += outcome.deleted;
-        if outcome.failed > 0 {
+        if outcome.failed() > 0 {
             tracing::warn!(
                 "Failed to delete {} of {} R2 orphan chunk(s); samples: {:?}",
-                outcome.failed,
+                outcome.failed(),
                 outcome.attempted,
                 outcome.failure_samples
             );
         }
+
+        // Price the delete before the cleanup below drops the rows that hold
+        // the sizes. Keys R2 refused are still in the bucket, so their bytes
+        // were not freed.
+        result.r2_bytes_freed = estimate_r2_bytes_freed(
+            db_path,
+            r2_freed_hashes(&r2_orphans, &outcome.failed_hashes),
+        )
+        .await?;
     }
 
     // Delete chunk_access rows for all deleted orphans (blocking DB)
@@ -757,6 +851,136 @@ mod tests {
         let mut conn = Connection::open_in_memory().unwrap();
         conary_core::db::schema::ensure_current(&conn).unwrap();
         assert_eq!(delete_chunk_access_rows(&mut conn, &[]).unwrap(), 0);
+    }
+
+    fn insert_sized_chunk_access(conn: &Connection, hash: &str, size_bytes: i64) {
+        conn.execute(
+            "INSERT INTO chunk_access (hash, size_bytes, access_count, protected)
+             VALUES (?1, ?2, 1, 0)",
+            rusqlite::params![hash, size_bytes],
+        )
+        .unwrap();
+    }
+
+    /// The freed-bytes estimate must count the chunks R2 removed and only those:
+    /// a key R2 refused is still occupying the bucket.
+    #[test]
+    fn r2_bytes_freed_excludes_hashes_r2_refused() {
+        let conn = Connection::open_in_memory().unwrap();
+        conary_core::db::schema::ensure_current(&conn).unwrap();
+        insert_sized_chunk_access(&conn, "deleted-a", 1_000);
+        insert_sized_chunk_access(&conn, "deleted-b", 20);
+        insert_sized_chunk_access(&conn, "refused", 400_000);
+        // A chunk nobody asked to delete must not be priced into the run.
+        insert_sized_chunk_access(&conn, "untouched", 9_999);
+
+        let submitted = vec![
+            "deleted-a".to_string(),
+            "deleted-b".to_string(),
+            "refused".to_string(),
+        ];
+        let failed = BTreeSet::from(["refused".to_string()]);
+
+        let freed = r2_freed_hashes(&submitted, &failed);
+        assert_eq!(freed.len(), 2);
+        assert!(!freed.contains("refused"));
+
+        assert_eq!(sum_chunk_access_bytes(&conn, &freed).unwrap(), 1_020);
+    }
+
+    /// The estimate must not bind one host variable per hash: production runs
+    /// price hundreds of thousands of orphans in one pass.
+    #[test]
+    fn r2_bytes_estimate_handles_more_hashes_than_sqlite_host_variables() {
+        let conn = Connection::open_in_memory().unwrap();
+        conary_core::db::schema::ensure_current(&conn).unwrap();
+        for i in 0..33_000 {
+            insert_sized_chunk_access(&conn, &format!("hash-{i:05}"), 2);
+        }
+
+        let mut hashes: HashSet<String> = (0..33_000).map(|i| format!("hash-{i:05}")).collect();
+        // A hash with no chunk_access row contributes nothing.
+        hashes.insert("never-recorded".to_string());
+
+        assert_eq!(sum_chunk_access_bytes(&conn, &hashes).unwrap(), 66_000);
+    }
+
+    #[test]
+    fn r2_bytes_estimate_is_zero_without_hashes() {
+        let conn = Connection::open_in_memory().unwrap();
+        conary_core::db::schema::ensure_current(&conn).unwrap();
+        insert_sized_chunk_access(&conn, "orphan", 512);
+
+        assert_eq!(
+            sum_chunk_access_bytes(&conn, &HashSet::new()).unwrap(),
+            0,
+            "an empty delete set must not sum the whole table"
+        );
+    }
+
+    /// A dry run reports what it would remove without touching disk, R2, or the
+    /// `chunk_access` rows it priced.
+    #[tokio::test]
+    async fn dry_run_counts_orphans_without_deleting_them() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("remi.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conary_core::db::schema::ensure_current(&conn).unwrap();
+        insert_sized_chunk_access(&conn, "abcdef0123456789", 4_096);
+        drop(conn);
+
+        let objects_dir = tmp.path().join("objects");
+        std::fs::create_dir_all(objects_dir.join("ab")).unwrap();
+        std::fs::write(objects_dir.join("ab").join("cdef0123456789"), b"chunk").unwrap();
+
+        let result = run_chunk_gc(&db_path, &objects_dir, None, true, 0)
+            .await
+            .unwrap();
+
+        assert_eq!(result.local_scanned, 1);
+        assert_eq!(result.local_deleted, 1);
+        // No R2 store configured: nothing was listed, so nothing is priced.
+        assert_eq!(result.r2_scanned, 0);
+        assert_eq!(result.r2_deleted, 0);
+        assert_eq!(result.r2_bytes_freed, 0);
+        assert!(objects_dir.join("ab").join("cdef0123456789").exists());
+
+        let conn = Connection::open(&db_path).unwrap();
+        let rows: i64 = conn
+            .query_row("SELECT COUNT(*) FROM chunk_access", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(rows, 1, "a dry run must not delete chunk_access rows");
+    }
+
+    /// The real path deletes the local orphan, measures its bytes, and drops its
+    /// `chunk_access` row.
+    #[tokio::test]
+    async fn real_run_deletes_local_orphans_and_their_access_rows() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("remi.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conary_core::db::schema::ensure_current(&conn).unwrap();
+        insert_sized_chunk_access(&conn, "abcdef0123456789", 4_096);
+        drop(conn);
+
+        let objects_dir = tmp.path().join("objects");
+        std::fs::create_dir_all(objects_dir.join("ab")).unwrap();
+        let chunk = objects_dir.join("ab").join("cdef0123456789");
+        std::fs::write(&chunk, b"chunk bytes").unwrap();
+
+        let result = run_chunk_gc(&db_path, &objects_dir, None, false, 0)
+            .await
+            .unwrap();
+
+        assert_eq!(result.local_deleted, 1);
+        assert_eq!(result.local_bytes_freed, b"chunk bytes".len() as u64);
+        assert!(!chunk.exists());
+
+        let conn = Connection::open(&db_path).unwrap();
+        let rows: i64 = conn
+            .query_row("SELECT COUNT(*) FROM chunk_access", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(rows, 0);
     }
 
     #[test]

--- a/apps/remi/src/server/conversion/storage.rs
+++ b/apps/remi/src/server/conversion/storage.rs
@@ -77,6 +77,74 @@ fn chunk_and_store_ccs_artifact(
     })
 }
 
+/// How one write-through pass over the artifact's chunks ended.
+enum WriteThroughOutcome {
+    /// Every chunk was read, verified, and offered to the uploader.
+    Completed(Duration),
+    /// A local chunk had been deleted underneath the pass. The caller repairs
+    /// the CAS and restarts; the elapsed time so far is still reported.
+    ChunkMissing { hash: String, elapsed: Duration },
+}
+
+/// Upload every chunk in `hashes` once, reading each back from the local CAS.
+///
+/// A chunk that is missing ends the pass early when `allow_restart` is set, so
+/// the caller can repair the CAS and start over. Without it, a missing chunk is
+/// a hard error carrying the same context as any other failed read.
+///
+/// An upload failure is warned and skipped rather than propagated, matching how
+/// R2 write-through has always treated a transient upload error: the chunk is on
+/// local disk either way, and the next conversion or serve re-uploads it.
+///
+/// A chunk that reads back with the wrong hash is always a hard error. That is
+/// corruption, not a garbage-collection race, and rewriting over it would
+/// destroy the evidence.
+async fn write_through_pass<F, Fut>(
+    objects_dir: &Path,
+    hashes: &BTreeSet<String>,
+    allow_restart: bool,
+    upload: &F,
+) -> Result<WriteThroughOutcome>
+where
+    F: Fn(String, Vec<u8>) -> Fut,
+    Fut: Future<Output = Result<()>>,
+{
+    let mut elapsed = Duration::default();
+
+    for hash in hashes {
+        let started = Instant::now();
+        let chunk_path = object_path(objects_dir, hash)?;
+        let data = match tokio::fs::read(&chunk_path).await {
+            Ok(data) => data,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound && allow_restart => {
+                elapsed += started.elapsed();
+                return Ok(WriteThroughOutcome::ChunkMissing {
+                    hash: hash.clone(),
+                    elapsed,
+                });
+            }
+            Err(e) => {
+                return Err(anyhow::Error::new(e))
+                    .with_context(|| format!("read local CAS chunk {hash} for R2 write-through"));
+            }
+        };
+
+        let actual_hash = conary_core::hash::sha256(&data);
+        if actual_hash != *hash {
+            anyhow::bail!("local CAS chunk failed R2 integrity check: {actual_hash} != {hash}");
+        }
+
+        if let Err(e) = upload(hash.clone(), data).await {
+            tracing::warn!("R2 write-through failed for chunk {}: {}", hash, e);
+        } else {
+            debug!("R2 write-through: uploaded chunk {}", hash);
+        }
+        elapsed += started.elapsed();
+    }
+
+    Ok(WriteThroughOutcome::Completed(elapsed))
+}
+
 impl ConversionService {
     /// Store the emitted CCS artifact as ordered content-defined chunks.
     #[cfg(test)]
@@ -94,8 +162,9 @@ impl ConversionService {
             .context("conversion did not emit a CCS artifact")?;
         let objects_dir = self.chunk_dir.join("objects");
         let local_objects_dir = objects_dir.clone();
+        let local_artifact = package_path.clone();
         let local = tokio::task::spawn_blocking(move || {
-            chunk_and_store_ccs_artifact(&package_path, &local_objects_dir)
+            chunk_and_store_ccs_artifact(&local_artifact, &local_objects_dir)
         })
         .await
         .context("join emitted CCS artifact chunking task")??;
@@ -111,64 +180,36 @@ impl ConversionService {
             }
         }
 
-        let r2_duration = if let Some(ref r2) = self.r2_store {
-            let mut duration = Duration::default();
-            let unique_hashes: BTreeSet<_> = local
+        // Persist chunk_access before the R2 write-through, not after it. The
+        // upsert refreshes last_accessed, and that timestamp is the only thing
+        // that puts a chunk this conversion deduplicated against inside the
+        // chunk GC's grace window. Running it after the write-through left every
+        // chunk of a large artifact unprotected for the whole upload, which is
+        // how a concurrent GC deleted one out from under the read below.
+        self.persist_chunk_sizes(&exact_sizes).await?;
+
+        let r2_duration = if let Some(r2) = self.r2_store.clone() {
+            let unique_hashes: BTreeSet<String> = local
                 .ordered_chunks
                 .iter()
                 .map(|(hash, _)| hash.clone())
                 .collect();
-            for hash in unique_hashes {
-                let r2_started = Instant::now();
-                let chunk_path = object_path(&objects_dir, &hash)?;
-                let data = tokio::fs::read(&chunk_path)
-                    .await
-                    .with_context(|| format!("read local CAS chunk {hash} for R2 write-through"))?;
-                let actual_hash = conary_core::hash::sha256(&data);
-                if actual_hash != hash {
-                    anyhow::bail!(
-                        "local CAS chunk failed R2 integrity check: {actual_hash} != {hash}"
-                    );
-                }
-                if let Err(e) = r2.put_chunk(&hash, &data).await {
-                    tracing::warn!("R2 write-through failed for chunk {}: {}", hash, e);
-                } else {
-                    debug!("R2 write-through: uploaded chunk {}", hash);
-                }
-                duration += r2_started.elapsed();
-            }
-            Some(duration)
+            Some(
+                self.write_through_to_r2(
+                    &objects_dir,
+                    &package_path,
+                    &unique_hashes,
+                    &exact_sizes,
+                    move |hash, data| {
+                        let r2 = r2.clone();
+                        async move { r2.put_chunk(&hash, &data).await }
+                    },
+                )
+                .await?,
+            )
         } else {
             None
         };
-
-        if !exact_sizes.is_empty() {
-            let db_path = self.db_path.clone();
-            let writer = self.database_writer.clone();
-            tokio::task::spawn_blocking(move || -> Result<()> {
-                writer.execute(|| {
-                    let mut conn = crate::server::open_runtime_db(&db_path)?;
-                    let tx =
-                        conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
-                    for (hash, size) in exact_sizes {
-                        if let Some(existing) = ChunkAccess::find_by_hash(&tx, &hash)?
-                            && existing.size_bytes != size
-                        {
-                            anyhow::bail!(
-                                "chunk {hash} size disagrees with persisted CAS authority: \
-                                 {} != {size}",
-                                existing.size_bytes
-                            );
-                        }
-                        ChunkAccess::new(hash, size).upsert(&tx)?;
-                    }
-                    tx.commit()?;
-                    Ok(())
-                })
-            })
-            .await
-            .context("join exact chunk-size persistence task")??;
-        }
 
         let chunk_hashes = local
             .ordered_chunks
@@ -181,6 +222,122 @@ impl ConversionService {
             cas_duration: local.cas_duration,
             r2_duration,
         })
+    }
+
+    /// Write every chunk of the emitted artifact through to R2, restarting the
+    /// whole pass once if a concurrent chunk GC deletes a local chunk mid-flight.
+    ///
+    /// Resuming at the missing chunk is not enough. The GC that removed it is
+    /// deleting a whole snapshot of orphans, so chunks this pass already
+    /// uploaded can be removed from R2 behind it. Restarting from the first hash
+    /// re-uploads everything and leaves the published chunk list pointing at
+    /// objects that exist. The cost is a duplicate upload of the chunks already
+    /// sent in the abandoned pass; that is accepted rather than optimized,
+    /// because the restart path is rare (one occurrence across a GC that deleted
+    /// 2.1M chunks) and a chunk list pointing at R2 404s is not.
+    ///
+    /// The CAS repair and the `chunk_access` refresh both run before any further
+    /// upload work, so the recreated chunks are back inside the GC's grace window
+    /// before the second pass spends time on them.
+    ///
+    /// Exactly one restart is allowed. The artifact has just been re-chunked at
+    /// that point, so a chunk still missing during the second pass is not this
+    /// race and fails with the same error a missing chunk has always produced.
+    ///
+    /// Residual, accepted: a GC bulk delete that lands after the restarted
+    /// uploads can still remove a deduplicated object, and no amount of retrying
+    /// inside the conversion closes that. Closing it needs the conversion and the
+    /// GC to synchronize -- issue #316's deferred option 2. What the
+    /// reference-time `chunk_access` touch does buy is a bound: only a conversion
+    /// that began before the GC's grace query can be caught, because any later
+    /// one is inside the grace window the GC honors.
+    async fn write_through_to_r2<F, Fut>(
+        &self,
+        objects_dir: &Path,
+        package_path: &Path,
+        hashes: &BTreeSet<String>,
+        exact_sizes: &BTreeMap<String, i64>,
+        upload: F,
+    ) -> Result<Duration>
+    where
+        F: Fn(String, Vec<u8>) -> Fut,
+        Fut: Future<Output = Result<()>>,
+    {
+        let mut duration = Duration::default();
+        let mut restarts_left = 1usize;
+
+        loop {
+            match write_through_pass(objects_dir, hashes, restarts_left > 0, &upload).await? {
+                WriteThroughOutcome::Completed(elapsed) => {
+                    duration += elapsed;
+                    return Ok(duration);
+                }
+                WriteThroughOutcome::ChunkMissing { hash, elapsed } => {
+                    duration += elapsed;
+                    restarts_left -= 1;
+                    tracing::warn!(
+                        "local CAS chunk {} disappeared during R2 write-through; \
+                         rewriting the emitted artifact's chunks and restarting the pass",
+                        hash
+                    );
+
+                    let restart_started = Instant::now();
+                    let repair_artifact = package_path.to_path_buf();
+                    let repair_objects = objects_dir.to_path_buf();
+                    tokio::task::spawn_blocking(move || {
+                        chunk_and_store_ccs_artifact(&repair_artifact, &repair_objects)
+                    })
+                    .await
+                    .context("join CAS repair task for R2 write-through")??;
+                    duration += restart_started.elapsed();
+
+                    // The GC pass that removed the chunk file also removed its
+                    // chunk_access row. Put the sizes and the grace timestamp
+                    // back before re-uploading anything.
+                    self.persist_chunk_sizes(exact_sizes).await?;
+                }
+            }
+        }
+    }
+
+    /// Record each chunk's exact size in `chunk_access`.
+    ///
+    /// The upsert also refreshes `last_accessed`, which is what the chunk GC's
+    /// grace period reads, so this doubles as the reference-time touch for
+    /// chunks that deduplicated against an already-stored copy.
+    async fn persist_chunk_sizes(&self, exact_sizes: &BTreeMap<String, i64>) -> Result<()> {
+        if exact_sizes.is_empty() {
+            return Ok(());
+        }
+
+        let exact_sizes = exact_sizes.clone();
+        let db_path = self.db_path.clone();
+        let writer = self.database_writer.clone();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            writer.execute(|| {
+                let mut conn = crate::server::open_runtime_db(&db_path)?;
+                let tx =
+                    conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+                for (hash, size) in exact_sizes {
+                    if let Some(existing) = ChunkAccess::find_by_hash(&tx, &hash)?
+                        && existing.size_bytes != size
+                    {
+                        anyhow::bail!(
+                            "chunk {hash} size disagrees with persisted CAS authority: \
+                             {} != {size}",
+                            existing.size_bytes
+                        );
+                    }
+                    ChunkAccess::new(hash, size).upsert(&tx)?;
+                }
+                tx.commit()?;
+                Ok(())
+            })
+        })
+        .await
+        .context("join exact chunk-size persistence task")??;
+
+        Ok(())
     }
 
     /// Calculate the typed SHA-256 checksum of a file.
@@ -198,6 +355,7 @@ mod tests {
     use super::super::test_support::make_conversion_result;
     use super::*;
     use std::path::{Path, PathBuf};
+    use std::sync::{Arc, Mutex};
 
     fn initialized_db(temp_dir: &tempfile::TempDir) -> PathBuf {
         let db_path = temp_dir.path().join("remi.db");
@@ -315,6 +473,288 @@ mod tests {
         let result2 = conversion_result_for(artifact_path);
         let hashes2 = service.store_chunks(&result2).await.unwrap();
         assert_eq!(hashes1, hashes2);
+    }
+
+    /// A conversion that deduplicates against already-stored chunks must still
+    /// refresh `chunk_access.last_accessed`, because that timestamp is the only
+    /// thing the chunk GC's grace period consults before deleting an orphan.
+    #[tokio::test]
+    async fn dedup_reference_refreshes_the_chunk_gc_grace_window() {
+        const ANCIENT: &str = "2020-01-01 00:00:00";
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let chunk_dir = temp_dir.path().join("chunks");
+        std::fs::create_dir_all(&chunk_dir).unwrap();
+        let artifact_path = temp_dir.path().join("dedup.ccs");
+        std::fs::write(&artifact_path, artifact_data(77, 800_000)).unwrap();
+
+        let db_path = initialized_db(&temp_dir);
+        let service = ConversionService::new(
+            chunk_dir,
+            temp_dir.path().to_path_buf(),
+            db_path.clone(),
+            None,
+        );
+
+        let hashes = service
+            .store_chunks(&conversion_result_for(artifact_path.clone()))
+            .await
+            .unwrap();
+        assert!(hashes.len() > 1);
+
+        // Age every row past any plausible grace period, then convert the same
+        // artifact again: every chunk is already in the CAS, so this second run
+        // stores nothing new and only takes references.
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute("UPDATE chunk_access SET last_accessed = ?1", [ANCIENT])
+            .unwrap();
+        drop(conn);
+
+        service
+            .store_chunks(&conversion_result_for(artifact_path))
+            .await
+            .unwrap();
+
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let still_ancient: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM chunk_access WHERE last_accessed <= ?1",
+                [ANCIENT],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            still_ancient, 0,
+            "a deduplicated chunk kept a stale last_accessed, so the GC grace \
+             period would not cover it"
+        );
+    }
+
+    /// Drive the write-through machine over a temp CAS, recording every upload
+    /// it performs. The uploader is a parameter precisely so the restart
+    /// behavior is observable without a live R2 bucket.
+    struct WriteThroughHarness {
+        _temp_dir: tempfile::TempDir,
+        service: ConversionService,
+        objects_dir: PathBuf,
+        artifact_path: PathBuf,
+        db_path: PathBuf,
+        /// Sorted exactly as the write-through pass walks them.
+        hashes: BTreeSet<String>,
+        exact_sizes: BTreeMap<String, i64>,
+    }
+
+    impl WriteThroughHarness {
+        fn new(seed: u64, len: usize) -> Self {
+            let temp_dir = tempfile::TempDir::new().unwrap();
+            let chunk_dir = temp_dir.path().join("chunks");
+            std::fs::create_dir_all(&chunk_dir).unwrap();
+            let objects_dir = chunk_dir.join("objects");
+            let artifact_path = temp_dir.path().join("raced.ccs");
+            std::fs::write(&artifact_path, artifact_data(seed, len)).unwrap();
+
+            let stored = chunk_and_store_ccs_artifact(&artifact_path, &objects_dir).unwrap();
+            assert!(
+                stored.ordered_chunks.len() > 2,
+                "the restart tests need an artifact that chunks into several pieces"
+            );
+            let hashes: BTreeSet<String> = stored
+                .ordered_chunks
+                .iter()
+                .map(|(hash, _)| hash.clone())
+                .collect();
+            let exact_sizes: BTreeMap<String, i64> =
+                stored.ordered_chunks.iter().cloned().collect();
+
+            let db_path = initialized_db(&temp_dir);
+            let service = ConversionService::new(
+                chunk_dir,
+                temp_dir.path().to_path_buf(),
+                db_path.clone(),
+                None,
+            );
+
+            Self {
+                _temp_dir: temp_dir,
+                service,
+                objects_dir,
+                artifact_path,
+                db_path,
+                hashes,
+                exact_sizes,
+            }
+        }
+
+        /// The chunk the pass visits last, so a delete there proves every
+        /// earlier chunk was re-uploaded rather than skipped.
+        fn last_visited_hash(&self) -> String {
+            self.hashes.iter().next_back().unwrap().clone()
+        }
+
+        fn delete_chunk(&self, hash: &str) {
+            std::fs::remove_file(object_path(&self.objects_dir, hash).unwrap()).unwrap();
+        }
+
+        fn chunk_access_rows(&self) -> i64 {
+            rusqlite::Connection::open(&self.db_path)
+                .unwrap()
+                .query_row("SELECT COUNT(*) FROM chunk_access", [], |row| row.get(0))
+                .unwrap()
+        }
+
+        /// Run the machine, recording `(hash, chunk_access rows visible)` for
+        /// every upload in order.
+        async fn run(&self) -> Result<(Duration, Vec<(String, i64)>)> {
+            let uploads = Arc::new(Mutex::new(Vec::new()));
+            let recorder = Arc::clone(&uploads);
+            let db_path = self.db_path.clone();
+            let duration = self
+                .service
+                .write_through_to_r2(
+                    &self.objects_dir,
+                    &self.artifact_path,
+                    &self.hashes,
+                    &self.exact_sizes,
+                    move |hash, _data| {
+                        let recorder = Arc::clone(&recorder);
+                        let db_path = db_path.clone();
+                        async move {
+                            let rows: i64 = rusqlite::Connection::open(&db_path)
+                                .unwrap()
+                                .query_row("SELECT COUNT(*) FROM chunk_access", [], |row| {
+                                    row.get(0)
+                                })
+                                .unwrap();
+                            recorder.lock().unwrap().push((hash, rows));
+                            Ok(())
+                        }
+                    },
+                )
+                .await?;
+            let uploads = uploads.lock().unwrap().clone();
+            Ok((duration, uploads))
+        }
+    }
+
+    /// The observed production race: a concurrent GC unlinks a chunk this
+    /// conversion is writing through. The conversion must survive it, and must
+    /// restart the pass rather than resume -- the same GC snapshot can delete
+    /// objects this pass already uploaded, so resuming would publish a chunk
+    /// list pointing at R2 objects that are gone.
+    #[tokio::test]
+    async fn write_through_restarts_the_whole_pass_when_a_chunk_is_deleted_mid_flight() {
+        let harness = WriteThroughHarness::new(13, 900_000);
+        let missing = harness.last_visited_hash();
+        let total = harness.hashes.len();
+
+        harness.delete_chunk(&missing);
+
+        let (_, uploads) = harness
+            .run()
+            .await
+            .expect("write-through must survive a chunk deleted mid-pass");
+
+        // First pass uploads everything before the missing chunk and stops;
+        // the restart then uploads all of them again plus the repaired one.
+        assert_eq!(
+            uploads.len(),
+            (total - 1) + total,
+            "the restart must re-upload the chunks the abandoned pass had sent,              not resume at the missing one"
+        );
+        let restarted: Vec<String> = uploads[total - 1..]
+            .iter()
+            .map(|(hash, _)| hash.clone())
+            .collect();
+        assert_eq!(
+            restarted,
+            harness.hashes.iter().cloned().collect::<Vec<_>>(),
+            "the second pass must cover every chunk in order"
+        );
+        assert!(
+            object_path(&harness.objects_dir, &missing)
+                .unwrap()
+                .exists(),
+            "the repair must restore the deleted chunk file"
+        );
+    }
+
+    /// A GC deletes the chunk file and its `chunk_access` row together. The
+    /// restart must put the protection rows back before it spends any more time
+    /// uploading, or the second pass runs unprotected too.
+    #[tokio::test]
+    async fn write_through_restores_chunk_access_before_re_uploading() {
+        let harness = WriteThroughHarness::new(29, 900_000);
+        let missing = harness.last_visited_hash();
+        let total = harness.hashes.len();
+
+        harness
+            .service
+            .persist_chunk_sizes(&harness.exact_sizes)
+            .await
+            .unwrap();
+        assert_eq!(harness.chunk_access_rows(), total as i64);
+
+        // What a GC run does: unlink the chunk, then drop its tracking rows.
+        harness.delete_chunk(&missing);
+        rusqlite::Connection::open(&harness.db_path)
+            .unwrap()
+            .execute("DELETE FROM chunk_access", [])
+            .unwrap();
+
+        let (_, uploads) = harness.run().await.unwrap();
+
+        let (abandoned, restarted) = uploads.split_at(total - 1);
+        assert!(
+            abandoned.iter().all(|(_, rows)| *rows == 0),
+            "the abandoned pass ran after the GC dropped the rows"
+        );
+        assert!(
+            restarted.iter().all(|(_, rows)| *rows == total as i64),
+            "every upload after the restart must see its protection row restored"
+        );
+    }
+
+    /// Exactly one restart. The artifact has just been re-chunked, so a chunk
+    /// still missing in the second pass is not this race, and it fails with the
+    /// error a missing chunk has always produced.
+    #[tokio::test]
+    async fn write_through_restarts_at_most_once() {
+        let harness = WriteThroughHarness::new(21, 900_000);
+        let missing = harness.last_visited_hash();
+        harness.delete_chunk(&missing);
+
+        // Replace the artifact so the repair cannot reproduce the deleted chunk.
+        std::fs::write(&harness.artifact_path, artifact_data(99, 900_000)).unwrap();
+
+        let error = harness.run().await.unwrap_err().to_string();
+        assert!(
+            error.contains(&format!(
+                "read local CAS chunk {missing} for R2 write-through"
+            )),
+            "{error}"
+        );
+    }
+
+    /// Corruption is not a garbage-collection race. It is a hard error in the
+    /// first pass, where a restart would otherwise have been allowed, so a
+    /// rewrite can never paper over it.
+    #[tokio::test]
+    async fn write_through_rejects_a_corrupt_local_chunk_without_restarting() {
+        let harness = WriteThroughHarness::new(44, 900_000);
+        let corrupt = harness.last_visited_hash();
+        std::fs::write(
+            object_path(&harness.objects_dir, &corrupt).unwrap(),
+            b"not the chunk",
+        )
+        .unwrap();
+
+        let error = harness.run().await.unwrap_err().to_string();
+        assert!(error.contains("failed R2 integrity check"), "{error}");
+        assert_eq!(
+            std::fs::read(object_path(&harness.objects_dir, &corrupt).unwrap()).unwrap(),
+            b"not the chunk",
+            "a corrupt chunk must be left as evidence, not rewritten"
+        );
     }
 
     #[tokio::test]

--- a/apps/remi/src/server/r2.rs
+++ b/apps/remi/src/server/r2.rs
@@ -10,6 +10,7 @@ use s3::Bucket;
 use s3::Region;
 use s3::creds::Credentials;
 use s3::serde_types::{DeleteObjectsResult, ObjectIdentifier};
+use std::collections::BTreeSet;
 
 /// Maximum keys S3/R2 accepts in one `DeleteObjects` request.
 const R2_DELETE_BATCH_SIZE: usize = 1000;
@@ -51,15 +52,27 @@ pub struct R2BatchDeleteOutcome {
     pub attempted: usize,
     /// Keys R2 removed (or that were already absent)
     pub deleted: usize,
-    /// Keys R2 refused, plus keys in a batch whose request failed outright
-    pub failed: usize,
+    /// Keys R2 refused, plus keys in a batch whose request failed outright.
+    ///
+    /// Held in full rather than counted: the caller subtracts these from what it
+    /// submitted to decide which chunks are actually gone, and a count cannot
+    /// answer that. Size is bounded by the submitted key set the caller already
+    /// holds.
+    pub failed_hashes: BTreeSet<String>,
     /// Up to `R2_DELETE_FAILURE_SAMPLES` (hash, error) pairs for diagnostics
     pub failure_samples: Vec<(String, String)>,
 }
 
 impl R2BatchDeleteOutcome {
+    /// Number of keys that were not removed.
+    pub fn failed(&self) -> usize {
+        self.failed_hashes.len()
+    }
+
     fn record_failure(&mut self, hash: &str, error: &str) {
-        self.failed += 1;
+        if !self.failed_hashes.insert(hash.to_string()) {
+            return;
+        }
         if self.failure_samples.len() < R2_DELETE_FAILURE_SAMPLES {
             self.failure_samples
                 .push((hash.to_string(), error.to_string()));
@@ -69,8 +82,7 @@ impl R2BatchDeleteOutcome {
     /// Fold a batch whose request succeeded.
     ///
     /// S3 reports only the keys it refused; deletion is idempotent, so every
-    /// other key in the batch is gone whether or not it existed. That matches
-    /// what the single-key `delete_chunk` path counts as a delete.
+    /// other key in the batch is gone whether or not it existed.
     fn fold_batch(&mut self, batch: &[String], failures: &[(String, String)]) {
         for (hash, error) in failures {
             self.record_failure(hash, error);
@@ -191,16 +203,6 @@ impl R2Store {
                 }
             }
         }
-    }
-
-    /// Delete a chunk from R2. Returns `true` if the object was deleted,
-    /// `false` if it did not exist.
-    pub async fn delete_chunk(&self, hash: &str) -> Result<bool> {
-        let key = self.chunk_key(hash);
-        let response = self.bucket.delete_object(&key).await?;
-
-        // S3/R2 returns 204 for successful delete, 404 if not found
-        Ok(response.status_code() < 300)
     }
 
     /// Delete many chunks from R2 using the S3 multi-object delete API.
@@ -441,7 +443,7 @@ mod tests {
 
         assert_eq!(outcome.attempted, 5);
         assert_eq!(outcome.deleted, 4);
-        assert_eq!(outcome.failed, 1);
+        assert_eq!(outcome.failed(), 1);
         assert_eq!(
             outcome.failure_samples,
             vec![(
@@ -465,7 +467,7 @@ mod tests {
         outcome.fold_batch_request_failure(&second, "connection reset");
 
         assert_eq!(outcome.deleted, 3);
-        assert_eq!(outcome.failed, 3);
+        assert_eq!(outcome.failed(), 3);
         assert_eq!(outcome.failure_samples.len(), 3);
         assert!(
             outcome
@@ -486,7 +488,7 @@ mod tests {
         outcome.fold_batch_request_failure(&batch, "timeout");
 
         assert_eq!(outcome.deleted, 0);
-        assert_eq!(outcome.failed, 250);
+        assert_eq!(outcome.failed(), 250);
         assert_eq!(outcome.failure_samples.len(), R2_DELETE_FAILURE_SAMPLES);
         // Samples are the first failures seen, not a random subset.
         assert_eq!(outcome.failure_samples[0].0, "hash-000000");
@@ -511,7 +513,7 @@ mod tests {
         );
 
         assert_eq!(outcome.deleted, 0);
-        assert_eq!(outcome.failed, 3);
+        assert_eq!(outcome.failed(), 3);
     }
 
     #[test]


### PR DESCRIPTION
## What this fixes

**#316 (GC vs in-flight conversion race, one production instance 2026-08-08):** investigation showed the grace-touch already existed but ran after the entire R2 write-through loop — pure ordering. Now: protection rows persist before the pass, and the pass itself is a restart machine: first missing chunk → re-chunk the artifact → re-persist protection → restart the whole pass (a resume could publish chunk lists pointing at R2 objects the same GC snapshot deleted post-upload — second-model review finding). One restart per conversion, structurally terminating; post-restart miss or any corruption is a hard error with the verbatim production string. Residual (bulk delete after restarted uploads) documented; closing it fully is #316's deferred GC/conversion synchronization option.

**#312 (r2_bytes_freed always 0):** populated from a single O(table) streaming scan of chunk_access sizes, read before row cleanup, refused keys excluded via `R2BatchDeleteOutcome.failed_hashes` (bare count replaced — one owner for the fact). Dry-run populates the R2 estimate and prices exactly the submitted set; the local/R2 dry-run asymmetry is deliberate and documented (measured vs estimated must not share a field mode-dependently).

Also: dead `R2Store::delete_chunk` removed; `run_chunk_gc` gained its first end-to-end tests (dry-run and real-run over a temp store).

## Review chain

Opus implementation → my review → Luna (Codex) second-model review, whose two findings (resume-vs-restart publishing gap, unprotected recreated chunks) drove the restart-pass design → re-implementation → mutation-tested property coverage: resume-instead-of-restart and dropped-reprotection mutations each fail exactly their own test.

## Verification (run, real output)

`cargo test -p remi`: 622 lib / 5 bin / 3 cli_help passed, 0 failed. `cargo check --workspace --all-targets` clean (public struct changed). Clippy `-D warnings` clean, fmt clean. Independent reviewer re-runs matched at every round.

Found en route, filed separately: #317 (GC deletes chunk_access rows for R2-refused keys).

Closes #316. Closes #312. Refs #310, #317.