### PR TITLE
fix(repository): store each file-provide path once, version every contract that embeds it

### DIFF
--- a/apps/conary/src/commands/adopt/packages/tests.rs
+++ b/apps/conary/src/commands/adopt/packages/tests.rs
@@ -468,13 +468,14 @@ fn preview_and_apply_share_identity_mode_and_record_plan() {
         file.kind,
         conary_core::repository::dependency_model::RepositoryCapabilityKind::File
     );
-    assert!(matches!(
-        &file.provenance,
+    // The row above was found by its capability, which is the path; provenance
+    // states only that a signed RPM file record established it.
+    assert_eq!(
+        file.provenance,
         conary_core::repository::dependency_model::CapabilityProvenance::SourceDerivedFile {
             format: conary_core::repository::dependency_model::SourcePackageFormat::Rpm,
-            source_path,
-        } if source_path == live_file.to_string_lossy().as_ref()
-    ));
+        }
+    );
 }
 
 #[test]

--- a/apps/conary/src/commands/repo_static/tests.rs
+++ b/apps/conary/src/commands/repo_static/tests.rs
@@ -171,8 +171,9 @@ fn repo_identity_toml(name: &str, description: Option<&str>, root_key_ids: &[Str
     let description = description
         .map(|value| format!("description = \"{value}\"\n"))
         .unwrap_or_default();
+    let schema = conary_core::repository::static_repo::SCHEMA_VERSION;
     format!(
-        "schema = 1\n[repo]\nname = \"{name}\"\n{description}[trust]\nroot_key_ids = [{root_keys}]\n"
+        "schema = {schema}\n[repo]\nname = \"{name}\"\n{description}[trust]\nroot_key_ids = [{root_keys}]\n"
     )
 }
 

--- a/crates/conary-core/src/ccs/v3/validation.rs
+++ b/crates/conary-core/src/ccs/v3/validation.rs
@@ -686,7 +686,6 @@ mod tests {
             provenance:
                 crate::repository::dependency_model::CapabilityProvenance::SourcePromisedPath {
                     format: crate::repository::dependency_model::SourcePackageFormat::Rpm,
-                    source_path: path.to_string(),
                 },
             target: None,
             component: None,

--- a/crates/conary-core/src/db/models/converted.rs
+++ b/crates/conary-core/src/db/models/converted.rs
@@ -17,9 +17,9 @@ use strum_macros::{AsRefStr, Display, EnumString};
 /// Current conversion algorithm version
 /// Bump this when making changes that require re-conversion of existing packages.
 ///
-/// Revision 14 publishes source-promised (%ghost) paths as signed provider
-/// authority, so converted artifacts state their whole path ownership set.
-pub const CONVERSION_VERSION: i32 = 14;
+/// Revision 15 drops the duplicated path from every path-owning capability
+/// provenance, so a converted artifact states each owned path exactly once.
+pub const CONVERSION_VERSION: i32 = 15;
 /// Canonical digest of an empty repository-provide projection.
 pub const EMPTY_REPOSITORY_PROVIDES_DIGEST: &str =
     "sha256:4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945";

--- a/crates/conary-core/src/db/schema.rs
+++ b/crates/conary-core/src/db/schema.rs
@@ -12,12 +12,19 @@ use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 use std::path::Path;
 use tracing::info;
 
-/// Revision 26 of the current-only schema epoch.
+/// Revision 27 of the current-only schema epoch.
 ///
-/// Revision 26 retains revision 25's fail-closed persisted states and requires
-/// every source pin to persist an explicit dependency-mixing policy. Earlier
-/// pre-alpha databases must be rebuilt; no compatibility migration is provided.
-pub const SCHEMA_VERSION: i32 = 26;
+/// Revision 27 retains revision 26's fail-closed persisted states and explicit
+/// dependency-mixing policy, and stores every path-owning capability provenance
+/// without its duplicated path. The table definitions are unchanged, so the
+/// revision is what separates the two shapes: `provides.provenance` and
+/// `repository_provides.provenance` are JSON text inside a UNIQUE contract
+/// index, so a database mixing old and new rows would admit the same path twice
+/// as two distinct providers. No installed-state resync rebuilds
+/// `provides`, so the version gate is the only thing that can refuse the mix.
+/// Earlier pre-alpha databases must be rebuilt; no compatibility migration is
+/// provided.
+pub const SCHEMA_VERSION: i32 = 27;
 /// Stable identity that distinguishes this epoch from retired schema revisions.
 pub const SCHEMA_EPOCH: &str = "conary-current-v1";
 
@@ -212,7 +219,7 @@ mod tests {
     }
 
     #[test]
-    fn revision_25_requires_rebuild_for_revision_26() {
+    fn revision_26_requires_rebuild_for_revision_27() {
         let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(
             "CREATE TABLE schema_identity (
@@ -220,19 +227,81 @@ mod tests {
                 revision INTEGER NOT NULL
             );
             INSERT INTO schema_identity (epoch, revision)
-                VALUES ('conary-current-v1', 25);
+                VALUES ('conary-current-v1', 26);
             CREATE TABLE schema_version (
                 version INTEGER PRIMARY KEY,
                 applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             );
-            INSERT INTO schema_version (version) VALUES (25);",
+            INSERT INTO schema_version (version) VALUES (26);",
         )
         .unwrap();
 
         let error = ensure_current(&conn).unwrap_err();
         assert_eq!(
             error.to_string(),
-            "Database schema rebuild required: database uses schema epoch conary-current-v1 revision 25; this pre-alpha build supports only schema epoch conary-current-v1 revision 26"
+            "Database schema rebuild required: database uses schema epoch conary-current-v1 revision 26; this pre-alpha build supports only schema epoch conary-current-v1 revision 27"
+        );
+    }
+
+    /// The revision, not the table text, is what separates the two provenance
+    /// shapes. `provides.provenance` is JSON inside a UNIQUE contract index and
+    /// no resync rebuilds installed rows, so a database carrying the previous
+    /// revision must be refused rather than silently mixed.
+    #[test]
+    fn a_database_holding_duplicated_path_provenance_cannot_pass_the_version_gate() {
+        let conn = Connection::open_in_memory().unwrap();
+        ensure_current(&conn).unwrap();
+
+        // Exactly the shape revision 26 wrote for one package-owned path.
+        let retired =
+            r#"{"role":"source-derived-file","format":"rpm","source_path":"/usr/bin/sh"}"#;
+        let current = r#"{"role":"source-derived-file","format":"rpm"}"#;
+        conn.execute(
+            "INSERT INTO troves
+             (name, version, type, install_source, install_reason, version_scheme)
+             VALUES ('tool', '1', 'package', 'repository', 'explicit', 'rpm')",
+            [],
+        )
+        .unwrap();
+        let trove_id = conn.last_insert_rowid();
+        for provenance in [retired, current] {
+            conn.execute(
+                "INSERT INTO provides
+                 (trove_id, capability, kind, version_scheme, architecture_qualifier_kind, provenance)
+                 VALUES (?1, '/usr/bin/sh', 'file', 'rpm', 'implicit', ?2)",
+                params![trove_id, provenance],
+            )
+            .unwrap();
+        }
+
+        // The UNIQUE contract index admits both, so one path has two providers:
+        // this is the state the version gate exists to keep out.
+        assert_eq!(
+            conn.query_row(
+                "SELECT COUNT(*) FROM provides WHERE trove_id = ?1 AND capability = '/usr/bin/sh'",
+                params![trove_id],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+            2,
+        );
+
+        conn.execute(
+            "UPDATE schema_identity SET revision = ?1",
+            params![SCHEMA_VERSION - 1],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE schema_version SET version = ?1",
+            params![SCHEMA_VERSION - 1],
+        )
+        .unwrap();
+
+        let error = ensure_current(&conn).unwrap_err();
+        assert!(
+            matches!(error, Error::SchemaRebuildRequired { supported_revision, .. }
+                if supported_revision == SCHEMA_VERSION),
+            "{error}"
         );
     }
 

--- a/crates/conary-core/src/repository/dependency_model.rs
+++ b/crates/conary-core/src/repository/dependency_model.rs
@@ -57,6 +57,12 @@ impl SourcePackageFormat {
 
 /// Why a capability exists. Exact package identity is deliberately distinct
 /// from every declared or derived capability.
+///
+/// A path-owning variant states only *why* the path is a capability. It never
+/// carries the path: the capability's own name is the path, so restating it in
+/// provenance would be one fact with two owners that can disagree -- and, at
+/// repository scale, one stored copy of every file path per package in the
+/// distribution.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(tag = "role", rename_all = "kebab-case")]
 pub enum CapabilityProvenance {
@@ -66,9 +72,9 @@ pub enum CapabilityProvenance {
         format: SourcePackageFormat,
         record_index: u32,
     },
+    /// A path the source package ships, derived from one exact signed record.
     SourceDerivedFile {
         format: SourcePackageFormat,
-        source_path: String,
     },
     /// A path the source package owns but ships no content for, materialized by
     /// its own lifecycle (RPM `%ghost`).
@@ -79,7 +85,6 @@ pub enum CapabilityProvenance {
     /// decide, instead of letting a promise pass silently as a shipped file.
     SourcePromisedPath {
         format: SourcePackageFormat,
-        source_path: String,
     },
 }
 
@@ -361,21 +366,14 @@ impl ProvidedCapability {
                     self.name
                 )));
             }
-            CapabilityProvenance::SourceDerivedFile { source_path, .. }
-                if self.kind != RepositoryCapabilityKind::File || !source_path.starts_with('/') =>
-            {
-                return Err(crate::error::Error::ParseError(
-                    "source-derived file capability requires a file kind and absolute source path"
-                        .to_string(),
-                ));
-            }
-            CapabilityProvenance::SourcePromisedPath { source_path, .. }
-                if self.kind != RepositoryCapabilityKind::File
-                    || !source_path.starts_with('/')
-                    || source_path != &self.name =>
+            // Both path-owning provenances name the path through the capability
+            // itself, so the one absolute-path-and-file-kind rule covers both.
+            CapabilityProvenance::SourceDerivedFile { .. }
+            | CapabilityProvenance::SourcePromisedPath { .. }
+                if self.kind != RepositoryCapabilityKind::File || !self.name.starts_with('/') =>
             {
                 return Err(crate::error::Error::ParseError(format!(
-                    "promised path capability '{}' requires a file kind and a matching absolute source path",
+                    "source path capability '{}' requires a file kind and an absolute path name",
                     self.name
                 )));
             }
@@ -401,10 +399,7 @@ impl ProvidedCapability {
             version_relation: None,
             version_scheme: format.version_scheme(),
             architecture_qualifier: ProvideArchitectureQualifier::Implicit,
-            provenance: CapabilityProvenance::SourceDerivedFile {
-                format,
-                source_path: path.to_string(),
-            },
+            provenance: CapabilityProvenance::SourceDerivedFile { format },
         }
     }
 
@@ -419,10 +414,7 @@ impl ProvidedCapability {
             version_relation: None,
             version_scheme: format.version_scheme(),
             architecture_qualifier: ProvideArchitectureQualifier::Implicit,
-            provenance: CapabilityProvenance::SourcePromisedPath {
-                format,
-                source_path: path.to_string(),
-            },
+            provenance: CapabilityProvenance::SourcePromisedPath { format },
         }
     }
 
@@ -1054,23 +1046,89 @@ mod tests {
 
     #[test]
     fn capability_validation_rejects_malformed_provenance_and_architecture() {
+        // The capability name is the only path a source-path provenance has, so
+        // a relative name is exactly the malformation the rule must catch.
         let mut capability = ProvidedCapability {
             kind: RepositoryCapabilityKind::File,
-            name: "/usr/bin/tool".to_string(),
+            name: "usr/bin/tool".to_string(),
             version: None,
             version_relation: None,
             version_scheme: VersionScheme::Arch,
             architecture_qualifier: ProvideArchitectureQualifier::Implicit,
             provenance: CapabilityProvenance::SourceDerivedFile {
                 format: SourcePackageFormat::Alpm,
-                source_path: "usr/bin/tool".to_string(),
             },
         };
         assert!(capability.validate().is_err());
 
+        capability.provenance = CapabilityProvenance::SourcePromisedPath {
+            format: SourcePackageFormat::Alpm,
+        };
+        assert!(capability.validate().is_err());
+
+        // The same relative name is fine once nothing claims it is a path.
         capability.provenance = CapabilityProvenance::AuthorDeclared;
+        capability.kind = RepositoryCapabilityKind::Generic;
+        capability.validate().unwrap();
+
         capability.architecture_qualifier = ProvideArchitectureQualifier::Exact(String::new());
         assert!(capability.validate().is_err());
+    }
+
+    #[test]
+    fn a_path_capability_never_stores_its_path_in_provenance() {
+        // The persisted and signed shape is the contract: `repository_provides`
+        // holds one row per package-owned path for a whole distribution, so a
+        // duplicated path is one copy of every file path in the repository.
+        let shipped = ProvidedCapability::payload_file(SourcePackageFormat::Rpm, "/usr/bin/sh");
+        let promised = ProvidedCapability::promised_path(SourcePackageFormat::Rpm, "/var/run/tool");
+        let declared = ProvidedCapability {
+            kind: RepositoryCapabilityKind::Generic,
+            name: "webserver".to_string(),
+            version: None,
+            version_relation: None,
+            version_scheme: VersionScheme::Rpm,
+            architecture_qualifier: ProvideArchitectureQualifier::Implicit,
+            provenance: CapabilityProvenance::SourceDeclared {
+                format: SourcePackageFormat::Rpm,
+                record_index: 7,
+            },
+        };
+
+        for capability in [&shipped, &promised] {
+            let encoded = serde_json::to_value(&capability.provenance).unwrap();
+            assert_eq!(
+                encoded
+                    .as_object()
+                    .unwrap()
+                    .keys()
+                    .map(String::as_str)
+                    .collect::<BTreeSet<_>>(),
+                BTreeSet::from(["role", "format"]),
+                "a path provenance carries only why the path is a capability"
+            );
+            assert!(
+                !serde_json::to_string(&capability.provenance)
+                    .unwrap()
+                    .contains(&capability.name),
+                "provenance must not restate the capability path"
+            );
+            capability.validate().unwrap();
+        }
+
+        assert_eq!(
+            serde_json::to_string(&shipped.provenance).unwrap(),
+            r#"{"role":"source-derived-file","format":"rpm"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&promised.provenance).unwrap(),
+            r#"{"role":"source-promised-path","format":"rpm"}"#
+        );
+        // A non-path provenance is untouched by that cut.
+        assert_eq!(
+            serde_json::to_string(&declared.provenance).unwrap(),
+            r#"{"role":"source-declared","format":"rpm","record_index":7}"#
+        );
     }
 
     #[test]
@@ -1103,10 +1161,7 @@ mod tests {
                 assert_eq!(provide.version_scheme, format.version_scheme());
                 assert_eq!(
                     provide.provenance,
-                    CapabilityProvenance::SourceDerivedFile {
-                        format,
-                        source_path: provide.name.clone(),
-                    }
+                    CapabilityProvenance::SourceDerivedFile { format }
                 );
             }
         }
@@ -1123,7 +1178,6 @@ mod tests {
             architecture_qualifier: ProvideArchitectureQualifier::Implicit,
             provenance: CapabilityProvenance::SourceDerivedFile {
                 format: SourcePackageFormat::Rpm,
-                source_path: "/usr/bin/sh".to_string(),
             },
         }];
 

