### PR TITLE
feat(repository): ingest filelists.xml as signed file-provider authority

### DIFF
--- a/crates/conary-core/src/repository/parsers/fedora.rs
+++ b/crates/conary-core/src/repository/parsers/fedora.rs
@@ -2,11 +2,15 @@
 
 //! Fedora/RPM repository metadata parser
 //!
-//! Parses Fedora-style repomd.xml and primary.xml files which contain
-//! RPM package metadata in XML format.
+//! Parses Fedora-style repomd.xml, primary.xml, and filelists.xml files which
+//! contain RPM package metadata in XML format.
 //! Generator-selected `<file>` records in primary.xml are package-owned file
 //! provides. This follows createrepo_c's pinned primary metadata contract:
 //! <https://github.com/rpm-software-management/createrepo_c/blob/5cf41fe5d703901d78078ed18c67ab667e446c1a/src/xml_dump.c#L175-L225>.
+//! primary.xml carries only the paths that contract selects, so complete
+//! package file ownership comes from the signed filelists.xml document
+//! (`fedora/filelists.rs`), which is projected into the same typed file
+//! capabilities.
 
 use super::common::{self, MAX_PACKAGE_SIZE};
 use super::{ChecksumType, PackageMetadata, RepositoryParser};
@@ -25,13 +29,18 @@ use quick_xml::events::Event;
 use serde_json::json;
 use tracing::{debug, info};
 
+mod filelists;
+mod files;
 mod metalink;
 mod provides;
 mod relation;
+mod repomd;
+use files::FileRecordReader;
 use metalink::parse_metalink_repomd_identity;
 use relation::{
     RpmProvideConstraint, rpm_provide_constraint, rpm_relation_native_text, rpm_require_to_group,
 };
+use repomd::{RepoMdDocument, RepoMdIndex, RepoMdRecord};
 
 /// Fedora/RPM repository parser
 pub struct FedoraParser {
@@ -59,11 +68,26 @@ impl FormatSection {
     }
 }
 
