### PR TITLE
fix(install): verify installed packages' promises the transaction relies on

### DIFF
--- a/apps/conary/src/commands/composefs_ops.rs
+++ b/apps/conary/src/commands/composefs_ops.rs
@@ -529,9 +529,18 @@ mod tests {
         ));
 
         drop(first);
+        // Serialization is what the two assertions above prove, and they hold
+        // regardless of scheduling because `first` is still held. This last wait
+        // only proves liveness -- the worker does eventually acquire -- so its
+        // bound is an anti-hang backstop, not a contract. `TEST_MOUNT_SKIP_LOCK`
+        // is a plain `std::sync::Mutex` with no fairness guarantee, and every
+        // install test in this process contends for it, so the worker can be
+        // passed over for as long as those tests keep the guard. Do not tighten
+        // this into a latency assertion: it would fail whenever the suite grows
+        // a test that holds the guard across more transactions.
         assert_eq!(
             acquired_rx
-                .recv_timeout(std::time::Duration::from_secs(5))
+                .recv_timeout(std::time::Duration::from_secs(120))
                 .unwrap(),
             None
         );

--- a/apps/conary/src/commands/install/batch.rs
+++ b/apps/conary/src/commands/install/batch.rs
@@ -20,6 +20,7 @@ mod config;
 mod execution;
 mod ordering;
 mod preparation;
+mod promises;
 mod relations;
 
 use super::ccs_removal_hooks::CcsRemovalHookPlan;
