### PR TITLE
test(repository): make the Remi polling contract exhaustive for both clients

### DIFF
--- a/crates/conary-core/src/repository/remi/protocol.rs
+++ b/crates/conary-core/src/repository/remi/protocol.rs
@@ -26,6 +26,10 @@ pub struct JobStatus {
 }
 
 /// Exact lifecycle states published by Remi's job-status endpoint.
+///
+/// The wire names are owned by `apps/remi/src/server/handlers/jobs.rs`. A state
+/// outside this set is rejected during deserialization rather than treated as
+/// active work.
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum ConversionJobState {
@@ -33,6 +37,15 @@ pub enum ConversionJobState {
     Converting,
     Ready,
     Failed,
+}
+
+impl ConversionJobState {
+    /// Every state the shared polling contract admits.
+    ///
+    /// Extend this when Remi publishes a new job state; the contract test
+    /// drives both clients through each entry.
+    #[cfg(test)]
+    pub(super) const ALL: [Self; 4] = [Self::Pending, Self::Converting, Self::Ready, Self::Failed];
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/conary-core/src/repository/remi/tests.rs
+++ b/crates/conary-core/src/repository/remi/tests.rs
@@ -283,111 +283,179 @@ async fn fetch_package_requests_identity_encoding() {
     );
 }
 
-#[tokio::test]
-async fn get_package_rejects_retired_job_status() {
-    use tokio::net::TcpListener;
-
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let base_url = format!("http://{}", listener.local_addr().unwrap());
-
-    tokio::spawn(async move {
-        let accepted =
-            r#"{"status":"queued","job_id":"35","poll_url":"/v1/jobs/35","eta_seconds":1}"#;
-        write_json_response(&listener, "202 Accepted", accepted).await;
-
-        let unsupported = r#"{
-            "job_id": "35",
-            "status": "blocked",
-            "distro": "fedora",
-            "package": "kernel-core",
-            "version": "6.19.10-300.fc44",
-            "architecture": "x86_64",
-            "progress": null,
-            "error": null,
-            "manifest": null
-        }"#;
-        write_json_response(&listener, "200 OK", unsupported).await;
-    });
-
-    let client = RemiClient::new(&base_url).unwrap();
-    let err = client
-        .get_package("fedora", "kernel-core", None, Some("x86_64"))
-        .await
-        .unwrap_err();
-    let message = err.to_string();
-
-    assert!(message.contains("unknown variant `blocked`"), "{message}");
-}
-
+/// Poll cycles the former fixed 300-second cutoff allowed at the 2-second poll
+/// interval. An active job must survive more than this many cycles.
 const POLLS_BEYOND_FORMER_FIVE_MINUTE_CUTOFF: usize = 152;
 
