### PR TITLE
fix(ci): take upstream registries off the lifecycle image hot path

### DIFF
--- a/.github/actions/cache-base-image/action.yml
+++ b/.github/actions/cache-base-image/action.yml
@@ -1,0 +1,81 @@
+name: cache-base-image
+description: >-
+  Load a lifecycle test image's digest-pinned base image from an
+  actions/cache entry keyed on that digest, so the upstream registry
+  (registry.fedoraproject.org or docker.io) is off the CI hot path on every
+  cache hit. On a cache miss the base image is pulled once, with bounded
+  retry, and the cache is populated for the next run. Because the cache key
+  is the digest baked into the Containerfile's FROM line, a stale cache is
+  impossible by construction: an upstream tag bump only takes effect once the
+  Containerfile is deliberately re-pinned (issue #323).
+inputs:
+  distro:
+    description: Test distro slug (fedora44, ubuntu-26.04, arch).
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Resolve the pinned base image reference
+      id: base-image
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        containerfile="apps/conary/tests/integration/remi/containers/Containerfile.${{ inputs.distro }}"
+        [[ -f "$containerfile" ]] || {
+          echo "no Containerfile for distro ${{ inputs.distro }}: $containerfile" >&2
+          exit 1
+        }
+
+        ref="$(grep -m1 '^FROM ' "$containerfile" | awk '{print $2}')"
+        [[ "$ref" == *@sha256:* ]] || {
+          echo "FROM line in $containerfile is not digest-pinned: $ref" >&2
+          exit 1
+        }
+
+        digest="${ref##*@sha256:}"
+        echo "ref=$ref" >> "$GITHUB_OUTPUT"
+        echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+    - name: Restore the cached base image
+      id: cache
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      with:
+        path: ~/.cache/conary-base-images/${{ inputs.distro }}.tar
+        key: conary-base-image-${{ inputs.distro }}-${{ steps.base-image.outputs.digest }}
+
+    - name: Load the cached base image
+      if: steps.cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: docker load --input ~/.cache/conary-base-images/${{ inputs.distro }}.tar
+
+    - name: Pull the base image by digest (cache miss)
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        BASE_IMAGE_REF: ${{ steps.base-image.outputs.ref }}
+      run: |
+        set -euo pipefail
+
+        max_attempts=3
+        attempt=1
+        until docker pull "$BASE_IMAGE_REF"; do
+          if (( attempt >= max_attempts )); then
+            echo "failed to pull $BASE_IMAGE_REF after $max_attempts attempts" >&2
+            exit 1
+          fi
+          sleep_for=$(( attempt * 5 ))
+          echo "pull attempt $attempt of $max_attempts failed for $BASE_IMAGE_REF, retrying in ${sleep_for}s..." >&2
+          sleep "$sleep_for"
+          attempt=$(( attempt + 1 ))
+        done
+
+    - name: Save the pulled base image into the cache
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        BASE_IMAGE_REF: ${{ steps.base-image.outputs.ref }}
+      run: |
+        set -euo pipefail
+        mkdir -p ~/.cache/conary-base-images
+        docker save --output ~/.cache/conary-base-images/${{ inputs.distro }}.tar "$BASE_IMAGE_REF"

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -155,6 +155,9 @@ jobs:
       - uses: ./.github/actions/build-static-conary
       - name: Build the lifecycle harness
         run: cargo build -p conary -p conary-test
+      - uses: ./.github/actions/cache-base-image
+        with:
+          distro: ${{ matrix.distro }}
       - name: Build the ${{ matrix.distro }} test image
         run: cargo run -p conary-test -- images build --distro "${{ matrix.distro }}"
       - name: Capture the native oracle and run Cartesian lifecycle parity

--- a/.github/workflows/release-artifact-proof.yml
+++ b/.github/workflows/release-artifact-proof.yml
@@ -154,6 +154,9 @@ jobs:
       - uses: ./.github/actions/build-static-conary
       - name: Build the lifecycle harness
         run: cargo build -p conary -p conary-test
+      - uses: ./.github/actions/cache-base-image
+        with:
+          distro: ${{ matrix.distro }}
       - name: Install the published native package in the test image
         run: >-
           cargo run -p conary-test --

--- a/apps/conary/tests/integration/remi/containers/Containerfile.arch
+++ b/apps/conary/tests/integration/remi/containers/Containerfile.arch
@@ -4,8 +4,17 @@
 # Modes:
 #   binary  (default) - copies the pre-built static binary directly
 #   package           - installs from pkg.tar.zst via pacman
-
-FROM docker.io/library/archlinux:latest
+#
+# The base image is pinned by digest so upstream tag drift (Arch is a rolling
+# release; "latest" moves daily) is a deliberate bump, not silent CI exposure
+# (issue #323). Re-resolve with (needs an anonymous Docker Hub pull token
+# first):
+#   token=$(curl -s 'https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/archlinux:pull' | jq -r .token)
+#   curl -sI -H "Authorization: Bearer $token" \
+#     -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json' \
+#     https://registry-1.docker.io/v2/library/archlinux/manifests/latest
+# and take the Docker-Content-Digest response header.
+FROM docker.io/library/archlinux:latest@sha256:345a872f6c95e082d4b8c050af637eebb57402c6e2177b411c3acf7df84eb33b
 
 ARG INSTALL_MODE=binary
 

--- a/apps/conary/tests/integration/remi/containers/Containerfile.fedora44
+++ b/apps/conary/tests/integration/remi/containers/Containerfile.fedora44
@@ -4,8 +4,13 @@
 # Modes:
 #   binary  (default) - copies the pre-built static binary directly
 #   package           - installs from RPM via dnf
-
-FROM registry.fedoraproject.org/fedora:44
+#
+# The base image is pinned by digest so upstream tag drift is a deliberate
+# bump, not silent CI exposure (issue #323). Re-resolve with:
+#   curl -sI -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json' \
+#     https://registry.fedoraproject.org/v2/fedora/manifests/44
+# and take the Docker-Content-Digest response header.
+FROM registry.fedoraproject.org/fedora:44@sha256:67aa3cac2eb64f9cdfbe826c6ede7826589281c6c9c0d0fad5cb74c94b415689
 
 ARG INSTALL_MODE=binary
 

--- a/apps/conary/tests/integration/remi/containers/Containerfile.ubuntu-26.04
+++ b/apps/conary/tests/integration/remi/containers/Containerfile.ubuntu-26.04
@@ -8,8 +8,16 @@
 # The staged binary is the static musl artifact from
 # scripts/build-static-conary.sh, so this image no longer compiles Conary from
 # source to escape the host's glibc and OpenSSL ABI.
-
-FROM docker.io/library/ubuntu:26.04
+#
+# The base image is pinned by digest so upstream tag drift is a deliberate
+# bump, not silent CI exposure (issue #323). Re-resolve with (needs an
+# anonymous Docker Hub pull token first):
+#   token=$(curl -s 'https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/ubuntu:pull' | jq -r .token)
+#   curl -sI -H "Authorization: Bearer $token" \
+#     -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json' \
+#     https://registry-1.docker.io/v2/library/ubuntu/manifests/26.04
+# and take the Docker-Content-Digest response header.
+FROM docker.io/library/ubuntu:26.04@sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03
 
 ARG INSTALL_MODE=binary
 


### PR DESCRIPTION
## Problem

Two gate failures on 2026-08-08 from `registry.fedoraproject.org` flakiness (#323), both at the base-image contact step: single-attempt pulls of mutable tags on a gate that runs 8+ times a day.

## Fix (mirror/cache direction, per operator decision)

- **Digest-pinned FROMs** in all three lifecycle Containerfiles, resolved live via each registry's manifest API (commands documented in-file for future bumps). Upstream tag drift becomes a deliberate re-pin, matching the digest-pinning house style already used for the packaging builder images.
- **`cache-base-image` composite action**: extracts the pinned reference (fail-closed if a FROM ever loses its digest), restores an `actions/cache` entry keyed on the digest, `docker load`s on hit — zero registry contact — or pulls by digest with 3-attempt backoff and saves on miss. Key = digest ⇒ stale cache impossible by construction.
- Wired into `pr-gate.yml` and `release-artifact-proof.yml`. No Rust changes: `BollardBackend::build_image` sets no pull flag, so the pre-loaded image satisfies the pinned FROM (verified in source).

## Verification

Local (real output): YAML parses, action-runtime pin check + fixtures, release-matrix check + fixtures, doc-truth, fmt — all green. **This PR's own CI run is the cache-miss + retry proof; its second run (or the next PR) proves the hit path.** Runtime cache behavior is CI-only provable, stated plainly.

Implemented by delegate, reviewed (action shell audited line-by-line). Closes #323.