### PR TITLE
fix(remi): keep refused-key GC rows and stop the SPA fallback lying

### DIFF
--- a/apps/remi/src/server/chunk_gc.rs
+++ b/apps/remi/src/server/chunk_gc.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use rusqlite::Connection;
 
-use super::r2::R2Store;
+use super::r2::{R2BatchDeleteOutcome, R2Store};
 
 /// Result of a garbage collection run.
 #[derive(Debug, Clone, Default)]
@@ -332,7 +332,8 @@ fn delete_chunk_access_rows(conn: &mut Connection, hashes: &[String]) -> Result<
 ///    are kept even if unreferenced, to avoid removing chunks for in-flight conversions.
 /// 5. Deletes orphans from local disk, R2, and the `chunk_access` table, in
 ///    that order: the R2 freed-bytes estimate reads `chunk_access.size_bytes`,
-///    which only exists until the row cleanup runs.
+///    which only exists until the row cleanup runs. A key R2 refused keeps its
+///    row so the next run can still price the retry.
 /// 6. In `dry_run` mode, logs what would be deleted without making changes.
 pub async fn run_chunk_gc(
     db_path: &Path,
@@ -341,6 +342,59 @@ pub async fn run_chunk_gc(
     dry_run: bool,
     grace_period_secs: u64,
 ) -> Result<GcResult> {
+    let Some(store) = r2_store else {
+        return run_chunk_gc_with_deleter(
+            db_path,
+            objects_dir,
+            None,
+            |_| async {
+                Err(anyhow::anyhow!(
+                    "chunk GC submitted an R2 delete without an R2 listing"
+                ))
+            },
+            dry_run,
+            grace_period_secs,
+        )
+        .await;
+    };
+
+    let r2_chunks = store.list_chunks().await.context("list R2 chunks")?;
+    run_chunk_gc_with_deleter(
+        db_path,
+        objects_dir,
+        Some(r2_chunks),
+        move |hashes: Arc<Vec<String>>| async move {
+            store
+                .delete_chunks(&hashes)
+                .await
+                .context("bulk delete R2 orphan chunks")
+        },
+        dry_run,
+        grace_period_secs,
+    )
+    .await
+}
+
+/// Run chunk garbage collection against an already-listed R2 key set and an
+/// injected bulk deleter.
+///
+/// The deleter is a parameter so a test can drive the real run against an R2
+/// that refuses keys; production passes `R2Store::delete_chunks`. It is handed
+/// an `Arc` of the submitted keys because the caller still needs that set
+/// afterwards to decide which chunks are actually gone, and a production run
+/// submits hundreds of thousands of them.
+async fn run_chunk_gc_with_deleter<F, Fut>(
+    db_path: &Path,
+    objects_dir: &Path,
+    r2_chunks: Option<Vec<String>>,
+    delete_r2: F,
+    dry_run: bool,
+    grace_period_secs: u64,
+) -> Result<GcResult>
+where
+    F: FnOnce(Arc<Vec<String>>) -> Fut,
+    Fut: Future<Output = Result<R2BatchDeleteOutcome>>,
+{
     let mut result = GcResult::default();
 
     // Step 1: Build referenced set (blocking DB work)
@@ -364,14 +418,9 @@ pub async fn run_chunk_gc(
         .context("scan_local_chunks")?;
     result.local_scanned = local_chunks.len();
 
-    // Step 3: Optionally list R2 chunks
-    let r2_chunks = if let Some(ref store) = r2_store {
-        let chunks = store.list_chunks().await.context("list R2 chunks")?;
-        result.r2_scanned = chunks.len();
-        chunks
-    } else {
-        Vec::new()
-    };
+    // Step 3: Account for the R2 listing, when R2 is configured at all.
+    let r2_chunks = r2_chunks.unwrap_or_default();
+    result.r2_scanned = r2_chunks.len();
 
     // Step 4: Find orphans (stored but not referenced)
     let local_set: HashSet<&str> = local_chunks.iter().map(String::as_str).collect();
@@ -409,16 +458,15 @@ pub async fn run_chunk_gc(
 
     // The keys the bulk delete below submits. Built once so a dry run reports
     // exactly the set a real run would remove, rather than a second expression
-    // that has to be kept in step with it.
-    let r2_orphans: Vec<String> = if r2_store.is_some() {
+    // that has to be kept in step with it. Without an R2 listing `r2_set` is
+    // empty, so this is empty too and the deleter is never called.
+    let r2_orphans: Arc<Vec<String>> = Arc::new(
         orphans_after_grace
             .iter()
             .filter(|h| r2_set.contains(h.as_str()))
             .cloned()
-            .collect()
-    } else {
-        Vec::new()
-    };
+            .collect(),
+    );
 
     if dry_run {
         // Populate counts for reporting even in dry-run
@@ -484,13 +532,9 @@ pub async fn run_chunk_gc(
     }
 
     // Bulk-delete the R2 orphans in one pass.
-    if let Some(ref store) = r2_store
-        && !r2_orphans.is_empty()
-    {
-        let outcome = store
-            .delete_chunks(&r2_orphans)
-            .await
-            .context("bulk delete R2 orphan chunks")?;
+    let mut r2_refused: BTreeSet<String> = BTreeSet::new();
+    if !r2_orphans.is_empty() {
+        let outcome = delete_r2(Arc::clone(&r2_orphans)).await?;
         result.r2_deleted += outcome.deleted;
         if outcome.failed() > 0 {
             tracing::warn!(
@@ -509,11 +553,27 @@ pub async fn run_chunk_gc(
             r2_freed_hashes(&r2_orphans, &outcome.failed_hashes),
         )
         .await?;
+        r2_refused = outcome.failed_hashes;
     }
 
-    // Delete chunk_access rows for all deleted orphans (blocking DB)
+    // Delete chunk_access rows for the orphans that are actually gone.
+    //
+    // A key R2 refused still has its object in the bucket, and that row holds
+    // the only record of its size. Orphan detection is listing-based, so the
+    // next run re-lists the surviving object and retries the delete -- but
+    // without the row it could not price what it freed, and `r2_bytes_freed`
+    // would silently under-report every retry. A failed local unlink is not
+    // excluded here: local bytes are measured by `stat` at unlink rather than
+    // read from the row, so the row carries nothing that path needs.
     let db_path_cleanup = db_path.to_path_buf();
-    let deleted_hashes = orphans_after_grace.clone();
+    let deleted_hashes: Vec<String> = if r2_refused.is_empty() {
+        orphans_after_grace
+    } else {
+        orphans_after_grace
+            .into_iter()
+            .filter(|hash| !r2_refused.contains(hash))
+            .collect()
+    };
     tokio::task::spawn_blocking(move || -> Result<()> {
         let mut conn = crate::server::open_runtime_db(&db_path_cleanup)?;
         let removed = delete_chunk_access_rows(&mut conn, &deleted_hashes)?;
@@ -981,6 +1041,174 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM chunk_access", [], |row| row.get(0))
             .unwrap();
         assert_eq!(rows, 0);
+    }
+
+    /// Seed a store whose only local chunk is `hash`, plus `chunk_access` rows
+    /// for every hash in `sized`.
+    fn seed_gc_store(sized: &[(&str, i64)]) -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("remi.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conary_core::db::schema::ensure_current(&conn).unwrap();
+        for (hash, size) in sized {
+            insert_sized_chunk_access(&conn, hash, *size);
+        }
+        drop(conn);
+
+        let objects_dir = tmp.path().join("objects");
+        std::fs::create_dir_all(&objects_dir).unwrap();
+        (tmp, db_path, objects_dir)
+    }
+
+    fn remaining_access_rows(db_path: &Path) -> Vec<String> {
+        let conn = Connection::open(db_path).unwrap();
+        let mut stmt = conn
+            .prepare("SELECT hash FROM chunk_access ORDER BY hash")
+            .unwrap();
+        let rows: Vec<String> = stmt
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        rows
+    }
+
+    /// A `chunk_access` row may only die once everything it describes is gone.
+    /// R2 refused `refused-orphan`, so its object is still in the bucket and its
+    /// recorded size is the only thing that can price the next run's retry.
+    #[tokio::test]
+    async fn refused_r2_orphan_keeps_its_chunk_access_row() {
+        let (_tmp, db_path, objects_dir) =
+            seed_gc_store(&[("deleted-orphan", 1_000), ("refused-orphan", 400_000)]);
+
+        let submitted = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let recorder = Arc::clone(&submitted);
+        let result = run_chunk_gc_with_deleter(
+            &db_path,
+            &objects_dir,
+            Some(vec![
+                "deleted-orphan".to_string(),
+                "refused-orphan".to_string(),
+            ]),
+            move |hashes: Arc<Vec<String>>| async move {
+                recorder.lock().unwrap().extend(hashes.iter().cloned());
+                Ok(R2BatchDeleteOutcome {
+                    attempted: hashes.len(),
+                    deleted: 1,
+                    failed_hashes: BTreeSet::from(["refused-orphan".to_string()]),
+                    failure_samples: vec![(
+                        "refused-orphan".to_string(),
+                        "AccessDenied: denied".to_string(),
+                    )],
+                })
+            },
+            false,
+            0,
+        )
+        .await
+        .unwrap();
+
+        let mut submitted = submitted.lock().unwrap().clone();
+        submitted.sort();
+        assert_eq!(submitted, vec!["deleted-orphan", "refused-orphan"]);
+
+        assert_eq!(result.r2_scanned, 2);
+        assert_eq!(result.r2_deleted, 1);
+        assert_eq!(
+            result.r2_bytes_freed, 1_000,
+            "a refused key's bytes are still in the bucket"
+        );
+
+        assert_eq!(
+            remaining_access_rows(&db_path),
+            vec!["refused-orphan".to_string()],
+            "the refused key must keep the row that records its size"
+        );
+    }
+
+    /// The other half of the same contract: a key R2 actually removed loses its
+    /// row, so a refusal is what keeps a row rather than the R2 path as a whole.
+    #[tokio::test]
+    async fn fully_deleted_r2_orphans_lose_their_chunk_access_rows() {
+        let (_tmp, db_path, objects_dir) = seed_gc_store(&[("orphan-a", 1_000), ("orphan-b", 20)]);
+
+        let result = run_chunk_gc_with_deleter(
+            &db_path,
+            &objects_dir,
+            Some(vec!["orphan-a".to_string(), "orphan-b".to_string()]),
+            |hashes: Arc<Vec<String>>| async move {
+                Ok(R2BatchDeleteOutcome {
+                    attempted: hashes.len(),
+                    deleted: hashes.len(),
+                    ..Default::default()
+                })
+            },
+            false,
+            0,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.r2_deleted, 2);
+        assert_eq!(result.r2_bytes_freed, 1_020);
+        assert!(remaining_access_rows(&db_path).is_empty());
+    }
+
+    /// A whole batch R2 could not even submit refuses every key in it, so no row
+    /// in that batch may be cleaned up.
+    #[tokio::test]
+    async fn r2_request_failure_keeps_every_chunk_access_row_it_covered() {
+        let (_tmp, db_path, objects_dir) = seed_gc_store(&[("orphan-a", 1_000), ("orphan-b", 20)]);
+
+        let result = run_chunk_gc_with_deleter(
+            &db_path,
+            &objects_dir,
+            Some(vec!["orphan-a".to_string(), "orphan-b".to_string()]),
+            |hashes: Arc<Vec<String>>| async move {
+                Ok(R2BatchDeleteOutcome {
+                    attempted: hashes.len(),
+                    deleted: 0,
+                    failed_hashes: hashes.iter().cloned().collect(),
+                    failure_samples: Vec::new(),
+                })
+            },
+            false,
+            0,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.r2_deleted, 0);
+        assert_eq!(result.r2_bytes_freed, 0);
+        assert_eq!(
+            remaining_access_rows(&db_path),
+            vec!["orphan-a".to_string(), "orphan-b".to_string()]
+        );
+    }
+
+    /// Without an R2 listing there is nothing to refuse, so every collected
+    /// orphan's row is cleaned up and the deleter is never called.
+    #[tokio::test]
+    async fn local_only_run_cleans_up_every_collected_row() {
+        let (_tmp, db_path, objects_dir) = seed_gc_store(&[("abcdef0123456789", 4_096)]);
+        std::fs::create_dir_all(objects_dir.join("ab")).unwrap();
+        std::fs::write(objects_dir.join("ab").join("cdef0123456789"), b"chunk").unwrap();
+
+        let result = run_chunk_gc_with_deleter(
+            &db_path,
+            &objects_dir,
+            None,
+            |_| async { panic!("no R2 listing means no R2 delete") },
+            false,
+            0,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.local_deleted, 1);
+        assert_eq!(result.r2_scanned, 0);
+        assert_eq!(result.r2_bytes_freed, 0);
+        assert!(remaining_access_rows(&db_path).is_empty());
     }
 
     #[test]

--- a/apps/remi/src/server/routes/public.rs
+++ b/apps/remi/src/server/routes/public.rs
@@ -2,6 +2,9 @@
 //! Public Remi router assembly and readiness endpoints.
 
 use super::*;
+use std::path::PathBuf;
+use tower::ServiceExt;
+use tower_http::services::{ServeDir, ServeFile};
 
 /// Create the main public application router
 ///
@@ -160,9 +163,11 @@ pub async fn create_router(state: Arc<RwLock<ServerState>>) -> Router {
     let web_routes = {
         let state_guard = state.read().await;
         state_guard.config.web_root.as_ref().map(|web_root| {
-            Router::new().fallback_service(tower_http::services::ServeDir::new(web_root).fallback(
-                tower_http::services::ServeFile::new(web_root.join("index.html")),
-            ))
+            let web_root = Arc::new(web_root.clone());
+            Router::new().fallback_service(
+                ServeDir::new(web_root.as_path())
+                    .fallback(get(serve_web_route).with_state(Arc::clone(&web_root))),
+            )
         })
     };
 
@@ -196,6 +201,61 @@ pub async fn create_router(state: Arc<RwLock<ServerState>>) -> Router {
     }
 
     app
+}
+
+/// Public path prefixes the package-index SPA resolves in the browser.
+///
+/// `web/` is a SvelteKit app built with the static adapter in fallback mode:
+/// one `index.html` plus its assets, with `/packages/{distro}/{name}` and the
+/// rest of the map routed client-side. Those paths have no file on disk, so the
+/// server must hand them the entry document.
+///
+/// The list is explicit because the wildcard fallback it replaces answered
+/// *every* unknown path with that document -- `conary-repo.toml`,
+/// `metadata/root.json`, anything -- as 200 `text/html`. A client probing for a
+/// file's presence got "yes" for every path it asked about, which is how a
+/// `conary repo add` against this host tried to parse the SPA page as TOML
+/// (issue #155). A path that is neither a file nor a declared route now fails
+/// closed.
+///
+/// This list must agree with `web/src/routes/` in both directions, and
+/// `spa_route_prefixes_match_declared_web_routes` below enforces that by
+/// reading the route tree: a route added there and missing here would 404 on
+/// reload, and an entry left here after a route is deleted would keep answering
+/// 200 for a path the app no longer has.
+const SPA_ROUTE_PREFIXES: &[&str] = &["/about", "/packages", "/search", "/stats"];
+
+/// Whether `path` is served by the SPA entry document rather than by a file.
+///
+/// `/` is served by `ServeDir` itself (directory index), so it is not listed
+/// here; a prefix matches its own path and anything nested beneath it.
+fn is_spa_route(path: &str) -> bool {
+    SPA_ROUTE_PREFIXES.iter().any(|route| {
+        path == *route
+            || path
+                .strip_prefix(route)
+                .is_some_and(|rest| rest.starts_with('/'))
+    })
+}
+
+/// Serve the SPA entry document for a declared client-side route, and a typed
+/// 404 for everything else `ServeDir` could not find on disk.
+async fn serve_web_route(State(web_root): State<Arc<PathBuf>>, request: Request<Body>) -> Response {
+    if !is_spa_route(request.uri().path()) {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "not found"})),
+        )
+            .into_response();
+    }
+
+    match ServeFile::new(web_root.join("index.html"))
+        .oneshot(request)
+        .await
+    {
+        Ok(response) => response.into_response(),
+        Err(infallible) => match infallible {},
+    }
 }
 
 async fn health_check() -> &'static str {
@@ -251,4 +311,227 @@ pub(super) async fn prometheus_metrics(
 ) -> String {
     let state = state.read().await;
     state.metrics.to_prometheus()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::ServerConfig;
+    use axum::extract::ConnectInfo;
+    use std::collections::BTreeSet;
+    use std::net::SocketAddr;
+    use std::path::Path;
+
+    /// Build the public router over a web root holding the SPA entry document
+    /// and one real static asset.
+    async fn web_app() -> (tempfile::TempDir, Router) {
+        let temp = tempfile::TempDir::new().unwrap();
+        let db_path = temp.path().join("remi.db");
+        let chunk_dir = temp.path().join("chunks");
+        let cache_dir = temp.path().join("cache");
+        let web_root = temp.path().join("web");
+        std::fs::create_dir_all(&chunk_dir).unwrap();
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        std::fs::create_dir_all(web_root.join("brand")).unwrap();
+        conary_core::db::init(&db_path).unwrap();
+
+        std::fs::write(
+            web_root.join("index.html"),
+            "<!doctype html><title>Conary package index</title>",
+        )
+        .unwrap();
+        std::fs::write(web_root.join("brand/conary-mark.svg"), "<svg/>").unwrap();
+
+        let state = Arc::new(RwLock::new(
+            ServerState::new(ServerConfig {
+                db_path,
+                chunk_dir,
+                cache_dir,
+                web_root: Some(web_root),
+                enable_rate_limit: false,
+                enable_audit_log: false,
+                enable_bloom_filter: false,
+                ..ServerConfig::default()
+            })
+            .expect("test server state"),
+        ));
+
+        (temp, create_router(state).await)
+    }
+
+    async fn get_path(app: &Router, uri: &str) -> (StatusCode, Option<String>, String) {
+        let mut request = Request::builder().uri(uri).body(Body::empty()).unwrap();
+        request
+            .extensions_mut()
+            .insert(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 49152))));
+        let response = app.clone().oneshot(request).await.unwrap();
+        let status = response.status();
+        let content_type = response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .map(|value| value.to_str().unwrap().to_string());
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (status, content_type, String::from_utf8_lossy(&body).into())
+    }
+
+    /// A path that is neither a file nor a declared SPA route must say so. The
+    /// probes below are the ones that actually misfired against the public
+    /// host: a static-repository identity file and a TUF metadata target.
+    #[tokio::test]
+    async fn unknown_public_paths_are_not_answered_with_the_spa_document() {
+        let (_temp, app) = web_app().await;
+
+        for path in [
+            "/definitely-not-a-real-path",
+            "/conary-repo.toml",
+            "/metadata/root.json",
+            "/packages.json",
+            "/aboutish",
+            "/v1/no-such-route",
+        ] {
+            let (status, content_type, body) = get_path(&app, path).await;
+            assert_eq!(status, StatusCode::NOT_FOUND, "{path} must 404");
+            let content_type = content_type.unwrap_or_default();
+            assert!(
+                !content_type.starts_with("text/html"),
+                "{path} answered {content_type}: {body}"
+            );
+            assert!(
+                !body.contains("<!doctype html>"),
+                "{path} served the SPA document: {body}"
+            );
+        }
+    }
+
+    /// The SPA still works: its entry path, its declared routes, and the dynamic
+    /// package routes beneath them all reach the entry document.
+    #[tokio::test]
+    async fn declared_spa_routes_serve_the_entry_document() {
+        let (_temp, app) = web_app().await;
+
+        for path in [
+            "/",
+            "/about",
+            "/packages",
+            "/packages/fedora",
+            "/packages/fedora/qemu-img",
+            "/search",
+            "/stats",
+        ] {
+            let (status, content_type, body) = get_path(&app, path).await;
+            assert_eq!(status, StatusCode::OK, "{path} must serve the SPA");
+            assert!(
+                content_type.unwrap_or_default().starts_with("text/html"),
+                "{path} must serve the SPA as html"
+            );
+            assert!(body.contains("Conary package index"), "{path}: {body}");
+        }
+    }
+
+    /// A real file under the web root is still served by `ServeDir`, with its
+    /// own type rather than the entry document's.
+    #[tokio::test]
+    async fn static_assets_under_the_web_root_still_serve() {
+        let (_temp, app) = web_app().await;
+
+        let (status, content_type, body) = get_path(&app, "/brand/conary-mark.svg").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(content_type.as_deref(), Some("image/svg+xml"));
+        assert_eq!(body, "<svg/>");
+    }
+
+    /// The API is unaffected: routes under `/v1` keep answering, and a query
+    /// against a distro the server does not carry keeps its own typed status
+    /// rather than falling through to the web fallback.
+    #[tokio::test]
+    async fn api_routes_are_unaffected_by_the_web_fallback() {
+        let (_temp, app) = web_app().await;
+
+        let (status, _, body) = get_path(&app, "/health").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "OK");
+
+        let (status, content_type, _) = get_path(&app, "/v1/federation/directory").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            content_type
+                .unwrap_or_default()
+                .starts_with("application/json"),
+            "federation directory must stay JSON"
+        );
+
+        let (status, _, _) = get_path(&app, "/v1/not-supported/metadata").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    /// `SPA_ROUTE_PREFIXES` is the server's copy of a fact the SPA owns, so the
+    /// route tree itself decides whether that copy is still true.
+    ///
+    /// Every top-level directory under `web/src/routes/` is one client-side
+    /// route, and every entry in the const must still have a directory. The
+    /// comparison is a set equality so both failures name themselves: a new
+    /// SvelteKit route fails here instead of 404-ing in production, and a
+    /// removed one cannot leave a stale prefix answering 200.
+    ///
+    /// Nested `[param]` directories do not appear here -- they live under their
+    /// parent, which the prefix match already covers. A top-level `[param]` or
+    /// `(group)` directory would fail this assertion, which is the right
+    /// outcome: neither maps to a plain prefix, so both need a decision rather
+    /// than a silent extra entry.
+    #[test]
+    fn spa_route_prefixes_match_declared_web_routes() {
+        let routes_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../web/src/routes");
+        let entries = std::fs::read_dir(&routes_dir).unwrap_or_else(|error| {
+            panic!(
+                "read the SPA route tree at {}: {error}. \
+                 This contract cannot be checked without it, and an unchecked \
+                 SPA_ROUTE_PREFIXES is how an unserved route reaches production.",
+                routes_dir.display()
+            )
+        });
+
+        let mut declared = BTreeSet::new();
+        for entry in entries {
+            let entry = entry.expect("read SPA route directory entry");
+            // `+page.svelte`, `+layout.svelte`, and `+error.svelte` at this
+            // level are the root route, which `ServeDir` serves as the
+            // directory index rather than through the prefix list.
+            if entry.file_type().expect("stat SPA route entry").is_dir() {
+                declared.insert(format!("/{}", entry.file_name().to_string_lossy()));
+            }
+        }
+
+        assert!(
+            !declared.is_empty(),
+            "found no route directories under {} -- the SPA declares several, \
+             so this is a broken path rather than an empty contract",
+            routes_dir.display()
+        );
+
+        let configured: BTreeSet<String> = SPA_ROUTE_PREFIXES
+            .iter()
+            .map(|r| (*r).to_string())
+            .collect();
+        assert_eq!(
+            configured,
+            declared,
+            "SPA_ROUTE_PREFIXES and web/src/routes/ disagree; \
+             only in the const: {:?}, only in the route tree: {:?}",
+            configured.difference(&declared).collect::<Vec<_>>(),
+            declared.difference(&configured).collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn spa_route_matching_is_prefix_bounded() {
+        assert!(is_spa_route("/packages"));
+        assert!(is_spa_route("/packages/"));
+        assert!(is_spa_route("/packages/fedora/qemu-img"));
+        assert!(!is_spa_route("/packages.json"));
+        assert!(!is_spa_route("/packagesish"));
+        assert!(!is_spa_route("/"));
+        assert!(!is_spa_route("/v1/search"));
+    }
 }


### PR DESCRIPTION
## Two small fixes batched for remi-v0.11.2

**#317 — GC row consistency:** `chunk_access` cleanup excludes R2-refused hashes (`R2BatchDeleteOutcome.failed_hashes` from #318) — a row dies only when everything it describes is gone. New injectable-deleter seam makes `run_chunk_gc`'s R2 branch testable for the first time (4 new tests: refused-keeps-row, deleted-loses-row, whole-batch-failure keeps all, local-only path). Mutation-checked: removing the filter fails exactly the two refusal tests. Deliberately not extended to failed local unlinks — their rows carry nothing the local path reads; reasoning lives in a code comment.

**#155 server half — public boundary honesty:** every unknown path returned 200 text/html (SPA fallback), which is how conary's static-repo probe ended up parsing a web page as TOML. Investigation showed the SPA genuinely uses SvelteKit history routing (`adapter-static` fallback mode, real `goto()` navigation), so the fix is an explicit namespace list, not fallback deletion: `/about`, `/packages`, `/search`, `/stats` serve the app; everything else 404s with the API's typed JSON shape. Bounded prefix matching (`/packages.json` 404s). A contract test reads `web/src/routes/` and asserts two-way set agreement with the list — route drift fails in CI, not production. Mutation-checked in three directions (new route dir, stale const entry, missing tree → hard failure, no skip).

## Review chain & disclosed acceptance

Opus implementation → my review (added the contract-test requirement) → Luna second-model review. Luna's remaining P2 — nested unknown paths inside a declared namespace (e.g. `/search/no-such-page`) still serve the SPA document — is **accepted, not fixed**: depth inside an owned namespace is the app router's jurisdiction (it renders its own 404 view), no Conary client probes those namespaces, and encoding SvelteKit's per-route depth grammar server-side creates a second drift surface. Revisit only if a real probe ever cares.

**Deploy-visible behavior change:** remi.conary.io answers unknown paths with 404 JSON instead of 200 HTML. `/health` remains the liveness surface.

## Verification (run, real output)

`cargo test -p remi`: 632 lib / 5 bin / 3 cli_help, 0 failed. Clippy `-D warnings` clean, fmt clean, doc-truth clean, `web/` tree untouched (`git status` clean). Independent reviewer re-runs matched.

Closes #317. Refs #155 (client half stays open), #318, #312.