### PR TITLE
chore: release remi-v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [remi-v0.12.0] - 2026-08-08
+
+### Added
+- ingest filelists.xml as signed file-provider authority (#329)
+
+### Changed
+- delete the consumerless AsyncRemiClient (#325)
+
+### Fixed
+- store each file-provide path once, version every contract that embeds it (#331)
+
 ## [remi-v0.11.2] - 2026-08-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4858,7 +4858,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remi"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/apps/remi/Cargo.toml
+++ b/apps/remi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remi"
-version = "0.11.2"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]


### PR DESCRIPTION
Release prep for remi-v0.12.0 (minor, from feat #329).

Ships since remi-v0.11.2:
- #329 / #285 — filelists.xml ingested as signed file-provider authority: RPM file deps outside primary's filter are now solvable; streaming under the signed open-size; expression-evaluated fail-closed rule. Measured: provides 658k→10.07M rows.
- #331 / #327 — file-provide paths stored once (DB 4.78→3.90GB, persist 446→392s at fedora44 scale); CONVERSION_VERSION 15, SCHEMA_VERSION 27, static document major 2 — all three embedding contracts gated.
- #321/#325 — exhaustive single-client polling contract; AsyncRemiClient deleted.
- #324 — lifecycle CI base images digest-pinned/cached (no prod impact).

**Deploy is a rebuild-and-resync** (schema 27 hard cut): the deploy helper snapshots the retired epoch, the candidate rebuilds, and repopulation proof gates completion. Post-deploy: first filelists-bearing fedora sync (~6.5min persist accepted by operator), CONVERSION_VERSION 15 lazy reconversion via scheduled prewarm, then chunk GC for the v14 generation. Operator accepted shipping ahead of #330 (index consolidation; will ride a future schema rev).

Refs #285, #327, #330.