-impl FedoraParser {
-    fn local_tag_name(tag_name: &str) -> &str {
-        tag_name.rsplit(':').next().unwrap_or(tag_name)
-    }
+/// Namespace-prefixed and unprefixed element names name the same element.
+fn local_tag_name(tag_name: &str) -> &str {
+    tag_name.rsplit(':').next().unwrap_or(tag_name)
+}
 
+/// Build one RPM version string from the exact epoch, version, and release a
+/// signed document records.
+///
+/// primary.xml and filelists.xml both carry `<version epoch ver rel/>`, so one
+/// owner keeps the corpus version and the filelists join comparable.
+fn rpm_version_text(epoch: Option<&str>, ver: &str, rel: &str) -> String {
+    let epoch = epoch.unwrap_or("0");
+    if epoch == "0" {
+        format!("{ver}-{rel}")
+    } else {
+        format!("{epoch}:{ver}-{rel}")
+    }
+}
+
+impl FedoraParser {
     /// Create a new Fedora/RPM parser
     pub fn new(architecture: String, trust: PreparedOpenPgpTrust) -> Result<Self> {
         if !matches!(trust.policy(), RepositoryTrustPolicy::Rpm { .. }) {
@@ -77,10 +101,10 @@ impl FedoraParser {
         })
     }
 
-    /// Download repomd.xml and find primary.xml location
+    /// Download repomd.xml and admit the metadata records Conary reads.
     ///
     /// Uses RepositoryClient for HTTP.
-    async fn get_primary_xml_location(&self, repo_url: &str) -> Result<PrimaryMetadataLocation> {
+    async fn fetch_repomd_index(&self, repo_url: &str) -> Result<RepoMdIndex> {
         let repomd_url = format!("{}/repodata/repomd.xml", repo_url.trim_end_matches('/'));
         debug!("Downloading repomd.xml from: {}", repomd_url);
 
@@ -116,194 +140,35 @@ impl FedoraParser {
         let xml_content = String::from_utf8(xml_bytes)
             .map_err(|e| Error::ParseError(format!("Invalid UTF-8 in repomd.xml: {}", e)))?;
 
-        // Parse repomd.xml to find primary location
-        let mut reader = Reader::from_str(&xml_content);
-        reader.config_mut().trim_text_end = true;
-
-        let mut buf = Vec::new();
-        let mut in_primary = false;
-        let mut location = None;
-        let mut checksum = None;
-        let mut checksum_type = None;
-        let mut size = None;
-        let mut current_field = None;
-        let mut primary_records = 0usize;
-
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(e)) if e.name().as_ref() == b"data" => {
-                    // Check if this is the primary data type
-                    for attr in e.attributes() {
-                        let attr = attr.map_err(|error| {
-                            Error::ParseError(format!(
-                                "Failed to parse repomd.xml data attribute: {error}"
-                            ))
-                        })?;
-                        if attr.key.as_ref() == b"type"
-                            && attr
-                                .decoded_and_normalized_value(
-                                    quick_xml::XmlVersion::Implicit1_0,
-                                    reader.decoder(),
-                                )
-                                .map_err(|error| {
-                                    Error::ParseError(format!(
-                                        "Failed to decode repomd.xml data type: {error}"
-                                    ))
-                                })?
-                                == "primary"
-                        {
-                            primary_records += 1;
-                            if primary_records > 1 {
-                                return Err(Error::ParseError(
-                                    "repomd.xml repeats primary metadata records".to_string(),
-                                ));
-                            }
-                            in_primary = true;
-                        }
-                    }
-                }
-                Ok(Event::Start(e)) if in_primary && e.name().as_ref() == b"checksum" => {
-                    current_field = Some("checksum");
-                    for attr in e.attributes() {
-                        let attr = attr.map_err(|error| {
-                            Error::ParseError(format!(
-                                "Failed to parse repomd.xml checksum attribute: {error}"
-                            ))
-                        })?;
-                        if attr.key.as_ref() == b"type" {
-                            checksum_type = Some(
-                                attr.decoded_and_normalized_value(
-                                    quick_xml::XmlVersion::Implicit1_0,
-                                    reader.decoder(),
-                                )
-                                .map_err(|error| {
-                                    Error::ParseError(format!(
-                                        "Failed to decode repomd.xml checksum type: {error}"
-                                    ))
-                                })?
-                                .into_owned(),
-                            );
-                        }
-                    }
-                }
-                Ok(Event::Start(e)) if in_primary && e.name().as_ref() == b"size" => {
-                    current_field = Some("size");
-                }
-                Ok(Event::Start(e) | Event::Empty(e))
-                    if e.name().as_ref() == b"location" && in_primary =>
-                {
-                    // Extract href attribute
-                    for attr in e.attributes() {
-                        let attr = attr.map_err(|error| {
-                            Error::ParseError(format!(
-                                "Failed to parse repomd.xml location attribute: {error}"
-                            ))
-                        })?;
-                        if attr.key.as_ref() == b"href" {
-                            location = Some(
-                                attr.decoded_and_normalized_value(
-                                    quick_xml::XmlVersion::Implicit1_0,
-                                    reader.decoder(),
-                                )
-                                .map_err(|error| {
-                                    Error::ParseError(format!(
-                                        "Failed to decode repomd.xml location: {error}"
-                                    ))
-                                })?
-                                .into_owned(),
-                            );
-                        }
-                    }
-                }
-                Ok(Event::Text(text)) if in_primary => {
-                    let value = text
-                        .xml_content(quick_xml::XmlVersion::Implicit1_0)
-                        .map_err(|error| {
-                            Error::ParseError(format!("Failed to decode repomd.xml text: {error}"))
-                        })?
-                        .trim()
-                        .to_string();
-                    match current_field {
-                        Some("checksum") => checksum = Some(value),
-                        Some("size") => size = Some(value),
-                        _ => {}
-                    }
-                }
-                Ok(Event::End(e)) if e.name().as_ref() == b"data" => {
-                    in_primary = false;
-                    current_field = None;
-                }
-                Ok(Event::End(e)) if matches!(e.name().as_ref(), b"checksum" | b"size") => {
-                    current_field = None;
-                }
-                Ok(Event::Eof) => break,
-                Err(e) => {
-                    return Err(Error::ParseError(format!(
-                        "Failed to parse repomd.xml: {}",
-                        e
-                    )));
-                }
-                _ => {}
-            }
-            buf.clear();
-        }
-
-        let href = location.ok_or_else(|| {
-            Error::ParseError("Could not find primary data location in repomd.xml".to_string())
-        })?;
-        common::validate_filename(&href).map_err(Error::ParseError)?;
-        if checksum_type.as_deref() != Some("sha256") {
-            return Err(Error::ParseError(format!(
-                "RPM primary metadata requires exact sha256 identity; found {:?}",
-                checksum_type.as_deref()
-            )));
-        }
-        let sha256 = checksum.ok_or_else(|| {
-            Error::ParseError("repomd.xml primary record has no checksum".to_string())
-        })?;
-        validate_sha256(&sha256, "repomd.xml primary")?;
-        let size = size
-            .ok_or_else(|| {
-                Error::ParseError("repomd.xml primary record has no compressed size".to_string())
-            })?
-            .parse::<u64>()
-            .map_err(|error| {
-                Error::ParseError(format!(
-                    "repomd.xml primary compressed size is invalid: {error}"
-                ))
-            })?;
-        Ok(PrimaryMetadataLocation { href, sha256, size })
+        // Parse repomd.xml into the records Conary reads.
+        repomd::parse_repomd(&xml_content)
     }
 
-    /// Download and decompress primary.xml
+    /// Download one metadata document and verify it against its signed record.
     ///
-    /// Uses RepositoryClient for HTTP and the compression module for auto-decompression.
-    async fn download_primary_xml(
+    /// The served (still compressed) bytes are what the signed repomd.xml
+    /// records, so identity is established before a decoder ever sees them.
+    async fn download_verified_document(
         &self,
         repo_url: &str,
-        location: &PrimaryMetadataLocation,
-    ) -> Result<String> {
-        let primary_url = format!("{}/{}", repo_url.trim_end_matches('/'), location.href);
-        debug!("Downloading primary.xml from: {}", primary_url);
+        record: &RepoMdRecord,
+    ) -> Result<(String, Vec<u8>)> {
+        let document_url = format!("{}/{}", repo_url.trim_end_matches('/'), record.href);
+        debug!(
+            "Downloading {} metadata from: {}",
+            record.document.label(),
+            document_url
+        );
 
         let client = RepositoryClient::new()?;
-        let raw_bytes = client.download_to_bytes(&primary_url).await?;
-        if raw_bytes.len() as u64 != location.size {
-            return Err(Error::GpgVerificationFailed(format!(
-                "signed repomd.xml authenticates primary metadata as {} bytes but the repository \
-                 served {} bytes",
-                location.size,
-                raw_bytes.len()
-            )));
-        }
-        let actual = crate::hash::sha256(&raw_bytes);
-        if actual != location.sha256 {
-            return Err(Error::GpgVerificationFailed(format!(
-                "RPM primary metadata identity mismatch: signed repomd.xml SHA256 is {}, \
-                 downloaded SHA256 is {}",
-                location.sha256, actual
-            )));
-        }
+        let raw_bytes = client.download_to_bytes(&document_url).await?;
+        record.verify_served_bytes(&raw_bytes)?;
+        Ok((document_url, raw_bytes))
+    }
+
+    /// Download, verify, and decompress primary.xml.
+    async fn download_primary_xml(&self, repo_url: &str, record: &RepoMdRecord) -> Result<String> {
+        let (primary_url, raw_bytes) = self.download_verified_document(repo_url, record).await?;
         let decompressed =
             decompress_metadata_auto(&raw_bytes, &format!("RPM primary metadata {primary_url}"))?;
         let content = String::from_utf8(decompressed).map_err(|error| {
@@ -327,18 +192,14 @@ impl FedoraParser {
         let mut current_tag = String::new();
         let mut in_format = false;
         let mut format_section = None;
-        let mut current_primary_file = None::<String>;
+        let mut file_record = FileRecordReader::new(RepoMdDocument::Primary);
 
         loop {
             match reader.read_event_into(&mut buf) {
                 Ok(Event::Start(e)) => {
                     let tag_name = String::from_utf8_lossy(e.name().as_ref()).to_string();
-                    let local_tag = Self::local_tag_name(&tag_name);
-                    if current_primary_file.is_some() {
-                        return Err(Error::ParseError(
-                            "RPM primary file record cannot contain nested elements".to_string(),
-                        ));
-                    }
+                    let local_tag = local_tag_name(&tag_name);
+                    file_record.reject_nested_element()?;
                     current_tag = tag_name.clone();
 
                     match local_tag {
@@ -364,10 +225,7 @@ impl FedoraParser {
                                     "RPM primary file record appears outside a package".to_string(),
                                 ));
                             }
-                            current_primary_file = Some(String::new());
-                            // A path's trailing XML whitespace is package
-                            // identity, not inter-element formatting.
-                            reader.config_mut().trim_text_end = false;
+                            file_record.open(&mut reader);
                         }
                         "checksum" => {
                             if let Some(ref mut pkg) = current_package {
@@ -400,12 +258,8 @@ impl FedoraParser {
                 }
                 Ok(Event::Empty(e)) => {
                     let tag_name = String::from_utf8_lossy(e.name().as_ref()).to_string();
-                    let local_tag = Self::local_tag_name(&tag_name);
-                    if current_primary_file.is_some() {
-                        return Err(Error::ParseError(
-                            "RPM primary file record cannot contain nested elements".to_string(),
-                        ));
-                    }
+                    let local_tag = local_tag_name(&tag_name);
+                    file_record.reject_nested_element()?;
 
                     match local_tag {
                         "version" => {
@@ -629,9 +483,7 @@ impl FedoraParser {
                             }
                         }
                         "file" if in_format => {
-                            return Err(Error::ParseError(
-                                "RPM primary file record must contain an absolute path".to_string(),
-                            ));
+                            return Err(file_record.empty_record_error());
                         }
                         _ => {}
                     }
@@ -657,9 +509,9 @@ impl FedoraParser {
                     if text.is_empty() {
                         continue;
                     }
-                    if let Some(file) = current_primary_file.as_mut() {
-                        file.push_str(&text);
-                    } else if let Some(ref mut pkg) = current_package {
+                    if !file_record.push_text(&text)
+                        && let Some(ref mut pkg) = current_package
+                    {
                         append_package_text(pkg, &current_tag, &text);
                     }
                 }
@@ -685,9 +537,9 @@ impl FedoraParser {
                                 .to_string()
                         }
                     };
-                    if let Some(file) = current_primary_file.as_mut() {
-                        file.push_str(&text);
-                    } else if let Some(ref mut pkg) = current_package {
+                    if !file_record.push_text(&text)
+                        && let Some(ref mut pkg) = current_package
+                    {
                         append_package_text(pkg, &current_tag, &text);
                     }
                 }
@@ -699,23 +551,17 @@ impl FedoraParser {
                                     "Failed to decode primary.xml CDATA: {error}"
                                 ))
                             })?;
-                    if let Some(file) = current_primary_file.as_mut() {
-                        file.push_str(&text);
-                    } else if let Some(ref mut pkg) = current_package {
+                    if !file_record.push_text(&text)
+                        && let Some(ref mut pkg) = current_package
+                    {
                         append_package_text(pkg, &current_tag, &text);
                     }
                 }
                 Ok(Event::End(e)) => {
                     let tag_name = String::from_utf8_lossy(e.name().as_ref()).to_string();
-                    let local_tag = Self::local_tag_name(&tag_name);
+                    let local_tag = local_tag_name(&tag_name);
                     if local_tag == "file" && in_format {
-                        let file = current_primary_file.take().ok_or_else(|| {
-                            Error::ParseError(
-                                "RPM primary file record ended without starting".to_string(),
-                            )
-                        })?;
-                        reader.config_mut().trim_text_end = true;
-                        let file = validate_primary_file_path(file)?;
+                        let file = file_record.close(&mut reader)?;
                         current_package
                             .as_mut()
                             .ok_or_else(|| {
@@ -758,14 +604,7 @@ impl FedoraParser {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct PrimaryMetadataLocation {
-    href: String,
-    sha256: String,
-    size: u64,
-}
-
-fn validate_sha256(value: &str, label: &str) -> Result<()> {
+pub(super) fn validate_sha256(value: &str, label: &str) -> Result<()> {
     if value.len() != 64
         || !value.bytes().all(|byte| byte.is_ascii_hexdigit())
         || value.bytes().any(|byte| byte.is_ascii_uppercase())
@@ -816,11 +655,7 @@ impl PackageBuilder {
         let rel = self
             .rel
             .ok_or_else(|| Error::ParseError("Missing release".to_string()))?;
-        let version = if epoch == "0" {
-            format!("{}-{}", ver, rel)
-        } else {
-            format!("{}:{}-{}", epoch, ver, rel)
-        };
+        let version = rpm_version_text(Some(&epoch), &ver, &rel);
 
         let checksum = self
             .checksum
@@ -924,15 +759,6 @@ impl PackageBuilder {
     }
 }
 
-fn validate_primary_file_path(path: String) -> Result<String> {
-    if path.is_empty() || !path.starts_with('/') {
-        return Err(Error::ParseError(
-            "RPM primary file record must contain an absolute path".to_string(),
-        ));
-    }
-    Ok(path)
-}
-
 fn append_package_text(package: &mut PackageBuilder, tag: &str, text: &str) {
     let field = match tag {
         "name" => Some(&mut package.name),
@@ -955,16 +781,40 @@ impl RepositoryParser for FedoraParser {
     async fn sync_metadata(&self, repo_url: &str) -> Result<Vec<PackageMetadata>> {
         info!("Syncing Fedora repository for {}", self.architecture);
 
-        // Get primary.xml location from repomd.xml
-        let primary_location = self.get_primary_xml_location(repo_url).await?;
+        // Admit the signed repomd.xml records Conary reads.
+        let repomd = self.fetch_repomd_index(repo_url).await?;
 
-        // Download and decompress primary.xml
-        let primary_xml = self
-            .download_primary_xml(repo_url, &primary_location)
-            .await?;
+        // Download, verify, and parse primary.xml.
+        let primary_xml = self.download_primary_xml(repo_url, &repomd.primary).await?;
+        let mut packages = self.parse_primary_xml(&primary_xml, repo_url)?;
+        drop(primary_xml);
 
-        // Parse primary.xml
-        let packages = self.parse_primary_xml(&primary_xml, repo_url)?;
+        // primary.xml carries only the generator-selected file set, so
+        // complete package file ownership comes from filelists.xml.
+        match repomd.filelists {
+            Some(record) => {
+                let (filelists_url, raw_bytes) =
+                    self.download_verified_document(repo_url, &record).await?;
+                let compressed =
+                    crate::compression::CompressionFormat::from_magic_bytes(&raw_bytes)
+                        != crate::compression::CompressionFormat::None;
+                let open_size = record.authenticated_open_size(compressed)?;
+                let ingest = filelists::ingest_verified_filelists(
+                    &mut packages,
+                    &raw_bytes,
+                    open_size,
+                    &filelists_url,
+                )?;
+                info!(
+                    "Ingested {} filelists package records: {} file capabilities added, {} already \
+                     published by primary.xml",
+                    ingest.records, ingest.files_added, ingest.files_already_known
+                );
+            }
+            None => {
+                filelists::require_no_filelists_dependent_requirements(&packages, repo_url)?;
+            }
+        }
 
         info!("Parsed {} packages from Fedora repository", packages.len());
         Ok(packages)

--- a/crates/conary-core/src/repository/parsers/fedora/filelists.rs
+++ b/crates/conary-core/src/repository/parsers/fedora/filelists.rs
@@ -1,0 +1,661 @@
+// conary-core/src/repository/parsers/fedora/filelists.rs
+
+//! Complete RPM package file ownership from the signed `filelists.xml`.
+//!
+//! `primary.xml` carries only the file records createrepo_c's yum-compatible
+//! selection rule keeps
+//! ([`cr_xml_dump_files()`](https://github.com/rpm-software-management/createrepo_c/blob/5cf41fe5d703901d78078ed18c67ab667e446c1a/src/xml_dump.c#L175-L225)
+//! writes a record into primary only when `cr_is_primary()` admits the path).
+//! Every other owned path -- most of `/usr/lib`, `/usr/lib64`, and
+//! `/usr/share` -- exists only in `filelists.xml`, which the same generator
+//! writes from the same package list through the same `<file>` writer with the
+//! filter turned off
+//! ([`cr_xml_dump_filelists()`](https://github.com/rpm-software-management/createrepo_c/blob/5cf41fe5d703901d78078ed18c67ab667e446c1a/src/xml_dump_filelists.c)).
+//!
+//! A file dependency on a filtered-out path has no repository provider without
+//! this document, which is exactly the unsolvable class this module closes.
+//! The projection is the same one primary files take: an unversioned typed
+//! file capability with `source-derived-file` provenance on the exact package
+//! (`parsers/fedora/provides.rs`). No selection rule is reimplemented here.
+//!
+//! ## Streaming
+//!
+//! Fedora 44's `filelists.xml` decompresses to roughly 830 MB, so the document
+//! is never materialized. It is decoded from the verified compressed bytes
+//! through a streaming decompressor bounded by the signed `<open-size>`, and
+//! each `<package>` record is folded into its package as it is read. Nothing
+//! is persisted until the whole sync snapshot is persisted, so a refusal at
+//! any point -- including the final length check -- leaves no partial state.
+//!
+//! ## Join
+//!
+//! `pkgid` is the package's SHA-256, which is the same identity `primary.xml`
+//! records as its `<checksum type="sha256">`. Both documents are authenticated
+//! by the same signed `repomd.xml` revision and are generated from the same
+//! package list, so the join is total: every filelists record must name a
+//! package primary published, every primary package must be named, and the
+//! records must agree on name, architecture, and EVR. A disagreement means the
+//! two signed documents describe different repositories, which is refused
+//! rather than resolved.
+
+use super::files::FileRecordReader;
+use super::provides::extend_file_provides;
+use super::repomd::RepoMdDocument;
+use super::{local_tag_name, rpm_version_text};
+use crate::error::{Error, Result};
+use crate::repository::dependency_model::{
+    RepositoryCapabilityKind, RepositoryRequirementExpression, RepositoryRequirementKind,
+};
+use crate::repository::parsers::PackageMetadata;
+use quick_xml::Reader;
+use quick_xml::events::{BytesStart, Event};
+use std::collections::{HashMap, HashSet};
+use std::io::{BufRead, Read};
+
+const DOCUMENT: RepoMdDocument = RepoMdDocument::Filelists;
+
+/// What one filelists ingest added to the package corpus.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) struct FilelistsIngest {
+    /// `<package>` records read.
+    pub(super) records: usize,
+    /// File capabilities added.
+    pub(super) files_added: usize,
+    /// Records already known from `primary.xml`, so no duplicate row is made.
+    pub(super) files_already_known: usize,
+}
+
+/// A reader that admits exactly the signed decompressed length.
+///
+/// The ceiling comes from the authenticated `repomd.xml` record, so a stream
+/// that decodes to more than the repository signed for is refused before the
+/// extra bytes are parsed, and a stream that stops early is caught by the
+/// final length comparison.
+struct AuthenticatedLengthReader<R> {
+    inner: R,
+    read: u64,
+    ceiling: u64,
+    label: &'static str,
+}
+
+impl<R: Read> AuthenticatedLengthReader<R> {
+    fn new(inner: R, ceiling: u64, label: &'static str) -> Self {
+        Self {
+            inner,
+            read: 0,
+            ceiling,
+            label,
+        }
+    }
+
+    const fn read_bytes(&self) -> u64 {
+        self.read
+    }
+}
+
+impl<R: Read> Read for AuthenticatedLengthReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let read = self.inner.read(buf)?;
+        self.read = self.read.saturating_add(read as u64);
+        if self.read > self.ceiling {
+            return Err(std::io::Error::other(format!(
+                "RPM {} metadata decodes to more than the {} bytes the signed repomd.xml declares",
+                self.label, self.ceiling
+            )));
+        }
+        Ok(read)
+    }
+}
+
+/// Decode and ingest one verified `filelists.xml` payload.
+///
+/// `compressed_bytes` must already have been verified against its signed
+/// `repomd.xml` record; this function owns only decoding and projection.
+pub(super) fn ingest_verified_filelists(
+    packages: &mut [PackageMetadata],
+    compressed_bytes: &[u8],
+    open_size: u64,
+    source: &str,
+) -> Result<FilelistsIngest> {
+    let format = crate::compression::CompressionFormat::from_magic_bytes(compressed_bytes);
+    let decoder =
+        crate::compression::create_decoder(compressed_bytes, format).map_err(|error| {
+            Error::ParseError(format!(
+                "failed to decode RPM filelists metadata {source}: {error}"
+            ))
+        })?;
+    let mut reader = std::io::BufReader::with_capacity(
+        256 * 1024,
+        AuthenticatedLengthReader::new(decoder, open_size, DOCUMENT.label()),
+    );
+
+    let ingest = ingest_filelists(packages, &mut reader, source)?;
+
+    let decoded = reader.get_ref().read_bytes();
+    if decoded != open_size {
+        return Err(Error::GpgVerificationFailed(format!(
+            "signed repomd.xml authenticates filelists metadata as {open_size} decompressed bytes \
+             but {source} decoded to {decoded} bytes"
+        )));
+    }
+    Ok(ingest)
+}
+
+/// Fold every `<package>` record of a filelists document into its package.
+pub(super) fn ingest_filelists<R: BufRead>(
+    packages: &mut [PackageMetadata],
+    document: R,
+    source: &str,
+) -> Result<FilelistsIngest> {
+    let mut by_pkgid: HashMap<&str, Vec<usize>> = HashMap::with_capacity(packages.len());
+    for (index, package) in packages.iter().enumerate() {
+        by_pkgid
+            .entry(package.checksum.as_str())
+            .or_default()
+            .push(index);
+    }
+    // `by_pkgid` borrows the corpus, so resolve every record's targets into
+    // owned indices before any package is mutated.
+    let by_pkgid: HashMap<String, Vec<usize>> = by_pkgid
+        .into_iter()
+        .map(|(pkgid, indices)| (pkgid.to_string(), indices))
+        .collect();
+
+    let mut reader = Reader::from_reader(document);
+    reader.config_mut().trim_text_end = true;
+
+    let mut buf = Vec::new();
+    let mut record = FileRecordReader::new(DOCUMENT);
+    let mut cursor: Option<PackageCursor> = None;
+    let mut declared_packages: Option<usize> = None;
+    let mut matched = vec![false; packages.len()];
+    let mut ingest = FilelistsIngest::default();
+
+    loop {
+        let event = reader.read_event_into(&mut buf).map_err(|error| {
+            Error::ParseError(format!("Failed to parse filelists.xml {source}: {error}"))
+        })?;
+
+        match event {
+            Event::Start(ref element) | Event::Empty(ref element) => {
+                let closed = matches!(event, Event::Empty(_));
+                record.reject_nested_element()?;
+                let local =
+                    local_tag_name(&String::from_utf8_lossy(element.name().as_ref())).to_string();
+                match local.as_str() {
+                    "filelists" => {
+                        declared_packages =
+                            match attribute(element, &reader, b"packages", "packages count")? {
+                                Some(value) => Some(value.parse::<usize>().map_err(|error| {
+                                    Error::ParseError(format!(
+                                        "filelists.xml declares an invalid package count: {error}"
+                                    ))
+                                })?),
+                                None => None,
+                            };
+                    }
+                    "package" => {
+                        if cursor.is_some() {
+                            return Err(Error::ParseError(
+                                "filelists.xml package record cannot nest another package record"
+                                    .to_string(),
+                            ));
+                        }
+                        cursor = Some(PackageCursor::open(
+                            element,
+                            &reader,
+                            &by_pkgid,
+                            packages,
+                            &mut matched,
+                        )?);
+                        ingest.records += 1;
+                    }
+                    "version" => {
+                        let cursor = cursor.as_mut().ok_or_else(|| {
+                            Error::ParseError(
+                                "filelists.xml version record appears outside a package"
+                                    .to_string(),
+                            )
+                        })?;
+                        cursor.admit_version(element, &reader, packages)?;
+                    }
+                    "file" => {
+                        if cursor.is_none() {
+                            return Err(Error::ParseError(
+                                "RPM filelists file record appears outside a package".to_string(),
+                            ));
+                        }
+                        if closed {
+                            return Err(record.empty_record_error());
+                        }
+                        record.open(&mut reader);
+                    }
+                    _ => {}
+                }
+            }
+            Event::Text(ref text) => {
+                if record.is_open() {
+                    let decoded = text
+                        .xml_content(quick_xml::XmlVersion::Implicit1_0)
+                        .map_err(|error| {
+                            Error::ParseError(format!(
+                                "Failed to decode filelists.xml text: {error}"
+                            ))
+                        })?;
+                    let unescaped = quick_xml::escape::unescape(&decoded).map_err(|error| {
+                        Error::ParseError(format!("Failed to unescape filelists.xml text: {error}"))
+                    })?;
+                    record.push_text(&unescaped);
+                }
+            }
+            Event::CData(ref data) => {
+                if record.is_open() {
+                    let text = data
+                        .xml_content(quick_xml::XmlVersion::Implicit1_0)
+                        .map_err(|error| {
+                            Error::ParseError(format!(
+                                "Failed to decode filelists.xml CDATA: {error}"
+                            ))
+                        })?;
+                    record.push_text(&text);
+                }
+            }
+            Event::GeneralRef(ref reference) => {
+                if record.is_open() {
+                    let text = match reference.resolve_char_ref().map_err(|error| {
+                        Error::ParseError(format!(
+                            "Failed to resolve filelists.xml character reference: {error}"
+                        ))
+                    })? {
+                        Some(character) => character.to_string(),
+                        None => {
+                            let entity = reference.decode().map_err(|error| {
+                                Error::ParseError(format!(
+                                    "Failed to decode filelists.xml entity reference: {error}"
+                                ))
+                            })?;
+                            quick_xml::escape::resolve_xml_entity(&entity)
+                                .ok_or_else(|| {
+                                    Error::ParseError(format!(
+                                        "filelists.xml uses undeclared entity '&{entity};'"
+                                    ))
+                                })?
+                                .to_string()
+                        }
+                    };
+                    record.push_text(&text);
+                }
+            }
+            Event::End(ref element) => {
+                let local =
+                    local_tag_name(&String::from_utf8_lossy(element.name().as_ref())).to_string();
+                match local.as_str() {
+                    "file" => {
+                        let path = record.close(&mut reader)?;
+                        let cursor = cursor.as_mut().ok_or_else(|| {
+                            Error::ParseError(
+                                "RPM filelists file record appears outside a package".to_string(),
+                            )
+                        })?;
+                        cursor.admit_file(path, packages, &mut ingest);
+                    }
+                    "package" => {
+                        let cursor = cursor.take().ok_or_else(|| {
+                            Error::ParseError(
+                                "filelists.xml ended a package that was never started".to_string(),
+                            )
+                        })?;
+                        cursor.close()?;
+                    }
+                    _ => {}
+                }
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    if cursor.is_some() {
+        return Err(Error::ParseError(
+            "filelists.xml ended inside an unterminated package record".to_string(),
+        ));
+    }
+    if let Some(declared) = declared_packages
+        && declared != ingest.records
+    {
+        return Err(Error::ParseError(format!(
+            "filelists.xml declares {declared} packages but carries {} package records",
+            ingest.records
+        )));
+    }
+    if let Some(index) = matched.iter().position(|matched| !matched) {
+        let package = &packages[index];
+        return Err(Error::ParseError(format!(
+            "signed filelists.xml {source} publishes no file record for package {} {} (pkgid {}); \
+             the two signed documents describe different package sets",
+            package.name, package.version, package.checksum
+        )));
+    }
+
+    Ok(ingest)
+}
+
+/// One open `<package>` record and the corpus entries it feeds.
+struct PackageCursor {
+    pkgid: String,
+    targets: Vec<usize>,
+    /// Paths this package already provides, so a path both documents carry
+    /// becomes exactly one capability row.
+    known_paths: HashSet<String>,
+    version_seen: bool,
+}
+
+impl PackageCursor {
+    fn open<R>(
+        element: &BytesStart<'_>,
+        reader: &Reader<R>,
+        by_pkgid: &HashMap<String, Vec<usize>>,
+        packages: &[PackageMetadata],
+        matched: &mut [bool],
+    ) -> Result<Self> {
+        let pkgid = required_attribute(element, reader, b"pkgid", "package pkgid")?;
+        let name = required_attribute(element, reader, b"name", "package name")?;
+        let arch = required_attribute(element, reader, b"arch", "package arch")?;
+
+        let targets = by_pkgid.get(&pkgid).cloned().ok_or_else(|| {
+            Error::ParseError(format!(
+                "signed filelists.xml publishes file records for pkgid {pkgid} ({name}.{arch}), \
+                 which the signed primary.xml does not publish; the two signed documents describe \
+                 different package sets"
+            ))
+        })?;
+
+        let mut known_paths = HashSet::new();
+        for &index in &targets {
+            let package = &packages[index];
+            if package.name != name {
+                return Err(Self::disagreement(&pkgid, "name", &name, &package.name));
+            }
+            let package_arch = package.architecture.as_deref().unwrap_or_default();
+            if package_arch != arch {
+                return Err(Self::disagreement(
+                    &pkgid,
+                    "architecture",
+                    &arch,
+                    package_arch,
+                ));
+            }
+            known_paths.extend(
+                package
+                    .provides
+                    .iter()
+                    .filter(|provide| provide.kind == RepositoryCapabilityKind::File)
+                    .map(|provide| provide.name.clone()),
+            );
+            matched[index] = true;
+        }
+
+        Ok(Self {
+            pkgid,
+            targets,
+            known_paths,
+            version_seen: false,
+        })
+    }
+
+    fn disagreement(pkgid: &str, field: &str, filelists: &str, primary: &str) -> Error {
+        Error::ParseError(format!(
+            "signed filelists.xml and primary.xml disagree on pkgid {pkgid}: filelists {field} is \
+             '{filelists}' but primary {field} is '{primary}'"
+        ))
+    }
+
+    fn admit_version<R>(
+        &mut self,
+        element: &BytesStart<'_>,
+        reader: &Reader<R>,
+        packages: &[PackageMetadata],
+    ) -> Result<()> {
+        let epoch = attribute(element, reader, b"epoch", "package epoch")?;
+        let ver = required_attribute(element, reader, b"ver", "package version")?;
+        let rel = required_attribute(element, reader, b"rel", "package release")?;
+        let version = rpm_version_text(epoch.as_deref(), &ver, &rel);
+        for &index in &self.targets {
+            let package = &packages[index];
+            if package.version != version {
+                return Err(Self::disagreement(
+                    &self.pkgid,
+                    "version",
+                    &version,
+                    &package.version,
+                ));
+            }
+        }
+        self.version_seen = true;
+        Ok(())
+    }
+
+    fn admit_file(
+        &mut self,
+        path: String,
+        packages: &mut [PackageMetadata],
+        ingest: &mut FilelistsIngest,
+    ) {
+        if !self.known_paths.insert(path.clone()) {
+            ingest.files_already_known += 1;
+            return;
+        }
+        for &index in &self.targets {
+            extend_file_provides(&mut packages[index].provides, &path);
+        }
+        ingest.files_added += 1;
+    }
+
+    fn close(self) -> Result<()> {
+        if !self.version_seen {
+            return Err(Error::ParseError(format!(
+                "filelists.xml package record for pkgid {} carries no version",
+                self.pkgid
+            )));
+        }
+        Ok(())
+    }
+}
+
+fn attribute<R>(
+    element: &BytesStart<'_>,
+    reader: &Reader<R>,
+    key: &[u8],
+    field: &str,
+) -> Result<Option<String>> {
+    for attr in element.attributes() {
+        let attr = attr.map_err(|error| {
+            Error::ParseError(format!("Failed to parse filelists.xml {field}: {error}"))
+        })?;
+        if attr.key.as_ref() == key {
+            return Ok(Some(
+                attr.decoded_and_normalized_value(
+                    quick_xml::XmlVersion::Implicit1_0,
+                    reader.decoder(),
+                )
+                .map_err(|error| {
+                    Error::ParseError(format!("Failed to decode filelists.xml {field}: {error}"))
+                })?
+                .into_owned(),
+            ));
+        }
+    }
+    Ok(None)
+}
+
+fn required_attribute<R>(
+    element: &BytesStart<'_>,
+    reader: &Reader<R>,
+    key: &[u8],
+    field: &str,
+) -> Result<String> {
+    attribute(element, reader, key, field)?.ok_or_else(|| {
+        Error::ParseError(format!(
+            "filelists.xml record is missing its required {field} attribute"
+        ))
+    })
+}
+
+/// Refuse a repository whose packages carry file dependencies its signed
+/// `repomd.xml` cannot answer.
+///
+/// A dependency name that starts with `/` is a file dependency, not a
+/// capability name (<https://rpm.org/docs/latest/manual/spec.html#dependencies>;
+/// upstream `libsolv` selects file dependencies for its provider index the
+/// same way in `pool_addfileprovides_queue()`). Its only repository providers
+/// are package file records. When the repository publishes no `filelists`
+/// record, the sole file authority available is primary's generator-filtered
+/// set, so a path outside that set has no provider and can never be solved.
+///
+/// That is refused here, naming the repository and the missing record, rather
+/// than surfacing later as an anonymous "no candidates were found" conflict.
+/// When the repository does publish `filelists`, Conary holds complete file
+/// ownership and a missing path is an ordinary unsatisfied dependency.
+///
+/// The decision is made on the group's typed boolean expression, never on its
+/// flattened alternatives: a flattened view cannot tell `(cap or /path)` from
+/// `(cap and /path)`, and the conjunction is exactly the unsolvable case.
+pub(super) fn require_no_filelists_dependent_requirements(
+    packages: &[PackageMetadata],
+    repo_url: &str,
+) -> Result<()> {
+    let mut provided_paths: HashSet<&str> = HashSet::new();
+    for package in packages {
+        provided_paths.extend(
+            package
+                .provides
+                .iter()
+                .filter(|provide| provide.kind == RepositoryCapabilityKind::File)
+                .map(|provide| provide.name.as_str()),
+        );
+    }
+
+    for package in packages {
+        for group in &package.requirements {
+            // Only a positive dependency needs a provider. A conflict,
+            // obsoletion, or optional relation is satisfied by absence.
+            if !matches!(
+                group.kind,
+                RepositoryRequirementKind::Depends | RepositoryRequirementKind::PreDepends
+            ) {
+                continue;
+            }
+            if may_hold_without_filelists(&group.expression, &provided_paths) {
+                continue;
+            }
+
+            let paths = unprovidable_paths(&group.expression, &provided_paths).join("', '");
+            return Err(Error::ParseError(format!(
+                "repository {repo_url} package {} {} requires path '{paths}', but its signed \
+                 repomd.xml publishes no filelists record. primary.xml carries only the \
+                 generator-filtered file set, so this path has no repository provider. The \
+                 repository must publish filelists.xml.",
+                package.name, package.version
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Whether a requirement expression can still be satisfied when every absolute
+/// path outside primary's filtered file set is known to have no provider.
+///
+/// The assignment is deliberately optimistic, because this rule must never
+/// refuse a repository that could resolve:
+///
+/// - an atom naming a path the filtered primary set does not provide can never
+///   hold, since a file dependency's only repository providers are package file
+///   records;
+/// - every other atom may hold;
+/// - no atom is *guaranteed* to hold, because a provider for it may simply be
+///   absent, so any condition may fail and a conditional requirement stays
+///   satisfiable through its else branch.
+///
+/// Repeated occurrences of one atom are evaluated independently. That can only
+/// make an expression look more satisfiable, so it can cost a refusal that was
+/// warranted but can never invent one that was not.
+fn may_hold_without_filelists(
+    expression: &RepositoryRequirementExpression,
+    provided_paths: &HashSet<&str>,
+) -> bool {
+    match expression {
+        RepositoryRequirementExpression::Atom(clause) => {
+            !is_unprovidable_path(&clause.name, provided_paths)
+        }
+        RepositoryRequirementExpression::And(operands) => operands
+            .iter()
+            .all(|operand| may_hold_without_filelists(operand, provided_paths)),
+        RepositoryRequirementExpression::Or(operands) => operands
+            .iter()
+            .any(|operand| may_hold_without_filelists(operand, provided_paths)),
+        // `(A if B)` requires A when B holds, and takes its else branch
+        // otherwise. B may always fail, so an absent else branch leaves the
+        // requirement satisfiable.
+        RepositoryRequirementExpression::If {
+            requirement,
+            condition,
+            otherwise,
+        } => {
+            (may_hold_without_filelists(condition, provided_paths)
+                && may_hold_without_filelists(requirement, provided_paths))
+                || otherwise
+                    .as_deref()
+                    .is_none_or(|otherwise| may_hold_without_filelists(otherwise, provided_paths))
+        }
+        // `(A unless B)` requires A when B fails, and takes its else branch
+        // when B holds.
+        RepositoryRequirementExpression::Unless {
+            requirement,
+            condition,
+            otherwise,
+        } => {
+            may_hold_without_filelists(requirement, provided_paths)
+                || (may_hold_without_filelists(condition, provided_paths)
+                    && otherwise.as_deref().is_none_or(|otherwise| {
+                        may_hold_without_filelists(otherwise, provided_paths)
+                    }))
+        }
+        // `with` needs one provider satisfying both sides, so both must be
+        // satisfiable; `without` constrains which provider may be chosen, and
+        // that constraint is optimistically satisfiable.
+        RepositoryRequirementExpression::With { left, right } => {
+            may_hold_without_filelists(left, provided_paths)
+                && may_hold_without_filelists(right, provided_paths)
+        }
+        RepositoryRequirementExpression::Without { left, .. } => {
+            may_hold_without_filelists(left, provided_paths)
+        }
+    }
+}
+
+/// The path atoms of one expression that the filtered primary set cannot
+/// provide, in the order the source wrote them.
+fn unprovidable_paths<'a>(
+    expression: &'a RepositoryRequirementExpression,
+    provided_paths: &HashSet<&str>,
+) -> Vec<&'a str> {
+    expression
+        .atoms()
+        .into_iter()
+        .map(|clause| clause.name.as_str())
+        .filter(|name| is_unprovidable_path(name, provided_paths))
+        .collect()
+}
+
+/// An RPM dependency name that starts with `/` is a dependency on a path
+/// rather than on a capability name, and the filtered primary file set is the
+/// only file authority a repository without `filelists.xml` publishes.
+fn is_unprovidable_path(name: &str, provided_paths: &HashSet<&str>) -> bool {
+    name.starts_with('/') && !provided_paths.contains(name)
+}
+
+#[cfg(test)]
+#[path = "filelists/tests.rs"]
+mod tests;

--- a/crates/conary-core/src/repository/parsers/fedora/filelists/tests.rs
+++ b/crates/conary-core/src/repository/parsers/fedora/filelists/tests.rs
@@ -1,0 +1,649 @@
+// conary-core/src/repository/parsers/fedora/filelists/tests.rs
+
+use super::*;
+use crate::db::models::Repository;
+use crate::repository::dependency_model::{CapabilityProvenance, SourcePackageFormat};
+use crate::repository::parsers::fedora::tests::parser;
+
+const CONSUMER_PKGID: &str = "1111111111111111111111111111111111111111111111111111111111111111";
+const PROVIDER_PKGID: &str = "2222222222222222222222222222222222222222222222222222222222222222";
+
+/// A primary.xml carrying exactly what createrepo_c's selection rule keeps:
+/// `crypto-policies` requires a `/usr/lib` path, and `systemd` publishes only
+/// its `bin/` paths here.
+fn primary_document() -> String {
+    format!(
+        r#"
+<metadata xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+  <package type="rpm">
+    <name>crypto-policies</name>
+    <arch>noarch</arch>
+    <version epoch="0" ver="20260101" rel="1.fc44"/>
+    <checksum type="sha256">{CONSUMER_PKGID}</checksum>
+    <size package="1024"/>
+    <location href="Packages/c/crypto-policies-20260101-1.fc44.noarch.rpm"/>
+    <format>
+      <rpm:requires>
+        <rpm:entry name="/usr/lib/systemd/systemd-update-helper"/>
+      </rpm:requires>
+    </format>
+  </package>
+  <package type="rpm">
+    <name>systemd</name>
+    <arch>x86_64</arch>
+    <version epoch="0" ver="258" rel="4.fc44"/>
+    <checksum type="sha256">{PROVIDER_PKGID}</checksum>
+    <size package="2048"/>
+    <location href="Packages/s/systemd-258-4.fc44.x86_64.rpm"/>
+    <format>
+      <rpm:provides>
+        <rpm:entry name="systemd" flags="EQ" epoch="0" ver="258" rel="4.fc44"/>
+      </rpm:provides>
+      <file>/usr/bin/systemctl</file>
+    </format>
+  </package>
+</metadata>
+"#
+    )
+}
+
+/// The same two packages as the generator writes them with the primary filter
+/// off: every owned path, including the `/usr/lib` entry primary drops and the
+/// `/usr/bin` entry primary keeps.
+fn filelists_document() -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<filelists xmlns="http://linux.duke.edu/metadata/filelists" packages="2">
+<package pkgid="{CONSUMER_PKGID}" name="crypto-policies" arch="noarch">
+  <version epoch="0" ver="20260101" rel="1.fc44"/>
+  <file type="dir">/usr/share/crypto-policies</file>
+  <file>/usr/share/crypto-policies/DEFAULT/opensslcnf.txt</file>
+</package>
+<package pkgid="{PROVIDER_PKGID}" name="systemd" arch="x86_64">
+  <version epoch="0" ver="258" rel="4.fc44"/>
+  <file>/usr/bin/systemctl</file>
+  <file>/usr/lib/systemd/systemd-update-helper</file>
+  <file type="dir">/usr/lib/systemd/system</file>
+  <file type="ghost">/usr/lib/systemd/system/default.target</file>
+</package>
+</filelists>
+"#
+    )
+}
+
+fn parse_primary() -> Vec<PackageMetadata> {
+    parser()
+        .parse_primary_xml(&primary_document(), "https://repo.test/fedora")
+        .unwrap()
+}
+
+fn file_capabilities(package: &PackageMetadata) -> Vec<&str> {
+    package
+        .provides
+        .iter()
+        .filter(|provide| provide.kind == RepositoryCapabilityKind::File)
+        .map(|provide| provide.name.as_str())
+        .collect()
+}
+
+fn ingest(packages: &mut [PackageMetadata], document: &str) -> Result<FilelistsIngest> {
+    ingest_filelists(
+        packages,
+        document.as_bytes(),
+        "https://repo.test/filelists.xml",
+    )
+}
+
+#[test]
+fn filelists_publishes_every_owned_path_the_primary_filter_drops() {
+    let mut packages = parse_primary();
+    assert_eq!(file_capabilities(&packages[1]), vec!["/usr/bin/systemctl"]);
+
+    let ingest = ingest(&mut packages, &filelists_document()).unwrap();
+
+    assert_eq!(ingest.records, 2);
+    assert_eq!(
+        file_capabilities(&packages[0]),
+        vec![
+            "/usr/share/crypto-policies",
+            "/usr/share/crypto-policies/DEFAULT/opensslcnf.txt",
+        ]
+    );
+    // Directory and %ghost records are package-owned paths, exactly as they
+    // are in primary.xml, so the generator's `type` attribute does not gate
+    // the projection.
+    assert_eq!(
+        file_capabilities(&packages[1]),
+        vec![
+            "/usr/bin/systemctl",
+            "/usr/lib/systemd/systemd-update-helper",
+            "/usr/lib/systemd/system",
+            "/usr/lib/systemd/system/default.target",
+        ]
+    );
+}
+
+#[test]
+fn filelists_paths_carry_the_same_provenance_primary_paths_carry() {
+    let mut packages = parse_primary();
+    ingest(&mut packages, &filelists_document()).unwrap();
+
+    let filelists_only = packages[1]
+        .provides
+        .iter()
+        .find(|provide| provide.name == "/usr/lib/systemd/systemd-update-helper")
+        .expect("filelists-only path");
+    let primary_selected = packages[1]
+        .provides
+        .iter()
+        .find(|provide| provide.name == "/usr/bin/systemctl")
+        .expect("primary-selected path");
+
+    for provide in [filelists_only, primary_selected] {
+        assert_eq!(provide.kind, RepositoryCapabilityKind::File);
+        assert!(provide.version.is_none());
+        assert!(provide.version_relation.is_none());
+        assert_eq!(
+            provide.provenance,
+            CapabilityProvenance::SourceDerivedFile {
+                format: SourcePackageFormat::Rpm,
+                source_path: provide.name.clone(),
+            }
+        );
+    }
+}
+
+#[test]
+fn a_path_both_documents_publish_becomes_exactly_one_capability() {
+    let mut packages = parse_primary();
+    let ingest = ingest(&mut packages, &filelists_document()).unwrap();
+
+    assert_eq!(ingest.files_already_known, 1);
+    assert_eq!(
+        packages[1]
+            .provides
+            .iter()
+            .filter(|provide| provide.name == "/usr/bin/systemctl")
+            .count(),
+        1
+    );
+    assert_eq!(ingest.files_added, 5);
+}
+
+#[test]
+fn repeated_filelists_ingest_cannot_duplicate_a_capability() {
+    let mut packages = parse_primary();
+    ingest(&mut packages, &filelists_document()).unwrap();
+    let after_first = file_capabilities(&packages[1]).len();
+
+    let second = ingest(&mut packages, &filelists_document()).unwrap();
+
+    assert_eq!(second.files_added, 0);
+    assert_eq!(file_capabilities(&packages[1]).len(), after_first);
+}
+
+/// The exact issue #285 failure: a `/usr/lib` file dependency has no
+/// repository provider from the filtered primary set, and resolves once the
+/// signed filelists document is ingested.
+#[test]
+fn a_file_dependency_outside_the_primary_filter_resolves_after_filelists_ingest() {
+    fn solve(packages: Vec<PackageMetadata>) -> crate::resolver::sat::SatResolution {
+        let (_temp, conn) = crate::db::testing::create_test_db();
+        let mut repository = Repository::new(
+            "fedora-44".to_string(),
+            "https://repo.test/fedora".to_string(),
+        );
+        repository.source_profile = Some("fedora-44".to_string());
+        let repository_id = repository.insert(&conn).unwrap();
+
+        let rows = packages
+            .into_iter()
+            .map(|package| {
+                crate::repository::sync::synced_package_row(
+                    repository_id,
+                    "fedora-44",
+                    "https://repo.test/fedora",
+                    None,
+                    package,
+                )
+            })
+            .collect::<Vec<_>>();
+        crate::repository::sync::persist_synced_package_rows(&conn, repository_id, rows).unwrap();
+
+        crate::resolver::sat::solve_install_with_policy(
+            &conn,
+            &[(
+                "crypto-policies".to_string(),
+                crate::version::VersionConstraint::Any,
+            )],
+            &crate::repository::resolution_policy::ResolutionPolicy::new().with_mixing(
+                crate::repository::resolution_policy::DependencyMixingPolicy::Permissive,
+            ),
+        )
+        .unwrap()
+    }
+
+    let primary_only = solve(parse_primary());
+    assert!(
+        primary_only.conflict_message.is_some(),
+        "the filtered primary file set alone must not resolve a /usr/lib path dependency"
+    );
+
+    let mut packages = parse_primary();
+    ingest(&mut packages, &filelists_document()).unwrap();
+    let with_filelists = solve(packages);
+
+    assert!(
+        with_filelists.conflict_message.is_none(),
+        "{with_filelists:?}"
+    );
+    let installed = with_filelists
+        .install_order
+        .iter()
+        .map(|package| package.name.as_str())
+        .collect::<Vec<_>>();
+    assert!(installed.contains(&"crypto-policies"));
+    assert!(installed.contains(&"systemd"));
+}
+
+// ---------------------------------------------------------------------------
+// Join between the two signed documents
+// ---------------------------------------------------------------------------
+
+#[test]
+fn filelists_record_for_an_unpublished_package_is_refused() {
+    let mut packages = parse_primary();
+    let document = filelists_document().replace(
+        &format!(r#"pkgid="{PROVIDER_PKGID}""#),
+        &format!(r#"pkgid="{}""#, "3".repeat(64)),
+    );
+
+    let error = ingest(&mut packages, &document).unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("which the signed primary.xml does not publish"),
+        "{error}"
+    );
+}
+
+#[test]
+fn a_package_with_no_filelists_record_is_refused() {
+    let mut packages = parse_primary();
+    let document = format!(
+        r#"<filelists packages="1">
+<package pkgid="{PROVIDER_PKGID}" name="systemd" arch="x86_64">
+  <version epoch="0" ver="258" rel="4.fc44"/>
+  <file>/usr/bin/systemctl</file>
+</package>
+</filelists>"#
+    );
+
+    let error = ingest(&mut packages, &document).unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("publishes no file record for package crypto-policies"),
+        "{error}"
+    );
+}
+
+#[test]
+fn filelists_that_disagrees_with_primary_identity_is_refused() {
+    for (field, from, to) in [
+        ("name", r#"name="systemd""#, r#"name="systemd-udev""#),
+        ("architecture", r#"arch="x86_64""#, r#"arch="aarch64""#),
+        (
+            "version",
+            r#"ver="258" rel="4.fc44""#,
+            r#"ver="259" rel="4.fc44""#,
+        ),
+    ] {
+        let mut packages = parse_primary();
+        let document = filelists_document().replacen(from, to, 1);
+
+        let error = ingest(&mut packages, &document).unwrap_err();
+
+        assert!(
+            error.to_string().contains(&format!(
+                "disagree on pkgid {PROVIDER_PKGID}: filelists {field}"
+            )),
+            "{field}: {error}"
+        );
+    }
+}
+
+#[test]
+fn filelists_that_miscounts_its_own_records_is_refused() {
+    let mut packages = parse_primary();
+    let document = filelists_document().replace(r#"packages="2""#, r#"packages="3""#);
+
+    let error = ingest(&mut packages, &document).unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("declares 3 packages but carries 2 package records"),
+        "{error}"
+    );
+}
+
+#[test]
+fn filelists_package_without_a_version_is_refused() {
+    let mut packages = parse_primary();
+    let document =
+        filelists_document().replace(r#"<version epoch="0" ver="258" rel="4.fc44"/>"#, "");
+
+    let error = ingest(&mut packages, &document).unwrap_err();
+
+    assert!(error.to_string().contains("carries no version"), "{error}");
+}
+
+// ---------------------------------------------------------------------------
+// The `<file>` grammar is one owner shared with primary.xml
+// ---------------------------------------------------------------------------
+
+/// Everything primary.xml's file grammar admits, filelists.xml admits, and
+/// everything one refuses the other refuses. The documents are written by one
+/// generator function, so one parser owner has to admit exactly one language.
+#[test]
+fn both_documents_admit_exactly_the_same_file_record_language() {
+    let admitted = [
+        ("<file>/usr/bin/bash</file>", "/usr/bin/bash"),
+        ("<file type=\"ghost\">/usr/bin/sh</file>", "/usr/bin/sh"),
+        ("<file type=\"dir\">/usr/share/doc</file>", "/usr/share/doc"),
+        (
+            "<file>/opt/provider&amp;selected</file>",
+            "/opt/provider&selected",
+        ),
+        (
+            "<file>/usr<![CDATA[/local/bin/cdata]]></file>",
+            "/usr/local/bin/cdata",
+        ),
+        (
+            "<file>/usr/bin/trailing-space </file>",
+            "/usr/bin/trailing-space ",
+        ),
+    ];
+
+    for (record, expected) in admitted {
+        let from_primary = primary_file_paths(record);
+        let from_filelists = filelists_file_paths(record).unwrap();
+        assert_eq!(from_primary, vec![expected], "primary: {record}");
+        assert_eq!(from_filelists, vec![expected], "filelists: {record}");
+    }
+
+    let refused = [
+        (
+            "<file>/usr<unexpected/>/bin/bash</file>",
+            "cannot contain nested elements",
+        ),
+        (
+            "<file>/usr<file>/bin/bash</file></file>",
+            "cannot contain nested elements",
+        ),
+        ("<file/>", "must contain an absolute path"),
+        ("<file></file>", "must contain an absolute path"),
+        ("<file>usr/bin/bash</file>", "must contain an absolute path"),
+    ];
+
+    for (record, expected) in refused {
+        let primary_error = parser()
+            .parse_primary_xml(&primary_with_file_records(record), "https://repo.test")
+            .unwrap_err()
+            .to_string();
+        let filelists_error = filelists_file_paths(record).unwrap_err().to_string();
+        assert!(primary_error.contains(expected), "primary: {primary_error}");
+        assert!(
+            filelists_error.contains(expected),
+            "filelists: {filelists_error}"
+        );
+    }
+}
+
+fn primary_with_file_records(records: &str) -> String {
+    format!(
+        r#"
+<metadata xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+  <package type="rpm">
+    <name>systemd</name>
+    <arch>x86_64</arch>
+    <version epoch="0" ver="258" rel="4.fc44"/>
+    <checksum type="sha256">{PROVIDER_PKGID}</checksum>
+    <size package="2048"/>
+    <location href="Packages/s/systemd-258-4.fc44.x86_64.rpm"/>
+    <format>
+      {records}
+    </format>
+  </package>
+</metadata>
+"#
+    )
+}
+
+fn primary_file_paths(records: &str) -> Vec<String> {
+    let packages = parser()
+        .parse_primary_xml(&primary_with_file_records(records), "https://repo.test")
+        .unwrap();
+    file_capabilities(&packages[0])
+        .into_iter()
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn filelists_file_paths(records: &str) -> Result<Vec<String>> {
+    let mut packages = parser()
+        .parse_primary_xml(&primary_with_file_records(""), "https://repo.test")
+        .unwrap();
+    let document = format!(
+        r#"<filelists packages="1">
+<package pkgid="{PROVIDER_PKGID}" name="systemd" arch="x86_64">
+  <version epoch="0" ver="258" rel="4.fc44"/>
+  {records}
+</package>
+</filelists>"#
+    );
+    ingest(&mut packages, &document)?;
+    Ok(file_capabilities(&packages[0])
+        .into_iter()
+        .map(ToString::to_string)
+        .collect())
+}
+
+// ---------------------------------------------------------------------------
+// Decoding one verified document
+// ---------------------------------------------------------------------------
+
+fn gzip(content: &str) -> Vec<u8> {
+    use std::io::Write;
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+    encoder.write_all(content.as_bytes()).unwrap();
+    encoder.finish().unwrap()
+}
+
+#[test]
+fn a_compressed_filelists_document_is_ingested_without_materializing_it() {
+    let mut packages = parse_primary();
+    let document = filelists_document();
+    let compressed = gzip(&document);
+
+    let ingest = ingest_verified_filelists(
+        &mut packages,
+        &compressed,
+        document.len() as u64,
+        "https://repo.test/filelists.xml.gz",
+    )
+    .unwrap();
+
+    assert_eq!(ingest.records, 2);
+    assert!(
+        file_capabilities(&packages[1]).contains(&"/usr/lib/systemd/systemd-update-helper"),
+        "{:?}",
+        file_capabilities(&packages[1])
+    );
+}
+
+#[test]
+fn a_document_longer_than_the_signed_decompressed_length_is_refused() {
+    let mut packages = parse_primary();
+    let document = filelists_document();
+    let compressed = gzip(&document);
+
+    let error = ingest_verified_filelists(
+        &mut packages,
+        &compressed,
+        document.len() as u64 - 1,
+        "https://repo.test/filelists.xml.gz",
+    )
+    .unwrap_err();
+
+    assert!(
+        error.to_string().contains("decodes to more than the"),
+        "{error}"
+    );
+}
+
+#[test]
+fn a_document_shorter_than_the_signed_decompressed_length_is_refused() {
+    let mut packages = parse_primary();
+    let document = filelists_document();
+    let compressed = gzip(&document);
+
+    let error = ingest_verified_filelists(
+        &mut packages,
+        &compressed,
+        document.len() as u64 + 1,
+        "https://repo.test/filelists.xml.gz",
+    )
+    .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("decompressed bytes but https://repo.test/filelists.xml.gz decoded to"),
+        "{error}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Failing closed when the repository publishes no filelists record
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_path_requirement_without_a_filelists_record_refuses_the_repository() {
+    let packages = parse_primary();
+
+    let error = require_no_filelists_dependent_requirements(&packages, "https://repo.test/fedora")
+        .unwrap_err();
+
+    let message = error.to_string();
+    assert!(message.contains("https://repo.test/fedora"), "{message}");
+    assert!(message.contains("crypto-policies"), "{message}");
+    assert!(
+        message.contains("/usr/lib/systemd/systemd-update-helper"),
+        "{message}"
+    );
+    assert!(message.contains("filelists"), "{message}");
+}
+
+#[test]
+fn a_path_requirement_the_primary_file_set_provides_is_not_filelists_dependent() {
+    let mut packages = parse_primary();
+    packages[0].requirements = requirement_groups("/usr/bin/systemctl");
+
+    require_no_filelists_dependent_requirements(&packages, "https://repo.test/fedora").unwrap();
+}
+
+#[test]
+fn a_capability_requirement_is_never_filelists_dependent() {
+    let mut packages = parse_primary();
+    packages[0].requirements = requirement_groups("systemd");
+
+    require_no_filelists_dependent_requirements(&packages, "https://repo.test/fedora").unwrap();
+}
+
+#[test]
+fn an_alternative_beside_an_unprovided_path_is_not_filelists_dependent() {
+    let mut packages = parse_primary();
+    packages[0].requirements = requirement_groups("(/usr/lib/systemd/systemd or systemd)");
+
+    require_no_filelists_dependent_requirements(&packages, "https://repo.test/fedora").unwrap();
+}
+
+#[test]
+fn a_conditional_path_requirement_is_not_filelists_dependent() {
+    let mut packages = parse_primary();
+    packages[0].requirements =
+        requirement_groups("(/usr/lib/systemd/systemd if /usr/lib/systemd/systemd-update-helper)");
+
+    require_no_filelists_dependent_requirements(&packages, "https://repo.test/fedora").unwrap();
+}
+
+/// A flattened alternatives view cannot tell a conjunction from a
+/// disjunction, so a mandatory path conjunct beside a satisfiable capability
+/// looks resolvable while it is not. The decision reads the typed expression.
+#[test]
+fn a_mandatory_path_conjunct_refuses_the_repository() {
+    let mut packages = parse_primary();
+    packages[0].requirements = requirement_groups("(systemd and /usr/lib/systemd/systemd)");
+
+    let error = require_no_filelists_dependent_requirements(&packages, "https://repo.test/fedora")
+        .unwrap_err();
+
+    let message = error.to_string();
+    assert!(message.contains("/usr/lib/systemd/systemd"), "{message}");
+    assert!(message.contains("crypto-policies"), "{message}");
+    assert!(message.contains("filelists"), "{message}");
+}
+
+#[test]
+fn every_unprovidable_path_of_a_refused_conjunction_is_named() {
+    let mut packages = parse_primary();
+    packages[0].requirements =
+        requirement_groups("(/usr/lib/systemd/systemd and /usr/share/factory/etc)");
+
+    let error = require_no_filelists_dependent_requirements(&packages, "https://repo.test/fedora")
+        .unwrap_err();
+
+    let message = error.to_string();
+    assert!(message.contains("/usr/lib/systemd/systemd"), "{message}");
+    assert!(message.contains("/usr/share/factory/etc"), "{message}");
+}
+
+#[test]
+fn a_conjunction_whose_path_the_primary_file_set_provides_is_admitted() {
+    let mut packages = parse_primary();
+    packages[0].requirements = requirement_groups("(systemd and /usr/bin/systemctl)");
+
+    require_no_filelists_dependent_requirements(&packages, "https://repo.test/fedora").unwrap();
+}
+
+#[test]
+fn a_path_conflict_is_not_filelists_dependent() {
+    let mut packages = parse_primary();
+    packages[0].requirements = vec![
+        crate::repository::package_relation::parse_native_relation(
+            RepositoryRequirementKind::Conflict,
+            crate::repository::versioning::VersionScheme::Rpm,
+            "/usr/lib/systemd/systemd",
+        )
+        .unwrap(),
+    ];
+
+    require_no_filelists_dependent_requirements(&packages, "https://repo.test/fedora").unwrap();
+}
+
+fn requirement_groups(
+    native_text: &str,
+) -> Vec<crate::repository::dependency_model::RepositoryRequirementGroup> {
+    vec![
+        crate::repository::requirement::parse_native_requirement(
+            RepositoryRequirementKind::Depends,
+            crate::repository::versioning::VersionScheme::Rpm,
+            native_text,
+        )
+        .unwrap(),
+    ]
+}

--- a/crates/conary-core/src/repository/parsers/fedora/files.rs
+++ b/crates/conary-core/src/repository/parsers/fedora/files.rs
@@ -1,0 +1,107 @@
+// conary-core/src/repository/parsers/fedora/files.rs
+
+//! The one `<file>` record grammar shared by RPM repository metadata.
+//!
+//! Pinned `createrepo_c` `5cf41fe5d703901d78078ed18c67ab667e446c1a` emits
+//! package-owned paths through a single writer,
+//! [`cr_xml_dump_files()`](https://github.com/rpm-software-management/createrepo_c/blob/5cf41fe5d703901d78078ed18c67ab667e446c1a/src/xml_dump.c#L175-L225),
+//! for both `primary.xml` and `filelists.xml`. The only difference between the
+//! two documents is the generator's primary-selection filter, which decides
+//! *which* records are written, never *how* one record is written: the element
+//! text is the absolute path and an optional `type` attribute names `dir` or
+//! `ghost`.
+//!
+//! Both Conary parsers therefore read a record through this owner, so a path
+//! one document admits can never be a path the other rejects.
+//!
+//! The `type` attribute does not gate provider projection. RPM's own file
+//! provides come from the package's complete file list, so a directory or a
+//! `%ghost` entry owned by a package is a path that package provides; upstream
+//! `libsolv` likewise extends solvables with every `filelists` entry. Conary
+//! preserves every signed record and does not reimplement any selection rule.
+
+use super::repomd::RepoMdDocument;
+use crate::error::{Error, Result};
+use quick_xml::Reader;
+
+/// Accumulates the text of one `<file>` record for one document.
+pub(super) struct FileRecordReader {
+    document: RepoMdDocument,
+    text: Option<String>,
+}
+
+impl FileRecordReader {
+    pub(super) const fn new(document: RepoMdDocument) -> Self {
+        Self {
+            document,
+            text: None,
+        }
+    }
+
+    /// Whether a record is currently open and consuming text.
+    pub(super) const fn is_open(&self) -> bool {
+        self.text.is_some()
+    }
+
+    /// A path is element text, never markup: any nested element inside a record
+    /// would make the path ambiguous, so it is refused rather than flattened.
+    pub(super) fn reject_nested_element(&self) -> Result<()> {
+        if self.is_open() {
+            return Err(Error::ParseError(format!(
+                "RPM {} file record cannot contain nested elements",
+                self.document.label()
+            )));
+        }
+        Ok(())
+    }
+
+    /// Open a record.
+    ///
+    /// Trailing XML whitespace inside the element is package identity, not
+    /// inter-element formatting, so text trimming is disabled while the record
+    /// is open.
+    pub(super) fn open<R>(&mut self, reader: &mut Reader<R>) {
+        self.text = Some(String::new());
+        reader.config_mut().trim_text_end = false;
+    }
+
+    /// Append decoded text to the open record. Returns `false` when no record
+    /// is open, so the caller can route the text to its own fields.
+    pub(super) fn push_text(&mut self, text: &str) -> bool {
+        match self.text.as_mut() {
+            Some(path) => {
+                path.push_str(text);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Close the open record and return its validated absolute path.
+    pub(super) fn close<R>(&mut self, reader: &mut Reader<R>) -> Result<String> {
+        let path = self.text.take().ok_or_else(|| {
+            Error::ParseError(format!(
+                "RPM {} file record ended without starting",
+                self.document.label()
+            ))
+        })?;
+        reader.config_mut().trim_text_end = true;
+        self.validate_path(path)
+    }
+
+    /// The refusal for a record that carries no path at all, such as
+    /// `<file/>` or `<file></file>`.
+    pub(super) fn empty_record_error(&self) -> Error {
+        Error::ParseError(format!(
+            "RPM {} file record must contain an absolute path",
+            self.document.label()
+        ))
+    }
+
+    fn validate_path(&self, path: String) -> Result<String> {
+        if path.is_empty() || !path.starts_with('/') {
+            return Err(self.empty_record_error());
+        }
+        Ok(path)
+    }
+}

--- a/crates/conary-core/src/repository/parsers/fedora/provides.rs
+++ b/crates/conary-core/src/repository/parsers/fedora/provides.rs
@@ -56,12 +56,26 @@ pub(super) fn project_repository_provides(
         });
     }
 
-    projected.extend(primary_files.iter().cloned().map(|path| RepositoryProvide {
+    for path in primary_files {
+        extend_file_provides(&mut projected, path);
+    }
+    Ok(projected)
+}
+
+/// Project one package-owned path as a typed file capability.
+///
+/// Primary and filelists records are the same authority -- one generator
+/// writing the same `<file>` element from the same package file list -- so they
+/// produce the same capability with the same `source-derived-file` provenance
+/// through this one owner. Provenance carries the path the record named, which
+/// is what makes a later reader able to say which signed record a provider came
+/// from.
+pub(super) fn extend_file_provides(provides: &mut Vec<RepositoryProvide>, path: &str) {
+    provides.push(RepositoryProvide {
         provenance: CapabilityProvenance::SourceDerivedFile {
             format: SourcePackageFormat::Rpm,
-            source_path: path.clone(),
+            source_path: path.to_string(),
         },
-        ..RepositoryProvide::file(path)
-    }));
-    Ok(projected)
+        ..RepositoryProvide::file(path.to_string())
+    });
 }

--- a/crates/conary-core/src/repository/parsers/fedora/repomd.rs
+++ b/crates/conary-core/src/repository/parsers/fedora/repomd.rs
@@ -1,0 +1,373 @@
+// conary-core/src/repository/parsers/fedora/repomd.rs
+
+//! Exact `repomd.xml` record admission for the RPM metadata documents Conary
+//! reads.
+//!
+//! `repomd.xml` is the signed root of RPM repository metadata: the size and
+//! SHA-256 it records authenticate every other document, so a document Conary
+//! reads must have a record here and must match that record exactly.
+//! Pinned `createrepo_c` `5cf41fe5d703901d78078ed18c67ab667e446c1a` writes one
+//! `<data type="...">` record per generated document
+//! (<https://github.com/rpm-software-management/createrepo_c/blob/5cf41fe5d703901d78078ed18c67ab667e446c1a/src/xml_dump_repomd.c>),
+//! including the decompressed `<open-size>`/`<open-checksum>` pair whenever the
+//! served document is compressed.
+//!
+//! Conary reads exactly two of those records:
+//!
+//! - `primary`: the package corpus, its relations, and the generator-filtered
+//!   file set.
+//! - `filelists`: complete package file ownership, which is the only authority
+//!   for a file dependency on a path the primary filter drops.
+//!
+//! Record types Conary does not read are ignored. A repeated record for a type
+//! Conary does read is fatal: the repository would be naming two different
+//! authorities for one document.
+
+use super::{local_tag_name, validate_sha256};
+use crate::error::{Error, Result};
+use crate::repository::parsers::common;
+use quick_xml::Reader;
+use quick_xml::events::{BytesStart, Event};
+
+/// One metadata document Conary reads out of `repomd.xml`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RepoMdDocument {
+    Primary,
+    Filelists,
+}
+
+impl RepoMdDocument {
+    /// The exact `type` attribute createrepo_c writes for this document.
+    const fn repomd_type(self) -> &'static str {
+        match self {
+            Self::Primary => "primary",
+            Self::Filelists => "filelists",
+        }
+    }
+
+    /// Diagnostic label; identical to the record type on purpose, so an error
+    /// names the record an operator can look up in the signed document.
+    pub(super) const fn label(self) -> &'static str {
+        self.repomd_type()
+    }
+
+    fn from_type(value: &str) -> Option<Self> {
+        [Self::Primary, Self::Filelists]
+            .into_iter()
+            .find(|document| document.repomd_type() == value)
+    }
+}
+
+/// One authenticated `repomd.xml` record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct RepoMdRecord {
+    pub(super) document: RepoMdDocument,
+    /// Repository-relative location of the served document.
+    pub(super) href: String,
+    /// SHA-256 of the served (still compressed) bytes.
+    pub(super) sha256: String,
+    /// Size in bytes of the served (still compressed) document.
+    pub(super) size: u64,
+    /// Size in bytes of the decompressed document. createrepo_c writes this
+    /// only for a compressed document, so an uncompressed document keeps it
+    /// absent and `size` is already the decompressed length.
+    pub(super) open_size: Option<u64>,
+}
+
+impl RepoMdRecord {
+    /// Verify served bytes against this signed record before anything reads
+    /// them.
+    ///
+    /// Size is checked first so a truncated or padded document is named as
+    /// such instead of surfacing as a digest mismatch.
+    pub(super) fn verify_served_bytes(&self, bytes: &[u8]) -> Result<()> {
+        let label = self.document.label();
+        if bytes.len() as u64 != self.size {
+            return Err(Error::GpgVerificationFailed(format!(
+                "signed repomd.xml authenticates {label} metadata as {} bytes but the repository \
+                 served {} bytes",
+                self.size,
+                bytes.len()
+            )));
+        }
+        let actual = crate::hash::sha256(bytes);
+        if actual != self.sha256 {
+            return Err(Error::GpgVerificationFailed(format!(
+                "RPM {label} metadata identity mismatch: signed repomd.xml SHA256 is {}, \
+                 downloaded SHA256 is {}",
+                self.sha256, actual
+            )));
+        }
+        Ok(())
+    }
+
+    /// The exact decompressed length the signed record admits.
+    ///
+    /// This is the authenticated ceiling a streaming reader applies, so the
+    /// bound on decoder memory comes from the signed document rather than from
+    /// a locally chosen constant.
+    pub(super) fn authenticated_open_size(&self, compressed: bool) -> Result<u64> {
+        match (compressed, self.open_size) {
+            (false, _) => Ok(self.size),
+            (true, Some(open_size)) => Ok(open_size),
+            (true, None) => Err(Error::ParseError(format!(
+                "repomd.xml {} record serves a compressed document without an <open-size>; the \
+                 signed decompressed length is required to read it",
+                self.document.label()
+            ))),
+        }
+    }
+}
+
+/// Every record Conary reads out of one signed `repomd.xml`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct RepoMdIndex {
+    pub(super) primary: RepoMdRecord,
+    /// Absent when the repository publishes no `filelists` record at all.
+    pub(super) filelists: Option<RepoMdRecord>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RecordField {
+    Checksum,
+    Size,
+    OpenSize,
+}
+
+#[derive(Default)]
+struct RecordBuilder {
+    checksum: Option<String>,
+    checksum_type: Option<String>,
+    size: Option<String>,
+    open_size: Option<String>,
+    href: Option<String>,
+}
+
+impl RecordBuilder {
+    fn build(self, document: RepoMdDocument) -> Result<RepoMdRecord> {
+        let label = document.label();
+        let href = self.href.ok_or_else(|| {
+            Error::ParseError(format!(
+                "Could not find {label} data location in repomd.xml"
+            ))
+        })?;
+        common::validate_filename(&href).map_err(Error::ParseError)?;
+
+        if self.checksum_type.as_deref() != Some("sha256") {
+            return Err(Error::ParseError(format!(
+                "RPM {label} metadata requires exact sha256 identity; found {:?}",
+                self.checksum_type.as_deref()
+            )));
+        }
+        let sha256 = self.checksum.ok_or_else(|| {
+            Error::ParseError(format!("repomd.xml {label} record has no checksum"))
+        })?;
+        validate_sha256(&sha256, &format!("repomd.xml {label}"))?;
+
+        let size = self
+            .size
+            .ok_or_else(|| {
+                Error::ParseError(format!("repomd.xml {label} record has no compressed size"))
+            })?
+            .parse::<u64>()
+            .map_err(|error| {
+                Error::ParseError(format!(
+                    "repomd.xml {label} compressed size is invalid: {error}"
+                ))
+            })?;
+
+        let open_size = self
+            .open_size
+            .map(|value| {
+                value.parse::<u64>().map_err(|error| {
+                    Error::ParseError(format!(
+                        "repomd.xml {label} decompressed size is invalid: {error}"
+                    ))
+                })
+            })
+            .transpose()?;
+
+        Ok(RepoMdRecord {
+            document,
+            href,
+            sha256,
+            size,
+            open_size,
+        })
+    }
+}
+
+fn attribute_value<R>(
+    element: &BytesStart<'_>,
+    reader: &Reader<R>,
+    key: &[u8],
+    field: &str,
+) -> Result<Option<String>> {
+    for attr in element.attributes() {
+        let attr = attr.map_err(|error| {
+            Error::ParseError(format!("Failed to parse repomd.xml {field}: {error}"))
+        })?;
+        if attr.key.as_ref() == key {
+            return Ok(Some(
+                attr.decoded_and_normalized_value(
+                    quick_xml::XmlVersion::Implicit1_0,
+                    reader.decoder(),
+                )
+                .map_err(|error| {
+                    Error::ParseError(format!("Failed to decode repomd.xml {field}: {error}"))
+                })?
+                .into_owned(),
+            ));
+        }
+    }
+    Ok(None)
+}
+
+fn element_local_name(name: &[u8]) -> String {
+    local_tag_name(&String::from_utf8_lossy(name)).to_string()
+}
+
+/// Parse one authenticated `repomd.xml` into the records Conary reads.
+pub(super) fn parse_repomd(xml_content: &str) -> Result<RepoMdIndex> {
+    let mut reader = Reader::from_str(xml_content);
+    reader.config_mut().trim_text_end = true;
+
+    let mut buf = Vec::new();
+    let mut current: Option<(RepoMdDocument, RecordBuilder)> = None;
+    let mut field: Option<RecordField> = None;
+    let mut primary: Option<RepoMdRecord> = None;
+    let mut filelists: Option<RepoMdRecord> = None;
+
+    loop {
+        let event = reader
+            .read_event_into(&mut buf)
+            .map_err(|error| Error::ParseError(format!("Failed to parse repomd.xml: {error}")))?;
+        let (element, closed) = match &event {
+            Event::Start(e) => (Some(e), false),
+            Event::Empty(e) => (Some(e), true),
+            _ => (None, false),
+        };
+
+        if let Some(element) = element {
+            let local = element_local_name(element.name().as_ref());
+            if local == "data" {
+                let declared = attribute_value(element, &reader, b"type", "data type")?;
+                current = declared
+                    .as_deref()
+                    .and_then(RepoMdDocument::from_type)
+                    .map(|document| (document, RecordBuilder::default()));
+                field = None;
+                if let Some((document, _)) = &current {
+                    let occupied = match document {
+                        RepoMdDocument::Primary => primary.is_some(),
+                        RepoMdDocument::Filelists => filelists.is_some(),
+                    };
+                    if occupied {
+                        return Err(Error::ParseError(format!(
+                            "repomd.xml repeats {} metadata records",
+                            document.label()
+                        )));
+                    }
+                }
+                if closed && let Some((document, builder)) = current.take() {
+                    // A self-closed record declares a document with no served
+                    // identity at all; build it so the missing field is named.
+                    store_record(
+                        &mut primary,
+                        &mut filelists,
+                        document,
+                        builder.build(document)?,
+                    )?;
+                }
+            } else if let Some((_, builder)) = current.as_mut() {
+                field = match local.as_str() {
+                    "checksum" => {
+                        builder.checksum_type =
+                            attribute_value(element, &reader, b"type", "checksum type")?;
+                        Some(RecordField::Checksum)
+                    }
+                    "size" => Some(RecordField::Size),
+                    "open-size" => Some(RecordField::OpenSize),
+                    "location" => {
+                        builder.href = attribute_value(element, &reader, b"href", "location")?;
+                        None
+                    }
+                    // `open-checksum` and every other child are not this
+                    // record's served identity and must never be read as one.
+                    _ => None,
+                };
+                if closed {
+                    field = None;
+                }
+            }
+            buf.clear();
+            continue;
+        }
+
+        match event {
+            Event::Text(text) => {
+                if let Some((_, builder)) = current.as_mut() {
+                    let value = text
+                        .xml_content(quick_xml::XmlVersion::Implicit1_0)
+                        .map_err(|error| {
+                            Error::ParseError(format!("Failed to decode repomd.xml text: {error}"))
+                        })?
+                        .trim()
+                        .to_string();
+                    match field {
+                        Some(RecordField::Checksum) => builder.checksum = Some(value),
+                        Some(RecordField::Size) => builder.size = Some(value),
+                        Some(RecordField::OpenSize) => builder.open_size = Some(value),
+                        None => {}
+                    }
+                }
+            }
+            Event::End(end) => {
+                if element_local_name(end.name().as_ref()) == "data"
+                    && let Some((document, builder)) = current.take()
+                {
+                    store_record(
+                        &mut primary,
+                        &mut filelists,
+                        document,
+                        builder.build(document)?,
+                    )?;
+                }
+                field = None;
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    let primary = primary.ok_or_else(|| {
+        Error::ParseError("Could not find primary data location in repomd.xml".to_string())
+    })?;
+
+    Ok(RepoMdIndex { primary, filelists })
+}
+
+fn store_record(
+    primary: &mut Option<RepoMdRecord>,
+    filelists: &mut Option<RepoMdRecord>,
+    document: RepoMdDocument,
+    record: RepoMdRecord,
+) -> Result<()> {
+    let slot = match document {
+        RepoMdDocument::Primary => primary,
+        RepoMdDocument::Filelists => filelists,
+    };
+    if slot.is_some() {
+        return Err(Error::ParseError(format!(
+            "repomd.xml repeats {} metadata records",
+            document.label()
+        )));
+    }
+    *slot = Some(record);
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "repomd/tests.rs"]
+mod tests;

--- a/crates/conary-core/src/repository/parsers/fedora/repomd/tests.rs
+++ b/crates/conary-core/src/repository/parsers/fedora/repomd/tests.rs
@@ -1,0 +1,259 @@
+// conary-core/src/repository/parsers/fedora/repomd/tests.rs
+
+use super::*;
+
+const PRIMARY_SHA: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const PRIMARY_OPEN_SHA: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const FILELISTS_SHA: &str = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+const FILELISTS_OPEN_SHA: &str = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+
+/// The record shape createrepo_c writes, including the `<open-checksum>` and
+/// `<open-size>` pair it emits for a compressed document.
+fn repomd_with(records: &str) -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<repomd xmlns="http://linux.duke.edu/metadata/repo">
+  <revision>1776864872</revision>
+{records}
+</repomd>
+"#
+    )
+}
+
+fn primary_record() -> String {
+    format!(
+        r#"  <data type="primary">
+    <checksum type="sha256">{PRIMARY_SHA}</checksum>
+    <open-checksum type="sha256">{PRIMARY_OPEN_SHA}</open-checksum>
+    <location href="repodata/primary.xml.zst"/>
+    <timestamp>1776864872</timestamp>
+    <size>15678154</size>
+    <open-size>185300395</open-size>
+  </data>"#
+    )
+}
+
+fn filelists_record() -> String {
+    format!(
+        r#"  <data type="filelists">
+    <checksum type="sha256">{FILELISTS_SHA}</checksum>
+    <open-checksum type="sha256">{FILELISTS_OPEN_SHA}</open-checksum>
+    <location href="repodata/filelists.xml.zst"/>
+    <timestamp>1776864872</timestamp>
+    <size>46935343</size>
+    <open-size>829071915</open-size>
+  </data>"#
+    )
+}
+
+fn other_record() -> String {
+    format!(
+        r#"  <data type="filelists_db">
+    <checksum type="sha256">{FILELISTS_SHA}</checksum>
+    <location href="repodata/filelists.sqlite.zst"/>
+    <size>62143089</size>
+    <open-size>398798848</open-size>
+  </data>"#
+    )
+}
+
+#[test]
+fn both_documents_conary_reads_are_admitted_with_their_signed_identity() {
+    let index = parse_repomd(&repomd_with(&format!(
+        "{}\n{}\n{}",
+        primary_record(),
+        other_record(),
+        filelists_record()
+    )))
+    .unwrap();
+
+    assert_eq!(
+        index.primary,
+        RepoMdRecord {
+            document: RepoMdDocument::Primary,
+            href: "repodata/primary.xml.zst".to_string(),
+            sha256: PRIMARY_SHA.to_string(),
+            size: 15_678_154,
+            open_size: Some(185_300_395),
+        }
+    );
+    assert_eq!(
+        index.filelists,
+        Some(RepoMdRecord {
+            document: RepoMdDocument::Filelists,
+            href: "repodata/filelists.xml.zst".to_string(),
+            sha256: FILELISTS_SHA.to_string(),
+            size: 46_935_343,
+            open_size: Some(829_071_915),
+        })
+    );
+}
+
+/// `<open-checksum>` describes the decompressed bytes, never the served ones.
+/// Reading it as the record's identity would authenticate the document against
+/// the wrong digest.
+#[test]
+fn the_open_checksum_is_never_read_as_the_served_identity() {
+    let index = parse_repomd(&repomd_with(&primary_record())).unwrap();
+
+    assert_eq!(index.primary.sha256, PRIMARY_SHA);
+    assert_ne!(index.primary.sha256, PRIMARY_OPEN_SHA);
+}
+
+#[test]
+fn a_repository_without_a_filelists_record_is_parsed_without_one() {
+    let index = parse_repomd(&repomd_with(&format!(
+        "{}\n{}",
+        primary_record(),
+        other_record()
+    )))
+    .unwrap();
+
+    assert!(index.filelists.is_none());
+}
+
+#[test]
+fn a_repeated_record_for_a_document_conary_reads_is_refused() {
+    for (label, records) in [
+        (
+            "primary",
+            format!("{}\n{}", primary_record(), primary_record()),
+        ),
+        (
+            "filelists",
+            format!(
+                "{}\n{}\n{}",
+                primary_record(),
+                filelists_record(),
+                filelists_record()
+            ),
+        ),
+    ] {
+        let error = parse_repomd(&repomd_with(&records)).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains(&format!("repomd.xml repeats {label} metadata records")),
+            "{label}: {error}"
+        );
+    }
+}
+
+#[test]
+fn a_filelists_record_holds_the_same_identity_discipline_primary_holds() {
+    let cases = [
+        (
+            filelists_record().replace(
+                &format!(r#"<checksum type="sha256">{FILELISTS_SHA}</checksum>"#),
+                "",
+            ),
+            "requires exact sha256 identity",
+        ),
+        (
+            filelists_record().replace("sha256", "sha1"),
+            "requires exact sha256 identity",
+        ),
+        (
+            filelists_record().replace(FILELISTS_SHA, "not-a-digest"),
+            "SHA256 must be exactly 64 lowercase hexadecimal digits",
+        ),
+        (
+            filelists_record().replace("<size>46935343</size>", ""),
+            "repomd.xml filelists record has no compressed size",
+        ),
+        (
+            filelists_record().replace("<size>46935343</size>", "<size>huge</size>"),
+            "repomd.xml filelists compressed size is invalid",
+        ),
+        (
+            filelists_record().replace(
+                r#"<location href="repodata/filelists.xml.zst"/>"#,
+                r#"<location href="../../etc/passwd"/>"#,
+            ),
+            "path traversal",
+        ),
+        (
+            filelists_record().replace(r#"<location href="repodata/filelists.xml.zst"/>"#, ""),
+            "Could not find filelists data location in repomd.xml",
+        ),
+    ];
+
+    for (record, expected) in cases {
+        let error =
+            parse_repomd(&repomd_with(&format!("{}\n{record}", primary_record()))).unwrap_err();
+        assert!(error.to_string().contains(expected), "{expected}: {error}");
+    }
+}
+
+#[test]
+fn a_missing_primary_record_is_refused() {
+    let error = parse_repomd(&repomd_with(&filelists_record())).unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("Could not find primary data location in repomd.xml"),
+        "{error}"
+    );
+}
+
+#[test]
+fn served_bytes_must_match_the_signed_size_and_digest() {
+    let record = RepoMdRecord {
+        document: RepoMdDocument::Filelists,
+        href: "repodata/filelists.xml".to_string(),
+        sha256: crate::hash::sha256(b"filelists"),
+        size: 9,
+        open_size: None,
+    };
+
+    record.verify_served_bytes(b"filelists").unwrap();
+
+    let short = record.verify_served_bytes(b"filelist").unwrap_err();
+    assert!(
+        short
+            .to_string()
+            .contains("authenticates filelists metadata as 9 bytes but the repository served 8"),
+        "{short}"
+    );
+
+    let wrong = record.verify_served_bytes(b"FILELISTS").unwrap_err();
+    assert!(
+        wrong
+            .to_string()
+            .contains("RPM filelists metadata identity mismatch"),
+        "{wrong}"
+    );
+}
+
+#[test]
+fn the_decompressed_ceiling_comes_from_the_signed_record() {
+    let compressed = RepoMdRecord {
+        document: RepoMdDocument::Filelists,
+        href: "repodata/filelists.xml.zst".to_string(),
+        sha256: FILELISTS_SHA.to_string(),
+        size: 46_935_343,
+        open_size: Some(829_071_915),
+    };
+    assert_eq!(
+        compressed.authenticated_open_size(true).unwrap(),
+        829_071_915
+    );
+
+    let uncompressed = RepoMdRecord {
+        open_size: None,
+        ..compressed.clone()
+    };
+    assert_eq!(
+        uncompressed.authenticated_open_size(false).unwrap(),
+        46_935_343
+    );
+
+    let error = uncompressed.authenticated_open_size(true).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("serves a compressed document without an <open-size>"),
+        "{error}"
+    );
+}

--- a/crates/conary-core/src/repository/parsers/fedora/tests.rs
+++ b/crates/conary-core/src/repository/parsers/fedora/tests.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::repository::dependency_model::RepositoryCapabilityKind;
 use crate::repository::dependency_model::{ConditionalRequirementBehavior, ProvideVersionRelation};
 
-fn parser() -> FedoraParser {
+pub(super) fn parser() -> FedoraParser {
     let trust = PreparedOpenPgpTrust::for_test(RepositoryTrustPolicy::Rpm {
         metadata: RpmMetadataAuthority::Metalink {
             url: "https://mirrors.example.test/metalink".to_string(),

--- a/crates/conary-core/src/repository/sync.rs
+++ b/crates/conary-core/src/repository/sync.rs
@@ -22,9 +22,10 @@ use super::registry::{self, RepositoryFormat};
 use super::static_repo::sync::fetch_static_sync_snapshot;
 use super::trust::openpgp::PreparedOpenPgpTrust;
 use super::versioning::VersionScheme;
-pub(in crate::repository) use native::{capability_kind_to_db, convert_requirement_groups};
-use native::{
-    normalized_repository_capabilities, persist_native_sync_rows, persist_synced_package_rows,
+use native::persist_native_sync_rows;
+pub(in crate::repository) use native::{
+    capability_kind_to_db, convert_requirement_groups, persist_synced_package_rows,
+    synced_package_row,
 };
 #[cfg(test)]
 use remi::remi_sync_row;
@@ -79,50 +80,15 @@ async fn fetch_repository_native_snapshot(
     let synced_packages: Vec<SyncedPackageRow> = packages
         .into_iter()
         .map(|pkg_meta| {
-            let provides = normalized_repository_capabilities(&pkg_meta);
-
-            // Rebase download URL if content_url is configured (reference mirror)
-            let download_url = rebase_download_url(
-                &pkg_meta.download_url,
+            synced_package_row(
+                repo_id,
+                &source_profile_id,
                 &repo.url,
                 repo.content_url.as_deref(),
-            );
-
-            let version_scheme = pkg_meta.version_scheme;
-            let mut repo_pkg = RepositoryPackage::new(
-                repo_id,
-                pkg_meta.name,
-                pkg_meta.version,
-                version_scheme,
-                pkg_meta.checksum,
-                pkg_meta.size as i64,
-                download_url,
-            );
-
-            repo_pkg.architecture = pkg_meta.architecture;
-            repo_pkg.debian_multi_arch = pkg_meta.debian_multi_arch;
-            repo_pkg.description = pkg_meta.description;
-            repo_pkg.metadata = match &pkg_meta.extra_metadata {
-                serde_json::Value::Null => None,
-                value => Some(value.to_string()),
-            };
-
-            // Persist the exact repository profile. Package format remains a
-            // separate typed field and is never promoted to distro authority.
-            repo_pkg.source_profile = Some(source_profile_id.clone());
-
-            // Convert parser-level requirement groups to DB models
-            let (req_groups, req_group_clauses) =
-                convert_requirement_groups(0, &pkg_meta.requirements);
-
-            Ok(SyncedPackageRow {
-                package: repo_pkg,
-                provides,
-                requirement_groups: req_groups,
-                requirement_group_clauses: req_group_clauses,
-            })
+                pkg_meta,
+            )
         })
-        .collect::<Result<_>>()?;
+        .collect();
     Ok(RepositorySyncSnapshot::NativeRows(synced_packages))
 }
 

--- a/crates/conary-core/src/repository/sync/native.rs
+++ b/crates/conary-core/src/repository/sync/native.rs
@@ -41,7 +41,7 @@ pub(super) fn persist_native_sync_rows(
     Ok(count)
 }
 
-pub(super) fn persist_synced_package_rows(
+pub(in crate::repository) fn persist_synced_package_rows(
     conn: &Connection,
     repo_id: i64,
     synced_packages: Vec<SyncedPackageRow>,
@@ -120,6 +120,54 @@ pub(super) fn append_synced_package_rows(
     RepositoryRequirement::batch_insert(conn, &grouped_clauses)?;
 
     Ok(count)
+}
+
+/// Build the complete normalized row set for one parsed package.
+///
+/// Native sync and its tests share this owner so the capability projection,
+/// requirement conversion, and reference-mirror rebasing that turn one parsed
+/// package into persistable rows cannot drift apart.
+pub(in crate::repository) fn synced_package_row(
+    repo_id: i64,
+    source_profile: &str,
+    repo_url: &str,
+    content_url: Option<&str>,
+    pkg_meta: PackageMetadata,
+) -> SyncedPackageRow {
+    let provides = normalized_repository_capabilities(&pkg_meta);
+    let download_url = super::rebase_download_url(&pkg_meta.download_url, repo_url, content_url);
+    let version_scheme = pkg_meta.version_scheme;
+    let mut repo_pkg = RepositoryPackage::new(
+        repo_id,
+        pkg_meta.name,
+        pkg_meta.version,
+        version_scheme,
+        pkg_meta.checksum,
+        pkg_meta.size as i64,
+        download_url,
+    );
+
+    repo_pkg.architecture = pkg_meta.architecture;
+    repo_pkg.debian_multi_arch = pkg_meta.debian_multi_arch;
+    repo_pkg.description = pkg_meta.description;
+    repo_pkg.metadata = match &pkg_meta.extra_metadata {
+        serde_json::Value::Null => None,
+        value => Some(value.to_string()),
+    };
+
+    // Persist the exact repository profile. Package format remains a separate
+    // typed field and is never promoted to distro authority.
+    repo_pkg.source_profile = Some(source_profile.to_string());
+
+    let (requirement_groups, requirement_group_clauses) =
+        convert_requirement_groups(0, &pkg_meta.requirements);
+
+    SyncedPackageRow {
+        package: repo_pkg,
+        provides,
+        requirement_groups,
+        requirement_group_clauses,
+    }
 }
 
 pub(super) fn normalized_repository_capabilities(

--- a/crates/conary-core/src/repository/sync/tests.rs
+++ b/crates/conary-core/src/repository/sync/tests.rs
@@ -3,6 +3,7 @@
 mod tests {
     use super::*;
     use crate::ccs::signing::SigningKeyPair;
+    use crate::repository::sync::native::normalized_repository_capabilities;
     use crate::db::models::{
         ConvertedPackage, RepositoryPackage, RepositoryPackageKey, RepositoryProvide,
         RepositoryRequirement, RepositoryRequirementGroup as DbRequirementGroup,

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -441,6 +441,9 @@ package transactions.
 `crates/conary-core/src/repository/trust/openpgp/arch/`;
 `crates/conary-core/src/repository/parsers/`;
 `crates/conary-core/src/repository/parsers/fedora/metalink.rs`;
+`crates/conary-core/src/repository/parsers/fedora/repomd.rs`;
+`crates/conary-core/src/repository/parsers/fedora/files.rs`;
+`crates/conary-core/src/repository/parsers/fedora/filelists.rs`;
 `crates/conary-core/src/repository/parsers/fedora/provides.rs`;
 `crates/conary-core/src/repository/sync.rs`;
 `crates/conary-core/src/repository/download.rs`;

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -100,11 +100,16 @@ scriptlet summaries, and content hashes stay on other public projections
 because sync does not consume them.
 `GET /v1/{distro}/metadata` is not a client-sync fallback.
 
-For Fedora, normalized provides include every generator-selected `<file>`
-record from authenticated `primary.xml` as `kind = "file"` with exact
-`source-derived-file` provenance. The sparse page and per-name lookup project
-that persisted typed row unchanged; Remi does not derive file providers from
-package names or filter them through its own path rules.
+For Fedora, normalized provides include every package-owned `<file>` record
+from authenticated `primary.xml` and `filelists.xml` as `kind = "file"` with
+exact `source-derived-file` provenance. The sparse page and per-name lookup
+project that persisted typed row unchanged; Remi does not derive file
+providers from package names or filter them through its own path rules.
+Complete file ownership is what makes a path dependency outside createrepo's
+primary filter solvable, and it is the dominant row population: Fedora 44
+`Everything/x86_64` carries 9.5M file providers against 76,354 packages, so
+sparse pages, their wire payload, and the replace transaction all scale with
+it.
 
 Remi opens SQLite once for each HTTP page, selects all visible package/version
 rows for the page together, and batch-loads their normalized provides and

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -236,10 +236,12 @@ The supported chains are:
   package stanza's exact SHA-256 and size authenticate its `.deb`.
 - RPM: repository metadata and packages have distinct authorities. Either a
   detached OpenPGP signature or an exact HTTPS metalink identity authenticates
-  `repomd.xml`; its SHA-256 and size authenticate `primary.xml`; primary
-  metadata supplies exact package relations and generator-selected file
-  providers and authenticates the RPM bytes; and an independently pinned
-  package certificate verifies the RPM's embedded OpenPGP signature.
+  `repomd.xml`; its SHA-256 and size authenticate `primary.xml` and, by the
+  same discipline, `filelists.xml`; primary metadata supplies exact package
+  relations and generator-selected file providers and authenticates the RPM
+  bytes; filelists supplies complete package file ownership; and an
+  independently pinned package certificate verifies the RPM's embedded OpenPGP
+  signature.
 - Arch: one exact keyring source supplies the pinned master certificates,
   their certifications, packager certificates, and the companion
   `<keyring>-revoked` disabled-key list. An explicit threshold says how many
@@ -326,7 +328,7 @@ prerequisite. The Fedora parser preserves that marker as the typed
 name. Direct RPM parsing projects the corresponding header sense flags through
 the same relation kind.
 
-RPM primary-file authority is derived from `createrepo_c`
+RPM file authority is derived from `createrepo_c`
 `5cf41fe5d703901d78078ed18c67ab667e446c1a`: its
 [`cr_xml_dump_files()`](https://github.com/rpm-software-management/createrepo_c/blob/5cf41fe5d703901d78078ed18c67ab667e446c1a/src/xml_dump.c#L175-L225)
 selects and emits package-owned `<file>` records in `primary.xml`, and its
@@ -337,6 +339,45 @@ provenance on the exact package. The projection is owned by
 `repository/parsers/fedora/provides.rs`. It does not reimplement createrepo's
 path-selection rule or infer providers from package names, payload guesses, or
 a curated path list.
+
+That selection rule is a filter, so `primary.xml` is not complete file
+ownership: the same generator writes every owned path through the same
+`<file>` writer into `filelists.xml` with the filter off
+([`cr_xml_dump_filelists()`](https://github.com/rpm-software-management/createrepo_c/blob/5cf41fe5d703901d78078ed18c67ab667e446c1a/src/xml_dump_filelists.c)).
+Conary reads both documents. `repository/parsers/fedora/repomd.rs` admits the
+`primary` and `filelists` records with one size plus SHA-256 discipline;
+`repository/parsers/fedora/files.rs` owns the one `<file>` record grammar both
+parsers read, so a path one document admits is never a path the other rejects;
+`repository/parsers/fedora/filelists.rs` folds each `<package>` record into the
+package `primary.xml` published, joined on `pkgid` (the package SHA-256), and
+projects each path through the same `provides.rs` owner. A path both documents
+carry becomes exactly one capability. The join is total: both signed documents
+must name the same package set and agree on name, architecture, and EVR.
+Directory and `%ghost` records are owned paths in both documents, so the
+`type` attribute does not gate the projection.
+
+A repository that publishes no `filelists` record is refused at sync when any
+package carries a positive dependency that cannot be satisfied at all under
+that filter. An RPM dependency name beginning with `/` is a dependency on a
+path, so a path outside the filtered primary set has no possible repository
+provider. The decision evaluates the requirement's typed boolean expression,
+never its flattened alternatives: every unprovidable path atom is false, every
+other atom may hold, and no atom is guaranteed to hold, so a conditional stays
+satisfiable through its else branch. A group is refused only when the
+expression cannot hold under that optimistic assignment, which refuses
+`(cap and /unprovidable)` while admitting `(cap or /unprovidable)` and
+`(/unprovidable if cap)`. Repeated atoms are evaluated independently, which can
+only cost a warranted refusal and never invent one. The typed refusal names the
+repository, the package, the paths, and the missing document instead of
+surfacing later as an anonymous solver conflict. When filelists is published, a
+missing path is an ordinary unsatisfied dependency.
+
+Fedora 44 `Everything/x86_64` measures that cost exactly (repomd revision
+1776864872): 76,354 packages, 81,720 file providers from `primary.xml`, and
+9,416,909 more from `filelists.xml`, taking `repository_provides` from 657,873
+rows to 10,074,782 and the synced SQLite database from 0.61 GB to 4.77 GB. The
+829 MB decompressed document is never materialized: it is streamed from the
+verified compressed bytes under the ceiling the signed `<open-size>` declares.
 
 The contract was derived against the package managers' and repository
 generators' own documentation:


### PR DESCRIPTION
## #285, option (a) per the design brief and operator decision

Full filelists.xml ingest at sync as a second authenticated metadata document. Streaming was forced, not chosen: fedora44's filelists decompresses to 829MB against the 512MiB metadata budget — the in-memory idiom cannot ingest it at all. The decoder streams under the signed `<open-size>` ceiling; the join to primary is total (typed refusals for unknown pkgid, uncovered packages, identity disagreements, miscounts); nothing persists unless the whole snapshot does.

The fail-closed rule evaluates each requirement group's typed boolean expression under the optimistic assignment (non-path atoms may hold; paths outside filtered primary cannot; nothing is guaranteed to hold, so conditionals stay satisfiable). A no-filelists repo is refused only when no satisfying resolution can exist without filelists — the error names repo, package, and every unprovidable path.

## Measured on live Fedora 44 (76,354 packages, digest-verified artifacts, debug build)

| | primary only | with filelists |
|---|---|---|
| file capabilities | 81,720 | 9,498,629 |
| repository_provides rows | 657,873 | 10,074,782 |
| synced DB | 608 MB | 4.77 GB |
| persist | 42.7 s | 422.7 s |
| peak RSS | 959 MB | 3.70 GB |

Dedup contract empirically confirmed: primary's file set is an exact subset (files_already_known == 81,720). **Operational note: #327 (path stored twice per provides row — most of the 4.77GB) gates the remi release that ships this to production, by operator decision.**

## Review chain

Opus implementation with live-corpus measurement → reviewer hold on release pending #327 → Luna second-model review found the flat-alternatives view admitted rich conjunctions with mandatory path atoms → evaluator rewrite that subsumed and DELETED both special cases (also fixing a second latent all-paths-conditional bug the behavior gate was hiding) → mutation-checked in both directions (flat logic admits what it must refuse AND refuses what it must admit).

## Verification (run, real output)

`cargo test -p conary-core` full: 3383 passed, 0 failed. Fedora parser subtree: 67 passed (31 new). `cargo test -p conary`: 53 binaries clean. `cargo test -p remi`: 640 passed (remi consumes this sync path). Workspace clippy `-D warnings` clean, fmt clean, doc-truth clean. Resolution card focused proof (7 commands) + interaction gate (6 commands) clean. Six+ mutation checks across fail-closed, dedup, coverage, and the expression evaluator.

Found and filed: #327 (storage lever, release gate), #328 (two unexplained load-dependent intermittent tests, not touched by this diff).

Closes #285.