--- a/crates/conary-core/src/repository/parsers/fedora/filelists/tests.rs
+++ b/crates/conary-core/src/repository/parsers/fedora/filelists/tests.rs
@@ -147,7 +147,6 @@ fn filelists_paths_carry_the_same_provenance_primary_paths_carry() {
             provide.provenance,
             CapabilityProvenance::SourceDerivedFile {
                 format: SourcePackageFormat::Rpm,
-                source_path: provide.name.clone(),
             }
         );
     }

--- a/crates/conary-core/src/repository/parsers/fedora/provides.rs
+++ b/crates/conary-core/src/repository/parsers/fedora/provides.rs
@@ -67,14 +67,14 @@ pub(super) fn project_repository_provides(
 /// Primary and filelists records are the same authority -- one generator
 /// writing the same `<file>` element from the same package file list -- so they
 /// produce the same capability with the same `source-derived-file` provenance
-/// through this one owner. Provenance carries the path the record named, which
-/// is what makes a later reader able to say which signed record a provider came
-/// from.
+/// through this one owner. Provenance states only that a signed source file
+/// record established the capability; the capability's own name is the path,
+/// and storing it a second time would cost one copy of every path in the
+/// distribution.
 pub(super) fn extend_file_provides(provides: &mut Vec<RepositoryProvide>, path: &str) {
     provides.push(RepositoryProvide {
         provenance: CapabilityProvenance::SourceDerivedFile {
             format: SourcePackageFormat::Rpm,
-            source_path: path.to_string(),
         },
         ..RepositoryProvide::file(path.to_string())
     });

--- a/crates/conary-core/src/repository/parsers/fedora/tests.rs
+++ b/crates/conary-core/src/repository/parsers/fedora/tests.rs
@@ -278,7 +278,6 @@ fn primary_xml_projects_every_generator_selected_file_as_a_typed_provide() {
         && provide.provenance
             == crate::repository::dependency_model::CapabilityProvenance::SourceDerivedFile {
                 format: crate::repository::dependency_model::SourcePackageFormat::Rpm,
-                source_path: provide.name.clone(),
             }));
 }
 

