### PR TITLE
fix(install): ordering witnesses come from the transaction's end state

### DIFF
--- a/apps/conary/src/commands/install/batch.rs
+++ b/apps/conary/src/commands/install/batch.rs
@@ -22,6 +22,7 @@ mod ordering;
 mod preparation;
 mod promises;
 mod relations;
+mod witness_universe;
 
 use super::ccs_removal_hooks::CcsRemovalHookPlan;
 use super::inner;

--- a/apps/conary/src/commands/install/batch/ordering.rs
+++ b/apps/conary/src/commands/install/batch/ordering.rs
@@ -2,9 +2,11 @@
 
 //! Deterministic dependency-first ordering for an exact selected batch.
 
-use super::promises::PromiseWitnessPlan;
+use super::promises::{PromiseWitnessPlan, dependency_requirements};
 use super::*;
-use conary_core::repository::dependency_model::RepositoryRequirementKind;
+use conary_core::repository::dependency_model::{
+    RepositoryRequirementGroup, RepositoryRequirementKind,
+};
 use conary_core::resolver::identity::{PackageIdentity, ProvidedCapability};
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -15,6 +17,11 @@ use std::collections::{BTreeMap, BTreeSet};
 /// packages and already installed ones -- because a promise made by an earlier
 /// transaction can hold up this one's edge, and because a single-package batch
 /// has promises to answer for even though it has nothing to order.
