### PR TITLE
fix(db): drop the redundant kind+capability index from repository_provides

### DIFF
--- a/crates/conary-core/src/db/current_schema/sql/repository.sql
+++ b/crates/conary-core/src/db/current_schema/sql/repository.sql
@@ -437,10 +437,12 @@ CREATE TABLE repository_provides (
         );
 CREATE INDEX idx_repository_provides_pkg
             ON repository_provides(repository_package_id);
+-- Capability is the only column any provider lookup seeks on. A
+-- (kind, capability) composite cannot serve a capability-only seek, and the one
+-- statement that also filters kind seeks this index and filters the rows one
+-- capability holds, so the composite is not carried.
 CREATE INDEX idx_repository_provides_capability
             ON repository_provides(capability);
-CREATE INDEX idx_repository_provides_kind_capability
-            ON repository_provides(kind, capability);
 CREATE TABLE repository_requirement_groups (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             repository_package_id INTEGER NOT NULL,

--- a/crates/conary-core/src/db/models/repository_capability.rs
+++ b/crates/conary-core/src/db/models/repository_capability.rs
@@ -14,6 +14,104 @@ use rusqlite::{Connection, Row, params};
 use std::collections::{BTreeMap, BTreeSet};
 use std::io;
 
+/// Every statement this module issues against `repository_provides`.
+///
+/// The SQL lives in named constants so the query-plan proof in this module's
+/// tests reads the same text the production path executes. `repository_provides`
+/// is the largest table Conary persists (10.07M rows on Fedora 44
+/// `Everything/x86_64` with `filelists.xml`), so which index each statement can
+/// seek through is a contract, not an implementation detail.
+const INSERT_PROVIDE_SQL: &str = "INSERT INTO repository_provides
+             (repository_package_id, capability, version, kind, raw, version_scheme,
+              version_relation, architecture_qualifier_kind, architecture, provenance)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)";
+
+const SELECT_BY_PACKAGE_SQL: &str =
+    "SELECT id, repository_package_id, capability, version, version_relation, kind, raw,
+                    version_scheme, architecture_qualifier_kind, architecture, provenance
+             FROM repository_provides
+             WHERE repository_package_id = ?1
+             ORDER BY capability, version";
+
+const SELECT_CONVERSION_INPUTS_SQL: &str =
+    "SELECT p.id, p.repository_package_id, p.capability, p.version,
+                    p.version_relation, p.kind, p.raw, p.version_scheme,
+                    p.architecture_qualifier_kind, p.architecture, p.provenance,
+                    rp.id, rp.checksum
+             FROM repository_packages rp
+             JOIN repositories r ON r.id = rp.repository_id
+             LEFT JOIN repository_provides p ON p.repository_package_id = rp.id
+             WHERE r.enabled = 1
+               AND r.source_profile = ?1
+               AND rp.name = ?2
+               AND rp.version = ?3
+               AND rp.architecture = ?4
+               AND rp.size > 0
+             ORDER BY rp.id, p.id";
+
+/// `{placeholders}` is replaced with the bound package-id list for one batch.
+const SELECT_BY_PACKAGES_TEMPLATE: &str =
+    "SELECT id, repository_package_id, capability, version, version_relation, kind, raw,
+                        version_scheme, architecture_qualifier_kind, architecture, provenance
+                 FROM repository_provides
+                 WHERE repository_package_id IN ({placeholders})";
+
+const SELECT_BY_CAPABILITY_SQL: &str =
+    "SELECT rp.id, rp.repository_package_id, rp.capability, rp.version,
+                    rp.version_relation, rp.kind, rp.raw, rp.version_scheme,
+                    rp.architecture_qualifier_kind, rp.architecture, rp.provenance
+             FROM repository_provides rp
+             JOIN repository_packages pkg ON pkg.id = rp.repository_package_id
+             JOIN repositories repo ON repo.id = pkg.repository_id
+             WHERE repo.enabled = 1 AND rp.capability = ?1
+             ORDER BY rp.capability, rp.version";
+
+const SELECT_BY_CLI_EXACT_QUERY_SQL: &str =
+    "SELECT rp.id, rp.repository_package_id, rp.capability, rp.version,
+                    rp.version_relation, rp.kind, rp.raw, rp.version_scheme,
+                    rp.architecture_qualifier_kind, rp.architecture, rp.provenance
+             FROM repository_provides rp
+             JOIN repository_packages pkg ON pkg.id = rp.repository_package_id
+             JOIN repositories repo ON repo.id = pkg.repository_id
+             WHERE repo.enabled = 1
+               AND (
+                 rp.raw = ?1
+                 OR (
+                   (rp.raw IS NULL OR rp.raw = '')
+                   AND (rp.kind IS NULL OR rp.kind = '' OR rp.kind = 'package')
+                   AND rp.capability = ?1
+                 )
+               )
+             ORDER BY rp.capability, rp.version";
+
+const SELECT_BY_CAPABILITY_WITH_NAME_SQL: &str =
+    "SELECT rp.id, rp.repository_package_id, rp.capability, rp.version,
+                    rp.version_relation, rp.kind, rp.raw, rp.version_scheme,
+                    rp.architecture_qualifier_kind, rp.architecture, rp.provenance, pkg.name
+             FROM repository_provides rp
+             JOIN repository_packages pkg ON pkg.id = rp.repository_package_id
+             JOIN repositories repo ON repo.id = pkg.repository_id
+             WHERE repo.enabled = 1 AND rp.capability = ?1
+             ORDER BY rp.capability, rp.version";
+
+const SELECT_BY_CAPABILITY_AND_KIND_SQL: &str =
+    "SELECT rp.id, rp.repository_package_id, rp.capability, rp.version,
+                    rp.version_relation, rp.kind, rp.raw, rp.version_scheme,
+                    rp.architecture_qualifier_kind, rp.architecture, rp.provenance
+             FROM repository_provides rp
+             JOIN repository_packages pkg ON pkg.id = rp.repository_package_id
+             JOIN repositories repo ON repo.id = pkg.repository_id
+             WHERE repo.enabled = 1 AND rp.capability = ?1 AND rp.kind = ?2
+             ORDER BY rp.capability, rp.version";
+
+const DELETE_BY_PACKAGE_SQL: &str =
+    "DELETE FROM repository_provides WHERE repository_package_id = ?1";
+
+const DELETE_BY_REPOSITORY_SQL: &str = "DELETE FROM repository_provides
+             WHERE repository_package_id IN (
+                 SELECT id FROM repository_packages WHERE repository_id = ?1
+             )";
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RepositoryProvide {
     pub id: Option<i64>,
@@ -82,10 +180,7 @@ impl RepositoryProvide {
         let (qualifier_kind, architecture) =
             architecture_qualifier_to_db(&self.architecture_qualifier);
         conn.execute(
-            "INSERT INTO repository_provides
-             (repository_package_id, capability, version, kind, raw, version_scheme,
-              version_relation, architecture_qualifier_kind, architecture, provenance)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            INSERT_PROVIDE_SQL,
             params![
                 self.repository_package_id,
                 &self.capability,
@@ -109,12 +204,7 @@ impl RepositoryProvide {
             return Ok(0);
         }
 
-        let mut stmt = conn.prepare_cached(
-            "INSERT INTO repository_provides
-             (repository_package_id, capability, version, kind, raw, version_scheme,
-              version_relation, architecture_qualifier_kind, architecture, provenance)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
-        )?;
+        let mut stmt = conn.prepare_cached(INSERT_PROVIDE_SQL)?;
 
         for provide in provides {
             let (qualifier_kind, architecture) =
@@ -140,13 +230,7 @@ impl RepositoryProvide {
         conn: &Connection,
         repository_package_id: i64,
     ) -> Result<Vec<Self>> {
-        let mut stmt = conn.prepare(
-            "SELECT id, repository_package_id, capability, version, version_relation, kind, raw,
-                    version_scheme, architecture_qualifier_kind, architecture, provenance
-             FROM repository_provides
-             WHERE repository_package_id = ?1
-             ORDER BY capability, version",
-        )?;
+        let mut stmt = conn.prepare(SELECT_BY_PACKAGE_SQL)?;
         let rows = stmt
             .query_map([repository_package_id], Self::from_row)?
             .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -174,22 +258,7 @@ impl RepositoryProvide {
         package_version: &str,
         package_architecture: &str,
     ) -> Result<Vec<(String, String)>> {
-        let mut stmt = conn.prepare(
-            "SELECT p.id, p.repository_package_id, p.capability, p.version,
-                    p.version_relation, p.kind, p.raw, p.version_scheme,
-                    p.architecture_qualifier_kind, p.architecture, p.provenance,
-                    rp.id, rp.checksum
-             FROM repository_packages rp
-             JOIN repositories r ON r.id = rp.repository_id
-             LEFT JOIN repository_provides p ON p.repository_package_id = rp.id
-             WHERE r.enabled = 1
-               AND r.source_profile = ?1
-               AND rp.name = ?2
-               AND rp.version = ?3
-               AND rp.architecture = ?4
-               AND rp.size > 0
-             ORDER BY rp.id, p.id",
-        )?;
+        let mut stmt = conn.prepare(SELECT_CONVERSION_INPUTS_SQL)?;
         let rows = stmt
             .query_map(
                 params![
@@ -316,12 +385,7 @@ impl RepositoryProvide {
                 .map(|index| format!("?{index}"))
                 .collect::<Vec<_>>()
                 .join(", ");
-            let sql = format!(
-                "SELECT id, repository_package_id, capability, version, version_relation, kind, raw,
-                        version_scheme, architecture_qualifier_kind, architecture, provenance
-                 FROM repository_provides
-                 WHERE repository_package_id IN ({placeholders})"
-            );
+            let sql = SELECT_BY_PACKAGES_TEMPLATE.replace("{placeholders}", &placeholders);
             let mut stmt = conn.prepare(&sql)?;
             rows.extend(
                 stmt.query_map(
@@ -342,16 +406,7 @@ impl RepositoryProvide {
     }
 
     pub fn find_by_capability(conn: &Connection, capability: &str) -> Result<Vec<Self>> {
-        let mut stmt = conn.prepare(
-            "SELECT rp.id, rp.repository_package_id, rp.capability, rp.version,
-                    rp.version_relation, rp.kind, rp.raw, rp.version_scheme,
-                    rp.architecture_qualifier_kind, rp.architecture, rp.provenance
-             FROM repository_provides rp
-             JOIN repository_packages pkg ON pkg.id = rp.repository_package_id
-             JOIN repositories repo ON repo.id = pkg.repository_id
-             WHERE repo.enabled = 1 AND rp.capability = ?1
-             ORDER BY rp.capability, rp.version",
-        )?;
+        let mut stmt = conn.prepare(SELECT_BY_CAPABILITY_SQL)?;
         let rows = stmt
             .query_map([capability], Self::from_row)?
             .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -361,24 +416,7 @@ impl RepositoryProvide {
     /// Find rows that exactly match a CLI query without interpreting normalized
     /// typed capability rows as untyped user input.
     pub fn find_by_cli_exact_query(conn: &Connection, capability: &str) -> Result<Vec<Self>> {
-        let mut stmt = conn.prepare(
-            "SELECT rp.id, rp.repository_package_id, rp.capability, rp.version,
-                    rp.version_relation, rp.kind, rp.raw, rp.version_scheme,
-                    rp.architecture_qualifier_kind, rp.architecture, rp.provenance
-             FROM repository_provides rp
-             JOIN repository_packages pkg ON pkg.id = rp.repository_package_id
-             JOIN repositories repo ON repo.id = pkg.repository_id
-             WHERE repo.enabled = 1
-               AND (
-                 rp.raw = ?1
-                 OR (
-                   (rp.raw IS NULL OR rp.raw = '')
-                   AND (rp.kind IS NULL OR rp.kind = '' OR rp.kind = 'package')
-                   AND rp.capability = ?1
-                 )
-               )
-             ORDER BY rp.capability, rp.version",
-        )?;
+        let mut stmt = conn.prepare(SELECT_BY_CLI_EXACT_QUERY_SQL)?;
         let rows = stmt
             .query_map([capability], Self::from_row)?
             .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -395,16 +433,7 @@ impl RepositoryProvide {
         conn: &Connection,
         capability: &str,
     ) -> Result<Vec<(Self, String)>> {
-        let mut stmt = conn.prepare(
-            "SELECT rp.id, rp.repository_package_id, rp.capability, rp.version,
-                    rp.version_relation, rp.kind, rp.raw, rp.version_scheme,
-                    rp.architecture_qualifier_kind, rp.architecture, rp.provenance, pkg.name
-             FROM repository_provides rp
-             JOIN repository_packages pkg ON pkg.id = rp.repository_package_id
-             JOIN repositories repo ON repo.id = pkg.repository_id
-             WHERE repo.enabled = 1 AND rp.capability = ?1
-             ORDER BY rp.capability, rp.version",
-        )?;
+        let mut stmt = conn.prepare(SELECT_BY_CAPABILITY_WITH_NAME_SQL)?;
         let rows = stmt
             .query_map([capability], |row| {
                 let provide = Self {
@@ -432,16 +461,7 @@ impl RepositoryProvide {
         capability: &str,
         kind: &str,
     ) -> Result<Vec<Self>> {
-        let mut stmt = conn.prepare(
-            "SELECT rp.id, rp.repository_package_id, rp.capability, rp.version,
-                    rp.version_relation, rp.kind, rp.raw, rp.version_scheme,
-                    rp.architecture_qualifier_kind, rp.architecture, rp.provenance
-             FROM repository_provides rp
-             JOIN repository_packages pkg ON pkg.id = rp.repository_package_id
-             JOIN repositories repo ON repo.id = pkg.repository_id
-             WHERE repo.enabled = 1 AND rp.capability = ?1 AND rp.kind = ?2
-             ORDER BY rp.capability, rp.version",
-        )?;
+        let mut stmt = conn.prepare(SELECT_BY_CAPABILITY_AND_KIND_SQL)?;
         let rows = stmt
             .query_map(params![capability, kind], Self::from_row)?
             .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -450,22 +470,13 @@ impl RepositoryProvide {
 
     /// Delete all provides for a specific repository package.
     pub fn delete_by_package(conn: &Connection, repository_package_id: i64) -> Result<()> {
-        conn.execute(
-            "DELETE FROM repository_provides WHERE repository_package_id = ?1",
-            [repository_package_id],
-        )?;
+        conn.execute(DELETE_BY_PACKAGE_SQL, [repository_package_id])?;
         Ok(())
     }
 
     /// Delete all provides for packages belonging to a repository.
     pub fn delete_by_repository(conn: &Connection, repository_id: i64) -> Result<()> {
-        conn.execute(
-            "DELETE FROM repository_provides
-             WHERE repository_package_id IN (
-                 SELECT id FROM repository_packages WHERE repository_id = ?1
-             )",
-            [repository_id],
-        )?;
+        conn.execute(DELETE_BY_REPOSITORY_SQL, [repository_id])?;
         Ok(())
     }
 
@@ -606,6 +617,127 @@ mod tests {
             [],
         )
         .unwrap();
+    }
+
+    /// Every statement this module issues against `repository_provides`, with
+    /// the batch template resolved to a bound list. The query-plan proof below
+    /// reads this list, so a statement added without a plan is a test failure,
+    /// not an unnoticed table scan.
+    fn owned_statements() -> Vec<(&'static str, String)> {
+        vec![
+            ("insert", INSERT_PROVIDE_SQL.to_string()),
+            (
+                "find_by_repository_package",
+                SELECT_BY_PACKAGE_SQL.to_string(),
+            ),
+            (
+                "conversion_inputs_for_source_identity",
+                SELECT_CONVERSION_INPUTS_SQL.to_string(),
+            ),
+            (
+                "find_by_repository_packages",
+                SELECT_BY_PACKAGES_TEMPLATE.replace("{placeholders}", "?1, ?2"),
+            ),
+            ("find_by_capability", SELECT_BY_CAPABILITY_SQL.to_string()),
+            (
+                "find_by_cli_exact_query",
+                SELECT_BY_CLI_EXACT_QUERY_SQL.to_string(),
+            ),
+            (
+                "find_by_capability_with_name",
+                SELECT_BY_CAPABILITY_WITH_NAME_SQL.to_string(),
+            ),
+            (
+                "find_by_capability_and_kind",
+                SELECT_BY_CAPABILITY_AND_KIND_SQL.to_string(),
+            ),
+            ("delete_by_package", DELETE_BY_PACKAGE_SQL.to_string()),
+            ("delete_by_repository", DELETE_BY_REPOSITORY_SQL.to_string()),
+        ]
+    }
+
+    fn query_plan(conn: &Connection, sql: &str) -> Vec<String> {
+        let mut stmt = conn
+            .prepare(&format!("EXPLAIN QUERY PLAN {sql}"))
+            .unwrap_or_else(|error| panic!("prepare plan for {sql}: {error}"));
+        for index in 1..=stmt.parameter_count() {
+            stmt.raw_bind_parameter(index, rusqlite::types::Null)
+                .unwrap();
+        }
+        let mut rows = stmt.raw_query();
+        let mut plan = Vec::new();
+        while let Some(row) = rows.next().unwrap() {
+            plan.push(row.get::<_, String>(3).unwrap());
+        }
+        plan
+    }
+
+    /// `repository_provides` is the largest table Conary persists, so its index
+    /// inventory is a contract. A `(kind, capability)` composite cannot serve a
+    /// capability-only seek, which is what every provider lookup issues, so
+    /// exactly two indexes are carried: the package key and the capability key.
+    #[test]
+    fn repository_provides_carries_exactly_the_package_and_capability_indexes() {
+        let conn = test_db();
+
+        let mut indexes = conn
+            .prepare(
+                "SELECT name FROM sqlite_master
+                 WHERE type = 'index' AND tbl_name = 'repository_provides'
+                 ORDER BY name",
+            )
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        indexes.sort();
+
+        assert_eq!(
+            indexes,
+            vec![
+                "idx_repository_provides_capability".to_string(),
+                "idx_repository_provides_pkg".to_string(),
+            ],
+            "an index on repository_provides costs ~0.8 GB at filelists scale; \
+             adding one needs its own query-plan proof"
+        );
+    }
+
+    /// The property, not the instance: no statement this module owns may reach
+    /// `repository_provides` by scanning it, and every statement that filters
+    /// `capability` must seek the capability index -- including the one that
+    /// also filters `kind`, which no longer has a composite to seek.
+    #[test]
+    fn every_owned_statement_reaches_repository_provides_through_an_index() {
+        let conn = test_db();
+
+        for (label, sql) in owned_statements() {
+            let plan = query_plan(&conn, &sql);
+            for step in &plan {
+                assert!(
+                    !(step.starts_with("SCAN") && step.contains("repository_provides")),
+                    "{label} scans repository_provides: {plan:?}"
+                );
+            }
+        }
+
+        for label in [
+            "find_by_capability",
+            "find_by_capability_with_name",
+            "find_by_capability_and_kind",
+        ] {
+            let (_, sql) = owned_statements()
+                .into_iter()
+                .find(|(name, _)| *name == label)
+                .expect("statement is inventoried");
+            let plan = query_plan(&conn, &sql);
+            assert!(
+                plan.iter().any(|step| step
+                    == "SEARCH rp USING INDEX idx_repository_provides_capability (capability=?)"),
+                "{label} must seek the capability index: {plan:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/conary-core/src/db/schema.rs
+++ b/crates/conary-core/src/db/schema.rs
@@ -12,19 +12,21 @@ use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 use std::path::Path;
 use tracing::info;
 
-/// Revision 27 of the current-only schema epoch.
+/// Revision 28 of the current-only schema epoch.
 ///
-/// Revision 27 retains revision 26's fail-closed persisted states and explicit
-/// dependency-mixing policy, and stores every path-owning capability provenance
-/// without its duplicated path. The table definitions are unchanged, so the
-/// revision is what separates the two shapes: `provides.provenance` and
-/// `repository_provides.provenance` are JSON text inside a UNIQUE contract
-/// index, so a database mixing old and new rows would admit the same path twice
-/// as two distinct providers. No installed-state resync rebuilds
-/// `provides`, so the version gate is the only thing that can refuse the mix.
-/// Earlier pre-alpha databases must be rebuilt; no compatibility migration is
-/// provided.
-pub const SCHEMA_VERSION: i32 = 27;
+/// Revision 28 retains revision 27's fail-closed persisted states, explicit
+/// dependency-mixing policy, and path-free capability provenance, and carries
+/// one capability index on `repository_provides` instead of two. `capability`
+/// was the second column of the retired `(kind, capability)` composite, so that
+/// index could never serve the capability-only seek every provider lookup
+/// issues; the single-column index serves those seeks, and the one statement
+/// that also filters `kind` seeks the same index and filters the rows a single
+/// capability holds. An index is physical schema that a database keeps for the
+/// life of the file, so a revision-27 database still carries the retired index
+/// and reports a schema its build no longer defines. The revision gate is what
+/// keeps the two apart. Earlier pre-alpha databases must be rebuilt; no
+/// compatibility migration is provided.
+pub const SCHEMA_VERSION: i32 = 28;
 /// Stable identity that distinguishes this epoch from retired schema revisions.
 pub const SCHEMA_EPOCH: &str = "conary-current-v1";
 
@@ -219,7 +221,7 @@ mod tests {
     }
 
     #[test]
-    fn revision_26_requires_rebuild_for_revision_27() {
+    fn revision_27_requires_rebuild_for_revision_28() {
         let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(
             "CREATE TABLE schema_identity (
@@ -227,19 +229,19 @@ mod tests {
                 revision INTEGER NOT NULL
             );
             INSERT INTO schema_identity (epoch, revision)
-                VALUES ('conary-current-v1', 26);
+                VALUES ('conary-current-v1', 27);
             CREATE TABLE schema_version (
                 version INTEGER PRIMARY KEY,
                 applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             );
-            INSERT INTO schema_version (version) VALUES (26);",
+            INSERT INTO schema_version (version) VALUES (27);",
         )
         .unwrap();
 
         let error = ensure_current(&conn).unwrap_err();
         assert_eq!(
             error.to_string(),
-            "Database schema rebuild required: database uses schema epoch conary-current-v1 revision 26; this pre-alpha build supports only schema epoch conary-current-v1 revision 27"
+            "Database schema rebuild required: database uses schema epoch conary-current-v1 revision 27; this pre-alpha build supports only schema epoch conary-current-v1 revision 28"
         );
     }
 
@@ -286,16 +288,13 @@ mod tests {
             2,
         );
 
-        conn.execute(
-            "UPDATE schema_identity SET revision = ?1",
-            params![SCHEMA_VERSION - 1],
-        )
-        .unwrap();
-        conn.execute(
-            "UPDATE schema_version SET version = ?1",
-            params![SCHEMA_VERSION - 1],
-        )
-        .unwrap();
+        // Revision 26 is the last revision that wrote this shape. Naming it
+        // absolutely keeps the test pinned to that database, not to whatever
+        // revision happens to sit one below the current constant.
+        conn.execute("UPDATE schema_identity SET revision = 26", [])
+            .unwrap();
+        conn.execute("UPDATE schema_version SET version = 26", [])
+            .unwrap();
 
         let error = ensure_current(&conn).unwrap_err();
         assert!(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-08
-revision: 41
+revision: 42
 summary: Describe workspace architecture, source-authority projections, repository trust, package transactions, lifecycle execution, typed carrier security, generation GC, and service boundaries
 ---
 
@@ -582,14 +582,18 @@ The schema itself is split by ownership under
 `crates/conary-core/src/db/current_schema/sql/`: local package-manager state,
 repository/service state, and Remi conversion/administration state.
 
-Schema revision 27 retains revision 26's fail-closed persisted-state
-constraints and explicit `strict`, `guarded`, or `permissive` dependency-mixing
-policy on every persisted source pin, and stores every path-owning capability
-provenance without a duplicated path. That last change moves no table
-definition, so the revision is the only thing separating the two shapes:
-`provides.provenance` is JSON text inside a UNIQUE contract index and no resync
-rebuilds installed rows, so a database mixing both shapes would admit one path
-twice as two distinct providers.
+Schema revision 28 retains revision 27's fail-closed persisted-state
+constraints, explicit `strict`, `guarded`, or `permissive` dependency-mixing
+policy on every persisted source pin, and path-free capability provenance, and
+carries one capability index on `repository_provides` instead of two. Neither
+change moves a table definition, so the revision is the only thing separating
+the shapes. Revision 27's cut was correctness: `provides.provenance` is JSON
+text inside a UNIQUE contract index and no resync rebuilds installed rows, so a
+database mixing both provenance shapes would admit one path twice as two
+distinct providers. Revision 28's cut is physical: an index lives in the
+database file for its lifetime, so a revision-27 database would keep serving a
+`(kind, capability)` index the build no longer defines, and its physical schema
+would disagree with the revision it reports.
 
 Databases from retired schema revisions are rejected with an exact recovery
 command. `conary system rebuild-db --discard-state --yes` consolidates the

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-08
-revision: 17
+revision: 18
 summary: Document Remi source, sparse sync, signing, canonical-map, repository trust, conversion, publication, and serving authority
 ---
 
@@ -276,11 +276,11 @@ the authenticated source artifact. Public, OCI, index, search, chunk, and
 garbage-collection paths validate that typed artifact instead of filling
 missing fields with guesses or empty values. Architecture and the repository
 provide digest are required constructor and API-view fields, and the current
-schema rejects missing, empty, or malformed values. Schema revision 27 retains
-revision 26's source-authority, fail-closed state constraints, and explicit
-mixing policy for every persisted source pin, and stores path-owning capability
-provenance without a duplicated path. It is a pre-alpha
-hard cut: prior databases are rebuilt and re-ingested from configured
+schema rejects missing, empty, or malformed values. Schema revision 28 retains
+revision 27's source-authority, fail-closed state constraints, explicit mixing
+policy for every persisted source pin, and path-free capability provenance, and
+carries one capability index on `repository_provides` instead of two. It is a
+pre-alpha hard cut: prior databases are rebuilt and re-ingested from configured
 repository authority rather than migrated. Local conversion tracking is
 written only after the CCS install transaction commits.
 

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-08
-revision: 30
+revision: 31
 summary: Document exact profile-owned source policy, multi-root model authority, Remi CCS package authority, canonical map authority, native repository authority, package identity, full-adoption root continuity, and lifecycle handoff
 ---
 
@@ -391,8 +391,33 @@ RSS from 6.33 GiB to 5.15 GiB, with row counts identical. What remains is not
 provenance: at 4.78 GB the `repository_provides` table held 2,332 MB against
 1,684 MB of index (869 MB for `(kind, capability)`, 815 MB for `(capability)`,
 127 MB for the package key), so every path is still stored once in the table
-and twice more in indexes. Path interning or index consolidation is the next
-lever, not a second pass over provenance.
+and twice more in indexes.
+
+Index consolidation is the lever that answered. `capability` was the second
+column of the `(kind, capability)` composite, so that index could never serve a
+capability-only seek -- which is what every provider lookup issues -- and only
+the single statement that also filters `kind` could use it. Schema revision 28
+retires it. Measured on the same corpus and revision, with row counts identical
+at 10,074,782: the synced database falls from 3,903,258,624 to 2,991,742,976
+bytes (-23.4%), and the difference is exactly the 911,515,648 bytes the retired
+index occupied, with the table (1,570,963,456), the capability index
+(854,863,872), and the package key (133,562,368) byte-identical across the
+pair. Peak process RSS is unchanged (0.2% across six runs): an index that is
+not read during a sync costs disk, not resident memory.
+
+The kind-filtering statement now seeks the capability index and filters the
+rows one capability holds. No statement in the inventory falls back to a table
+scan, before or after. The corpus bounds that filter exactly: its most-provided
+capability is `/usr/lib/.build-id` at 20,494 providers, and 9,498,629 of the
+10,074,782 rows are `file`, so the worst measured latency change is +6.7 ms on
+a hot capability whose kind does not match, while an ordinary package lookup is
+unchanged at 0.014 ms.
+
+Persist-phase timing is deliberately not quoted for this change. Five
+same-binary baseline syncs on this host ranged from 450.5 s to 952.4 s under
+concurrent build load, a spread far larger than any delta worth claiming, so
+the persist effect of maintaining one fewer index across 10M inserts remains
+unpriced rather than estimated.
 
 The contract was derived against the package managers' and repository
 generators' own documentation:


### PR DESCRIPTION
## #330, decided by query plans and priced by bytes

The issue guessed either index could die; EXPLAIN + mutation proved the single-column index is load-bearing (composite-only collapses capability seeks to a 10M-row traversal) and the composite is the redundancy. Third option (reorder) priced and rejected on measurement. All 12 statements touching the table inventoried with before/after plans against real 3.9GB/2.99GB databases; zero regressions to scan; kind-query latency defended on the hottest corpus capability (+1.5% matching, +6.7ms worst mismatched).

**Size: −911,515,648 bytes (−23.35%), byte-exact to the retired index, reproduced across two trios.** Persist: honestly UNPRICED — both trios failed the ±15% baseline-variance bound under sibling load (trio 2 reversed trio 1's direction, which is what stopped a false directional claim); docs state the gap instead of a number.

SCHEMA_VERSION 27→28 per the established gate (rides the NEXT release — production just took 27's rebuild with v0.12.0, so 28 waits for the next scheduled one). Tests: gate (absolute revisions), index inventory, statement-plan pinning (with the honest note that no-SCAN alone was toothless — explicit seek assertions have the teeth); all mutation-checked.

## Verification (real output, private target dir)

conary-core 3387 / conary / remi / conaryd all green; workspace clippy `-D warnings`, fmt, doc-truth; BOTH owning cards' (resolution, database-state) focused proofs + gates green. Luna review: clean, no findings.

Found and filed: #340 (ProvidesIndex::build loads 10M rows per install — biggest remaining filelists-scale item), #341 (query-path scan + dead fn), #342 (agent-context.sh bash -lc resets CARGO_TARGET_DIR — caused a card proof to verify a different binary, caught by test-count mismatch).

Closes #330. Refs #327, #329, #331.