--- a/crates/conary-core/src/repository/static_repo/format.rs
+++ b/crates/conary-core/src/repository/static_repo/format.rs
@@ -14,7 +14,15 @@ use crate::repository::versioning::{VersionScheme, parse_repo_constraint};
 
 use super::paths::validate_repo_relative_path;
 
-const SCHEMA_VERSION: u64 = 1;
+/// Document major for every static repository document a client parses.
+///
+/// Major 2 carries capability provenance without its duplicated path. A major-1
+/// index cannot be read as major 2 and a major-1 client cannot read a major-2
+/// index -- the provenance shapes are incompatible in both directions -- so the
+/// major is what clients gate on, exactly as the format specification requires.
+/// The publisher stamps this constant rather than a literal so a published
+/// document and the parser that admits it cannot drift apart.
+pub const SCHEMA_VERSION: u64 = 2;
 const SHA256_HEX_LEN: usize = 64;
 const ED25519_PUBLIC_KEY_LEN: usize = 32;
 const MAX_REPO_NAME_LEN: usize = 64;
@@ -444,7 +452,7 @@ fn validate_lower_hex(value: &str, expected_len: usize, field: &str) -> Result<(
 
 #[cfg(test)]
 mod tests {
-    use super::{PackageKeysFile, RepoIdentity, StaticIndex};
+    use super::{PackageKeysFile, RepoIdentity, SCHEMA_VERSION, StaticIndex};
     use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 
     const VALID_ROOT_KEY_ID: &str =
@@ -453,36 +461,12 @@ mod tests {
 
     #[test]
     fn repo_identity_rejects_bad_name() {
-        let input = r#"
-schema = 1
+        let input = format!(
+            r#"
+schema = {SCHEMA_VERSION}
 [repo]
 name = "Bad_Name"
 description = "bad"
-[trust]
-root_key_ids = ["9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"]
-"#;
-        assert!(RepoIdentity::parse(input).is_err());
-    }
-
-    #[test]
-    fn repo_identity_rejects_bad_root_key_id() {
-        let input = r#"
-schema = 1
-[repo]
-name = "good-name"
-[trust]
-root_key_ids = ["not-a-key"]
-"#;
-        assert!(RepoIdentity::parse(input).is_err());
-    }
-
-    #[test]
-    fn repo_identity_rejects_unknown_schema() {
-        let input = format!(
-            r#"
-schema = 2
-[repo]
-name = "good-name"
 [trust]
 root_key_ids = ["{VALID_ROOT_KEY_ID}"]
 "#
@@ -491,19 +475,133 @@ root_key_ids = ["{VALID_ROOT_KEY_ID}"]
     }
 
     #[test]
+    fn repo_identity_rejects_bad_root_key_id() {
+        let input = format!(
+            r#"
+schema = {SCHEMA_VERSION}
+[repo]
+name = "good-name"
+[trust]
+root_key_ids = ["not-a-key"]
+"#
+        );
+        assert!(RepoIdentity::parse(&input).is_err());
+    }
+
+    #[test]
+    fn repo_identity_rejects_unknown_schema() {
+        // Both directions: the retired major and any future major.
+        for schema in [SCHEMA_VERSION - 1, SCHEMA_VERSION + 1] {
+            let input = format!(
+                r#"
+schema = {schema}
+[repo]
+name = "good-name"
+[trust]
+root_key_ids = ["{VALID_ROOT_KEY_ID}"]
+"#
+            );
+            let error = RepoIdentity::parse(&input).unwrap_err();
+            assert!(
+                error.to_string().contains(&format!(
+                    "repo identity schema {schema} is unsupported; expected {SCHEMA_VERSION}"
+                )),
+                "{error}"
+            );
+        }
+    }
+
+    #[test]
     fn static_index_rejects_unknown_schema() {
+        for schema in [SCHEMA_VERSION - 1, SCHEMA_VERSION + 1] {
+            let input = valid_index_json(
+                schema,
+                "packages/acme-widget/acme-widget-1.4.2-1-x86_64.ccs",
+                1048576,
+            );
+            let error = StaticIndex::parse(&input).unwrap_err();
+            assert!(
+                error.to_string().contains(&format!(
+                    "static index schema {schema} is unsupported; expected {SCHEMA_VERSION}"
+                )),
+                "{error}"
+            );
+        }
+    }
+
+    /// A retired-major index carrying the retired provenance shape must be
+    /// refused by the version gate, not deserialized into the current shape
+    /// with its duplicated path silently dropped.
+    #[test]
+    fn a_retired_major_index_carrying_a_duplicated_provenance_path_is_refused() {
+        // Major 1 is named absolutely, not as `SCHEMA_VERSION - 1`: it is the
+        // exact published major whose provenance carried a duplicated path.
+        // A relative bound would follow the constant back down and prove
+        // nothing about whether the major was actually raised for that change.
+        const RETIRED_DUPLICATED_PATH_MAJOR: u64 = 1;
+
         let input = valid_index_json(
-            2,
+            RETIRED_DUPLICATED_PATH_MAJOR,
             "packages/acme-widget/acme-widget-1.4.2-1-x86_64.ccs",
             1048576,
+        )
+        .replace(
+            r#"{ "role": "exact-identity" }"#,
+            r#"{ "role": "source-derived-file", "format": "ccs", "source_path": "/usr/bin/widget" }"#,
         );
-        assert!(StaticIndex::parse(&input).is_err());
+        let error = StaticIndex::parse(&input).unwrap_err();
+        assert!(
+            error.to_string().contains(&format!(
+                "static index schema {RETIRED_DUPLICATED_PATH_MAJOR} is unsupported; expected {SCHEMA_VERSION}"
+            )),
+            "{error}"
+        );
+
+        // The same retired major is refused for the identity and key documents,
+        // so no static document can be read under the old provenance shape.
+        let identity = format!(
+            r#"
+schema = {RETIRED_DUPLICATED_PATH_MAJOR}
+[repo]
+name = "acme-tools"
+[trust]
+root_key_ids = ["{VALID_ROOT_KEY_ID}"]
+"#
+        );
+        assert!(RepoIdentity::parse(&identity).is_err());
+        assert!(
+            PackageKeysFile::parse(&valid_package_keys_json(
+                RETIRED_DUPLICATED_PATH_MAJOR,
+                &BASE64.encode([1_u8; 32])
+            ))
+            .is_err()
+        );
+    }
+
+    /// The publisher stamps the constant, so a published document and the
+    /// parser that admits it cannot drift apart.
+    #[test]
+    fn every_published_document_stamps_the_current_major() {
+        let index = StaticIndex::parse(&valid_index_json(
+            SCHEMA_VERSION,
+            "packages/acme-widget/acme-widget-1.4.2-1-x86_64.ccs",
+            1048576,
+        ))
+        .unwrap();
+        assert_eq!(index.schema, SCHEMA_VERSION);
+
+        let keys = PackageKeysFile::parse(&valid_package_keys_json(
+            SCHEMA_VERSION,
+            &BASE64.encode([1_u8; 32]),
+        ))
+        .unwrap();
+        assert_eq!(keys.schema, SCHEMA_VERSION);
     }
 
     #[test]
     fn static_index_rejects_package_filename_mismatch() {
         let input = valid_index_json(
-            1,
+            SCHEMA_VERSION,
             "packages/acme-widget/wrong-name-1.4.2-1-x86_64.ccs",
             1048576,
         );
@@ -512,14 +610,18 @@ root_key_ids = ["{VALID_ROOT_KEY_ID}"]
 
     #[test]
     fn static_index_rejects_package_path_outside_name_directory() {
-        let input = valid_index_json(1, "packages/other/acme-widget-1.4.2-1-x86_64.ccs", 1048576);
+        let input = valid_index_json(
+            SCHEMA_VERSION,
+            "packages/other/acme-widget-1.4.2-1-x86_64.ccs",
+            1048576,
+        );
         assert!(StaticIndex::parse(&input).is_err());
     }
 
     #[test]
     fn static_index_rejects_package_size_above_i64_max() {
         let input = valid_index_json(
-            1,
+            SCHEMA_VERSION,
             "packages/acme-widget/acme-widget-1.4.2-1-x86_64.ccs",
             i64::MAX as u64 + 1,
         );
@@ -530,7 +632,7 @@ root_key_ids = ["{VALID_ROOT_KEY_ID}"]
     fn static_index_rejects_duplicate_package_identity() {
         let input = format!(
             r#"{{
-  "schema": 1,
+  "schema": {SCHEMA_VERSION},
   "name": "acme-tools",
   "index_version": 7,
   "generated": "2026-06-10T18:00:00Z",
@@ -588,7 +690,7 @@ root_key_ids = ["{VALID_ROOT_KEY_ID}"]
     #[test]
     fn static_index_rejects_string_dependency_contract() {
         let mut value: serde_json::Value = serde_json::from_str(&valid_index_json(
-            1,
+            SCHEMA_VERSION,
             "packages/acme-widget/acme-widget-1.4.2-1-x86_64.ccs",
             1048576,
         ))
@@ -608,7 +710,7 @@ root_key_ids = ["{VALID_ROOT_KEY_ID}"]
     #[test]
     fn static_index_preserves_same_name_compatibility_capability() {
         let mut value: serde_json::Value = serde_json::from_str(&valid_index_json(
-            1,
+            SCHEMA_VERSION,
             "packages/acme-widget/acme-widget-1.4.2-1-x86_64.ccs",
             1048576,
         ))
@@ -643,7 +745,7 @@ root_key_ids = ["{VALID_ROOT_KEY_ID}"]
     #[test]
     fn static_index_rejects_negative_requirement_groups() {
         let mut value: serde_json::Value = serde_json::from_str(&valid_index_json(
-            1,
+            SCHEMA_VERSION,
             "packages/acme-widget/acme-widget-1.4.2-1-x86_64.ccs",
             1048576,
         ))
@@ -680,7 +782,7 @@ root_key_ids = ["{VALID_ROOT_KEY_ID}"]
     #[test]
     fn static_index_round_trips_typed_relation_authority() {
         let mut value: serde_json::Value = serde_json::from_str(&valid_index_json(
-            1,
+            SCHEMA_VERSION,
             "packages/acme-widget/acme-widget-1.4.2-1-x86_64.ccs",
             1048576,
         ))
@@ -701,7 +803,7 @@ root_key_ids = ["{VALID_ROOT_KEY_ID}"]
     #[test]
     fn static_index_rejects_malformed_typed_relation_constraint() {
         let mut value: serde_json::Value = serde_json::from_str(&valid_index_json(
-            1,
+            SCHEMA_VERSION,
             "packages/acme-widget/acme-widget-1.4.2-1-x86_64.ccs",
             1048576,
         ))
@@ -727,19 +829,19 @@ root_key_ids = ["{VALID_ROOT_KEY_ID}"]
 
     #[test]
     fn package_keys_reject_unknown_schema() {
-        let input = valid_package_keys_json(2, &BASE64.encode([0_u8; 32]));
+        let input = valid_package_keys_json(SCHEMA_VERSION + 1, &BASE64.encode([0_u8; 32]));
         assert!(PackageKeysFile::parse(&input).is_err());
     }
 
     #[test]
     fn package_keys_reject_malformed_public_key() {
-        let input = valid_package_keys_json(1, "not base64!");
+        let input = valid_package_keys_json(SCHEMA_VERSION, "not base64!");
         assert!(PackageKeysFile::parse(&input).is_err());
     }
 
     #[test]
     fn package_keys_reject_wrong_public_key_length() {
-        let input = valid_package_keys_json(1, &BASE64.encode([0_u8; 31]));
+        let input = valid_package_keys_json(SCHEMA_VERSION, &BASE64.encode([0_u8; 31]));
         assert!(PackageKeysFile::parse(&input).is_err());
     }
 
@@ -759,12 +861,13 @@ root_key_ids = ["{VALID_ROOT_KEY_ID}"]
     #[test]
     fn package_keys_reject_empty_keys_for_non_empty_index() {
         let index = StaticIndex::parse(&valid_index_json(
-            1,
+            SCHEMA_VERSION,
             "packages/acme-widget/acme-widget-1.4.2-1-x86_64.ccs",
             1048576,
         ))
         .unwrap();
-        let keys = PackageKeysFile::parse(r#"{"schema":1,"keys":[]}"#).unwrap();
+        let keys =
+            PackageKeysFile::parse(&format!(r#"{{"schema":{SCHEMA_VERSION},"keys":[]}}"#)).unwrap();
         assert!(keys.validate_for_index(&index).is_err());
     }
 

--- a/crates/conary-core/src/repository/static_repo/mod.rs
+++ b/crates/conary-core/src/repository/static_repo/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod sync;
 
 pub use format::{
     PackageKeyEntry, PackageKeyStatus, PackageKeysFile, RepoIdentity, RepoIdentityRepo,
-    RepoIdentityTrust, StaticIndex, StaticPackageEntry,
+    RepoIdentityTrust, SCHEMA_VERSION, StaticIndex, StaticPackageEntry,
 };
 pub use location::RepoLocation;
 pub use paths::validate_repo_relative_path;

--- a/crates/conary-core/src/repository/static_repo/publish.rs
+++ b/crates/conary-core/src/repository/static_repo/publish.rs
@@ -22,8 +22,8 @@ use crate::repository::static_repo::publish_gate::{
     format_publish_gate_failures, verify_static_artifact_publish_eligibility,
 };
 use crate::repository::static_repo::{
-    PackageKeysFile, RepoIdentity, RepoIdentityRepo, RepoIdentityTrust, RepoLocation, StaticIndex,
-    StaticPackageEntry, validate_repo_relative_path,
+    PackageKeysFile, RepoIdentity, RepoIdentityRepo, RepoIdentityTrust, RepoLocation,
+    SCHEMA_VERSION, StaticIndex, StaticPackageEntry, validate_repo_relative_path,
 };
 use crate::trust::ceremony::{create_initial_root, rotate_key, rotate_publish_key};
 use crate::trust::generate::{generate_snapshot, generate_targets, generate_timestamp};
@@ -633,7 +633,7 @@ fn build_index(
     package_entries: Vec<StaticPackageEntry>,
 ) -> StaticIndex {
     StaticIndex {
-        schema: 1,
+        schema: SCHEMA_VERSION,
         name: repo_name.to_string(),
         index_version: targets_version,
         generated: Utc::now(),
@@ -736,7 +736,7 @@ fn build_identity(
         .keyids
         .clone();
     let identity = RepoIdentity {
-        schema: 1,
+        schema: SCHEMA_VERSION,
         repo: RepoIdentityRepo {
             name: options.repo_name.clone(),
             description: options.repo_description.clone(),
@@ -895,7 +895,7 @@ fn write_atomic_temp_file(path: &Path, file: &mut File, bytes: &[u8]) -> Result<
 
 fn validate_repo_name_for_identity(repo_name: &str) -> Result<()> {
     let identity = RepoIdentity {
-        schema: 1,
+        schema: SCHEMA_VERSION,
         repo: RepoIdentityRepo {
             name: repo_name.to_string(),
             description: None,

--- a/crates/conary-core/src/repository/static_repo/publish_context/key_management.rs
+++ b/crates/conary-core/src/repository/static_repo/publish_context/key_management.rs
@@ -7,7 +7,9 @@ use std::path::Path;
 use anyhow::{Context, Result};
 
 use crate::ccs::signing::SigningKeyPair;
-use crate::repository::static_repo::{PackageKeyEntry, PackageKeyStatus, PackageKeysFile};
+use crate::repository::static_repo::{
+    PackageKeyEntry, PackageKeyStatus, PackageKeysFile, SCHEMA_VERSION,
+};
 use crate::trust::keys::signing_keypair_to_tuf_key;
 use crate::trust::metadata::{RootMetadata, Signed};
 
@@ -234,7 +236,7 @@ pub(crate) fn build_package_keys_file(
     });
 
     let keys = PackageKeysFile {
-        schema: 1,
+        schema: SCHEMA_VERSION,
         keys: entries,
     };
     keys.validate()?;

--- a/crates/conary-core/src/repository/static_repo/publish_context/tests.rs
+++ b/crates/conary-core/src/repository/static_repo/publish_context/tests.rs
@@ -117,7 +117,7 @@ fn new_repo_does_not_trust_stray_package_keys_without_metadata() {
     let repo_root = temp.path().join("repo");
     std::fs::create_dir_all(repo_root.join("keys")).unwrap();
     let keys = PackageKeysFile {
-        schema: 1,
+        schema: crate::repository::static_repo::SCHEMA_VERSION,
         keys: vec![PackageKeyEntry {
             algorithm: "ed25519".to_string(),
             public_key: stray_key.public_key_base64(),

--- a/crates/conary-core/src/repository/static_repo/publish_gate/tests.rs
+++ b/crates/conary-core/src/repository/static_repo/publish_gate/tests.rs
@@ -28,7 +28,7 @@ fn package_key(id: &str, public_key: &str, status: PackageKeyStatus) -> PackageK
 #[test]
 fn accepted_signers_include_only_active_package_keys() {
     let keys = PackageKeysFile {
-        schema: 1,
+        schema: crate::repository::static_repo::SCHEMA_VERSION,
         keys: vec![
             package_key("active", "pub-active", PackageKeyStatus::Active),
             package_key("retired", "pub-retired", PackageKeyStatus::Retired),
@@ -43,7 +43,7 @@ fn accepted_signers_include_only_active_package_keys() {
 #[test]
 fn retired_signer_cannot_authorize_new_publish() {
     let keys = PackageKeysFile {
-        schema: 1,
+        schema: crate::repository::static_repo::SCHEMA_VERSION,
         keys: vec![package_key(
             "retired",
             "pub-retired",
@@ -58,7 +58,7 @@ fn retired_signer_cannot_authorize_new_publish() {
 #[test]
 fn duplicate_active_signers_fail_closed() {
     let keys = PackageKeysFile {
-        schema: 1,
+        schema: crate::repository::static_repo::SCHEMA_VERSION,
         keys: vec![
             package_key("dup", "pub-one", PackageKeyStatus::Active),
             package_key("dup", "pub-two", PackageKeyStatus::Active),

--- a/crates/conary-core/src/repository/static_repo/sync.rs
+++ b/crates/conary-core/src/repository/static_repo/sync.rs
@@ -240,6 +240,7 @@ mod tests {
         RepositoryCapabilityKind, RepositoryProvide, RepositoryRequirementClause,
         RepositoryRequirementGroup, RepositoryRequirementKind,
     };
+    use crate::repository::static_repo::SCHEMA_VERSION;
     use crate::repository::sync::types::RepositorySyncSnapshot;
     use crate::trust::metadata::{TargetDescription, VerifiedTufState};
     use std::collections::BTreeMap;
@@ -298,7 +299,7 @@ mod tests {
             let provides = Self::typed_provides();
             let requirements = Self::typed_requirements();
             let index = serde_json::json!({
-                "schema": 1,
+                "schema": SCHEMA_VERSION,
                 "name": "acme-tools",
                 "index_version": index_version,
                 "generated": "2026-06-10T18:00:00Z",
@@ -328,7 +329,7 @@ mod tests {
             let provides = Self::typed_provides();
             let requirements = Self::typed_requirements();
             let index = serde_json::json!({
-                "schema": 1,
+                "schema": SCHEMA_VERSION,
                 "name": "acme-tools",
                 "index_version": 7,
                 "generated": "2026-06-10T18:00:00Z",
@@ -394,7 +395,7 @@ mod tests {
 
         fn write_valid_package_keys(&mut self) {
             let keys = serde_json::json!({
-                "schema": 1,
+                "schema": SCHEMA_VERSION,
                 "keys": [
                     {
                         "algorithm": "ed25519",
@@ -418,7 +419,7 @@ mod tests {
 
         fn write_package_keys_with_status(&mut self, status: &str) {
             let keys = serde_json::json!({
-                "schema": 1,
+                "schema": SCHEMA_VERSION,
                 "keys": [{
                     "algorithm": "ed25519",
                     "public_key": self.package_key_active,

--- a/crates/conary-core/src/repository/sync/tests.rs
+++ b/crates/conary-core/src/repository/sync/tests.rs
@@ -106,7 +106,7 @@ mod tests {
             .with_native_text("libbar".to_string());
 
             let index = json!({
-                "schema": 1,
+                "schema": crate::repository::static_repo::SCHEMA_VERSION,
                 "name": "acme-tools",
                 "index_version": 7,
                 "generated": "2026-06-10T18:00:00Z",
@@ -132,7 +132,7 @@ mod tests {
             .unwrap();
 
             let keys = json!({
-                "schema": 1,
+                "schema": crate::repository::static_repo::SCHEMA_VERSION,
                 "keys": [
                     {
                         "algorithm": "ed25519",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-06
-revision: 40
+last_updated: 2026-08-08
+revision: 41
 summary: Describe workspace architecture, source-authority projections, repository trust, package transactions, lifecycle execution, typed carrier security, generation GC, and service boundaries
 ---
 
@@ -582,10 +582,14 @@ The schema itself is split by ownership under
 `crates/conary-core/src/db/current_schema/sql/`: local package-manager state,
 repository/service state, and Remi conversion/administration state.
 
-Schema revision 26 retains revision 25's fail-closed persisted-state
-constraints and requires every persisted source pin to carry an explicit
-`strict`, `guarded`, or `permissive` dependency-mixing policy. Omitting the
-policy never selects one on the operator's behalf.
+Schema revision 27 retains revision 26's fail-closed persisted-state
+constraints and explicit `strict`, `guarded`, or `permissive` dependency-mixing
+policy on every persisted source pin, and stores every path-owning capability
+provenance without a duplicated path. That last change moves no table
+definition, so the revision is the only thing separating the two shapes:
+`provides.provenance` is JSON text inside a UNIQUE contract index and no resync
+rebuilds installed rows, so a database mixing both shapes would admit one path
+twice as two distinct providers.
 
 Databases from retired schema revisions are rejected with an exact recovery
 command. `conary system rebuild-db --discard-state --yes` consolidates the

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-06
-revision: 16
+last_updated: 2026-08-08
+revision: 17
 summary: Document Remi source, sparse sync, signing, canonical-map, repository trust, conversion, publication, and serving authority
 ---
 
@@ -276,9 +276,10 @@ the authenticated source artifact. Public, OCI, index, search, chunk, and
 garbage-collection paths validate that typed artifact instead of filling
 missing fields with guesses or empty values. Architecture and the repository
 provide digest are required constructor and API-view fields, and the current
-schema rejects missing, empty, or malformed values. Schema revision 26 retains
-revision 25's source-authority and fail-closed state constraints while requiring
-an explicit mixing policy for every persisted source pin. It is a pre-alpha
+schema rejects missing, empty, or malformed values. Schema revision 27 retains
+revision 26's source-authority, fail-closed state constraints, and explicit
+mixing policy for every persisted source pin, and stores path-owning capability
+provenance without a duplicated path. It is a pre-alpha
 hard cut: prior databases are rebuilt and re-ingested from configured
 repository authority rather than migrated. Local conversion tracking is
 written only after the CCS install transaction commits.

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-08
-revision: 29
+revision: 30
 summary: Document exact profile-owned source policy, multi-root model authority, Remi CCS package authority, canonical map authority, native repository authority, package identity, full-adoption root continuity, and lifecycle handoff
 ---
 
@@ -339,7 +339,11 @@ record as an unversioned typed file provider with `source-derived-file`
 provenance on the exact package. The projection is owned by
 `repository/parsers/fedora/provides.rs`. It does not reimplement createrepo's
 path-selection rule or infer providers from package names, payload guesses, or
-a curated path list.
+a curated path list. The provenance names the source format only: the
+capability is the path, so a path-owning provenance never restates it. At this
+scale that is not a stylistic point -- a duplicated path is one extra copy of
+every package-owned path in the distribution, in both the synced database and
+every converted artifact's signed capability list.
 
 That selection rule is a filter, so `primary.xml` is not complete file
 ownership: the same generator writes every owned path through the same
@@ -376,9 +380,19 @@ missing path is an ordinary unsatisfied dependency.
 Fedora 44 `Everything/x86_64` measures that cost exactly (repomd revision
 1776864872): 76,354 packages, 81,720 file providers from `primary.xml`, and
 9,416,909 more from `filelists.xml`, taking `repository_provides` from 657,873
-rows to 10,074,782 and the synced SQLite database from 0.61 GB to 4.77 GB. The
+rows to 10,074,782 and the synced SQLite database from 0.61 GB to 3.90 GB. The
 829 MB decompressed document is never materialized: it is streamed from the
 verified compressed bytes under the ceiling the signed `<open-size>` declares.
+
+Dropping the duplicated path from file provenance is measured on that same
+corpus and revision: the synced database falls from 4.78 GB to 3.90 GB
+(-18.3%), the persist phase from 446.3 s to 392.3 s (-12.1%), and peak process
+RSS from 6.33 GiB to 5.15 GiB, with row counts identical. What remains is not
+provenance: at 4.78 GB the `repository_provides` table held 2,332 MB against
+1,684 MB of index (869 MB for `(kind, capability)`, 815 MB for `(capability)`,
+127 MB for the package key), so every path is still stored once in the table
+and twice more in indexes. Path interning or index consolidation is the next
+lever, not a second pass over provenance.
 
 The contract was derived against the package managers' and repository
 generators' own documentation:

--- a/docs/specs/ccs-format-v3.md
+++ b/docs/specs/ccs-format-v3.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-03
-revision: 10
+last_updated: 2026-08-08
+revision: 11
 summary: Canonical current signed CCS v3 identity, capability, archive, payload, and trust contract
 ---
 
@@ -97,7 +97,9 @@ architecture qualifier, and either no version authority or a paired typed
 relation and version boundary. RPM may use all five ordered relations; Debian,
 Arch, and Conary providers may use only equality. It also signs one closed
 provenance role: `author-declared`, `source-declared` with source format and
-record position, or `source-derived-file` with source format and path. Exact
+record position, or `source-derived-file` / `source-promised-path` with source
+format alone. A path role never carries the path: the capability name is the
+path, and a second copy would be one fact with two owners. Exact
 package identity exists only in `identity`; resolution derives its one exact
 package-name provider from that field. A same-name source capability may carry
 a different compatibility version without becoming a second identity.

--- a/docs/specs/source-package-authority.md
+++ b/docs/specs/source-package-authority.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-06
-revision: 4
+last_updated: 2026-08-08
+revision: 5
 summary: Define lossless RPM, Debian, ALPM, and CCS package authority plus explicit consumer projections
 ---
 
@@ -199,6 +199,11 @@ Capability provenance is a closed enum with at least these roles:
 | `author-declared` | Explicit capability in a directly authored CCS package |
 | `source-declared` | Exact RPM, Debian, or ALPM provision with source-format identity and source-record position |
 | `source-derived-file` | Capability derived by one pinned source-format rule from an exact payload record |
+| `source-promised-path` | A path the source package owns but ships no content for, materialized by its own lifecycle |
+
+A path role carries its source format and nothing else. The capability's name
+is the path, so provenance never restates it: one path, one owner, and one
+stored copy per package-owned path across a whole distribution.
 
 Package-name satisfaction comes directly from signed `identity`. It is not a
 fourth capability role. A duplicate or contradictory identity, an unknown

--- a/docs/specs/static-repo-format-v1.md
+++ b/docs/specs/static-repo-format-v1.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-25
-revision: 6
+last_updated: 2026-08-08
+revision: 7
 summary: Standalone normative contract for the static Conary repository format, publisher behavior, client behavior, and operator key lifecycle
 ---
 
@@ -85,7 +85,7 @@ This file is **not** TUF-protected (it is what you read before trust exists);
 it MUST NOT carry key material, URLs, or anything a client uses after add.
 Everything security-relevant in it is cross-checked against root.json (§6.1).
 
-    schema = 1
+    schema = 2
 
     [repo]
     name = "acme-tools"
@@ -103,7 +103,7 @@ Everything security-relevant in it is cross-checked against root.json (§6.1).
 
 Field rules:
 
-- `schema` (integer) MUST be `1`. Clients MUST reject unknown majors.
+- `schema` (integer) MUST be `2`. Clients MUST reject unknown majors.
 - `repo.name`: `[a-z0-9][a-z0-9-]*`, max 64 chars. Shown at add time; the
   client-side repo name remains whatever the user passed to `repo add`.
 - `repo.description`: optional display text shown during trust establishment;
@@ -125,7 +125,7 @@ sha256+length against the verified `targets.json` entry for path
 index.
 
     {
-      "schema": 1,
+      "schema": 2,
       "name": "acme-tools",
       "index_version": 7,
       "generated": "2026-06-10T18:00:00Z",
@@ -183,7 +183,7 @@ index.
 
 Field rules:
 
-- `schema` (u64): MUST be `1`; reject unknown majors. On the wire this is a
+- `schema` (u64): MUST be `2`; reject unknown majors. On the wire this is a
   JSON number; implementations deserialize it to `u64` and reject
   non-integer or out-of-range values.
 - `name`: display identity matching `conary-repo.toml` `repo.name`; clients
@@ -225,7 +225,10 @@ Field rules:
   when a source declaration intentionally reuses the package name at another
   compatibility version. Each versioned capability carries a paired
   `version_relation`, and source-declared or source-derived entries carry their
-  exact source format plus record index or source path.
+  exact source format plus, for a source declaration, its record index. A
+  path-owning provenance (`source-derived-file`, `source-promised-path`)
+  carries its source format only: the capability name is the path, and the
+  document MUST NOT restate it.
   A publisher MUST project capability kinds from the verified CCS authority
   document or manifest field that declared them. It MUST NOT infer `File`,
   `Soname`, `Virtual`, or any other kind from punctuation, path shape, or a
@@ -310,7 +313,7 @@ Already-bootstrapped clients discover rotations by probing
 ### 4.4 Package-key distribution: `keys/package-keys.json`
 
     {
-      "schema": 1,
+      "schema": 2,
       "keys": [
         {
           "algorithm": "ed25519",
@@ -324,7 +327,7 @@ Already-bootstrapped clients discover rotations by probing
 
 Field rules:
 
-- `schema` (u64): MUST be `1`; reject unknown majors. On the wire this is a
+- `schema` (u64): MUST be `2`; reject unknown majors. On the wire this is a
   JSON number; implementations deserialize it to `u64` and reject
   non-integer or out-of-range values.
 - `keys`: array of package-signing public-key entries; empty is invalid for
@@ -584,7 +587,7 @@ for a future v2 consistent-snapshot upgrade.
    mismatch; only a strictly lower timestamp version is rollback.
 2. Fetch `<url>/index.json`; verify length and sha256 against the
    verified targets entry for path `index.json` **before parsing**.
-3. Parse; verify `schema == 1` and `index_version == targets.version`.
+3. Parse; verify `schema == 2` and `index_version == targets.version`.
 4. Fetch + verify `keys/package-keys.json` the same way (targets entry,
    then parse); reject any key entry whose `status` is not `"active"` or
    `"retired"`; update the repo's package trust policy with
@@ -762,7 +765,13 @@ this is load-bearing, not hygiene).
   semantics (§8).
 - Versioning: `schema` majors in `conary-repo.toml`/`index.json` gate
   breaking changes; TUF `spec_version` stays 1.0.31 per the in-tree
-  implementation.
+  implementation. The document major is a different axis from the repository
+  layout generation discussed above: major `2` is current because capability
+  provenance stopped restating the path it already names, and major `1` (which
+  carried that duplicated path) is retired and MUST be rejected. The major is
+  owned by `static_repo::format::SCHEMA_VERSION`, which the publisher stamps
+  and the parser gates on, so a published document and the client that admits
+  it cannot drift apart.
 - Remi (M2) MUST produce byte-format-identical repos (it is "one producer of
   the same format" per the parent spec); its DB-backed TUF serving and this
   file-based layout share `trust/` types and generation functions.


### PR DESCRIPTION
## #327, with its premise corrected by measurement

The duplicated path is 18.3% of the filelists-scale DB, not "most": live Fedora 44 (identical repomd revision to #329's baseline, absolutes directly comparable): **DB 4.78→3.90GB, persist 446→392s, peak RSS −18.7%**, rows/counts unchanged. The bigger remaining lever is the redundant capability indexes — #330, with dbstat evidence.

## The cut

`SourceDerivedFile`/`SourcePromisedPath` provenance no longer carries `source_path` (field deleted, not emptied). Only production reader was `validate()`; the copies were constructor-equal by construction. Validation now strengthens: relative name + path provenance refused.

## Three contracts, three gates (second-model review caught two missing)

| contract | bump | enforcement |
|---|---|---|
| converted CCS | CONVERSION_VERSION 15 | remi lazy reconvert |
| SQLite DB | SCHEMA_VERSION 27 | refuse-and-rebuild at open — required, not cosmetic: the provides UNIQUE index keys on provenance text, so mixed shapes admit one path twice as two providers (test-pinned) |
| static repo documents | major 2 | typed refusal both directions; publisher's four hardcoded literals now stamp the constant |

## Rigor notes

Mutation-checked five directions; one initially FAILED to catch (constant-relative version test survived the revert) and was rewritten to name major 1 absolutely until it caught — reported as evidence, not hidden. The new gate immediately caught one stale fixture still stamping major 1 (fixed forward, gate not weakened).

## Verification (run, real output)

conary-core 3385 / conary / remi / conaryd all green; workspace clippy `-D warnings` clean; fmt clean; doc-truth clean; resolution card focused proof (7) + interaction gate (6) clean. Docs: static-repo-format-v1.md rev 7 (major 2 throughout, layout-generation axis disambiguated), ARCHITECTURE.md rev 41, remi.md rev 17, source-selection.md rev 30, source-package-authority.md rev 5, ccs-format-v3.md rev 11.

**Deploy note:** shipping this to production remi is a rebuild-and-resync (schema gate), not a rolling deploy. Release sequencing decision tracked with the operator.

Closes #327. Refs #329, #330.