+///
+/// Both questions are asked of the transaction's end state, never of the
+/// database as it stands: [`super::witness_universe`] withholds every installed
+/// identity this transaction deletes, so an edge can only be certified against
+/// capabilities that still exist once the transaction commits.
 pub(super) fn order_packages_for_transaction(
     conn: &Connection,
     packages: &mut Vec<PreparedPackage>,
@@ -31,23 +38,47 @@ pub(super) fn order_packages_for_transaction(
     }
 
     let native_architecture = conary_core::repository::registry::detect_system_arch();
-    let installed = conary_core::resolver::load_installed_package_identities(conn)?
-        .into_iter()
-        .map(|mut identity| {
-            if identity.architecture.as_deref().is_none_or(str::is_empty) {
-                identity.architecture = Some(native_architecture.clone());
-            }
-            identity
-        })
-        .collect::<Vec<_>>();
+    let installed = super::witness_universe::surviving_installed_identities(
+        conn,
+        packages,
+        &native_architecture,
+    )?;
     let selected = packages
         .iter()
         .map(|package| transaction_identity(package, &native_architecture))
         .collect::<Vec<_>>();
     if packages.len() < 2 {
+        // A single-package batch has no edges to order, but it still reasons
+        // against a universe its own execution shrinks. When the package it
+        // supersedes -- or relation-removes -- was the only provider of one of
+        // its own requirements, nothing downstream would notice: with no holder
+        // left, promise planning has no obligation to record and the post
+        // condition has nothing to re-ask. So the transaction asks here, with
+        // the same expression evaluation and the same diagnostic the ordered
+        // path uses.
+        //
+        // This is exactly the withheld-identity case, not general single-package
+        // validation against installed state, which is its own open question.
+        let mut witnesses = installed;
+        witnesses.extend(selected.iter().cloned());
+        for package in packages.iter() {
+            for requirement in dependency_requirements(package) {
+                require_expression_satisfied(
+                    package,
+                    requirement,
+                    depending_architecture(package, &native_architecture),
+                    &native_architecture,
+                    &witnesses,
+                )?;
+            }
+        }
+        // The promise planner rebuilds this same universe from the installed
+        // identities and the selected ones, and decides holder side by position,
+        // so hand back the installed prefix rather than a second copy.
+        witnesses.truncate(witnesses.len() - selected.len());
         return super::promises::plan_promise_witnesses(
             packages,
-            installed,
+            witnesses,
             &selected,
             &native_architecture,
         );
@@ -57,17 +88,8 @@ pub(super) fn order_packages_for_transaction(
     let mut strong_edges = vec![BTreeSet::new(); packages.len()];
 
     for (dependent_index, package) in packages.iter().enumerate() {
-        let depending_architecture = package
-            .architecture
-            .as_deref()
-            .filter(|architecture| !architecture.is_empty())
-            .unwrap_or(&native_architecture);
-        for requirement in package.requirements.iter().filter(|requirement| {
-            matches!(
-                requirement.kind,
-                RepositoryRequirementKind::Depends | RepositoryRequirementKind::PreDepends
-            )
-        }) {
+        let depending_architecture = depending_architecture(package, &native_architecture);
+        for requirement in dependency_requirements(package) {
             let mut witnesses = installed.clone();
             witnesses.push(selected[dependent_index].clone());
             if expression_satisfied(
@@ -98,23 +120,13 @@ pub(super) fn order_packages_for_transaction(
                     break;
                 }
             }
-            if !expression_satisfied(
+            require_expression_satisfied(
+                package,
                 requirement,
-                package.semantics.version_scheme,
                 depending_architecture,
                 &native_architecture,
                 &witnesses,
-            )? {
-                anyhow::bail!(
-                    "selected package transaction does not satisfy exact {} requirement for {}: {}",
-                    requirement.kind.as_str(),
-                    package.name,
-                    requirement
-                        .native_text
-                        .as_deref()
-                        .unwrap_or("<typed expression>")
-                );
-            }
+            )?;
 
             // Remove every dispensable witness in a deterministic reverse
             // pass. The retained set is exact expression authority for the
@@ -162,6 +174,52 @@ pub(super) fn order_packages_for_transaction(
             .map(|index| slots[index].take().expect("package order repeats an index")),
     );
     Ok(plan)
+}
+
+/// The architecture a package's own requirements are evaluated for.
+fn depending_architecture<'a>(
+    package: &'a PreparedPackage,
+    native_architecture: &'a str,
+) -> &'a str {
+    package
+        .architecture
+        .as_deref()
+        .filter(|architecture| !architecture.is_empty())
+        .unwrap_or(native_architecture)
+}
+
+/// Certify one requirement against `witnesses`, or fail the transaction.
+///
+/// One owner for the diagnostic, because two paths ask this: the ordered path,
+/// after adding every batch member that could witness the edge, and the
+/// single-package path, which has only the surviving installed identities and
+/// the package itself. Both failures mean the same thing -- the transaction's
+/// end state does not provide what the package requires.
+fn require_expression_satisfied(
+    package: &PreparedPackage,
+    requirement: &RepositoryRequirementGroup,
+    depending_architecture: &str,
+    native_architecture: &str,
+    witnesses: &[PackageIdentity],
+) -> Result<()> {
+    if expression_satisfied(
+        requirement,
+        package.semantics.version_scheme,
+        depending_architecture,
+        native_architecture,
+        witnesses,
+    )? {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "selected package transaction does not satisfy exact {} requirement for {}: {}",
+        requirement.kind.as_str(),
+        package.name,
+        requirement
+            .native_text
+            .as_deref()
+            .unwrap_or("<typed expression>")
+    )
 }
 
 fn expression_satisfied(

--- a/apps/conary/src/commands/install/batch/promises.rs
+++ b/apps/conary/src/commands/install/batch/promises.rs
@@ -110,7 +110,11 @@ impl PromiseWitnessPlan {
     }
 }
 
-fn dependency_requirements(
+/// The hard requirements a transaction must be able to certify.
+///
+/// Shared with [`super::ordering`] so the edge validator and the promise
+/// planner cannot disagree about which requirements are in scope.
+pub(super) fn dependency_requirements(
     package: &PreparedPackage,
 ) -> impl Iterator<Item = &RepositoryRequirementGroup> {
     package.requirements.iter().filter(|requirement| {

--- a/apps/conary/src/commands/install/batch/relations.rs
+++ b/apps/conary/src/commands/install/batch/relations.rs
@@ -5,7 +5,38 @@
 use super::*;
 use std::collections::HashSet;
 
+/// The exact relation facts of one batch, in transaction-element order.
+///
+/// Relation planning is asked two different questions -- which installed
+/// packages leave (before ordering, by [`super::witness_universe`]) and where
+/// each removal is sequenced (here, after ordering) -- and both must present
+/// the batch the same way.
+pub(super) fn incoming_relation_facts(
+    packages: &[PreparedPackage],
+) -> Vec<conary_core::transaction::IncomingPackageRelations<'_>> {
+    packages
+        .iter()
+        .map(
+            |package| conary_core::transaction::IncomingPackageRelations {
+                name: &package.name,
+                version: &package.version,
+                architecture: package.architecture.as_deref(),
+                version_scheme: package.semantics.version_scheme,
+                provides: &package.provides,
+                relations: &package.relations,
+            },
+        )
+        .collect()
+}
+
 impl BatchInstaller<'_> {
+    /// Plan the negative-relation effects of the ordered batch.
+    ///
+    /// This runs after ordering because the transaction index each removal
+    /// carries is its sequencing point: the removal runs immediately before that
+    /// incoming element, and a package that conflicts with the removed one must
+    /// never be unpacked before it. Only the ordered batch knows which of
+    /// several triggering elements comes first.
     pub(super) fn plan_package_relations_for_batch(
         &self,
         conn: &Connection,
@@ -18,19 +49,7 @@ impl BatchInstaller<'_> {
             .into_iter()
             .flatten()
             .collect::<HashSet<_>>();
-        let incoming = packages
-            .iter()
-            .map(
-                |package| conary_core::transaction::IncomingPackageRelations {
-                    name: &package.name,
-                    version: &package.version,
-                    architecture: package.architecture.as_deref(),
-                    version_scheme: package.semantics.version_scheme,
-                    provides: &package.provides,
-                    relations: &package.relations,
-                },
-            )
-            .collect::<Vec<_>>();
+        let incoming = incoming_relation_facts(packages);
         let plan = conary_core::transaction::plan_package_relation_batch_facts(conn, &incoming)?;
 
         if let Some(removal) = plan

--- a/apps/conary/src/commands/install/batch/tests.rs
+++ b/apps/conary/src/commands/install/batch/tests.rs
@@ -11,6 +11,9 @@ use conary_core::payload::{
 };
 use std::collections::BTreeMap;
 
+#[path = "tests/witness_universe.rs"]
+mod witness_universe;
+
 fn payload_node(kind: PayloadNodeKind, mode: u32) -> PayloadNode {
     PayloadNode {
         kind,

--- a/apps/conary/src/commands/install/batch/tests/witness_universe.rs
+++ b/apps/conary/src/commands/install/batch/tests/witness_universe.rs
@@ -1,0 +1,290 @@
+// apps/conary/src/commands/install/batch/tests/witness_universe.rs
+
+//! The identities a transaction may reason with are the ones it leaves behind.
+//!
+//! Each test installs a prior transaction, then asks the ordering validator
+//! about a batch that deletes one of the identities that transaction left. The
+//! deleted identity's capabilities must not certify a dependency edge, because
+//! they are gone the moment this batch commits -- while the same capability
+//! carried forward by the incoming version, or held by a package this batch
+//! leaves alone, must still certify it.
+
+use super::*;
+use conary_core::repository::dependency_model::{
+    ProvidedCapability, RepositoryRequirementClause, RepositoryRequirementGroup,
+    RepositoryRequirementKind, SourcePackageFormat,
+};
+use conary_core::repository::versioning::VersionScheme;
+
+const PROMISED_CONFIG: &str = "/etc/crypto-policies/back-ends/krb5.config";
+const SHIPPED_LIBRARY: &str = "/usr/lib64/libcrypto.so.3";
+
+/// The exact installed trove a later batch supersedes.
+fn installed_trove(conn: &rusqlite::Connection, name: &str) -> Trove {
+    Trove::list_all(conn)
+        .unwrap()
+        .into_iter()
+        .find(|trove| trove.name == name)
+        .unwrap_or_else(|| panic!("the prior transaction must have installed {name}"))
+}
+
+/// `name` prepared as the exact upgrade of the installed trove it replaces.
+///
+/// Preparation binds an incoming package to the trove it supersedes. That
+/// binding, not the shared package name, is what makes the installed identity
+/// outgoing: a name can be shared by identities this transaction never touches.
+fn upgrade_of(conn: &rusqlite::Connection, name: &str, payload: &str) -> PreparedPackage {
+    let mut package = prepared_test_package(name, payload, b"upgraded");
+    package.version = "2.0.0".to_string();
+    package.provides = vec![crate::commands::test_helpers::exact_package_self_provider(
+        name,
+        "2.0.0",
+        VersionScheme::Rpm,
+    )];
+    package.install_reason = InstallReason::Dependency;
+    package.is_upgrade = true;
+    package.old_trove = Some(Box::new(installed_trove(conn, name)));
+    package
+}
+
+/// An ordinary source-derived provider for a path the package ships.
+fn shipped(path: &str) -> ProvidedCapability {
+    ProvidedCapability::payload_file(SourcePackageFormat::Rpm, path)
+}
+
+fn obsoletes(name: &str) -> RepositoryRequirementGroup {
+    RepositoryRequirementGroup::simple(
+        RepositoryRequirementKind::Obsolete,
+        RepositoryRequirementClause::name_only(name.to_string()),
+    )
+}
+
+fn database_after(temp: &std::path::Path, prior: Vec<PreparedPackage>) -> rusqlite::Connection {
+    let (db_path, _db_path_string) = db_with_prior_transaction(temp, prior);
+    conary_core::db::open(&db_path).unwrap()
+}
+
+fn ordered_names(packages: &[PreparedPackage]) -> Vec<&str> {
+    packages
+        .iter()
+        .map(|package| package.name.as_str())
+        .collect()
+}
+
+fn assert_unsatisfied_for(error: &anyhow::Error, dependent: &str) {
+    let message = format!("{error:#}");
+    assert!(
+        message.contains(&format!(
+            "selected package transaction does not satisfy exact depends requirement for {dependent}"
+        )),
+        "{message}"
+    );
+}
+
+#[test]
+fn an_upgrade_that_drops_a_promise_cannot_witness_the_edge_that_leaned_on_it() {
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let conn = database_after(
+        temp.path(),
+        vec![crypto_policies_with_promise(PROMISED_CONFIG)],
+    );
+
+    // The installed 1.0.0 promises the path. This transaction replaces it with
+    // a version that does not, so reading the promise off the row the
+    // transaction is about to delete certifies an edge against a capability
+    // that stops existing at commit.
+    let mut dropped = vec![
+        krb5_depending_on(depends_on(PROMISED_CONFIG)),
+        upgrade_of(
+            &conn,
+            "crypto-policies",
+            "/usr/share/crypto-policies/DEFAULT",
+        ),
+    ];
+
+    let error =
+        super::super::ordering::order_packages_for_transaction(&conn, &mut dropped).unwrap_err();
+
+    assert_unsatisfied_for(&error, "krb5-libs");
+}
+
+#[test]
+fn an_upgrade_that_keeps_the_promise_still_witnesses_the_edge() {
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let conn = database_after(
+        temp.path(),
+        vec![crypto_policies_with_promise(PROMISED_CONFIG)],
+    );
+
+    // Same supersession, but the incoming version carries the promise forward.
+    // Withholding the outgoing identity must not cost the transaction an edge
+    // its own members still provide -- and the promising member now has to be
+    // installed before the package that leans on it.
+    let mut kept = vec![
+        krb5_depending_on(depends_on(PROMISED_CONFIG)),
+        upgrade_of(
+            &conn,
+            "crypto-policies",
+            "/usr/share/crypto-policies/DEFAULT",
+        ),
+    ];
+    kept[1].provides.push(promised(PROMISED_CONFIG));
+
+    super::super::ordering::order_packages_for_transaction(&conn, &mut kept).unwrap();
+
+    assert_eq!(ordered_names(&kept), vec!["crypto-policies", "krb5-libs"]);
+}
+
+#[test]
+fn an_upgrade_that_drops_a_shipped_path_cannot_witness_the_edge_that_leaned_on_it() {
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let mut installed = prepared_test_package("openssl-libs", SHIPPED_LIBRARY, b"crypto");
+    installed.provides.push(shipped(SHIPPED_LIBRARY));
+    let conn = database_after(temp.path(), vec![installed]);
+
+    // Nothing about this is specific to promises: an ordinary provide the
+    // incoming version drops is just as absent at commit as a dropped promise.
+    let mut dropped = vec![
+        krb5_depending_on(depends_on(SHIPPED_LIBRARY)),
+        upgrade_of(&conn, "openssl-libs", "/usr/lib64/libcrypto.so.4"),
+    ];
+
+    let error =
+        super::super::ordering::order_packages_for_transaction(&conn, &mut dropped).unwrap_err();
+
+    assert_unsatisfied_for(&error, "krb5-libs");
+}
+
+#[test]
+fn an_upgrade_that_keeps_a_shipped_path_still_witnesses_the_edge() {
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let mut installed = prepared_test_package("openssl-libs", SHIPPED_LIBRARY, b"crypto");
+    installed.provides.push(shipped(SHIPPED_LIBRARY));
+    let conn = database_after(temp.path(), vec![installed]);
+
+    let mut kept = vec![
+        krb5_depending_on(depends_on(SHIPPED_LIBRARY)),
+        upgrade_of(&conn, "openssl-libs", SHIPPED_LIBRARY),
+    ];
+    kept[1].provides.push(shipped(SHIPPED_LIBRARY));
+
+    super::super::ordering::order_packages_for_transaction(&conn, &mut kept).unwrap();
+
+    assert_eq!(ordered_names(&kept), vec!["openssl-libs", "krb5-libs"]);
+}
+
+#[test]
+fn a_package_this_transaction_removes_by_relation_cannot_witness_an_edge() {
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let mut legacy = prepared_test_package("legacy-tool", "/usr/bin/tool", b"tool");
+    legacy.provides.push(shipped("/usr/bin/tool"));
+    let conn = database_after(temp.path(), vec![legacy]);
+    let dependent = || {
+        let mut dependent =
+            prepared_test_package("tool-plugin", "/usr/lib/tool/plugin.so", b"plug");
+        dependent.requirements = vec![depends_on("/usr/bin/tool")];
+        dependent
+    };
+
+    // Nothing in the batch is upgrading legacy-tool: the incoming package
+    // obsoletes it, which is decided by the same relation authority that plans
+    // the removal. The installed provider is outgoing all the same, so the path
+    // it owns cannot certify the plugin's requirement.
+    let mut obsoleting = prepared_test_package("modern-tool", "/usr/bin/modern-tool", b"modern");
+    obsoleting.relations = vec![obsoletes("legacy-tool")];
+    let mut removing = vec![dependent(), obsoleting];
+
+    let error =
+        super::super::ordering::order_packages_for_transaction(&conn, &mut removing).unwrap_err();
+
+    assert_unsatisfied_for(&error, "tool-plugin");
+
+    // The same batch without the relation leaves legacy-tool installed, and its
+    // path witnesses the requirement exactly as before.
+    let mut untouched = vec![
+        dependent(),
+        prepared_test_package("modern-tool", "/usr/bin/modern-tool", b"modern"),
+    ];
+
+    super::super::ordering::order_packages_for_transaction(&conn, &mut untouched)
+        .expect("an installed provider this batch leaves alone must still witness the edge");
+}
+
+#[test]
+fn a_lone_package_that_upgrades_away_its_own_promised_provider_fails() {
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let conn = database_after(
+        temp.path(),
+        vec![crypto_policies_with_promise(PROMISED_CONFIG)],
+    );
+
+    // One package, nothing to order, and the only holder of the promise it
+    // depends on is the version it replaces. Withholding that identity is
+    // right, but the batch must then say so: with no holder left there is no
+    // promise obligation to record, so silence here would commit an
+    // unsatisfiable dependency with nothing downstream left to catch it.
+    let mut lone = vec![upgrade_of(
+        &conn,
+        "crypto-policies",
+        "/usr/share/crypto-policies/DEFAULT",
+    )];
+    lone[0].requirements = vec![depends_on(PROMISED_CONFIG)];
+
+    let error =
+        super::super::ordering::order_packages_for_transaction(&conn, &mut lone).unwrap_err();
+
+    assert_unsatisfied_for(&error, "crypto-policies");
+}
+
+#[test]
+fn a_lone_package_that_upgrades_away_a_shipped_path_it_requires_fails() {
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let mut openssl = prepared_test_package("openssl-libs", SHIPPED_LIBRARY, b"crypto");
+    openssl.provides.push(shipped(SHIPPED_LIBRARY));
+    let conn = database_after(
+        temp.path(),
+        vec![openssl, crypto_policies_with_promise(PROMISED_CONFIG)],
+    );
+
+    // The withheld capability is an ordinary provide this time. The promised
+    // path is what gives a single-package batch a reason to compute a universe
+    // at all -- whether every single-package batch should validate against
+    // installed state is a separate open question -- and the requirement that
+    // fails is the shipped one the superseded version alone provided.
+    let mut lone = vec![upgrade_of(
+        &conn,
+        "openssl-libs",
+        "/usr/lib64/libcrypto.so.4",
+    )];
+    lone[0].requirements = vec![depends_on(PROMISED_CONFIG), depends_on(SHIPPED_LIBRARY)];
+
+    let error =
+        super::super::ordering::order_packages_for_transaction(&conn, &mut lone).unwrap_err();
+
+    assert_unsatisfied_for(&error, "openssl-libs");
+}
+
+#[test]
+fn a_lone_package_whose_provider_survives_the_transaction_orders() {
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let conn = database_after(
+        temp.path(),
+        vec![crypto_policies_with_promise(PROMISED_CONFIG)],
+    );
+
+    // Same single-package shape, same promise, but this batch touches nobody:
+    // the installed holder is still standing at commit, so the requirement is
+    // certified and the transaction proceeds to its promise obligations.
+    let mut lone = vec![krb5_depending_on(depends_on(PROMISED_CONFIG))];
+
+    super::super::ordering::order_packages_for_transaction(&conn, &mut lone)
+        .expect("a surviving installed holder must still certify a lone package's requirement");
+}

--- a/apps/conary/src/commands/install/batch/witness_universe.rs
+++ b/apps/conary/src/commands/install/batch/witness_universe.rs
@@ -1,0 +1,85 @@
+// apps/conary/src/commands/install/batch/witness_universe.rs
+
+//! Which installed identities may witness this transaction's own reasoning.
+//!
+//! Ordering and promise planning certify dependency edges against a set of
+//! package identities. That set is the transaction's *end state*, not the
+//! database as it stands when planning runs: an identity this transaction
+//! itself deletes cannot carry an edge the transaction is about to rely on.
+//!
+//! Two installed identities leave during a batch, and both used to remain
+//! admissible witnesses:
+//!
+//! * the pre-upgrade identity of a package the batch upgrades, whose
+//!   capabilities -- ordinary provides and promised paths alike -- the incoming
+//!   version is free to drop; and
+//! * an installed package an incoming negative relation removes, which is
+//!   selected by the same relation authority that plans the removal.
+//!
+//! Both are named by exact trove identity, never by package name: a name can be
+//! shared by parallel-installed identities, and only the trove this transaction
+//! deletes is leaving. The surviving set plus the incoming identities is what
+//! the transaction actually provides when it commits.
+
+use super::*;
+use conary_core::resolver::identity::PackageIdentity;
+use std::collections::BTreeSet;
+
+/// The installed identities that survive this transaction, ready to witness.
+///
+/// Architecture is defaulted to the native one where an installed row left it
+/// empty, because requirement evaluation compares architecture qualifiers and
+/// an installed identity with no architecture is a native-architecture one.
+pub(super) fn surviving_installed_identities(
+    conn: &Connection,
+    packages: &[PreparedPackage],
+    native_architecture: &str,
+) -> Result<Vec<PackageIdentity>> {
+    let outgoing = outgoing_installed_troves(conn, packages)?;
+    Ok(
+        conary_core::resolver::load_installed_package_identities(conn)?
+            .into_iter()
+            .filter(|identity| {
+                identity
+                    .installed_trove_id
+                    .is_none_or(|trove_id| !outgoing.contains(&trove_id))
+            })
+            .map(|mut identity| {
+                if identity.architecture.as_deref().is_none_or(str::is_empty) {
+                    identity.architecture = Some(native_architecture.to_string());
+                }
+                identity
+            })
+            .collect(),
+    )
+}
+
+/// Every installed trove this transaction deletes.
+///
+/// Superseded identities come from the batch itself: preparation already bound
+/// each incoming package to the exact installed trove it replaces.
+///
+/// Relation removals come from the same planner that later attaches them to the
+/// incoming packages, asked here for a different question. *Which* installed
+/// packages leave is a property of the batch's composition and installed state,
+/// so it is answerable before the batch is ordered. *When* each removal runs is
+/// not: a removal is sequenced before the earliest incoming element that
+/// triggers it, and "earliest" only exists once the transaction has an
+/// execution order. [`super::relations`] answers that second question after
+/// ordering, against the ordered batch.
+fn outgoing_installed_troves(
+    conn: &Connection,
+    packages: &[PreparedPackage],
+) -> Result<BTreeSet<i64>> {
+    let mut outgoing = packages
+        .iter()
+        .map(PreparedPackage::old_trove_id)
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect::<BTreeSet<_>>();
+    let incoming = super::relations::incoming_relation_facts(packages);
+    let plan = conary_core::transaction::plan_package_relation_batch_facts(conn, &incoming)?;
+    outgoing.extend(plan.removals.iter().map(|removal| removal.trove_id));
+    Ok(outgoing)
+}

--- a/crates/conary-core/src/transaction/package_relations/tests.rs
+++ b/crates/conary-core/src/transaction/package_relations/tests.rs
@@ -92,6 +92,17 @@ fn install_trove(conn: &Connection, name: &str, version: &str, scheme: VersionSc
     trove.insert(conn).unwrap()
 }
 
+fn relation_facts(package: &TestPackage) -> IncomingPackageRelations<'_> {
+    IncomingPackageRelations {
+        name: package.name(),
+        version: package.version(),
+        architecture: package.architecture(),
+        version_scheme: package.version_scheme(),
+        provides: &package.provides,
+        relations: package.relations(),
+    }
+}
+
 fn incoming(relation: RepositoryRequirementGroup) -> TestPackage {
     TestPackage {
         name: "newpkg".to_string(),
@@ -312,6 +323,63 @@ fn atomic_batch_attributes_installed_rich_conflict_to_all_causal_packages() {
         vec!["new-a".to_string(), "new-b".to_string()]
     );
     assert!(plan.removals[0].ownership_transfer_packages.is_empty());
+}
+
+#[test]
+fn batch_removal_set_is_order_free_while_its_sequencing_is_not() {
+    let (_temp, conn) = create_test_db();
+    let target = install_trove(&conn, "shared-target", "1", VersionScheme::Rpm);
+    let conflicting = |name: &str| TestPackage {
+        name: name.to_string(),
+        version: "1".to_string(),
+        provides: Vec::new(),
+        relations: vec![
+            parse_native_relation(
+                RepositoryRequirementKind::Conflict,
+                VersionScheme::Rpm,
+                "shared-target",
+            )
+            .unwrap(),
+        ],
+    };
+    let first = conflicting("new-a");
+    let second = conflicting("new-b");
+
+    let forward = plan_package_relation_batch_facts(
+        &conn,
+        &[relation_facts(&first), relation_facts(&second)],
+    )
+    .unwrap();
+    let reversed = plan_package_relation_batch_facts(
+        &conn,
+        &[relation_facts(&second), relation_facts(&first)],
+    )
+    .unwrap();
+
+    // Which installed packages leave depends on the batch's composition and the
+    // installed state, never on the order the batch is presented in. Ordering
+    // relies on exactly this: it withholds the outgoing identities before the
+    // transaction has an execution order at all.
+    let removed = |plan: &PackageRelationPlan| {
+        plan.removals
+            .iter()
+            .map(|removal| removal.trove_id)
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(removed(&forward), vec![target]);
+    assert_eq!(removed(&reversed), vec![target]);
+
+    // Where the removal is sequenced does depend on the order: it runs before
+    // the earliest element that triggers it, so it is planned against the
+    // ordered batch rather than reused from the pre-ordering answer.
+    assert_eq!(
+        forward.removals[0].triggering_incoming.package_name,
+        "new-a"
+    );
+    assert_eq!(
+        reversed.removals[0].triggering_incoming.package_name,
+        "new-b"
+    );
 }
 
 #[test]

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -190,6 +190,7 @@ mutation flows for local package operations.
 `apps/conary/src/commands/install/batch/config.rs`;
 `apps/conary/src/commands/install/batch/execution.rs`;
 `apps/conary/src/commands/install/batch/promises.rs`;
+`apps/conary/src/commands/install/batch/witness_universe.rs`;
 `apps/conary/src/commands/generation/selected_root.rs`;
 `apps/conary/src/commands/generation/config_transaction.rs`;
 `apps/conary/src/commands/generation/publication.rs`;

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-08
-revision: 41
+revision: 42
 summary: Define source-independent lifecycle, source-authority handoff, generation activation, and configuration transactions for RPM, Debian, and Arch packages
 ---
 
@@ -762,6 +762,50 @@ native-upgrade rollback schema or mutate a host root and compensate afterward.
 Once SQLite commits, the exact selected-root candidate and typed publication
 debt are the retry authority. Config auxiliary ownership remains defined by the
 documented suffix grammar and the forward `GenerationConfigTransaction`.
+
+### Ordering Witness Universe
+
+A transaction certifies its dependency edges against a set of package
+identities. That set is the transaction's end state, not the installed database
+as it stands while planning runs. An identity the transaction itself deletes
+cannot witness an edge the transaction relies on: the capability is gone at
+commit, so the edge was certified against something that never coexists with
+the packages it was certified for.
+
+The admitted universe is `(installed - outgoing) + incoming`, where `outgoing`
+is every installed trove this transaction deletes:
+
+- the pre-upgrade trove each incoming package supersedes, whose ordinary
+  provides and promised paths the incoming version is free to drop; and
+- every installed trove an incoming negative relation removes.
+
+Outgoing identities are named by exact installed trove identity, never by
+package name: parallel-installed identities can share a name, and only the
+trove this transaction deletes is leaving. Withholding an outgoing identity
+never costs a correct transaction an edge. A capability the incoming version
+carries forward is admitted as an incoming identity instead, and the edge it
+certifies then also orders the provider before its dependent, which the stale
+installed identity had been silently excusing.
+
+Which installed packages leave is a property of the batch's composition and the
+installed state, so relation planning answers that question before the batch is
+ordered. Where each removal is sequenced is a different question with a
+different answer: a removal runs immediately before the earliest incoming
+element that triggers it, and "earliest" exists only once the transaction has an
+execution order, so relation planning answers that one against the ordered
+batch.
+
+Withholding an identity must never make a transaction quieter than admitting it
+would have been. Where the universe is computed, every `Depends`/`PreDepends`
+requirement of every incoming package is certified against it, and a requirement
+the end state cannot satisfy fails the transaction with one typed diagnostic --
+including a batch of one package, which has no edges to order but can still be
+the transaction that removes the sole provider of its own requirement. Nothing
+downstream would report that case: with no holder left there is no promised-path
+obligation to record, so the post-condition below would have nothing to re-ask.
+
+The promised-path post-condition plans and re-evaluates against this same
+universe.
 
 ### Promised-Path Post-Condition
 


### PR DESCRIPTION
## #334: (installed − outgoing) + incoming, by exact trove id

Both filed shapes closed (pre-upgrade identities, relation-removed identities), with the load-bearing design distinction proven rather than asserted: the removal SET is order-invariant (test plans both orders — same set, different trigger attribution), so it's computed pre-ordering; removal SEQUENCING stays post-ordering because earliest-incoming attribution is order-dependent and pre-ordering it can sequence a removal after a conflicting unpack. #347 tracks the single-pass planner refactor.

**Review chain with a P1:** Luna caught that the new filtering regressed the single-package path — sole-provider-removed left no holder, no obligation, silent commit of an unsatisfiable dependency (pre-change, the stale provider at least produced a checkable obligation). Fixed narrowly: all paths including `len<2` certify every incoming Depends/PreDepends against the filtered universe with the shared typed diagnostic; duplicate filter/bail authority deduplicated into promises.rs; the #345 general question stays filed and the boundary is written into code comment and spec ("withholding must never make a transaction quieter than admitting would have been").

Negative control bonus: the kept-capability tests now order provider-first — the stale identity had been silently excusing that edge ordering.

## Verification (real output, disk-backed private target dir)

conary-core 3496/0, conary 1283/0 (+ #335's 10 promise tests untouched), fmt, workspace clippy `-D warnings`, doc-truth, install card focused proof (216 passed). Four mutation kills, each killing exactly its expected subset. Two env-caused test failures en route were diagnosed to tmpfs exhaustion (bus error in doctest link, EDQUOT in try-watch) — not retried, root-caused, and the hog removed from /tmp; TMPDIR=/var/tmp/<name> is the working recipe (hermetic-config requires root-or-self-owned ancestry, which excludes /conary paths).

Found and filed earlier from this slice: #344 (CCS dependency validation same-class), #345 (single-package validation gap, general form), #346 (deconfiguration witnesses), #347 (single-pass relation planning).

Closes #334. Refs #335, #345, #347.