### PR TITLE
fix(install): declare scriptlet failure posture as typed authority, keep the evidence

### DIFF
--- a/apps/conary/src/commands/install/native_events.rs
+++ b/apps/conary/src/commands/install/native_events.rs
@@ -113,6 +113,19 @@ pub(crate) struct PreparedNativeTransaction {
     host_capabilities: Option<conary_core::ccs::HostCapabilityInventory>,
     path_projection: NativePathProjection,
     activation_invocations: RefCell<Vec<CapturedNativeActivation>>,
+    continued_lifecycle_failures: RefCell<Vec<ContinuedLifecycleFailure>>,
+}
+
+/// A lifecycle entry that failed in a warn-and-continue class.
+///
+/// The source format proceeds past this failure, so the transaction does too,
+/// but the failure stays typed evidence rather than becoming a silent success.
+#[derive(Debug, Clone)]
+pub(crate) struct ContinuedLifecycleFailure {
+    pub(crate) package: String,
+    pub(crate) version: String,
+    pub(crate) entry: String,
+    pub(crate) failure: conary_core::scriptlet::ScriptletFailureOutcome,
 }
 
 #[derive(Debug, Clone)]
@@ -579,6 +592,7 @@ impl PreparedNativeTransaction {
             host_capabilities,
             path_projection,
             activation_invocations: RefCell::new(Vec::new()),
+            continued_lifecycle_failures: RefCell::new(Vec::new()),
         })
     }
 
@@ -778,6 +792,7 @@ impl PreparedNativeTransaction {
             host_capabilities,
             path_projection,
             activation_invocations: RefCell::new(Vec::new()),
+            continued_lifecycle_failures: RefCell::new(Vec::new()),
         })
     }
 

--- a/apps/conary/src/commands/install/native_events/execution.rs
+++ b/apps/conary/src/commands/install/native_events/execution.rs
@@ -58,7 +58,19 @@ impl PreparedNativeTransaction {
                     &event.stdin,
                     event.deb_package_refcount,
                 ),
-            ),
+            )
+            .map(|execution| {
+                if let runtime::EntryExecution::ContinuedAfterFailure(failure) = execution {
+                    self.continued_lifecycle_failures.borrow_mut().push(
+                        super::ContinuedLifecycleFailure {
+                            package: event.owner_package.clone(),
+                            version: event.owner_version.clone(),
+                            entry: entry_id.clone(),
+                            failure: *failure,
+                        },
+                    );
+                }
+            }),
             NativeEventProgram::Command { argv } => executor
                 .execute_native_command("native-transaction-hook", argv, &event.stdin)
                 .map_err(anyhow::Error::from),
@@ -201,6 +213,17 @@ impl PreparedNativeTransaction {
             warn!(error = %error, "Arch implicit ldconfig invocation failed");
         }
         Ok(())