-async fn spawn_active_job_server(active_polls: usize) -> (String, tokio::task::JoinHandle<()>) {
+const CONTRACT_JOB_ID: &str = "55";
+const CONTRACT_PACKAGE: &str = "kernel-modules-core";
+const CONTRACT_FAILURE_REASON: &str = "converter rejected payload";
+
+fn job_response(state: &str, error: Option<&str>, manifest: Option<&str>) -> String {
+    let error = match error {
+        Some(reason) => format!("\"{reason}\""),
+        None => "null".to_string(),
+    };
+    let manifest = manifest.unwrap_or("null");
+    format!(
+        r#"{{"job_id":"{CONTRACT_JOB_ID}","status":"{state}","distro":"fedora","package":"{CONTRACT_PACKAGE}","version":"6.19.10-300.fc44","architecture":"x86_64","progress":null,"error":{error},"manifest":{manifest}}}"#
+    )
+}
+
+fn ready_job_response() -> String {
+    let manifest = format!(
+        r#"{{"name":"{CONTRACT_PACKAGE}","version":"6.19.10-300.fc44","distro":"fedora","chunks":[],"total_size":0,"content_hash":"sha256:test"}}"#
+    );
+    job_response("ready", None, Some(&manifest))
+}
+
+/// Outcome the shared contract requires from every client for a given state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExpectedOutcome {
+    ReadyManifest,
+    ConversionFailed,
+}
+
+/// The poll responses that exercise `state`, and the outcome both clients must
+/// reach.
+///
+/// The match is exhaustive, so a new `ConversionJobState` cannot be added
+/// without stating its contract here.
+fn contract_case(state: ConversionJobState) -> (Vec<String>, ExpectedOutcome) {
+    let outlive_former_cutoff = |wire_state: &str| {
+        let mut responses =
+            vec![job_response(wire_state, None, None); POLLS_BEYOND_FORMER_FIVE_MINUTE_CUTOFF];
+        responses.push(ready_job_response());
+        (responses, ExpectedOutcome::ReadyManifest)
+    };
+
+    match state {
+        ConversionJobState::Pending => outlive_former_cutoff("pending"),
+        ConversionJobState::Converting => outlive_former_cutoff("converting"),
+        ConversionJobState::Ready => (vec![ready_job_response()], ExpectedOutcome::ReadyManifest),
+        ConversionJobState::Failed => (
+            vec![job_response("failed", Some(CONTRACT_FAILURE_REASON), None)],
+            ExpectedOutcome::ConversionFailed,
+        ),
+    }
+}
+
+/// Serve one 202 acceptance followed by `poll_responses` job-status bodies.
+async fn spawn_job_poll_server(
+    poll_responses: Vec<String>,
+) -> (String, tokio::task::JoinHandle<()>) {
     use tokio::net::TcpListener;
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let base_url = format!("http://{}", listener.local_addr().unwrap());
     let server = tokio::spawn(async move {
-        let accepted =
-            r#"{"status":"queued","job_id":"55","poll_url":"/v1/jobs/55","eta_seconds":null}"#;
-        write_json_response(&listener, "202 Accepted", accepted).await;
+        let accepted = format!(
+            r#"{{"status":"queued","job_id":"{CONTRACT_JOB_ID}","poll_url":"/v1/jobs/{CONTRACT_JOB_ID}","eta_seconds":null}}"#
+        );
+        write_json_response(&listener, "202 Accepted", &accepted).await;
 
-        for poll in 0..active_polls {
-            let state = if poll % 2 == 0 {
-                "pending"
-            } else {
-                "converting"
-            };
-            let active = format!(
-                r#"{{"job_id":"55","status":"{state}","distro":"fedora","package":"kernel-modules-core","version":"6.19.10-300.fc44","architecture":"x86_64","progress":null,"error":null,"manifest":null}}"#
-            );
-            write_json_response(&listener, "200 OK", &active).await;
+        for body in poll_responses {
+            write_json_response(&listener, "200 OK", &body).await;
         }
-
-        let ready = r#"{
-            "job_id":"55",
-            "status":"ready",
-            "distro":"fedora",
-            "package":"kernel-modules-core",
-            "version":"6.19.10-300.fc44",
-            "architecture":"x86_64",
-            "progress":100,
-            "error":null,
-            "manifest":{
-                "name":"kernel-modules-core",
-                "version":"6.19.10-300.fc44",
-                "distro":"fedora",
-                "chunks":[],
-                "total_size":0,
-                "content_hash":"sha256:test"
-            }
-        }"#;
-        write_json_response(&listener, "200 OK", ready).await;
     });
 
     (base_url, server)
 }
 
