### PR TITLE
chore: release remi-v0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [remi-v0.11.2] - 2026-08-08
+
+### Fixed
+- keep refused-key GC rows and stop the SPA fallback lying (#319)
+- close the GC/conversion race and report R2 bytes honestly (#318)
+
 ## [remi-v0.11.1] - 2026-08-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4858,7 +4858,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remi"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/apps/remi/Cargo.toml
+++ b/apps/remi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remi"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]


### PR DESCRIPTION
Release prep for remi-v0.11.2 (patch, from fixes #318 and #319).

Ships since remi-v0.11.1 — the GC-hardening and boundary-honesty batch:
- #318 — GC/conversion race closed at root (grace-touch reordered before the write-through; restart-once write-through pass so a repaired conversion can't publish references to GC-deleted R2 objects); r2_bytes_freed now real (refused keys excluded via failed_hashes). Closes #316, #312.
- #319 — chunk_access rows survive R2-refused deletes (#317); unknown public paths 404 with typed JSON instead of serving the SPA document (#155 server half; explicit namespace list + route-tree contract test).

Deploy-visible change: remi.conary.io unknown paths now 404 (was 200 text/html). /health is the liveness surface.

After merge: tag remi-v0.11.2, push to trigger release-build → deploy-and-verify.

Refs #316, #312, #317, #155.