@@ -285,7 +286,7 @@ impl<'a> BatchInstaller<'a> {
 
         // Open database connection
         let mut conn = open_db(self.db_path)?;
-        let witnessed_promises = ordering::order_packages_for_transaction(&conn, &mut packages)?;
+        let mut promise_plan = ordering::order_packages_for_transaction(&conn, &mut packages)?;
         self.plan_package_relations_for_batch(&conn, &mut packages)?;
         // Build transaction description
         let tx_description = if package_count == 1 {
@@ -416,7 +417,7 @@ impl<'a> BatchInstaller<'a> {
             &mut selected_root,
             rollback_root,
             &mut ccs_hook_executors,
-            &witnessed_promises,
+            &mut promise_plan,
         );
         let (_changeset_id, trove_ids, _retained_upgrade_trove_ids) = transaction_result?;
 

--- a/apps/conary/src/commands/install/batch/execution.rs
+++ b/apps/conary/src/commands/install/batch/execution.rs
@@ -16,52 +16,6 @@ use conary_core::scriptlet::ExecutionMode;
 use std::collections::BTreeSet;
 use std::path::Path;
 
-/// Prove every promised path the transaction *relied on* was actually created.
-///
-/// RPM's `%ghost` marks a path the package owns if present -- `rpm-spec.5`
-/// describes it as a file "not to be included in the package", used "when the
-/// attributes of the file are important while the contents is not (e.g. a log
-/// file)". It is not a claim that the package creates the path, and many
-/// promises (`/etc/fstab`, log files, generated certificate links) are
-/// legitimately absent after a fresh transaction. Verifying every declared
-/// promise therefore asserts something the source never said.
-///
-/// So this verifies exactly the promises a dependency edge was certified
-/// against, as computed by the ordering validator: the transaction proves its
-/// own reasoning and nothing beyond it. It still runs regardless of the
-/// declaring lifecycle entry's criticality, because RPM's warning-only slots
-/// let a scriptlet fail, or silently do nothing, while reporting success -- and
-/// it runs after the whole native graph, including post-transaction slots.
-///
-/// A path is materialized when it exists, symlinks included: the promise is
-/// that the path exists, never what its content resolves to.
-pub(super) fn verify_promised_paths_materialized(
-    witnessed: &[super::ordering::WitnessedPromise],
-    selected_root: &Path,
-) -> Result<()> {
-    for promise in witnessed {
-        let target = crate::commands::live_root::target_path(selected_root, &promise.path)
-            .with_context(|| {
-                format!(
-                    "promised path {} declared by {} is not addressable in the target root",
-                    promise.path, promise.provider
-                )
-            })?;
-        if std::fs::symlink_metadata(&target).is_err() {
-            anyhow::bail!(
-                "package {}-{} did not materialize promised path {} during its native lifecycle \
-                 (checked after the post-transaction stage); {} depends on it through {}",
-                promise.provider,
-                promise.provider_version,
-                promise.path,
-                promise.dependent,
-                promise.requirement
-            );
-        }
-    }
-    Ok(())
-}
-
 struct GraphExecutionInputs {
     final_incoming_paths: BTreeSet<String>,
     finalization_troves: Vec<Option<i64>>,
@@ -84,7 +38,7 @@ impl BatchInstaller<'_> {
         selected: &mut crate::commands::generation::selected_root::SelectedRootSession,
         rollback_root: conary_core::generation::root_manifest::CapturedSelectedRoot,
         ccs_hook_executors: &mut [Option<conary_core::ccs::HookExecutor>],
-        witnessed_promises: &[super::ordering::WitnessedPromise],
+        promise_plan: &mut super::promises::PromiseWitnessPlan,
     ) -> Result<(i64, Vec<i64>, Vec<i64>)> {
         let graph_inputs = self.prepare_graph_execution(conn, packages)?;
         let runtime_root = conary_core::runtime_root::ConaryRuntimeRoot::from_db_path(
@@ -123,7 +77,7 @@ impl BatchInstaller<'_> {
                 &graph_inputs,
                 &retained_upgrade_trove_ids,
             )?;
-            verify_promised_paths_materialized(witnessed_promises, &selected_root)?;
+            super::promises::verify_promised_paths_materialized(promise_plan, &selected_root)?;
             let mut activation_requests = native_transaction.take_activation_requests();
             for (package, executor) in packages.iter().zip(ccs_hook_executors.iter()) {
                 let (Some(ccs), Some(executor)) = (package.ccs.as_ref(), executor.as_ref()) else {

--- a/apps/conary/src/commands/install/batch/ordering.rs
+++ b/apps/conary/src/commands/install/batch/ordering.rs
@@ -2,34 +2,32 @@
 
 //! Deterministic dependency-first ordering for an exact selected batch.
 
+use super::promises::PromiseWitnessPlan;
 use super::*;
 use conary_core::repository::dependency_model::RepositoryRequirementKind;
 use conary_core::resolver::identity::{PackageIdentity, ProvidedCapability};
 use std::collections::{BTreeMap, BTreeSet};
 
-/// A promised path the transaction actually leaned on to satisfy a dependency.
+/// Order the batch and plan what it must prove about promised paths.
 ///
-/// RPM's `%ghost` means the package owns the path *if present*; it never says
-/// the package creates it, and paths like `/etc/fstab` or a log file are
-/// legitimately absent after a fresh transaction. So the only promises worth
-/// verifying are the ones a dependency edge was certified against: the
-/// transaction checks its own reasoning and claims nothing beyond it.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct WitnessedPromise {
-    pub(super) provider: String,
-    pub(super) provider_version: String,
-    pub(super) path: String,
-    pub(super) dependent: String,
-    pub(super) requirement: String,
-}
-
+/// Ordering and promise reliance are separate questions asked of the same
+/// facts. [`super::promises`] owns the second one for both holders -- incoming
+/// packages and already installed ones -- because a promise made by an earlier
+/// transaction can hold up this one's edge, and because a single-package batch
+/// has promises to answer for even though it has nothing to order.
 pub(super) fn order_packages_for_transaction(
     conn: &Connection,
     packages: &mut Vec<PreparedPackage>,
-) -> Result<Vec<WitnessedPromise>> {
-    let mut witnessed_promises = Vec::new();
-    if packages.len() < 2 {
-        return Ok(witnessed_promises);
+) -> Result<PromiseWitnessPlan> {
+    let requirement_atoms = super::promises::batch_requirement_atom_names(packages);
+    if packages.len() < 2
+        && !super::promises::batch_requirements_can_lean_on_a_promise(
+            conn,
+            packages,
+            &requirement_atoms,
+        )?
+    {
+        return Ok(PromiseWitnessPlan::empty());
     }
 
     let native_architecture = conary_core::repository::registry::detect_system_arch();
@@ -46,6 +44,14 @@ pub(super) fn order_packages_for_transaction(
         .iter()
         .map(|package| transaction_identity(package, &native_architecture))
         .collect::<Vec<_>>();
+    if packages.len() < 2 {
+        return super::promises::plan_promise_witnesses(
+            packages,
+            installed,
+            &selected,
+            &native_architecture,
+        );
+    }
     let stable_indices = stable_package_indices(packages);
     let mut edges = vec![BTreeSet::new(); packages.len()];
     let mut strong_edges = vec![BTreeSet::new(); packages.len()];
@@ -133,58 +139,6 @@ pub(super) fn order_packages_for_transaction(
                     selected_witnesses.remove(position);
                 }
             }
-            // A retained witness may hold the edge up through a promised path.
-            // Drop each promise in turn: if the edge falls, the transaction
-            // relied on that path existing and must later prove it does.
-            for provider_index in &selected_witnesses {
-                for promise in packages[*provider_index]
-                    .provides
-                    .iter()
-                    .filter(|provide| provide.is_promised_path())
-                {
-                    let mut without_promise = installed.clone();
-                    without_promise.push(selected[dependent_index].clone());
-                    for index in &selected_witnesses {
-                        let mut identity = selected[*index].clone();
-                        if index == provider_index {
-                            identity.provided_capabilities.retain(|capability| {
-                                !(capability.is_promised_path() && capability.name == promise.name)
-                            });
-                        }
-                        without_promise.push(identity);
-                    }
-                    if expression_satisfied(
-                        requirement,
-                        package.semantics.version_scheme,
-                        depending_architecture,
-                        &native_architecture,
-                        &without_promise,
-                    )? {
-                        continue;
-                    }
-                    let provider = &packages[*provider_index];
-                    let witnessed = WitnessedPromise {
-                        provider: provider.name.clone(),
-                        provider_version: provider.version.clone(),
-                        path: promise.name.clone(),
-                        dependent: package.name.clone(),
-                        requirement: requirement
-                            .native_text
-                            .as_deref()
-                            .unwrap_or("<typed expression>")
-                            .to_string(),
-                    };
-                    if !witnessed_promises
-                        .iter()
-                        .any(|existing: &WitnessedPromise| {
-                            existing.provider == witnessed.provider
-                                && existing.path == witnessed.path
-                        })
-                    {
-                        witnessed_promises.push(witnessed);
-                    }
-                }
-            }
             for provider_index in selected_witnesses {
                 edges[provider_index].insert(dependent_index);
                 if requirement.kind == RepositoryRequirementKind::PreDepends {
@@ -194,6 +148,12 @@ pub(super) fn order_packages_for_transaction(
         }
     }
 
+    let plan = super::promises::plan_promise_witnesses(
+        packages,
+        installed,
+        &selected,
+        &native_architecture,
+    )?;
     let order = dependency_first_scc_order(packages, &edges, &strong_edges);
     let mut slots = packages.drain(..).map(Some).collect::<Vec<_>>();
     packages.extend(
@@ -201,7 +161,7 @@ pub(super) fn order_packages_for_transaction(
             .into_iter()
             .map(|index| slots[index].take().expect("package order repeats an index")),
     );
-    Ok(witnessed_promises)
+    Ok(plan)
 }
 
 fn expression_satisfied(

--- a/apps/conary/src/commands/install/batch/promises.rs
+++ b/apps/conary/src/commands/install/batch/promises.rs
@@ -1,0 +1,433 @@
+// apps/conary/src/commands/install/batch/promises.rs
+
+//! Promised-path witness authority for one batch transaction.
+//!
+//! A promised path (RPM `%ghost`) is a path a package owns without shipping
+//! content for it. `rpm-spec.5` describes it as a file "not to be included in
+//! the package", used "when the attributes of the file are important while the
+//! contents is not (e.g. a log file)" -- ownership if present, never a claim
+//! that the package creates it. Many promises (`/etc/fstab`, log files,
+//! generated certificate links) are legitimately absent, so verifying every
+//! declared promise would assert something the source never said.
+//!
+//! What the transaction may assert is its own reasoning. Dependency resolution
+//! admits a promise as a provider, so an edge can be certified against a path
+//! no payload record creates; this module decides which requirements actually
+//! leaned on that admission and proves them against the assembled root.
+//!
+//! The decision is per requirement, never per promise. Two packages promising
+//! the same path, or one requirement naming two promised paths, would alibi
+//! each other under a promise-at-a-time counterfactual: dropping either leaves
+//! the other standing, so neither looks load-bearing and an unusable dependency
+//! commits. So planning strips *every* promise the requirement could lean on at
+//! once to decide reliance, and the post-condition re-evaluates the requirement
+//! with promises admitted only for paths that exist. That is the property worth
+//! proving -- the requirement holds against the disk -- and it neither misses a
+//! shared path nor fails a requirement whose alternative promise did
+//! materialize.
+
+use super::*;
+use conary_core::db::models::ProvideEntry;
+use conary_core::repository::dependency_model::{
+    CapabilityProvenance, ProvidedCapability, RepositoryRequirementGroup, RepositoryRequirementKind,
+};
+use conary_core::repository::versioning::VersionScheme;
+use conary_core::resolver::identity::PackageIdentity;
+use std::collections::BTreeSet;
+use std::path::Path;
+
+/// Which side of the transaction promised the path.
+///
+/// The distinction is not cosmetic: it decides the operator's remedy. A batch
+/// member that never materialized its promise fails the incoming package, while
+/// an already installed holder whose path went missing has to be repaired or
+/// reinstalled -- the incoming package is correct in that case. A path both
+/// sides promise names both remedies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PromiseHolder {
+    /// A package this transaction installs.
+    BatchMember,
+    /// A package that was already installed before this transaction.
+    Installed,
+}
+
+/// One package that promised a path, and how it came to be installed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PromiseHolderIdentity {
+    holder: PromiseHolder,
+    name: String,
+    version: String,
+}
+
+impl PromiseHolderIdentity {
+    fn unmaterialized(&self, path: &str) -> String {
+        match self.holder {
+            PromiseHolder::BatchMember => format!(
+                "package {}-{} did not materialize promised path {} during its native lifecycle",
+                self.name, self.version, path
+            ),
+            PromiseHolder::Installed => format!(
+                "installed package {}-{} no longer holds promised path {}; repair or reinstall {} \
+                 to restore the path",
+                self.name, self.version, path, self.name
+            ),
+        }
+    }
+}
+
+/// A promised path a requirement could lean on, with every package promising it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PromisedPath {
+    path: String,
+    holders: Vec<PromiseHolderIdentity>,
+}
+
+/// One requirement that cannot be satisfied without at least one promise.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PromiseObligation {
+    dependent: String,
+    requirement: RepositoryRequirementGroup,
+    version_scheme: VersionScheme,
+    depending_architecture: String,
+    paths: Vec<PromisedPath>,
+}
+
+/// Everything the transaction must prove about promised paths, plus the exact
+/// identities its reasoning was carried out against.
+///
+/// The universe is carried rather than recomputed so the post-condition asks
+/// the resolver the same question the planner asked, against the same facts.
+#[derive(Debug, Default)]
+pub(super) struct PromiseWitnessPlan {
+    native_architecture: String,
+    universe: Vec<PackageIdentity>,
+    obligations: Vec<PromiseObligation>,
+}
+
+impl PromiseWitnessPlan {
+    pub(super) fn empty() -> Self {
+        Self::default()
+    }
+}
+
+fn dependency_requirements(
+    package: &PreparedPackage,
+) -> impl Iterator<Item = &RepositoryRequirementGroup> {
+    package.requirements.iter().filter(|requirement| {
+        matches!(
+            requirement.kind,
+            RepositoryRequirementKind::Depends | RepositoryRequirementKind::PreDepends
+        )
+    })
+}
+
+fn requirement_text(requirement: &RepositoryRequirementGroup) -> &str {
+    requirement
+        .native_text
+        .as_deref()
+        .unwrap_or("<typed expression>")
+}
+
+/// Every capability name this batch names in a `Depends`/`PreDepends` atom.
+///
+/// This bounds which promises are even considered. It is exact data off the
+/// batch's own requirement expressions and decides nothing on its own: naming a
+/// path is not relying on it, which is what [`plan_promise_witnesses`] settles.
+pub(super) fn batch_requirement_atom_names(packages: &[PreparedPackage]) -> BTreeSet<String> {
+    let mut atoms = BTreeSet::new();
+    for package in packages {
+        for requirement in dependency_requirements(package) {
+            for clause in requirement.expression.atoms() {
+                atoms.insert(clause.name.clone());
+            }
+        }
+    }
+    atoms
+}
+
+/// Whether any package -- incoming or installed -- promises one of `atoms`.
+///
+/// A batch of two or more packages already loads the installed identity
+/// universe for ordering, so this exists for the single-package batch, which
+/// otherwise has no reason to load it at all. The incoming side is answered in
+/// memory; each installed probe is an indexed point lookup on
+/// `provides.capability` and the first hit ends the scan.
+pub(super) fn batch_requirements_can_lean_on_a_promise(
+    conn: &Connection,
+    packages: &[PreparedPackage],
+    atoms: &BTreeSet<String>,
+) -> Result<bool> {
+    let incoming = packages.iter().any(|package| {
+        package
+            .provides
+            .iter()
+            .any(|capability| capability.is_promised_path() && atoms.contains(&capability.name))
+    });
+    if incoming {
+        return Ok(true);
+    }
+    for atom in atoms {
+        let promised = ProvideEntry::find_all_by_capability(conn, atom)?
+            .iter()
+            .any(|entry| {
+                matches!(
+                    entry.provenance,
+                    CapabilityProvenance::SourcePromisedPath { .. }
+                )
+            });
+        if promised {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Decide which requirements this transaction cannot satisfy without a promise.
+///
+/// `installed` is consumed: the planner keeps the identity universe alive for
+/// the post-condition instead of rebuilding or re-cloning it.
+///
+/// Reliance is decided by stripping every candidate promise for a requirement
+/// at once. Removing them one at a time is what lets two holders of one path --
+/// or two promised alternatives of one expression -- excuse each other into
+/// invisibility.
+pub(super) fn plan_promise_witnesses(
+    packages: &[PreparedPackage],
+    installed: Vec<PackageIdentity>,
+    selected: &[PackageIdentity],
+    native_architecture: &str,
+) -> Result<PromiseWitnessPlan> {
+    let installed_count = installed.len();
+    let mut universe = installed;
+    universe.extend(selected.iter().cloned());
+
+    let mut obligations = Vec::new();
+    for package in packages {
+        let depending_architecture = package
+            .architecture
+            .as_deref()
+            .filter(|architecture| !architecture.is_empty())
+            .unwrap_or(native_architecture)
+            .to_string();
+        for requirement in dependency_requirements(package) {
+            let paths = promised_paths_named_by(requirement, &universe, installed_count);
+            if paths.is_empty() {
+                continue;
+            }
+            if !expression_satisfied(
+                requirement,
+                package.semantics.version_scheme,
+                &depending_architecture,
+                native_architecture,
+                &universe,
+            )? {
+                // The ordering validator owns an unsatisfiable edge. Inventing a
+                // promise failure here would replace its diagnostic with a worse
+                // one.
+                continue;
+            }
+
+            let stripped = strip_promised_paths(&mut universe, &paths);
+            let survived = expression_satisfied(
+                requirement,
+                package.semantics.version_scheme,
+                &depending_architecture,
+                native_architecture,
+                &universe,
+            );
+            restore_promised_paths(&mut universe, stripped);
+            if survived? {
+                continue;
+            }
+            obligations.push(PromiseObligation {
+                dependent: package.name.clone(),
+                requirement: requirement.clone(),
+                version_scheme: package.semantics.version_scheme,
+                depending_architecture: depending_architecture.clone(),
+                paths,
+            });
+        }
+    }
+
+    Ok(PromiseWitnessPlan {
+        native_architecture: native_architecture.to_string(),
+        universe,
+        obligations,
+    })
+}
+
+/// The promised paths this requirement names, each with every package that
+/// promises it.
+///
+/// Holder side is decided structurally by position in the universe, not by
+/// inspecting identity fields: everything below `installed_count` was installed
+/// before this transaction, everything above it is incoming.
+fn promised_paths_named_by(
+    requirement: &RepositoryRequirementGroup,
+    universe: &[PackageIdentity],
+    installed_count: usize,
+) -> Vec<PromisedPath> {
+    let atoms = requirement
+        .expression
+        .atoms()
+        .into_iter()
+        .map(|clause| clause.name.clone())
+        .collect::<BTreeSet<_>>();
+    let mut paths = Vec::new();
+    for atom in atoms {
+        let mut holders = Vec::new();
+        for (index, identity) in universe.iter().enumerate() {
+            if !identity
+                .provided_capabilities
+                .iter()
+                .any(|capability| capability.is_promised_path() && capability.name == atom)
+            {
+                continue;
+            }
+            holders.push(PromiseHolderIdentity {
+                holder: if index < installed_count {
+                    PromiseHolder::Installed
+                } else {
+                    PromiseHolder::BatchMember
+                },
+                name: identity.name.clone(),
+                version: identity.version.clone(),
+            });
+        }
+        if !holders.is_empty() {
+            paths.push(PromisedPath {
+                path: atom,
+                holders,
+            });
+        }
+    }
+    paths
+}
+
+/// Remove every promise for every named path from the whole universe, returning
+/// them so the caller can restore the universe afterwards.
+///
+/// Only promises are removed: a package that both promises and ships one path
+/// is rejected by signed-authority validation, but an unrelated capability
+/// sharing the name must keep witnessing the requirement.
+fn strip_promised_paths(
+    universe: &mut [PackageIdentity],
+    paths: &[PromisedPath],
+) -> Vec<(usize, ProvidedCapability)> {
+    let names = paths
+        .iter()
+        .map(|promised| promised.path.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut stripped = Vec::new();
+    for (index, identity) in universe.iter_mut().enumerate() {
+        identity.provided_capabilities.retain(|capability| {
+            if capability.is_promised_path() && names.contains(capability.name.as_str()) {
+                stripped.push((index, capability.clone()));
+                false
+            } else {
+                true
+            }
+        });
+    }
+    stripped
+}
+
+fn restore_promised_paths(
+    universe: &mut [PackageIdentity],
+    stripped: Vec<(usize, ProvidedCapability)>,
+) {
+    for (index, capability) in stripped {
+        universe[index].provided_capabilities.push(capability);
+    }
+}
+
+fn expression_satisfied(
+    requirement: &RepositoryRequirementGroup,
+    version_scheme: VersionScheme,
+    depending_architecture: &str,
+    native_architecture: &str,
+    packages: &[PackageIdentity],
+) -> Result<bool> {
+    conary_core::resolver::requirement_expression_satisfied(
+        &requirement.expression,
+        version_scheme,
+        depending_architecture,
+        native_architecture,
+        packages,
+    )
+    .map_err(anyhow::Error::from)
+}
+
+/// Prove every requirement that leaned on a promise still holds against the
+/// assembled root.
+///
+/// A promised path is admitted only if it exists, symlinks included and content
+/// unread: the promise is that the path exists, never what it resolves to. The
+/// requirement is then re-evaluated. That is deliberately weaker than requiring
+/// every promised path to exist -- an expression offering two promised
+/// alternatives is satisfied by either -- and deliberately stronger than
+/// checking promises one at a time, which two holders of one path would pass by
+/// pointing at each other.
+///
+/// This runs regardless of the declaring lifecycle entry's criticality, because
+/// RPM's warning-only slots let a scriptlet fail, or silently do nothing, while
+/// reporting success -- and it runs after the whole native graph, including
+/// post-transaction slots.
+pub(super) fn verify_promised_paths_materialized(
+    plan: &mut PromiseWitnessPlan,
+    selected_root: &Path,
+) -> Result<()> {
+    let PromiseWitnessPlan {
+        native_architecture,
+        universe,
+        obligations,
+    } = plan;
+    for obligation in obligations.iter() {
+        let mut absent = Vec::new();
+        for promised in &obligation.paths {
+            let target = crate::commands::live_root::target_path(selected_root, &promised.path)
+                .with_context(|| {
+                    format!(
+                        "promised path {} is not addressable in the target root",
+                        promised.path
+                    )
+                })?;
+            if std::fs::symlink_metadata(&target).is_err() {
+                absent.push(promised.clone());
+            }
+        }
+        if absent.is_empty() {
+            continue;
+        }
+
+        let stripped = strip_promised_paths(universe, &absent);
+        let satisfied = expression_satisfied(
+            &obligation.requirement,
+            obligation.version_scheme,
+            &obligation.depending_architecture,
+            native_architecture,
+            universe,
+        );
+        restore_promised_paths(universe, stripped);
+        if satisfied? {
+            continue;
+        }
+
+        let clauses = absent
+            .iter()
+            .flat_map(|promised| {
+                promised
+                    .holders
+                    .iter()
+                    .map(|holder| holder.unmaterialized(&promised.path))
+            })
+            .collect::<Vec<_>>();
+        anyhow::bail!(
+            "{} (checked after the post-transaction stage); {} depends on it through {}",
+            clauses.join("; "),
+            obligation.dependent,
+            requirement_text(&obligation.requirement)
+        );
+    }
+    Ok(())
+}

--- a/apps/conary/src/commands/install/batch/tests.rs
+++ b/apps/conary/src/commands/install/batch/tests.rs
@@ -1223,3 +1223,344 @@ fn a_witness_used_promise_already_present_satisfies_the_post_condition() {
         ChangesetStatus::Applied
     );
 }
+
+/// A database with a bootable runtime and one completed prior transaction.
+///
+/// Whatever that transaction installed is exactly what a later batch inherits:
+/// promises held by packages the later transaction never sees among its own
+/// members.
+fn db_with_prior_transaction(
+    temp: &std::path::Path,
+    prior: Vec<PreparedPackage>,
+) -> (std::path::PathBuf, String) {
+    let db_path = temp.join("conary.db");
+    std::fs::create_dir_all(temp.join("root")).unwrap();
+    conary_core::db::init(&db_path).unwrap();
+    crate::commands::test_helpers::seed_test_bootable_runtime(&db_path);
+    let db_path_string = db_path.to_string_lossy().into_owned();
+    BatchInstaller::new(&db_path_string, SandboxMode::Always)
+        .install_batch(prior)
+        .expect("the prior transaction must install");
+    (db_path, db_path_string)
+}
+
+fn crypto_policies_with_promise(promised_path: &str) -> PreparedPackage {
+    let mut holder = prepared_test_package(
+        "crypto-policies",
+        "/usr/share/crypto-policies/DEFAULT/krb5.txt",
+        b"policy",
+    );
+    holder.provides.push(promised(promised_path));
+    holder
+}
+
+fn every_changeset_applied(db_path: &std::path::Path) -> bool {
+    let conn = conary_core::db::open(db_path).unwrap();
+    conary_core::db::models::Changeset::list_all(&conn)
+        .unwrap()
+        .iter()
+        .all(|changeset| changeset.status == ChangesetStatus::Applied)
+}
+
+#[test]
+fn a_later_transaction_verifies_a_promise_it_relied_on_from_an_installed_package() {
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let promised_path = "/etc/crypto-policies/back-ends/krb5.config";
+    let later_batch = || {
+        let mut dependent = prepared_test_package("krb5-libs", "/usr/lib64/libkrb5.so.3", b"krb5");
+        dependent.requirements = vec![depends_on(promised_path)];
+        vec![dependent]
+    };
+
+    // The promise materialized during the earlier transaction, so the path the
+    // later one leans on is really there and the batch applies. The producer
+    // declares no capability for the path, so the installed promise is the only
+    // witness the requirement has.
+    let kept = tempfile::tempdir().unwrap();
+    let (kept_db, kept_db_string) = db_with_prior_transaction(
+        kept.path(),
+        vec![
+            crypto_policies_with_promise(promised_path),
+            prepared_test_package("materializer", promised_path, b"generated"),
+        ],
+    );
+
+    BatchInstaller::new(&kept_db_string, SandboxMode::Always)
+        .install_batch(later_batch())
+        .unwrap();
+
+    assert!(
+        every_changeset_applied(&kept_db),
+        "a present promise must not fail the transaction that relies on it"
+    );
+
+    // Same reasoning, same reliance, but the path was never created. Scoping
+    // the post-condition to the current batch left nothing to re-ask the disk.
+    let broken = tempfile::tempdir().unwrap();
+    let (_broken_db, broken_db_string) = db_with_prior_transaction(
+        broken.path(),
+        vec![crypto_policies_with_promise(promised_path)],
+    );
+
+    let error = BatchInstaller::new(&broken_db_string, SandboxMode::Always)
+        .install_batch(later_batch())
+        .unwrap_err();
+
+    let message = format!("{error:#}");
+    assert!(
+        message.contains(&format!(
+            "installed package crypto-policies-1.0.0 no longer holds promised path {promised_path}"
+        )),
+        "{message}"
+    );
+    // The remedy differs from a batch member that never materialized its own
+    // promise, so the diagnostic names the installed holder to repair.
+    assert!(
+        message.contains("repair or reinstall crypto-policies"),
+        "{message}"
+    );
+    assert!(
+        message.contains("krb5-libs depends on it through"),
+        "{message}"
+    );
+}
+
+#[test]
+fn an_installed_promise_no_batch_requirement_names_is_never_verified() {
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+
+    // Fedora's setup owns /etc/fstab as a %ghost and never creates it. Being
+    // installed does not put it in a later transaction's reach: only a promise
+    // that transaction leaned on is its business.
+    let mut setup = prepared_test_package("setup", "/etc/profile", b"profile");
+    setup.provides.push(promised("/etc/fstab"));
+    setup.provides.push(promised("/run/motd"));
+    let (db_path, db_path_string) = db_with_prior_transaction(temp.path(), vec![setup]);
+    let mut later = prepared_test_package("filesystem", "/usr/bin/filesystem-marker", b"marker");
+    later.requirements = vec![depends_on("setup")];
+
+    BatchInstaller::new(&db_path_string, SandboxMode::Always)
+        .install_batch(vec![later])
+        .unwrap();
+
+    assert!(
+        every_changeset_applied(&db_path),
+        "an installed promise nothing in the batch requires must not be verified"
+    );
+}
+
+#[test]
+fn an_installed_promise_an_alternative_satisfies_is_never_verified() {
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let promised_path = "/etc/crypto-policies/back-ends/krb5.config";
+
+    // The requirement names the promised path, but its other alternative is
+    // satisfied too, so the transaction never leaned on the path. Naming an
+    // atom is not relying on it -- which is why membership in the batch's atom
+    // set selects candidates and the counterfactual decides.
+    let (db_path, db_path_string) = db_with_prior_transaction(
+        temp.path(),
+        vec![crypto_policies_with_promise(promised_path)],
+    );
+    let mut later = prepared_test_package("krb5-libs", "/usr/lib64/libkrb5.so.3", b"krb5");
+    later.requirements = vec![
+        conary_core::repository::dependency_model::RepositoryRequirementGroup::alternatives(
+            conary_core::repository::dependency_model::RepositoryRequirementKind::Depends,
+            vec![
+                conary_core::repository::dependency_model::RepositoryRequirementClause::name_only(
+                    promised_path.to_string(),
+                ),
+                conary_core::repository::dependency_model::RepositoryRequirementClause::name_only(
+                    "crypto-policies".to_string(),
+                ),
+            ],
+        ),
+    ];
+
+    BatchInstaller::new(&db_path_string, SandboxMode::Always)
+        .install_batch(vec![later])
+        .unwrap();
+
+    assert!(
+        every_changeset_applied(&db_path),
+        "a promise an alternative made dispensable must not be verified"
+    );
+}
+
+fn package_promising(name: &str, payload: &str, promised_path: &str) -> PreparedPackage {
+    let mut package = prepared_test_package(name, payload, b"payload");
+    package.provides.push(promised(promised_path));
+    package.install_reason = InstallReason::Dependency;
+    package
+}
+
+fn krb5_depending_on(
+    requirement: conary_core::repository::dependency_model::RepositoryRequirementGroup,
+) -> PreparedPackage {
+    let mut dependent = prepared_test_package("krb5-libs", "/usr/lib64/libkrb5.so.3", b"krb5");
+    dependent.requirements = vec![requirement];
+    dependent
+}
+
+fn any_of(
+    first: &str,
+    second: &str,
+) -> conary_core::repository::dependency_model::RepositoryRequirementGroup {
+    conary_core::repository::dependency_model::RepositoryRequirementGroup::alternatives(
+        conary_core::repository::dependency_model::RepositoryRequirementKind::Depends,
+        vec![
+            conary_core::repository::dependency_model::RepositoryRequirementClause::name_only(
+                first.to_string(),
+            ),
+            conary_core::repository::dependency_model::RepositoryRequirementClause::name_only(
+                second.to_string(),
+            ),
+        ],
+    )
+}
+
+#[test]
+fn two_packages_promising_one_path_cannot_alibi_each_other() {
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let promised_path = "/etc/crypto-policies/back-ends/krb5.config";
+
+    // One installed holder and one incoming holder promise the same path, and
+    // nothing creates it. Asking whether either promise alone is load-bearing
+    // gets "no" twice -- each is excused by the other -- and an unusable
+    // dependency commits. The question has to be asked of the path.
+    let (_db_path, db_path_string) = db_with_prior_transaction(
+        temp.path(),
+        vec![crypto_policies_with_promise(promised_path)],
+    );
+
+    let error = BatchInstaller::new(&db_path_string, SandboxMode::Always)
+        .install_batch(vec![
+            krb5_depending_on(depends_on(promised_path)),
+            package_promising(
+                "crypto-policies-extra",
+                "/usr/share/crypto-policies/EXTRA",
+                promised_path,
+            ),
+        ])
+        .unwrap_err();
+
+    let message = format!("{error:#}");
+    // Both holders are named, each with the remedy its own side needs.
+    assert!(
+        message.contains(&format!(
+            "installed package crypto-policies-1.0.0 no longer holds promised path {promised_path}"
+        )),
+        "{message}"
+    );
+    assert!(
+        message.contains(&format!(
+            "package crypto-policies-extra-1.0.0 did not materialize promised path {promised_path}"
+        )),
+        "{message}"
+    );
+    assert!(
+        message.contains("krb5-libs depends on it through"),
+        "{message}"
+    );
+}
+
+#[test]
+fn two_packages_promising_one_present_path_satisfy_the_post_condition() {
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let promised_path = "/etc/crypto-policies/back-ends/krb5.config";
+
+    // Same two holders, but the path is really there. The post-condition asks
+    // the disk about the path, not about who is credited with it.
+    let (db_path, db_path_string) = db_with_prior_transaction(
+        temp.path(),
+        vec![
+            crypto_policies_with_promise(promised_path),
+            prepared_test_package("materializer", promised_path, b"generated"),
+        ],
+    );
+
+    BatchInstaller::new(&db_path_string, SandboxMode::Always)
+        .install_batch(vec![
+            krb5_depending_on(depends_on(promised_path)),
+            package_promising(
+                "crypto-policies-extra",
+                "/usr/share/crypto-policies/EXTRA",
+                promised_path,
+            ),
+        ])
+        .unwrap();
+
+    assert!(
+        every_changeset_applied(&db_path),
+        "a present path must satisfy every package that promised it"
+    );
+}
+
+#[test]
+fn an_or_of_two_promised_paths_fails_when_neither_materializes() {
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let first = "/etc/promise-first";
+    let second = "/etc/promise-second";
+
+    // Two promised alternatives excuse each other exactly like two holders of
+    // one path do, one level up the expression.
+    let (_db_path, db_path_string) = db_with_prior_transaction(
+        temp.path(),
+        vec![
+            package_promising("holder-first", "/usr/share/holder-first", first),
+            package_promising("holder-second", "/usr/share/holder-second", second),
+        ],
+    );
+
+    let error = BatchInstaller::new(&db_path_string, SandboxMode::Always)
+        .install_batch(vec![krb5_depending_on(any_of(first, second))])
+        .unwrap_err();
+
+    let message = format!("{error:#}");
+    assert!(
+        message.contains(&format!(
+            "installed package holder-first-1.0.0 no longer holds promised path {first}"
+        )),
+        "{message}"
+    );
+    assert!(
+        message.contains(&format!(
+            "installed package holder-second-1.0.0 no longer holds promised path {second}"
+        )),
+        "{message}"
+    );
+}
+
+#[test]
+fn an_or_of_two_promised_paths_passes_when_one_materializes() {
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let first = "/etc/promise-first";
+    let second = "/etc/promise-second";
+
+    // The requirement is satisfied by either alternative, so one materialized
+    // promise is the whole obligation. Demanding both would reject a correct
+    // transaction -- the exact over-enforcement #300 removed.
+    let (db_path, db_path_string) = db_with_prior_transaction(
+        temp.path(),
+        vec![
+            package_promising("holder-first", "/usr/share/holder-first", first),
+            package_promising("holder-second", "/usr/share/holder-second", second),
+            prepared_test_package("materializer", second, b"generated"),
+        ],
+    );
+
+    BatchInstaller::new(&db_path_string, SandboxMode::Always)
+        .install_batch(vec![krb5_depending_on(any_of(first, second))])
+        .unwrap();
+
+    assert!(
+        every_changeset_applied(&db_path),
+        "one materialized alternative must satisfy an OR of promised paths"
+    );
+}

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -189,6 +189,7 @@ mutation flows for local package operations.
 `apps/conary/src/commands/install/batch.rs`;
 `apps/conary/src/commands/install/batch/config.rs`;
 `apps/conary/src/commands/install/batch/execution.rs`;
+`apps/conary/src/commands/install/batch/promises.rs`;
 `apps/conary/src/commands/generation/selected_root.rs`;
 `apps/conary/src/commands/generation/config_transaction.rs`;
 `apps/conary/src/commands/generation/publication.rs`;

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-06
-revision: 40
+last_updated: 2026-08-08
+revision: 41
 summary: Define source-independent lifecycle, source-authority handoff, generation activation, and configuration transactions for RPM, Debian, and Arch packages
 ---
 
@@ -762,6 +762,52 @@ native-upgrade rollback schema or mutate a host root and compensate afterward.
 Once SQLite commits, the exact selected-root candidate and typed publication
 debt are the retry authority. Config auxiliary ownership remains defined by the
 documented suffix grammar and the forward `GenerationConfigTransaction`.
+
+### Promised-Path Post-Condition
+
+A promised path is a path a package owns without shipping content for it
+(RPM `%ghost`; `source-promised-path` in
+[`source-package-authority.md`](source-package-authority.md)). Dependency
+resolution admits it as a provider, so a transaction can certify a dependency
+edge against a path no payload record creates.
+
+`%ghost` means owned if present. It is not a claim that the package's lifecycle
+creates the path, so a transaction may not require every declared promise to
+exist; `/etc/fstab`, log files, and generated certificate links are legitimately
+absent. What a transaction may require is that its own reasoning survives
+contact with the assembled root.
+
+The unit of both decisions is the requirement, never the individual promise.
+A promise-at-a-time test is unsound in both directions: two packages promising
+one path, or one expression offering two promised paths, each excuse the other
+when removed singly, so nothing looks load-bearing and an unusable dependency
+commits.
+
+Planning: for each `Depends`/`PreDepends` requirement, remove every promise for
+every path the expression names from the identities the transaction admits. If
+the expression still holds, no promise was relied on and the transaction owes
+nothing. If it falls, the requirement is recorded together with those paths and
+every package promising each of them.
+
+Post-condition: after the native lifecycle graph completes, including
+post-transaction slots, each recorded requirement is re-evaluated with promised
+paths admitted only where the path exists in the selected root. Existence is the
+whole test, symlinks included and content unread: the promise states that the
+path exists, never what it resolves to. A requirement that no longer holds fails
+the transaction. This is deliberately weaker than demanding every promised path
+exist -- an expression satisfied by either of two promised alternatives needs
+only one -- and deliberately stronger than checking promises individually. The
+check ignores the declaring lifecycle entry's criticality, because a
+warning-only slot that fails or silently does nothing is precisely the case that
+would otherwise pass unnoticed.
+
+Both promise holders are in scope, and one failure may name several. A batch
+member's unmaterialized promise fails the incoming package. An already installed
+package's promise -- reachable because a later transaction's requirement can
+lean on an earlier transaction's promise -- names the installed holder to repair
+or reinstall, because the incoming package is not the defect. A path both sides
+promised names both remedies. A promise no requirement in the current
+transaction relied on is never checked.
 
 ## RPM
 


### PR DESCRIPTION
## #301, with the counterfactual made sound at requirement level

Investigation found the gap was wider than filed: single-package batches never reached witness computation at all (ordering's `len < 2` early return). New `batch/promises.rs` owns promise-witness authority for both holders; ordering consumes it; execution shrank.

**Semantics** (the load-bearing decision): reliance is decided per requirement — strip ALL promises for ALL paths the expression names, re-evaluate through the ordering validator's own `expression_satisfied`. Per-promise removal lets duplicate holders and promised OR-alternatives alibi each other into zero witnesses (second-model review catch); demanding every member fails satisfied alternatives (the #300 class). Both wrong directions are mutation-proven with real red output. Post-condition re-evaluates recorded requirements against the selected root's disk state; failures name every promising holder with per-holder remedies. #302's per-promise loop deleted — one owner.

## Verification record (all exit codes read directly)

conary lib 1037/0 + 53 suites clean, conary-core 3385/0, fmt, workspace clippy `-D warnings`, doc-truth, install card focused proof + gate (subsets of full runs). Five mutation kills across scoping, counterfactual soundness (both directions), and collection presence. Process notes preserved honestly: one earlier claim was written from expectation before output existed (delegate self-reported; re-verified real), and a grep pipeline masked a genuine suite failure — a mutex-starvation timeout diagnosed to root cause (two-transaction tests starving an unfair lock's 5s liveness backstop; backstop raised to 120s and documented, meaningful assertions untouched).

Found and already filed: #333 (O(edges×files) universe cloning), #334 (stale-identity witnesses: pre-upgrade promises, post-ordering relation removals).

Review chain: Opus → reviewer → Luna (duplicate-cover alibi) → corrected semantics that also overruled the reviewer's first proposal with a mutation-proven argument.

Closes #301. Refs #300, #302, #333, #334.