+    }
+
+    /// Drain the lifecycle failures this transaction ran past.
+    ///
+    /// Warn-and-continue is the source format's own posture, not an absence of
+    /// a failure. The transaction keeps each one as typed evidence so the run
+    /// is never reported as an unqualified success.
+    pub(crate) fn take_continued_lifecycle_failures(
+        &self,
+    ) -> Vec<super::ContinuedLifecycleFailure> {
+        std::mem::take(&mut *self.continued_lifecycle_failures.borrow_mut())
     }
 
     pub(crate) fn take_activation_requests(

--- a/apps/conary/src/commands/install/native_events/runtime.rs
+++ b/apps/conary/src/commands/install/native_events/runtime.rs
@@ -6,10 +6,21 @@ use super::{NativeBundleOwner, debian_runtime};
 use anyhow::{Context, Result};
 use conary_core::ccs::native_lifecycle::NativeLifecycleEntry;
 use conary_core::scriptlet::{
-    ExecutionMode, NativeInterpreterAvailability, NativeInvocationRuntime,
-    NativeLifecycleExecution, ScriptletExecutor, ScriptletFailureKind, ScriptletOutcome,
+    ExecutionMode, FailurePosture, LifecycleFailureClass, NativeInterpreterAvailability,
+    NativeInvocationRuntime, NativeLifecycleExecution, ScriptletExecutor, ScriptletFailureOutcome,
+    ScriptletOutcome,
 };
 use tracing::warn;
+
+/// What executing one native lifecycle entry did to the transaction.
+///
+/// A continued failure is evidence, not a success: the source format's own
+/// contract says the transaction proceeds past it, and the caller retains the
+/// typed outcome so the transaction can report what it ran past.
+pub(super) enum EntryExecution {
+    Completed,
+    ContinuedAfterFailure(Box<ScriptletFailureOutcome>),
+}
 
 struct EntryRuntimeContext {
     environment: Vec<String>,
@@ -46,7 +57,7 @@ pub(super) fn execute_entry(
     owner: &NativeBundleOwner,
     executor: &ScriptletExecutor,
     invocation: EntryInvocation<'_>,
-) -> Result<()> {
+) -> Result<EntryExecution> {
     let entry = bundle_entry_for_event(owner, invocation.entry_id)?;
     let context = entry_runtime_context(owner, entry, invocation.deb_package_refcount)?;
     let execution = native_lifecycle_execution(entry, &context.environment);
@@ -61,16 +72,27 @@ pub(super) fn execute_entry(
     } else {
         executor.execute_native_lifecycle_entry_with_outcome(&execution, &runtime)
     };
-    match outcome {
-        ScriptletOutcome::Failure(failure)
-            if entry.rpm_runtime.as_ref().is_some_and(|rpm| {
-                !rpm.critical
-                    && matches!(
-                        failure.failure_kind,
-                        ScriptletFailureKind::ScriptExited | ScriptletFailureKind::ScriptTimedOut
-                    )
-            }) =>
-        {
+    let ScriptletOutcome::Failure(failure) = outcome else {
+        return outcome
+            .into_result()
+            .map(|()| EntryExecution::Completed)
+            .map_err(anyhow::Error::from);
+    };
+    // The source format's own per-scriptlet-class table decides this, never the
+    // entry's name. See docs/specs/foreign-package-lifecycle-contracts.md,
+    // "RPM Scriptlet Failure Posture".
+    let posture = FailurePosture::for_lifecycle_failure(LifecycleFailureClass {
+        source_format: owner.bundle.source_format,
+        rpm_criticality: entry.rpm_runtime.as_ref().map(|rpm| rpm.criticality),
+        failure_kind: failure.failure_kind,
+    });
+    match posture {
+        FailurePosture::AbortsTransaction => Err(anyhow::Error::from(
+            ScriptletOutcome::Failure(failure)
+                .into_result()
+                .expect_err("a failure outcome must convert into a typed scriptlet error"),
+        )),
+        FailurePosture::WarnAndContinue => {
             warn!(
                 package = %owner.package_name,
                 version = %owner.package_version,
@@ -80,11 +102,10 @@ pub(super) fn execute_entry(
                 requested_sandbox = failure.requested_sandbox_mode.as_str(),
                 effective_sandbox = failure.effective_sandbox.as_str(),
                 error = %failure.message,
-                "RPM warning-only native lifecycle event failed; continuing transaction"
+                "native lifecycle event failed in a warn-and-continue class; continuing transaction"
             );
-            Ok(())
+            Ok(EntryExecution::ContinuedAfterFailure(Box::new(failure)))
         }
-        outcome => outcome.into_result().map_err(anyhow::Error::from),
     }
 }
 

--- a/apps/conary/src/commands/install/native_events/tests/rpm_warning.rs
+++ b/apps/conary/src/commands/install/native_events/tests/rpm_warning.rs
@@ -1,8 +1,10 @@
 // apps/conary/src/commands/install/native_events/tests/rpm_warning.rs
 
-//! RPM warning-only lifecycle execution coverage.
+//! RPM per-scriptlet-class lifecycle failure posture coverage.
 
 use super::*;
+use conary_core::ccs::native_transaction::{NativeTransactionGraph, NativeTransactionStep};
+use conary_core::packages::native_abi::RpmScriptletSlot;
 
 fn rpm_entry_event(bundle: &NativeLifecycleBundle) -> NativeTransactionEvent {
     let entry = &bundle.entries[0];
@@ -45,7 +47,34 @@ fn failing_rpm_bundle(criticality: RpmCriticality, critical: bool) -> NativeLife
     bundle
 }
 
+fn failing_rpm_bundle_for_slot(
+    entry_id: &str,
+    phase: LifecyclePath,
+    criticality: RpmCriticality,
+) -> NativeLifecycleBundle {
+    let mut bundle = failing_rpm_bundle(
+        criticality,
+        conary_core::scriptlet::FailurePosture::for_rpm_criticality(criticality)
+            .aborts_transaction(),
+    );
+    let entry = &mut bundle.entries[0];
+    entry.id = entry_id.to_string();
+    entry.native_slot = entry_id.trim_start_matches("rpm:").to_string();
+    entry.phase = phase;
+    entry.lifecycle_paths = vec![phase.as_str().to_string()];
+    entry.transaction_order.position = phase.as_str().to_string();
+    bundle
+}
+
 fn execute_single_event(bundle: NativeLifecycleBundle) -> anyhow::Result<()> {
+    prepare_single_event(bundle).1
+}
+
+/// Run one lifecycle event and hand back both the transaction and its result,
+/// so a continued failure can be inspected as the typed evidence it is.
+fn prepare_single_event(
+    bundle: NativeLifecycleBundle,
+) -> (PreparedNativeTransaction, anyhow::Result<()>) {
     let temp = tempfile::tempdir().unwrap();
     let db_path = temp.path().join("conary.db");
     conary_core::db::init(&db_path).unwrap();
@@ -56,7 +85,8 @@ fn execute_single_event(bundle: NativeLifecycleBundle) -> anyhow::Result<()> {
     let prepared =
         prepared_with_projected_event(bundle, event, NativeEventPathProjection::CurrentRoot);
 
-    prepared.execute_graph_event(&conn, 0, &root, &ExecutionMode::Install)
+    let result = prepared.execute_graph_event(&conn, 0, &root, &ExecutionMode::Install);
+    (prepared, result)
 }
 
 #[test]
@@ -94,6 +124,233 @@ fn warning_only_rpm_contract_failure_remains_fatal() {
     assert!(
         format!("{error:#}").contains("declares embedded Lua with interpreter '/bin/sh'"),
         "unexpected contract failure: {error:#}"
+    );
+}
+
+/// Every RPM scriptlet class the pinned table declares must reach the runtime
+/// with that posture. This is the contract between the declared table in
+/// `docs/specs/foreign-package-lifecycle-contracts.md` and the runtime that
+/// consumes it, not one pinned scriptlet.
+#[test]
+fn every_declared_rpm_class_gets_its_declared_runtime_posture() {
+    use conary_core::scriptlet::FailurePosture::{AbortsTransaction, WarnAndContinue};
+    // The expected posture column is the spec table, written out rather than
+    // read back from the policy module, so a change to the table changes this
+    // test's result instead of moving with it.
+    for (entry_id, phase, slot, expected) in [
+        (
+            "rpm:%pretrans",
+            LifecyclePath::PreTransaction,
+            RpmScriptletSlot::PreTrans,
+            AbortsTransaction,
+        ),
+        (
+            "rpm:%pre",
+            LifecyclePath::PreInstall,
+            RpmScriptletSlot::Pre,
+            AbortsTransaction,
+        ),
+        (
+            "rpm:%post",
+            LifecyclePath::PostInstall,
+            RpmScriptletSlot::Post,
+            WarnAndContinue,
+        ),
+        (
+            "rpm:%posttrans",
+            LifecyclePath::PostTransaction,
+            RpmScriptletSlot::PostTrans,
+            WarnAndContinue,
+        ),
+        (
+            "rpm:%preun",
+            LifecyclePath::PreRemove,
+            RpmScriptletSlot::PreUn,
+            AbortsTransaction,
+        ),
+        (
+            "rpm:%postun",
+            LifecyclePath::PostRemove,
+            RpmScriptletSlot::PostUn,
+            WarnAndContinue,
+        ),
+    ] {
+        // Only the persisted criticality comes from the table: it is what
+        // conversion would have stamped on an entry of this class.
+        let criticality =
+            conary_core::scriptlet::rpm_package_slot_authority(slot).effective_criticality(false);
+        let (prepared, result) = prepare_single_event(failing_rpm_bundle_for_slot(
+            entry_id,
+            phase,
+            criticality.persisted(),
+        ));
+        let continued = prepared.take_continued_lifecycle_failures();
+        match expected {
+            AbortsTransaction => {
+                let error = result
+                    .err()
+                    .unwrap_or_else(|| panic!("{entry_id} must fail the transaction"));
+                let error = format!("{error:#}");
+                assert!(
+                    error.contains("native transaction event failed for rpm-warning-fixture 1"),
+                    "{entry_id} aborted without the typed transaction failure: {error}"
+                );
+                assert!(
+                    continued.is_empty(),
+                    "{entry_id} aborted, so nothing was continued past"
+                );
+            }
+            WarnAndContinue => {
+                result.unwrap_or_else(|error| {
+                    panic!("{entry_id} must not fail its transaction: {error:#}")
+                });
+                assert_eq!(
+                    continued.len(),
+                    1,
+                    "{entry_id} continued but recorded no typed evidence"
+                );
+                assert_eq!(continued[0].entry, entry_id);
+                assert_eq!(
+                    continued[0].failure.failure_kind,
+                    conary_core::scriptlet::ScriptletFailureKind::ScriptExited
+                );
+            }
+        }
+    }
+}
+
+/// A `%pre` failure aborts before its package's payload boundary, so nothing
+/// the package ships can land. The graph, not the error text, proves it.
+#[test]
+fn a_pre_install_class_failure_aborts_before_the_payload_boundary() {
+    let temp = tempfile::tempdir().unwrap();
+    let db_path = temp.path().join("conary.db");
+    conary_core::db::init(&db_path).unwrap();
+    let conn = conary_core::db::open(&db_path).unwrap();
+    let root = temp.path().join("selected-root");
+    std::fs::create_dir(&root).unwrap();
+
+    let bundle = failing_rpm_bundle_for_slot(
+        "rpm:%pre",
+        LifecyclePath::PreInstall,
+        RpmCriticality::SlotDefault,
+    );
+    let event = rpm_entry_event(&bundle);
+    let mut prepared =
+        prepared_with_projected_event(bundle, event, NativeEventPathProjection::CurrentRoot);
+    prepared.plan.graph = NativeTransactionGraph {
+        steps: vec![
+            NativeTransactionStep::RunEvent { event_index: 0 },
+            NativeTransactionStep::ApplyPayload { change_index: 0 },
+        ],
+    };
+
+    let mut boundaries = Vec::new();
+    let error = crate::commands::install::native_graph::drive_native_graph_with(
+        &conn,
+        &prepared,
+        &root,
+        &ExecutionMode::Install,
+        |_, boundary| {
+            boundaries.push(boundary);
+            Ok(())
+        },
+    )
+    .expect_err("a %pre class failure must fail the transaction");
+
+    assert!(
+        format!("{error:#}").contains("native transaction event failed for rpm-warning-fixture 1"),
+        "unexpected %pre failure: {error:#}"
+    );
+    assert!(
+        boundaries.is_empty(),
+        "the payload boundary must not be crossed after a %pre failure: {boundaries:?}"
+    );
+}
+
+/// Evidence the transaction ran past must survive the transaction's own abort.
+///
+/// A `%post` that failed is most diagnostic precisely when a later step brings
+/// the transaction down, so the accumulator has to be drained and reported on
+/// the error exit as well as the success exit.
+#[test]
+fn a_continued_failure_is_still_reported_when_a_later_graph_step_aborts() {
+    let temp = tempfile::tempdir().unwrap();
+    let db_path = temp.path().join("conary.db");
+    conary_core::db::init(&db_path).unwrap();
+    let conn = conary_core::db::open(&db_path).unwrap();
+    let root = temp.path().join("selected-root");
+    std::fs::create_dir(&root).unwrap();
+
+    // Entry 0 fails in a warn-and-continue class; entry 1 fails in an aborting
+    // class later in the same graph.
+    let mut bundle = failing_rpm_bundle_for_slot(
+        "rpm:%post",
+        LifecyclePath::PostInstall,
+        RpmCriticality::WarningOnly,
+    );
+    let aborting = failing_rpm_bundle_for_slot(
+        "rpm:%pre",
+        LifecyclePath::PreInstall,
+        RpmCriticality::SlotDefault,
+    )
+    .entries
+    .remove(0);
+    bundle.entries.push(aborting);
+
+    let continuing_event = rpm_entry_event(&bundle);
+    let mut aborting_event = continuing_event.clone();
+    aborting_event.program = NativeEventProgram::BundleEntry {
+        entry_id: "rpm:%pre".to_string(),
+    };
+    aborting_event.order_key = format!("{}:rpm:%pre", bundle.source_package);
+
+    let mut prepared = prepared_with_projected_event(
+        bundle,
+        continuing_event,
+        NativeEventPathProjection::CurrentRoot,
+    );
+    prepared.plan.events.push(aborting_event);
+    prepared.path_projection = preflight::NativePathProjection::from_events(vec![
+        NativeEventPathProjection::CurrentRoot,
+        NativeEventPathProjection::CurrentRoot,
+    ]);
+    prepared.plan.graph = NativeTransactionGraph {
+        steps: vec![
+            NativeTransactionStep::RunEvent { event_index: 0 },
+            NativeTransactionStep::ApplyPayload { change_index: 0 },
+            NativeTransactionStep::RunEvent { event_index: 1 },
+        ],
+    };
+
+    // The payload boundary sits between the two events, so it observes the
+    // accumulator mid-graph without draining it.
+    let mut pending_mid_graph = None;
+    let error = crate::commands::install::native_graph::drive_native_graph_with(
+        &conn,
+        &prepared,
+        &root,
+        &ExecutionMode::Install,
+        |_, _| {
+            pending_mid_graph = Some(prepared.continued_lifecycle_failures.borrow().len());
+            Ok(())
+        },
+    )
+    .expect_err("the later aborting class must fail the transaction");
+
+    assert_eq!(
+        pending_mid_graph,
+        Some(1),
+        "the warn-and-continue failure must be recorded before the later step runs"
+    );
+    assert!(
+        format!("{error:#}").contains("native transaction event failed for rpm-warning-fixture 1"),
+        "the abort error must be unchanged: {error:#}"
+    );
+    assert!(
+        prepared.continued_lifecycle_failures.borrow().is_empty(),
+        "the continued failure must be drained and reported on the abort exit, \
+         not discarded with the transaction"
     );
 }
 

--- a/apps/conary/src/commands/install/native_graph.rs
+++ b/apps/conary/src/commands/install/native_graph.rs
@@ -134,6 +134,28 @@ pub(crate) fn drive_native_graph(
     execution_mode: &ExecutionMode,
     payload: &mut impl NativeGraphPayloadMutation,
 ) -> Result<()> {
+    let result = drive_native_graph_steps(
+        conn,
+        native_transaction,
+        selected_root,
+        execution_mode,
+        payload,
+    );
+    // Both exits report, because a later abort is exactly when "this package's
+    // %post already failed" is most diagnostic. Reporting only on success would
+    // discard that evidence with the transaction it explains. The abort error
+    // itself is untouched; these lines simply precede it.
+    report_continued_lifecycle_failures(native_transaction);
+    result
+}
+
+fn drive_native_graph_steps(
+    conn: &rusqlite::Connection,
+    native_transaction: &PreparedNativeTransaction,
+    selected_root: &Path,
+    execution_mode: &ExecutionMode,
+    payload: &mut impl NativeGraphPayloadMutation,
+) -> Result<()> {
     let mut arch_finalizer_executed = false;
     for step in native_transaction.graph_steps() {
         match *step {
@@ -179,6 +201,24 @@ pub(crate) fn drive_native_graph(
     }
     native_transaction.refresh_debian_admin_projection(conn, selected_root)?;
     Ok(())
+}
+
+/// Surface every lifecycle failure the transaction ran past.
+///
+/// The source format's failure table says the transaction proceeds, but the
+/// operator is still told, through the user-facing channel rather than an
+/// internal log record, that a package's own lifecycle did not complete.
+fn report_continued_lifecycle_failures(native_transaction: &PreparedNativeTransaction) {
+    for record in native_transaction.take_continued_lifecycle_failures() {
+        crate::ui::warn(&format!(
+            "{} {} lifecycle entry {} failed ({}) and the transaction continued: {}",
+            record.package,
+            record.version,
+            record.entry,
+            record.failure.failure_kind.as_str(),
+            record.failure.message
+        ));
+    }
 }
 
 pub(crate) fn finalize_owned_trove(

--- a/crates/conary-core/src/ccs/convert/scriptlet_bundle/format_metadata.rs
+++ b/crates/conary-core/src/ccs/convert/scriptlet_bundle/format_metadata.rs
@@ -8,8 +8,8 @@ use crate::ccs::native_lifecycle::{
     DebMaintainerInvocationMetadata, DebMaintainerMetadata,
     DebMaintainerMode as BundleDebMaintainerMode, DebTriggerAwaitMode as BundleDebTriggerAwaitMode,
     DebTriggerDirective as BundleDebTriggerDirective, DebTriggerMetadata, RpmBodyTransform,
-    RpmCriticality, RpmHeaderContext, RpmHeaderFact, RpmHeaderFactSource, RpmHeaderValue,
-    RpmMacroContext, RpmMacroDefinition, RpmMacroDefinitionSource, RpmProgram, RpmRuntimeMetadata,
+    RpmHeaderContext, RpmHeaderFact, RpmHeaderFactSource, RpmHeaderValue, RpmMacroContext,
+    RpmMacroDefinition, RpmMacroDefinitionSource, RpmProgram, RpmRuntimeMetadata,
     RpmSysusersDirective as BundleRpmSysusersDirective,
     RpmSysusersMetadata as BundleRpmSysusersMetadata, RpmTriggerAction as BundleRpmTriggerAction,
     RpmTriggerKind, RpmTriggerMetadata as BundleRpmTriggerMetadata, RpmTriggerTargetConstraint,
@@ -22,8 +22,8 @@ use crate::packages::native_abi::{
     NativeScriptletMetadata, NativeStdinContract, RpmHeaderFactSource as NativeRpmHeaderFactSource,
     RpmHeaderValueMetadata as NativeRpmHeaderValueMetadata,
     RpmMacroDefinitionSource as NativeRpmMacroDefinitionSource, RpmNativeScriptletMetadata,
-    RpmScriptletCriticality, RpmScriptletProgram,
-    RpmSysusersDirective as NativeRpmSysusersDirective, RpmTriggerAction, RpmTriggerFamily,
+    RpmScriptletProgram, RpmSysusersDirective as NativeRpmSysusersDirective, RpmTriggerAction,
+    RpmTriggerFamily,
 };
 pub(super) struct FormatMetadataProjection {
     pub(super) rpm_runtime: Option<RpmRuntimeMetadata>,
@@ -114,13 +114,8 @@ fn project_rpm_metadata(
         .into_iter()
         .flatten()
         .collect(),
-        critical: metadata.runtime.flags.critical,
-        criticality: match metadata.runtime.flags.criticality {
-            RpmScriptletCriticality::Header => RpmCriticality::Header,
-            RpmScriptletCriticality::SlotDefault => RpmCriticality::SlotDefault,
-            RpmScriptletCriticality::WarningOnly => RpmCriticality::WarningOnly,
-            RpmScriptletCriticality::ForcedWarningOnly => RpmCriticality::ForcedWarningOnly,
-        },
+        critical: metadata.runtime.flags.criticality.is_critical(),
+        criticality: metadata.runtime.flags.criticality.persisted(),
         raw_flags: metadata.runtime.flags.raw_bits,
         unknown_flags: metadata.runtime.flags.unknown_bits,
         install_prefixes: metadata.runtime.install_prefixes.clone(),

--- a/crates/conary-core/src/error.rs
+++ b/crates/conary-core/src/error.rs
@@ -37,6 +37,17 @@ impl ScriptletFailureKind {
             Self::EnforcementSetupFailed => "EnforcementSetupFailed",
         }
     }
+
+    /// Whether this failure is the source program's own result.
+    ///
+    /// Only a program that actually ran under the exact preflighted contract
+    /// and the selected-root enforcement boundary produces a result the source
+    /// format's failure table can speak about. Every other kind is a Conary
+    /// contract, process, sandbox, or enforcement failure, so a source format's
+    /// warning-only class must never suppress it.
+    pub const fn is_source_program_result(self) -> bool {
+        matches!(self, Self::ScriptExited | Self::ScriptTimedOut)
+    }
 }
 
 /// Core error types for Conary

--- a/crates/conary-core/src/packages/rpm.rs
+++ b/crates/conary-core/src/packages/rpm.rs
@@ -14,10 +14,10 @@ use crate::packages::traits::{
     NativeStdinContract, NativeTransactionOrder, NativeTransactionPosition, PackageFile,
     PackageFormat, RpmHeaderContextMetadata, RpmHeaderFactMetadata, RpmHeaderFactSource,
     RpmHeaderValueMetadata, RpmMacroContextMetadata, RpmMacroDefinitionMetadata,
-    RpmMacroDefinitionSource, RpmNativeScriptletMetadata, RpmScriptletCriticality,
-    RpmScriptletFlagsMetadata, RpmScriptletProgram, RpmScriptletRuntimeMetadata, RpmScriptletSlot,
-    RpmSysusersDirective, RpmSysusersMetadata, RpmTriggerAction, RpmTriggerCondition,
-    RpmTriggerFamily, RpmTriggerMetadata,
+    RpmMacroDefinitionSource, RpmNativeScriptletMetadata, RpmScriptletFlagsMetadata,
+    RpmScriptletProgram, RpmScriptletRuntimeMetadata, RpmScriptletSlot, RpmSysusersDirective,
+    RpmSysusersMetadata, RpmTriggerAction, RpmTriggerCondition, RpmTriggerFamily,
+    RpmTriggerMetadata,
 };
 use crate::repository::dependency_model::{
     RepositoryCapabilityKind, RepositoryRequirementGroup, RepositoryRequirementKind,

--- a/crates/conary-core/src/packages/rpm/scriptlets.rs
+++ b/crates/conary-core/src/packages/rpm/scriptlets.rs
@@ -1,6 +1,7 @@
 // conary-core/src/packages/rpm/scriptlets.rs
 
 use super::*;
+use crate::scriptlet::RpmClassAuthority;
 
 mod runtime_context;
 use runtime_context::ParsedRpmRuntimeContext;
@@ -15,8 +16,7 @@ impl RpmPackage {
 
     pub(super) fn rpm_scriptlet_flags_metadata(
         flags: rpm::ScriptletFlags,
-        default_critical: bool,
-        force_warning_only: bool,
+        authority: RpmClassAuthority,
     ) -> RpmScriptletFlagsMetadata {
         let mut names = Vec::new();
         if flags.contains(rpm::ScriptletFlags::EXPAND) {
@@ -33,15 +33,7 @@ impl RpmPackage {
             | rpm::ScriptletFlags::QFORMAT.bits()
             | rpm::ScriptletFlags::CRITICAL.bits();
         let header_critical = flags.contains(rpm::ScriptletFlags::CRITICAL);
-        let (critical, criticality) = if force_warning_only {
-            (false, RpmScriptletCriticality::ForcedWarningOnly)
-        } else if header_critical {
-            (true, RpmScriptletCriticality::Header)
-        } else if default_critical {
-            (true, RpmScriptletCriticality::SlotDefault)
-        } else {
-            (false, RpmScriptletCriticality::WarningOnly)
-        };
+        let criticality = authority.effective_criticality(header_critical);
 
         RpmScriptletFlagsMetadata {
             names,
@@ -49,7 +41,7 @@ impl RpmPackage {
             unknown_bits: flags.bits() & !known_bits,
             expand: flags.contains(rpm::ScriptletFlags::EXPAND),
             query_format: flags.contains(rpm::ScriptletFlags::QFORMAT),
-            critical,
+            critical: criticality.is_critical(),
             criticality,
         }
     }
@@ -57,8 +49,7 @@ impl RpmPackage {
     fn rpm_runtime_metadata(
         interpreter: &str,
         flags: rpm::ScriptletFlags,
-        default_critical: bool,
-        force_warning_only: bool,
+        authority: RpmClassAuthority,
         install_prefixes: &[String],
         context: &ParsedRpmRuntimeContext,
     ) -> RpmScriptletRuntimeMetadata {
@@ -69,7 +60,7 @@ impl RpmPackage {
             } else {
                 RpmScriptletProgram::External
             },
-            flags: Self::rpm_scriptlet_flags_metadata(flags, default_critical, force_warning_only),
+            flags: Self::rpm_scriptlet_flags_metadata(flags, authority),
             install_prefixes: install_prefixes.to_vec(),
             macro_context: if needs_macros {
                 context.macros.clone()
@@ -363,8 +354,7 @@ impl RpmPackage {
         let runtime = Self::rpm_runtime_metadata(
             &interpreter,
             flags,
-            Self::rpm_slot_is_critical(slot),
-            false,
+            crate::scriptlet::rpm_package_slot_authority(slot),
             install_prefixes,
             runtime_context,
         );
@@ -389,18 +379,6 @@ impl RpmPackage {
             }),
         });
         Ok(())
-    }
-
-    fn rpm_slot_is_critical(slot: RpmScriptletSlot) -> bool {
-        matches!(
-            slot,
-            RpmScriptletSlot::Pre
-                | RpmScriptletSlot::PreUn
-                | RpmScriptletSlot::PreTrans
-                | RpmScriptletSlot::PreUnTrans
-                | RpmScriptletSlot::Verify
-                | RpmScriptletSlot::Sysusers
-        )
     }
 
     fn add_rpm_sysusers_entries(
@@ -442,8 +420,9 @@ impl RpmPackage {
                         program: RpmScriptletProgram::Sysusers,
                         flags: Self::rpm_scriptlet_flags_metadata(
                             rpm::ScriptletFlags::from_bits_retain(0),
-                            true,
-                            false,
+                            crate::scriptlet::rpm_package_slot_authority(
+                                RpmScriptletSlot::Sysusers,
+                            ),
                         ),
                         install_prefixes: install_prefixes.to_vec(),
                         macro_context: RpmMacroContextMetadata::default(),
@@ -564,11 +543,7 @@ impl RpmPackage {
             let runtime = Self::rpm_runtime_metadata(
                 &interpreter,
                 flags,
-                matches!(
-                    primary_action,
-                    RpmTriggerAction::PreInstall | RpmTriggerAction::Uninstall
-                ),
-                family != RpmTriggerFamily::Package,
+                crate::scriptlet::rpm_trigger_authority(family, primary_action),
                 install_prefixes,
                 runtime_context,
             );

--- a/crates/conary-core/src/packages/rpm/tests.rs
+++ b/crates/conary-core/src/packages/rpm/tests.rs
@@ -3,8 +3,9 @@
 use super::*;
 use crate::packages::traits::{
     NativeArgumentValue, NativeLifecyclePath, NativeScriptletMetadata, NativeStdinContract,
-    RpmTriggerAction,
+    RpmScriptletCriticality, RpmTriggerAction,
 };
+use crate::scriptlet::RpmClassAuthority;
 
 fn package_for_test(name: &str, version: &str) -> RpmPackage {
     RpmPackage {
@@ -417,7 +418,10 @@ fn rpm_program_vector_splits_interpreter_and_args() {
 
 #[test]
 fn rpm_scriptlet_flags_preserve_names_and_bits() {
-    let flags = RpmPackage::rpm_scriptlet_flags_metadata(rpm::ScriptletFlags::EXPAND, false, false);
+    let flags = RpmPackage::rpm_scriptlet_flags_metadata(
+        rpm::ScriptletFlags::EXPAND,
+        RpmClassAuthority::DefaultWarnAndContinue,
+    );
 
     assert!(flags.names.contains(&"EXPAND".to_string()));
     assert_eq!(flags.raw_bits, rpm::ScriptletFlags::EXPAND.bits());
@@ -431,14 +435,15 @@ fn rpm_scriptlet_flags_preserve_names_and_bits() {
 fn rpm_effective_criticality_uses_slot_defaults_and_file_trigger_override() {
     let defaulted = RpmPackage::rpm_scriptlet_flags_metadata(
         rpm::ScriptletFlags::from_bits_retain(0),
-        true,
-        false,
+        RpmClassAuthority::DefaultAbortsTransaction,
     );
     assert!(defaulted.critical);
     assert_eq!(defaulted.criticality, RpmScriptletCriticality::SlotDefault);
 
-    let forced_warning =
-        RpmPackage::rpm_scriptlet_flags_metadata(rpm::ScriptletFlags::CRITICAL, true, true);
+    let forced_warning = RpmPackage::rpm_scriptlet_flags_metadata(
+        rpm::ScriptletFlags::CRITICAL,
+        RpmClassAuthority::ForcedWarnAndContinue,
+    );
     assert!(!forced_warning.critical);
     assert_eq!(
         forced_warning.criticality,

--- a/crates/conary-core/src/scriptlet/failure_policy.rs
+++ b/crates/conary-core/src/scriptlet/failure_policy.rs
@@ -1,0 +1,463 @@
+// conary-core/src/scriptlet/failure_policy.rs
+
+//! Typed per-scriptlet-class lifecycle failure posture.
+//!
+//! The source package format owns its lifecycle ABI, so a lifecycle failure is
+//! exactly as fatal as the source format's own contract says it is -- in both
+//! directions. This module is the single owner of that table. Conversion
+//! consults it to stamp an entry's effective criticality; the install runtime
+//! consults it to decide whether a failed entry aborts its transaction.
+//!
+//! The declared authority is
+//! `docs/specs/foreign-package-lifecycle-contracts.md`, "RPM Scriptlet Failure
+//! Posture". It is derived from pinned RPM
+//! [`lib/rpmscript.cc` `scriptInfo[]`](https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/lib/rpmscript.cc#L54-L99)
+//! `deflags`, the file-trigger clear at
+//! [`rpmScriptFromTriggerTag()`](https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/lib/rpmscript.cc#L689-L692),
+//! and the dispatch in
+//! [`runScript()`](https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/lib/transaction.cc#L1709-L1762).
+//!
+//! Nothing here matches a scriptlet name. The class is a typed value on both
+//! sides of the persisted contract.
+
+use super::ScriptletFailureKind;
+use crate::ccs::native_lifecycle::{RpmCriticality, SourceFormat};
+use crate::packages::native_abi::{
+    RpmScriptletCriticality, RpmScriptletSlot, RpmTriggerAction, RpmTriggerFamily,
+};
+
+/// What a lifecycle entry's failure does to the transaction that ran it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailurePosture {
+    /// The transaction fails. The source format itself refuses to proceed past
+    /// this class of failure, so Conary must not be more permissive.
+    AbortsTransaction,
+    /// The failure is reported as typed evidence and the transaction proceeds,
+    /// because the source format proceeds. Conary's promised-path
+    /// post-condition remains the backstop for a dependency witness that a
+    /// continued failure would otherwise leave unsatisfied.
+    WarnAndContinue,
+}
+
+/// The per-class cell of a source format's failure table, before the package
+/// header is consulted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RpmClassAuthority {
+    /// The class default is warn-and-continue; a header `CRITICAL` flag on this
+    /// entry promotes it to a transaction failure.
+    DefaultWarnAndContinue,
+    /// The class default is a transaction failure.
+    DefaultAbortsTransaction,
+    /// RPM clears `CRITICAL` for this class, so no header flag can promote it.
+    ForcedWarnAndContinue,
+}
+
+impl RpmClassAuthority {
+    /// The effective criticality RPM would stamp on an entry of this class
+    /// whose header carried (or did not carry) the `CRITICAL` flag.
+    pub const fn effective_criticality(self, header_critical: bool) -> RpmScriptletCriticality {
+        match self {
+            Self::ForcedWarnAndContinue => RpmScriptletCriticality::ForcedWarningOnly,
+            Self::DefaultWarnAndContinue | Self::DefaultAbortsTransaction if header_critical => {
+                RpmScriptletCriticality::Header
+            }
+            Self::DefaultWarnAndContinue => RpmScriptletCriticality::WarningOnly,
+            Self::DefaultAbortsTransaction => RpmScriptletCriticality::SlotDefault,
+        }
+    }
+}
+
+impl RpmScriptletCriticality {
+    /// Project the parsed criticality onto the persisted CCS contract value.
+    ///
+    /// The two enums are the same fact on either side of the conversion
+    /// boundary; this is the only place that crosses it.
+    pub const fn persisted(self) -> RpmCriticality {
+        match self {
+            Self::Header => RpmCriticality::Header,
+            Self::SlotDefault => RpmCriticality::SlotDefault,
+            Self::WarningOnly => RpmCriticality::WarningOnly,
+            Self::ForcedWarningOnly => RpmCriticality::ForcedWarningOnly,
+        }
+    }
+
+    /// Whether RPM treats a failure of an entry stamped with this criticality
+    /// as fatal to its transaction element.
+    pub const fn is_critical(self) -> bool {
+        FailurePosture::for_rpm_criticality(self.persisted()).aborts_transaction()
+    }
+}
+
+/// RPM's per-scriptlet-class default, from the pinned `scriptInfo[]` table.
+pub const fn rpm_package_slot_authority(slot: RpmScriptletSlot) -> RpmClassAuthority {
+    match slot {
+        RpmScriptletSlot::Pre
+        | RpmScriptletSlot::PreUn
+        | RpmScriptletSlot::PreTrans
+        | RpmScriptletSlot::PreUnTrans
+        | RpmScriptletSlot::Verify
+        | RpmScriptletSlot::Sysusers => RpmClassAuthority::DefaultAbortsTransaction,
+        RpmScriptletSlot::Post
+        | RpmScriptletSlot::PostUn
+        | RpmScriptletSlot::PostTrans
+        | RpmScriptletSlot::PostUnTrans
+        | RpmScriptletSlot::Trigger => RpmClassAuthority::DefaultWarnAndContinue,
+    }
+}
+
+/// RPM's per-trigger-class default. Package triggers keep the `scriptInfo[]`
+/// default for their action; file and transaction-file triggers have `CRITICAL`
+/// cleared unconditionally and never fail their transaction element.
+pub const fn rpm_trigger_authority(
+    family: RpmTriggerFamily,
+    action: RpmTriggerAction,
+) -> RpmClassAuthority {
+    match family {
+        RpmTriggerFamily::File | RpmTriggerFamily::TransactionFile => {
+            RpmClassAuthority::ForcedWarnAndContinue
+        }
+        RpmTriggerFamily::Package => match action {
+            RpmTriggerAction::PreInstall | RpmTriggerAction::Uninstall => {
+                RpmClassAuthority::DefaultAbortsTransaction
+            }
+            RpmTriggerAction::Install
+            | RpmTriggerAction::PostUninstall
+            | RpmTriggerAction::Unknown { .. } => RpmClassAuthority::DefaultWarnAndContinue,
+        },
+    }
+}
+
+/// The typed inputs the runtime has when a native lifecycle entry fails.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LifecycleFailureClass {
+    /// The source format whose lifecycle contract owns this entry.
+    pub source_format: SourceFormat,
+    /// The persisted effective criticality of an RPM entry, or `None` for an
+    /// entry that declares no RPM runtime contract.
+    pub rpm_criticality: Option<RpmCriticality>,
+    /// How the entry failed.
+    pub failure_kind: ScriptletFailureKind,
+}
+
+impl FailurePosture {
+    /// The posture the install runtime applies to a failed lifecycle entry.
+    ///
+    /// A source format's warn-and-continue class covers only a program exit or
+    /// timeout, and only after exact preflight and the selected-root
+    /// enforcement boundary have already succeeded. Missing interpreters,
+    /// malformed contracts, and process or sandbox setup failures are Conary
+    /// contract failures rather than source-program results, so they abort
+    /// whatever the class says: criticality is not a security-boundary bypass.
+    pub const fn for_lifecycle_failure(class: LifecycleFailureClass) -> Self {
+        if !class.failure_kind.is_source_program_result() {
+            return Self::AbortsTransaction;
+        }
+        match class.source_format {
+            SourceFormat::Rpm => match class.rpm_criticality {
+                Some(criticality) => Self::for_rpm_criticality(criticality),
+                // An RPM entry with no persisted RPM runtime contract has no
+                // declared class, so it gets the strict posture.
+                None => Self::AbortsTransaction,
+            },
+            // dpkg leaves a package whose maintainer script failed in an
+            // errored, unconfigured state rather than proceeding, and libalpm
+            // has no warning-only class. Both are transaction failures until
+            // their own slice declares a class table.
+            SourceFormat::Deb | SourceFormat::Arch => Self::AbortsTransaction,
+        }
+    }
+
+    /// The posture carried by an RPM entry's persisted effective criticality.
+    pub const fn for_rpm_criticality(criticality: RpmCriticality) -> Self {
+        match criticality {
+            RpmCriticality::Header | RpmCriticality::SlotDefault => Self::AbortsTransaction,
+            RpmCriticality::WarningOnly | RpmCriticality::ForcedWarningOnly => {
+                Self::WarnAndContinue
+            }
+        }
+    }
+
+    pub const fn aborts_transaction(self) -> bool {
+        matches!(self, Self::AbortsTransaction)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rpm_class(
+        criticality: RpmCriticality,
+        failure_kind: ScriptletFailureKind,
+    ) -> LifecycleFailureClass {
+        LifecycleFailureClass {
+            source_format: SourceFormat::Rpm,
+            rpm_criticality: Some(criticality),
+            failure_kind,
+        }
+    }
+
+    #[test]
+    fn every_rpm_package_slot_matches_the_pinned_scriptinfo_defaults() {
+        // Pinned rpm lib/rpmscript.cc scriptInfo[] deflags at
+        // a8f0192aee1c08bd1454ed2ac6ebaf506004b55c: prein, preun, pretrans,
+        // preuntrans, verify, and sysusers carry RPMSCRIPT_FLAG_CRITICAL; post,
+        // postun, posttrans, and postuntrans carry none.
+        for (slot, expected) in [
+            (
+                RpmScriptletSlot::Pre,
+                RpmClassAuthority::DefaultAbortsTransaction,
+            ),
+            (
+                RpmScriptletSlot::PreUn,
+                RpmClassAuthority::DefaultAbortsTransaction,
+            ),
+            (
+                RpmScriptletSlot::PreTrans,
+                RpmClassAuthority::DefaultAbortsTransaction,
+            ),
+            (
+                RpmScriptletSlot::PreUnTrans,
+                RpmClassAuthority::DefaultAbortsTransaction,
+            ),
+            (
+                RpmScriptletSlot::Verify,
+                RpmClassAuthority::DefaultAbortsTransaction,
+            ),
+            (
+                RpmScriptletSlot::Sysusers,
+                RpmClassAuthority::DefaultAbortsTransaction,
+            ),
+            (
+                RpmScriptletSlot::Post,
+                RpmClassAuthority::DefaultWarnAndContinue,
+            ),
+            (
+                RpmScriptletSlot::PostUn,
+                RpmClassAuthority::DefaultWarnAndContinue,
+            ),
+            (
+                RpmScriptletSlot::PostTrans,
+                RpmClassAuthority::DefaultWarnAndContinue,
+            ),
+            (
+                RpmScriptletSlot::PostUnTrans,
+                RpmClassAuthority::DefaultWarnAndContinue,
+            ),
+        ] {
+            assert_eq!(
+                rpm_package_slot_authority(slot),
+                expected,
+                "slot {slot:?} diverges from the pinned RPM scriptInfo default"
+            );
+        }
+    }
+
+    #[test]
+    fn file_triggers_can_never_be_promoted_by_a_header_flag() {
+        for family in [RpmTriggerFamily::File, RpmTriggerFamily::TransactionFile] {
+            for action in [
+                RpmTriggerAction::PreInstall,
+                RpmTriggerAction::Install,
+                RpmTriggerAction::Uninstall,
+                RpmTriggerAction::PostUninstall,
+            ] {
+                let authority = rpm_trigger_authority(family, action);
+                assert_eq!(authority, RpmClassAuthority::ForcedWarnAndContinue);
+                for header_critical in [false, true] {
+                    assert_eq!(
+                        FailurePosture::for_rpm_criticality(
+                            authority.effective_criticality(header_critical).persisted()
+                        ),
+                        FailurePosture::WarnAndContinue,
+                        "a {family:?} {action:?} trigger must never fail its transaction element"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn package_triggers_follow_their_action_class() {
+        for (action, expected) in [
+            (
+                RpmTriggerAction::PreInstall,
+                RpmClassAuthority::DefaultAbortsTransaction,
+            ),
+            (
+                RpmTriggerAction::Uninstall,
+                RpmClassAuthority::DefaultAbortsTransaction,
+            ),
+            (
+                RpmTriggerAction::Install,
+                RpmClassAuthority::DefaultWarnAndContinue,
+            ),
+            (
+                RpmTriggerAction::PostUninstall,
+                RpmClassAuthority::DefaultWarnAndContinue,
+            ),
+        ] {
+            assert_eq!(
+                rpm_trigger_authority(RpmTriggerFamily::Package, action),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn a_header_critical_flag_promotes_a_promotable_class_and_nothing_else() {
+        assert_eq!(
+            RpmClassAuthority::DefaultWarnAndContinue.effective_criticality(false),
+            RpmScriptletCriticality::WarningOnly
+        );
+        assert_eq!(
+            RpmClassAuthority::DefaultWarnAndContinue.effective_criticality(true),
+            RpmScriptletCriticality::Header
+        );
+        assert_eq!(
+            RpmClassAuthority::DefaultAbortsTransaction.effective_criticality(false),
+            RpmScriptletCriticality::SlotDefault
+        );
+        assert_eq!(
+            RpmClassAuthority::DefaultAbortsTransaction.effective_criticality(true),
+            RpmScriptletCriticality::Header
+        );
+        assert_eq!(
+            RpmClassAuthority::ForcedWarnAndContinue.effective_criticality(true),
+            RpmScriptletCriticality::ForcedWarningOnly
+        );
+    }
+
+    /// The parse side and the persisted side are the same fact. Everything the
+    /// parser can stamp must cross the conversion boundary into a value the
+    /// runtime admits with the identical posture.
+    #[test]
+    fn every_parsed_criticality_crosses_into_the_same_runtime_posture() {
+        for (parsed, persisted) in [
+            (RpmScriptletCriticality::Header, RpmCriticality::Header),
+            (
+                RpmScriptletCriticality::SlotDefault,
+                RpmCriticality::SlotDefault,
+            ),
+            (
+                RpmScriptletCriticality::WarningOnly,
+                RpmCriticality::WarningOnly,
+            ),
+            (
+                RpmScriptletCriticality::ForcedWarningOnly,
+                RpmCriticality::ForcedWarningOnly,
+            ),
+        ] {
+            assert_eq!(parsed.persisted(), persisted);
+            assert_eq!(
+                parsed.is_critical(),
+                FailurePosture::for_rpm_criticality(persisted).aborts_transaction()
+            );
+        }
+    }
+
+    /// Every class the parser can produce, for every header flag value, must
+    /// land on the posture the pinned table declares.
+    #[test]
+    fn every_rpm_class_reaches_the_runtime_with_its_declared_posture() {
+        let classes = [
+            (RpmScriptletSlot::Pre, FailurePosture::AbortsTransaction),
+            (RpmScriptletSlot::PreUn, FailurePosture::AbortsTransaction),
+            (
+                RpmScriptletSlot::PreTrans,
+                FailurePosture::AbortsTransaction,
+            ),
+            (
+                RpmScriptletSlot::PreUnTrans,
+                FailurePosture::AbortsTransaction,
+            ),
+            (RpmScriptletSlot::Verify, FailurePosture::AbortsTransaction),
+            (
+                RpmScriptletSlot::Sysusers,
+                FailurePosture::AbortsTransaction,
+            ),
+            (RpmScriptletSlot::Post, FailurePosture::WarnAndContinue),
+            (RpmScriptletSlot::PostUn, FailurePosture::WarnAndContinue),
+            (RpmScriptletSlot::PostTrans, FailurePosture::WarnAndContinue),
+            (
+                RpmScriptletSlot::PostUnTrans,
+                FailurePosture::WarnAndContinue,
+            ),
+        ];
+        for (slot, without_header_flag) in classes {
+            let authority = rpm_package_slot_authority(slot);
+            let posture = |header_critical| {
+                FailurePosture::for_lifecycle_failure(LifecycleFailureClass {
+                    source_format: SourceFormat::Rpm,
+                    rpm_criticality: Some(
+                        authority.effective_criticality(header_critical).persisted(),
+                    ),
+                    failure_kind: ScriptletFailureKind::ScriptExited,
+                })
+            };
+            assert_eq!(
+                posture(false),
+                without_header_flag,
+                "slot {slot:?} reaches the runtime with the wrong posture"
+            );
+            assert_eq!(
+                posture(true),
+                FailurePosture::AbortsTransaction,
+                "a header CRITICAL flag on {slot:?} must reach the runtime as fatal"
+            );
+        }
+    }
+
+    #[test]
+    fn warn_and_continue_covers_only_source_program_results() {
+        for failure_kind in [
+            ScriptletFailureKind::ScriptExited,
+            ScriptletFailureKind::ScriptTimedOut,
+        ] {
+            assert_eq!(
+                FailurePosture::for_lifecycle_failure(rpm_class(
+                    RpmCriticality::WarningOnly,
+                    failure_kind
+                )),
+                FailurePosture::WarnAndContinue
+            );
+        }
+        for failure_kind in [
+            ScriptletFailureKind::ContractViolation,
+            ScriptletFailureKind::ProgramUnavailable,
+            ScriptletFailureKind::ProcessSetupFailed,
+            ScriptletFailureKind::SandboxSetupUnavailable,
+        ] {
+            assert_eq!(
+                FailurePosture::for_lifecycle_failure(rpm_class(
+                    RpmCriticality::WarningOnly,
+                    failure_kind
+                )),
+                FailurePosture::AbortsTransaction,
+                "{failure_kind:?} is a Conary contract failure, not an RPM script result"
+            );
+        }
+    }
+
+    #[test]
+    fn a_format_without_a_declared_class_table_aborts() {
+        for source_format in [SourceFormat::Deb, SourceFormat::Arch] {
+            assert_eq!(
+                FailurePosture::for_lifecycle_failure(LifecycleFailureClass {
+                    source_format,
+                    rpm_criticality: None,
+                    failure_kind: ScriptletFailureKind::ScriptExited,
+                }),
+                FailurePosture::AbortsTransaction
+            );
+        }
+        assert_eq!(
+            FailurePosture::for_lifecycle_failure(LifecycleFailureClass {
+                source_format: SourceFormat::Rpm,
+                rpm_criticality: None,
+                failure_kind: ScriptletFailureKind::ScriptExited,
+            }),
+            FailurePosture::AbortsTransaction
+        );
+    }
+}

--- a/crates/conary-core/src/scriptlet/mod.rs
+++ b/crates/conary-core/src/scriptlet/mod.rs
@@ -30,6 +30,7 @@ mod arguments;
 mod boot_runtime_capture;
 mod boundary;
 mod executor;
+mod failure_policy;
 mod lifecycle_bridge;
 mod native_command;
 mod native_lifecycle;
@@ -45,6 +46,10 @@ mod types;
 
 pub use crate::activation::SystemdActivationInvocation;
 pub use executor::ScriptletExecutor;
+pub use failure_policy::{
+    FailurePosture, LifecycleFailureClass, RpmClassAuthority, rpm_package_slot_authority,
+    rpm_trigger_authority,
+};
 pub use lifecycle_bridge::{
     LifecycleBridgeConfig, LifecycleBridgeEndpoint, LifecycleBridgeHandler,
     LifecycleBridgeHandlerError, LifecycleBridgeRequest, LifecycleBridgeResponse,

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -101,8 +101,12 @@ commands.
   pre-payload sysusers target-interface execution starts in
   `crates/conary-core/src/scriptlet/sysusers.rs`; generic native argv remains
   selected-root confined in
-  `crates/conary-core/src/scriptlet/native_command.rs`. Exact source-independent
-  payload nodes start in `crates/conary-core/src/payload.rs`.
+  `crates/conary-core/src/scriptlet/native_command.rs`. The per-scriptlet-class
+  failure posture that decides whether a failed lifecycle entry aborts its
+  transaction is owned by `crates/conary-core/src/scriptlet/failure_policy.rs`
+  and declared in `docs/specs/foreign-package-lifecycle-contracts.md`. Exact
+  source-independent payload nodes start in
+  `crates/conary-core/src/payload.rs`.
   `apps/conary/src/commands/live_root/recovery.rs` is confined to the
   selected-root session journal implementation.
 - Declarative models, source selection, and replatforming:

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-06
-revision: 40
+last_updated: 2026-08-08
+revision: 41
 summary: Define source-independent lifecycle, source-authority handoff, generation activation, and configuration transactions for RPM, Debian, and Arch packages
 ---
 
@@ -863,15 +863,82 @@ interpreters such as `<lua>`. Those are executable ABI semantics. A plain
 process executor cannot run such an entry; the corresponding RPM expansion or
 embedded-interpreter contract is required Conary implementation.
 
-The persisted effective critical flag owns RPM script-result handling. Matching
-the pinned RPM
+### Lifecycle Failure Posture
+
+The source package format owns its lifecycle ABI, so a lifecycle failure is
+exactly as fatal as that format's own contract says it is, in both directions.
+Conary neither aborts where the format proceeds nor proceeds where the format
+aborts. The posture is a typed per-scriptlet-class table, not a judgment about
+the entry's name, body, or apparent importance.
+
+The table below is the declared authority. `conary-core`'s
+`scriptlet::failure_policy` module is its single implementation: conversion
+consults it to stamp each entry's effective criticality, and the install runtime
+consults it to decide whether a failed entry aborts its transaction. Neither
+side matches a scriptlet name at decision time.
+
+#### RPM Scriptlet Failure Posture
+
+Derived from pinned RPM
+[`lib/rpmscript.cc` `scriptInfo[]`](https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/lib/rpmscript.cc#L54-L99),
+whose per-tag `deflags` column sets `RPMSCRIPT_FLAG_CRITICAL`, and dispatched by
 [`runScript()`](https://github.com/rpm-software-management/rpm/blob/a8f0192aee1c08bd1454ed2ac6ebaf506004b55c/lib/transaction.cc#L1709-L1762),
-a failed non-critical script is reported but does not fail its transaction
-element, while a critical script failure remains fatal. Conary applies that
-source policy only to a program exit or timeout after exact preflight and the
-selected-root enforcement boundary have succeeded. Missing interpreters,
-malformed contracts, process or sandbox setup failures, and enforcement
-failures remain fatal; RPM criticality is not a security-boundary bypass.
+where `warn_only = !(rpmScriptFlags(script) & RPMSCRIPT_FLAG_CRITICAL)` and a
+warn-only failure is mapped back to `RPMRC_OK` after notifying the callback.
+RPM's own comment there records that the return code "only reflects whether the
+condition prevented install/erase (which is only happens with %prein and %preun
+scriptlets)".
+
+| Scriptlet class | Class default | Failure posture | Note |
+| --- | --- | --- | --- |
+| `%pretrans` | `CRITICAL` | aborts transaction | runs before any payload for the element lands |
+| `%pre` | `CRITICAL` | aborts transaction | runs before this package's payload lands |
+| `%post` | none | warn and continue | payload is already on disk |
+| `%posttrans` | none | warn and continue | |
+| `%preuntrans` | `CRITICAL` | aborts transaction | |
+| `%preun` | `CRITICAL` | aborts transaction | RPM prevents the erase |
+| `%postun` | none | warn and continue | |
+| `%postuntrans` | none | warn and continue | |
+| `%verify` | `CRITICAL` | aborts transaction | |
+| `%sysusers` | `CRITICAL` | aborts transaction | RPM's synthesized sysusers class |
+| `%triggerprein` | `CRITICAL` | aborts transaction | |
+| `%triggerun` | `CRITICAL` | aborts transaction | |
+| `%triggerin` | none | warn and continue | |
+| `%triggerpostun` | none | warn and continue | |
+| `%filetrigger*`, `%transfiletrigger*` | cleared | warn and continue | RPM clears `CRITICAL`; no header flag can promote a file trigger |
+
+A package header may carry `RPMSCRIPT_FLAG_CRITICAL` on an entry whose class
+defaults to none, which promotes that entry to aborting the transaction. Only
+the file-trigger classes refuse promotion, because RPM clears the bit for them
+unconditionally. The promotion outcome is persisted as the entry's effective
+criticality: `header`, `slot-default`, `warning-only`, or
+`forced-warning-only`.
+
+Conary applies a warn-and-continue posture only to a program exit or timeout
+after exact preflight and the selected-root enforcement boundary have succeeded.
+Missing interpreters, malformed contracts, process or sandbox setup failures,
+and enforcement failures remain fatal for every class: criticality is a source
+lifecycle contract, not a security-boundary bypass.
+
+A warn-and-continue failure is typed evidence, not a success. The transaction
+retains each one and reports it on the user-facing channel, and the promised-path
+post-condition in the shared transaction model remains the backstop: a
+warn-and-continue entry that fails to materialize a path the transaction relied
+on as a dependency witness still fails the transaction.
+
+#### Debian And Arch Failure Posture
+
+| Source format | Failure posture | Status |
+| --- | --- | --- |
+| Debian maintainer scripts | aborts transaction | pending the Debian lifecycle-posture slice |
+| Arch `.INSTALL` functions and ALPM hooks | aborts transaction | pending the ALPM lifecycle-posture slice |
+
+Neither format's table is declared yet, so every failure aborts, which is the
+strict direction. Debian's real contract is not RPM's: `dpkg` leaves a package
+whose `postinst` failed in an errored, unconfigured state and reports the
+transaction as failed rather than proceeding as if configured, so the Debian row
+must be replaced by a per-script table stating which script failures leave which
+`dpkg` package state before that format can claim class-accurate posture.
 
 ### RPM Runtime Compatibility
 


### PR DESCRIPTION
## #295, per the decision (with its %preun line corrected against pinned upstream)

Investigation reframed the issue: RPM runtime behavior on main was already upstream-correct — the defects were an undeclared boolean authority consumed inline, the table written twice with no spec row, and continued failures leaving zero evidence. The substantive behavioral change is evidence retention.

- `failure_policy.rs`: single typed owner (slot/trigger-keyed table, pinned citations from rpm a8f0192a); `rpm_slot_is_critical`, the inline trigger `matches!`, and a hand-written projection deleted. Aborts reuse the existing error path byte-identically and integrate with existing rollback (proven by a graph test asserting zero payload boundaries crossed on %pre failure).
- Continued failures: typed records surfaced via ui::warn at the one choke point, on both exits — Luna's review caught success-path-only draining (a later aborting step dropped the evidence with the transaction); fixed as a bind-report-return wrapper, mutation-proven with the mid-graph accumulator probe.
- Spec rev 41: 15-row RPM posture table with quoted pinned sources; deb/arch rows explicitly pending (dpkg's contract differs and is documented as such).

## Verification (real output, uncontended private target dir)

conary 1033 lib + 52 suites clean; conary-core 3393 green; workspace clippy `-D warnings` clean; fmt; doc-truth; install card's 12 focused-proof commands individually green. Mutation checks at both layers in both directions (%pre→warn and %post→abort each fail their tests) plus the evidence-on-abort mutation.

Found and filed: #336 (CCS contract: redundant critical bool + unpersisted typed slot), #337 (persist continued failures — no table exists for lifecycle events). Process note: shared CARGO_TARGET_DIR proved unsafe under parallel agents (rlib clobbered mid-run; diagnosed, not retried) — session-operational, worth remembering.

Review chain: Opus (which corrected the operator decision record against upstream source) → reviewer → Luna (evidence dropped on abort exits) → fix with targeted mutation kill.

Closes #295. Refs #336, #337, #297, #302.