-#[tokio::test]
-async fn both_clients_wait_past_the_former_five_minute_poll_cycle_count() {
-    let (base_url, server) = spawn_active_job_server(POLLS_BEYOND_FORMER_FIVE_MINUTE_CUTOFF).await;
-    let mut client = RemiClient::new(&base_url).unwrap();
+async fn regular_client_outcome(base_url: &str) -> Result<PackageManifest> {
+    let mut client = RemiClient::new(base_url).unwrap();
     client.core.poll_interval = Duration::from_millis(1);
-    let manifest = client
-        .get_package("fedora", "kernel-modules-core", None, Some("x86_64"))
+    client
+        .get_package("fedora", CONTRACT_PACKAGE, None, Some("x86_64"))
         .await
-        .unwrap();
-    assert_eq!(manifest.name, "kernel-modules-core");
+}
+
+async fn async_client_outcome(base_url: &str) -> Result<PackageManifest> {
+    let cache = tempfile::tempdir().unwrap();
+    let mut client = AsyncRemiClient::new(base_url, cache.path()).unwrap();
+    client.core.poll_interval = Duration::from_millis(1);
+    client
+        .get_package("fedora", CONTRACT_PACKAGE, None, Some("x86_64"))
+        .await
+}
+
+fn assert_contract_outcome(
+    result: Result<PackageManifest>,
+    expected: ExpectedOutcome,
+    state: ConversionJobState,
+    client: &str,
+) {
+    match expected {
+        ExpectedOutcome::ReadyManifest => {
+            let manifest = result.unwrap_or_else(|error| {
+                panic!("{client} client failed on {state:?}: {error}");
+            });
+            assert_eq!(manifest.name, CONTRACT_PACKAGE);
+        }
+        ExpectedOutcome::ConversionFailed => {
+            let message = result
+                .err()
+                .unwrap_or_else(|| panic!("{client} client accepted a failed {state:?} job"))
+                .to_string();
+            assert!(
+                message.contains("Conversion failed"),
+                "{client} client on {state:?}: {message}"
+            );
+            assert!(
+                message.contains(CONTRACT_FAILURE_REASON),
+                "{client} client dropped the server failure reason on {state:?}: {message}"
+            );
+        }
+    }
+}
+
+/// Every state the shared protocol admits reaches the same outcome in the
+/// regular and async clients, and no active state is failed on elapsed time.
+#[tokio::test]
+async fn both_clients_share_one_polling_state_contract() {
+    for state in ConversionJobState::ALL {
+        let (responses, expected) = contract_case(state);
+
+        let (base_url, server) = spawn_job_poll_server(responses.clone()).await;
+        assert_contract_outcome(
+            regular_client_outcome(&base_url).await,
+            expected,
+            state,
+            "regular",
+        );
+        server.await.unwrap();
+
+        let (base_url, server) = spawn_job_poll_server(responses).await;
+        assert_contract_outcome(
+            async_client_outcome(&base_url).await,
+            expected,
+            state,
+            "async",
+        );
+        server.await.unwrap();
+    }
+}
+
+/// A status outside the shared contract is a typed rejection in both clients,
+/// never silently treated as an active job.
+#[tokio::test]
+async fn both_clients_reject_a_status_outside_the_shared_contract() {
+    let retired = vec![job_response("blocked", None, None)];
+
+    let (base_url, server) = spawn_job_poll_server(retired.clone()).await;
+    let message = regular_client_outcome(&base_url)
+        .await
+        .expect_err("regular client accepted a retired job status")
+        .to_string();
+    assert!(message.contains("unknown variant `blocked`"), "{message}");
     server.await.unwrap();
 
-    let (base_url, server) = spawn_active_job_server(POLLS_BEYOND_FORMER_FIVE_MINUTE_CUTOFF).await;
-    let cache = tempfile::tempdir().unwrap();
-    let mut client = AsyncRemiClient::new(&base_url, cache.path()).unwrap();
-    client.core.poll_interval = Duration::from_millis(1);
-    let manifest = client
-        .get_package("fedora", "kernel-modules-core", None, Some("x86_64"))
+    let (base_url, server) = spawn_job_poll_server(retired).await;
+    let message = async_client_outcome(&base_url)
         .await
-        .unwrap();
-    assert_eq!(manifest.name, "kernel-modules-core");
+        .expect_err("async client accepted a retired job status")
+        .to_string();
+    assert!(message.contains("unknown variant `blocked`"), "{message}");
     server.await.unwrap();
 }
 

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-06
-revision: 27
+last_updated: 2026-08-08
+revision: 28
 summary: Document exact profile-owned source policy, multi-root model authority, Remi CCS package authority, canonical map authority, native repository authority, package identity, full-adoption root continuity, and lifecycle handoff
 ---
 
@@ -134,6 +134,10 @@ An accepted Remi conversion remains server-owned work until the typed job
 status reaches `ready` or `failed`. The client continues to observe `pending`
 and `converting` jobs; it does not turn elapsed wall time into conversion
 failure. Cancellation and complete-operation deadlines belong to the caller.
+The regular and async clients share one decision over the typed job state, so a
+status outside that contract is a typed rejection in both rather than an
+active job. Bounded transport and 5xx retries stay separate from that decision:
+exhausting them is a transport failure, not a conversion failure.
 
 ## Remi CCS Package Authority
 


### PR DESCRIPTION
## Audit result, not a behavior fix

#278's production fix already landed on main as #279 (`969a4652`) — no `POLL_TIMEOUT`, no 300s string anywhere in the tree. This PR closes the one real gap found auditing main against the issue's acceptance criteria: the contract test pinned instances, not the property.

- `ConversionJobState::ALL` + an exhaustive `contract_case` match: a new admitted state fails to compile until its contract is declared.
- Every state driven through BOTH clients (Failed was previously proven through neither; unsupported-status through one) against a mock server, 1ms poll interval, 152 active polls per waiting state — the former-cutoff property preserved per-state, no real sleeps, 2.5s suite.
- Mutation-checked: misclassifying `Pending` fails exactly the classifier test and the both-client contract test.
- Wire contract verified against the server source (`jobs.rs` emits pending|converting|ready|failed; the 202 "queued" string is a different field that never routes through the enum).
- `docs/modules/source-selection.md` rev 28: states the shared-decision and transport-retry-separation facts.

## Verification (run, real output)

Resolution feature card focused proof: repository::trust 43, parsers 68, download 9, sync 46, repository 561, resolver 126, package_relations 16 — all passing. Interaction gate: all six named suites passing. `cargo test -p conary-core` full: 3352 passed. Clippy workspace `-D warnings` clean, fmt clean, doc-truth clean.

## Found, filed/noted separately

- `AsyncRemiClient` has zero production consumers, and its transport-retry behavior has drifted from the regular client (no transient tolerance) — latent only because it's dead. Issue to follow.
- `agent-context.sh --path crates/conary-core/src/repository` doesn't route to the resolution card that owns the path — one-line hint-table gap for the next meta slice.

Refs #278 — its last open criterion (four-suite rerun with cold conversion evidence) already ran green on a head containing #279 (the 13/13 milestone), but with prewarmed fixtures; whether the criterion's substance is satisfied is an operator call for the issue, not this PR.