### PR TITLE
fix(remi): serve MCP as modern-only stateless Streamable HTTP on rmcp 3.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,6 +426,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,6 +1577,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+dependencies = [
+ "darling_core 0.24.0",
+ "darling_macro 0.24.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1598,6 +1614,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,6 +1646,17 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+dependencies = [
+ "darling_core 0.24.0",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5058,12 +5098,12 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "c8dddc5b1924b9a59fba420166160ca2c4663a4e01803e52eda33070f56d63c8"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "futures",
@@ -5089,15 +5129,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "6898e24cd16342b59bfa8a53c2c04b9cf62fc8a2cfea57b9c038b09984bfc521"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.0",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6096,9 +6136,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
 dependencies = [
  "bytes",
  "futures-util",
@@ -6198,6 +6238,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ mdns-sd = "0.20.0"
 dashmap = "6.0"
 
 # MCP
-rmcp = "1.7.0"
+rmcp = "3.1.2"
 schemars = "1.0"
 
 # Other shared

--- a/apps/conary-test/src/server/mcp.rs
+++ b/apps/conary-test/src/server/mcp.rs
@@ -279,7 +279,7 @@ impl TestMcpServer {
         })?;
 
         let text = to_json_text(&suites)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Start a new test run for a given suite, distro, and phase.
@@ -313,7 +313,7 @@ impl TestMcpServer {
             "phase": result.phase,
         });
         let text = to_json_text(&value)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Get the status and results of a specific test run.
@@ -327,7 +327,7 @@ impl TestMcpServer {
             match client.get_run(params.run_id as i64).await {
                 Ok(data) => {
                     let text = to_json_text(&data)?;
-                    return Ok(CallToolResult::success(vec![Content::text(text)]));
+                    return Ok(CallToolResult::success(vec![ContentBlock::text(text)]));
                 }
                 Err(e) => {
                     tracing::debug!(
@@ -345,7 +345,7 @@ impl TestMcpServer {
             Some(entry) => {
                 let json_str = to_json_report(&entry)
                     .map_err(|e| McpError::internal_error(format!("Report error: {e}"), None))?;
-                Ok(CallToolResult::success(vec![Content::text(json_str)]))
+                Ok(CallToolResult::success(vec![ContentBlock::text(json_str)]))
             }
             None => Err(McpError::invalid_params(
                 format!("Run {} not found", params.run_id),
@@ -380,7 +380,7 @@ impl TestMcpServer {
             {
                 Ok(data) => {
                     let text = to_json_text(&data)?;
-                    return Ok(CallToolResult::success(vec![Content::text(text)]));
+                    return Ok(CallToolResult::success(vec![ContentBlock::text(text)]));
                 }
                 Err(e) => {
                     tracing::debug!("Remi proxy failed for list_runs, falling back to local: {e}");
@@ -392,7 +392,7 @@ impl TestMcpServer {
         let summaries = service::list_runs(&self.state, limit);
 
         let text = to_json_text(&summaries)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Get the result of a single test within a run.
@@ -406,7 +406,7 @@ impl TestMcpServer {
             match client.get_test(params.run_id as i64, &params.test_id).await {
                 Ok(data) => {
                     let text = to_json_text(&data)?;
-                    return Ok(CallToolResult::success(vec![Content::text(text)]));
+                    return Ok(CallToolResult::success(vec![ContentBlock::text(text)]));
                 }
                 Err(e) => {
                     tracing::debug!(
@@ -438,7 +438,7 @@ impl TestMcpServer {
             })?;
 
         let text = to_json_text(test)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// List all configured distros with their Remi distro name and repo name.
@@ -448,7 +448,7 @@ impl TestMcpServer {
     async fn list_distros(&self) -> Result<CallToolResult, McpError> {
         let distros = service::list_distros(&self.state);
         let text = to_json_text(&distros)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Cancel a running test run by its run ID.
@@ -469,7 +469,7 @@ impl TestMcpServer {
             "status": "cancelled",
         });
         let text = to_json_text(&value)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Re-run a single test from a previous run.
@@ -502,7 +502,7 @@ impl TestMcpServer {
             "status": "pending",
         });
         let text = to_json_text(&value)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Get stdout/stderr logs from all attempts of a test.
@@ -519,7 +519,7 @@ impl TestMcpServer {
             {
                 Ok(data) => {
                     let text = to_json_text(&data)?;
-                    return Ok(CallToolResult::success(vec![Content::text(text)]));
+                    return Ok(CallToolResult::success(vec![ContentBlock::text(text)]));
                 }
                 Err(e) => {
                     tracing::debug!(
@@ -536,7 +536,7 @@ impl TestMcpServer {
             .map_err(error_to_mcp)?;
 
         let text = to_json_text(&logs)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Get artifact information and summary for a run.
@@ -549,7 +549,7 @@ impl TestMcpServer {
             service::get_run_artifacts(&self.state, params.run_id).map_err(error_to_mcp)?;
 
         let text = to_json_text(&artifacts)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Build a container image for a configured distro.
@@ -570,7 +570,7 @@ impl TestMcpServer {
             "status": "built",
         });
         let text = to_json_text(&value)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// List all available container images.
@@ -581,7 +581,7 @@ impl TestMcpServer {
             .map_err(anyhow_to_mcp)?;
 
         let text = to_json_text(&images)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Clean up stopped conary-test containers.
@@ -594,7 +594,7 @@ impl TestMcpServer {
             .map_err(anyhow_to_mcp)?;
 
         let text = to_json_text(&result)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     // -----------------------------------------------------------------------
@@ -623,7 +623,7 @@ impl TestMcpServer {
             "suites": suites,
         });
         let text = to_json_text(&value)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Remove old container images, keeping the N most recent per distro.
@@ -717,7 +717,7 @@ impl TestMcpServer {
             "errors": errors,
         });
         let text = to_json_text(&value)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Get details about a container image: tag, creation date, size, and labels.
@@ -762,7 +762,7 @@ impl TestMcpServer {
                 .unwrap_or(serde_json::json!([])),
         });
         let text = to_json_text(&value)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     // -----------------------------------------------------------------------
@@ -790,7 +790,7 @@ impl TestMcpServer {
                 run_command("git", &["fetch", "--all"], Some(&dir)).await?;
             output.push_str(&format_command_output("git fetch", code, &stdout, &stderr));
             if code != 0 {
-                return Ok(CallToolResult::success(vec![Content::text(output)]));
+                return Ok(CallToolResult::success(vec![ContentBlock::text(output)]));
             }
 
             let (code, stdout, stderr) =
@@ -802,13 +802,13 @@ impl TestMcpServer {
                 &stderr,
             ));
             if code != 0 {
-                return Ok(CallToolResult::success(vec![Content::text(output)]));
+                return Ok(CallToolResult::success(vec![ContentBlock::text(output)]));
             }
         } else {
             let (code, stdout, stderr) = run_command("git", &["pull"], Some(&dir)).await?;
             output.push_str(&format_command_output("git pull", code, &stdout, &stderr));
             if code != 0 {
-                return Ok(CallToolResult::success(vec![Content::text(output)]));
+                return Ok(CallToolResult::success(vec![ContentBlock::text(output)]));
             }
         }
 
@@ -830,7 +830,7 @@ impl TestMcpServer {
             &stderr,
         ));
 
-        Ok(CallToolResult::success(vec![Content::text(output)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(output)]))
     }
 
     /// Rebuild conary and/or conary-test binaries from current source.
@@ -890,7 +890,7 @@ impl TestMcpServer {
             }
         }
 
-        Ok(CallToolResult::success(vec![Content::text(output)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(output)]))
     }
 
     /// Restart the conary-test systemd user service.
@@ -916,7 +916,7 @@ impl TestMcpServer {
             "message": "Service restart scheduled in 1 second. The current process will be replaced.",
         });
         let text = to_json_text(&value)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Build test fixtures (CCS packages for integration tests).
@@ -958,7 +958,7 @@ impl TestMcpServer {
 
         let output =
             format_command_output(&format!("build-fixtures ({group})"), code, &stdout, &stderr);
-        Ok(CallToolResult::success(vec![Content::text(output)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(output)]))
     }
 
     /// Publish test fixtures to the Remi repository.
@@ -974,7 +974,7 @@ impl TestMcpServer {
         let (code, stdout, stderr) = run_command("bash", &[&script_path], Some(&dir)).await?;
 
         let output = format_command_output("publish-fixtures", code, &stdout, &stderr);
-        Ok(CallToolResult::success(vec![Content::text(output)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(output)]))
     }
 
     /// Get deployment status: binary version, uptime, WAL pending items,
@@ -985,7 +985,7 @@ impl TestMcpServer {
     async fn deploy_status(&self) -> Result<CallToolResult, McpError> {
         let status = service::deployment_status(&self.state).map_err(anyhow_to_mcp)?;
         let text = to_json_text(&status)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Flush pending WAL items to Remi.
@@ -1059,7 +1059,7 @@ impl TestMcpServer {
             "status": if failed == 0 { "ok" } else { "partial" },
         });
         let text = to_json_text(&value)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 }
 
@@ -1093,7 +1093,7 @@ impl ServerHandler for TestMcpServer {
         &self,
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<CallToolResult, McpError>> + Send + '_ {
+    ) -> impl Future<Output = Result<CallToolResponse, McpError>> + Send + '_ {
         let tool_context = ToolCallContext::new(self, request, context);
         async move { self.tool_router.call(tool_context).await }
     }

--- a/apps/conary/src/commands/packaging_mcp/server.rs
+++ b/apps/conary/src/commands/packaging_mcp/server.rs
@@ -155,7 +155,7 @@ impl ServerHandler for PackagingMcpServer {
         &self,
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<CallToolResult, McpError>> + Send + '_ {
+    ) -> impl Future<Output = Result<CallToolResponse, McpError>> + Send + '_ {
         let tool_context = ToolCallContext::new(self, request, context);
         async move { self.tool_router.call(tool_context).await }
     }

--- a/apps/remi/src/server/handlers/admin/mod.rs
+++ b/apps/remi/src/server/handlers/admin/mod.rs
@@ -135,9 +135,17 @@ pub(crate) mod test_helpers {
         std::fs::create_dir_all(&config.chunk_dir).unwrap();
         std::fs::create_dir_all(&config.cache_dir).unwrap();
 
-        let state = Arc::new(RwLock::new(
-            crate::server::ServerState::new(config).expect("test server state"),
-        ));
+        let mut server_state = crate::server::ServerState::new(config).expect("test server state");
+        // ServerState::with_options points test_db_path at the production
+        // /conary/test-data.db; every fixture-backed handler must stay inside
+        // the tempdir.
+        server_state.test_db_path = Some(
+            tmp.path()
+                .join("test-data.db")
+                .to_string_lossy()
+                .into_owned(),
+        );
+        let state = Arc::new(RwLock::new(server_state));
 
         // Build the external admin router (includes auth middleware)
         let app = crate::server::routes::create_external_admin_router(state, None);
@@ -169,9 +177,16 @@ pub(crate) mod test_helpers {
             release_publish: test_release_publish(db_path.parent().unwrap()),
             ..Default::default()
         };
-        let state = Arc::new(tokio::sync::RwLock::new(
-            crate::server::ServerState::new(config).expect("test server state"),
-        ));
+        let mut server_state = crate::server::ServerState::new(config).expect("test server state");
+        server_state.test_db_path = Some(
+            db_path
+                .parent()
+                .unwrap()
+                .join("test-data.db")
+                .to_string_lossy()
+                .into_owned(),
+        );
+        let state = Arc::new(tokio::sync::RwLock::new(server_state));
         crate::server::routes::create_external_admin_router(state, None)
     }
 

--- a/apps/remi/src/server/mcp.rs
+++ b/apps/remi/src/server/mcp.rs
@@ -12,6 +12,7 @@
 //! DB-touching tools delegate to [`crate::server::admin_service`] so that
 //! business logic is shared with the HTTP admin handlers.
 
+use std::borrow::Cow;
 use std::future::Future;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -56,9 +57,8 @@ fn chunk_gc_tool_output(report: &ChunkGcReport) -> Result<serde_json::Value, Mcp
 
 /// MCP server instance that wraps Remi admin operations as tools.
 ///
-/// Each MCP session gets its own `RemiMcpServer` clone, but they all share
-/// the same `Arc<RwLock<ServerState>>` so mutations (if any) are visible
-/// across sessions.
+/// Each MCP request gets a fresh `RemiMcpServer` clone, while all requests
+/// share the same `Arc<RwLock<ServerState>>` for Remi state.
 #[derive(Clone)]
 pub struct RemiMcpServer {
     state: Arc<RwLock<ServerState>>,
@@ -229,7 +229,7 @@ impl RemiMcpServer {
             .map_err(service_err_to_mcp)?;
 
         let text = to_json_text(&tokens)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Create a new admin API token. Returns the plaintext token once.
@@ -255,7 +255,7 @@ impl RemiMcpServer {
             "scopes": created.scopes,
         });
         let text = to_json_text(&result)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Delete an admin API token by ID.
@@ -273,7 +273,7 @@ impl RemiMcpServer {
         if deleted {
             let result = serde_json::json!({"status": "deleted", "token_id": params.token_id});
             let text = to_json_text(&result)?;
-            Ok(CallToolResult::success(vec![Content::text(text)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
         } else {
             Err(McpError::invalid_params(
                 format!("Token with ID {} not found", params.token_id),
@@ -313,7 +313,7 @@ impl RemiMcpServer {
             .collect();
 
         let text = to_json_text(&json)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Get details for a specific repository by name.
@@ -344,7 +344,7 @@ impl RemiMcpServer {
                     "default_strategy": r.default_strategy,
                 });
                 let text = to_json_text(&result)?;
-                Ok(CallToolResult::success(vec![Content::text(text)]))
+                Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
             }
             None => Err(McpError::invalid_params(
                 format!("Repository '{}' not found", params.name),
@@ -390,7 +390,7 @@ impl RemiMcpServer {
             .collect();
 
         let text = to_json_text(&json)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Add a federation peer by endpoint URL.
@@ -422,7 +422,7 @@ impl RemiMcpServer {
             "tier": peer.tier,
         });
         let text = to_json_text(&result)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Delete a federation peer by its peer ID.
@@ -440,7 +440,7 @@ impl RemiMcpServer {
         if deleted {
             let result = serde_json::json!({"status": "deleted", "peer_id": params.peer_id});
             let text = to_json_text(&result)?;
-            Ok(CallToolResult::success(vec![Content::text(text)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
         } else {
             Err(McpError::invalid_params(
                 format!("Peer with ID '{}' not found", params.peer_id),
@@ -473,7 +473,7 @@ impl RemiMcpServer {
         .map_err(service_err_to_mcp)?;
 
         let text = to_json_text(&entries)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Purge old audit log entries. Deletes entries older than the given date.
@@ -495,7 +495,7 @@ impl RemiMcpServer {
             "before": params.before,
         });
         let text = to_json_text(&result)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     // -----------------------------------------------------------------------
@@ -522,7 +522,7 @@ impl RemiMcpServer {
         .await
         .map_err(service_err_to_mcp)?;
         let text = to_json_text(&runs)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Get full details for a test run including all test result summaries.
@@ -535,7 +535,7 @@ impl RemiMcpServer {
             .await
             .map_err(service_err_to_mcp)?;
         let text = to_json_text(&detail)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Get a single test result with all execution steps and their logs.
@@ -548,7 +548,7 @@ impl RemiMcpServer {
             .await
             .map_err(service_err_to_mcp)?;
         let text = to_json_text(&detail)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Get test execution logs, optionally filtered by stream and step index.
@@ -569,7 +569,7 @@ impl RemiMcpServer {
         .await
         .map_err(service_err_to_mcp)?;
         let text = to_json_text(&logs)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Get aggregate test health: total runs, recent activity, and pass/fail
@@ -582,7 +582,7 @@ impl RemiMcpServer {
             .await
             .map_err(service_err_to_mcp)?;
         let text = to_json_text(&health)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     // -----------------------------------------------------------------------
@@ -612,7 +612,7 @@ impl RemiMcpServer {
             .map_err(service_err_to_mcp)?;
 
         let text = to_json_text(&chunk_gc_tool_output(&report)?)?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     // -----------------------------------------------------------------------
@@ -643,7 +643,7 @@ impl RemiMcpServer {
             "status": "ok",
             "new_mappings": count,
         }))?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
     /// Trigger an immediate Repology + AppStream fetch cycle.
@@ -678,7 +678,7 @@ impl RemiMcpServer {
             "repology_cached": repology_count,
             "appstream_cached": appstream_count,
         }))?;
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 }
 
@@ -687,6 +687,10 @@ impl RemiMcpServer {
 // ---------------------------------------------------------------------------
 
 impl ServerHandler for RemiMcpServer {
+    fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
+        Cow::Borrowed(&[ProtocolVersion::V_2026_07_28])
+    }
+
     fn get_info(&self) -> ServerInfo {
         server_info(
             "remi-mcp",
@@ -703,8 +707,10 @@ impl ServerHandler for RemiMcpServer {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> impl Future<Output = Result<ListToolsResult, McpError>> + Send + '_ {
+        let mut tools = self.tool_router.list_all();
+        tools.sort_by(|left, right| left.name.cmp(&right.name));
         std::future::ready(Ok(ListToolsResult {
-            tools: self.tool_router.list_all(),
+            tools,
             ..Default::default()
         }))
     }
@@ -713,7 +719,7 @@ impl ServerHandler for RemiMcpServer {
         &self,
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<CallToolResult, McpError>> + Send + '_ {
+    ) -> impl Future<Output = Result<CallToolResponse, McpError>> + Send + '_ {
         let tool_context = ToolCallContext::new(self, request, context);
         async move { self.tool_router.call(tool_context).await }
     }
@@ -738,6 +744,20 @@ mod tests {
 
         let info = server.get_info();
         assert_eq!(info.server_info.name, "remi-mcp");
+    }
+
+    #[test]
+    fn mcp_server_supports_only_the_modern_protocol_version() {
+        let config = crate::server::ServerConfig::default();
+        let state = Arc::new(RwLock::new(
+            crate::server::ServerState::new(config).expect("test server state"),
+        ));
+        let server = RemiMcpServer::new(state);
+
+        assert_eq!(
+            server.supported_protocol_versions().as_ref(),
+            [ProtocolVersion::V_2026_07_28]
+        );
     }
 
     #[test]

--- a/apps/remi/src/server/routes.rs
+++ b/apps/remi/src/server/routes.rs
@@ -365,10 +365,121 @@ async fn ban_middleware(
 mod tests {
     use super::*;
     use axum::body::Body;
+    use serde_json::{Value, json};
     use std::net::Ipv4Addr;
     use std::sync::Arc;
     use tokio::sync::RwLock;
     use tower::ServiceExt;
+
+    const MCP_PROTOCOL_VERSION: &str = "2026-07-28";
+    const MCP_TEST_TOKEN: &str = "test-admin-token-12345";
+
+    fn mcp_post(
+        id: i64,
+        method: &str,
+        header_version: &str,
+        body_version: &str,
+        request_params: Value,
+        name: Option<&str>,
+        origin: Option<&str>,
+    ) -> Request<Body> {
+        let mut params = request_params
+            .as_object()
+            .cloned()
+            .expect("MCP request parameters must be an object");
+        params.insert(
+            "_meta".to_string(),
+            json!({
+                "io.modelcontextprotocol/protocolVersion": body_version,
+                "io.modelcontextprotocol/clientInfo": {
+                    "name": "remi-router-test",
+                    "version": "1.0.0"
+                },
+                "io.modelcontextprotocol/clientCapabilities": {}
+            }),
+        );
+
+        let mut builder = Request::builder()
+            .method(Method::POST)
+            .uri("/mcp")
+            .header("Host", "localhost")
+            .header("Authorization", format!("Bearer {MCP_TEST_TOKEN}"))
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .header("MCP-Protocol-Version", header_version)
+            .header("Mcp-Method", method);
+        if let Some(name) = name {
+            builder = builder.header("Mcp-Name", name);
+        }
+        if let Some(origin) = origin {
+            builder = builder.header("Origin", origin);
+        }
+
+        builder
+            .body(Body::from(
+                serde_json::to_vec(&json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "method": method,
+                    "params": Value::Object(params),
+                }))
+                .unwrap(),
+            ))
+            .unwrap()
+    }
+
+    async fn mcp_json(response: Response) -> Value {
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&body).unwrap_or_else(|error| {
+            panic!(
+                "MCP response should be JSON: {error}; body={}",
+                String::from_utf8_lossy(&body)
+            )
+        })
+    }
+
+    fn tools_list_request(id: i64) -> Request<Body> {
+        mcp_post(
+            id,
+            "tools/list",
+            MCP_PROTOCOL_VERSION,
+            MCP_PROTOCOL_VERSION,
+            json!({}),
+            None,
+            None,
+        )
+    }
+
+    fn tools_call_request(id: i64) -> Request<Body> {
+        mcp_post(
+            id,
+            "tools/call",
+            MCP_PROTOCOL_VERSION,
+            MCP_PROTOCOL_VERSION,
+            json!({
+                "name": "test_health",
+                "arguments": {}
+            }),
+            Some("test_health"),
+            None,
+        )
+    }
+
+    fn tool_names(body: &Value) -> Vec<String> {
+        body["result"]["tools"]
+            .as_array()
+            .expect("tools/list should return a tools array")
+            .iter()
+            .map(|tool| {
+                tool["name"]
+                    .as_str()
+                    .expect("MCP tool should have a name")
+                    .to_string()
+            })
+            .collect()
+    }
 
     #[test]
     fn test_cors_layer_restricted_no_origins() {
@@ -532,13 +643,25 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(
-            matches!(
-                response.status(),
-                StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
-            ),
-            "unauthenticated MCP requests should be rejected"
-        );
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_route_rejects_invalid_bearer() {
+        let (app, _db_path) = crate::server::handlers::admin::test_helpers::test_app().await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/mcp")
+                    .header("Authorization", "Bearer invalid-mcp-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]
@@ -569,6 +692,156 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn modern_mcp_posts_are_stateless_and_tools_are_sorted() {
+        let (app, _db_path) = crate::server::handlers::admin::test_helpers::test_app().await;
+
+        let first = app.clone().oneshot(tools_list_request(1)).await.unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+        assert!(
+            first.headers().get("Mcp-Session-Id").is_none(),
+            "stateless MCP responses must not echo a session id"
+        );
+        let first_body = mcp_json(first).await;
+        assert_eq!(first_body["result"]["resultType"], "complete");
+        let names = tool_names(&first_body);
+        let mut sorted_names = names.clone();
+        sorted_names.sort();
+        assert_eq!(
+            names, sorted_names,
+            "tools/list order must be deterministic"
+        );
+
+        let second = app.oneshot(tools_list_request(2)).await.unwrap();
+        assert_eq!(second.status(), StatusCode::OK);
+        assert!(second.headers().get("Mcp-Session-Id").is_none());
+        let second_body = mcp_json(second).await;
+        assert_eq!(second_body["result"]["resultType"], "complete");
+        assert_eq!(tool_names(&second_body), names);
+    }
+
+    #[tokio::test]
+    async fn modern_mcp_tool_call_returns_complete_result() {
+        let (app, _db_path) = crate::server::handlers::admin::test_helpers::test_app().await;
+
+        let response = app.oneshot(tools_call_request(3)).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.headers().get("Mcp-Session-Id").is_none());
+        let body = mcp_json(response).await;
+        assert_eq!(body["result"]["resultType"], "complete");
+        assert_eq!(body["result"]["isError"], false);
+    }
+
+    #[tokio::test]
+    async fn modern_mcp_rejects_unsupported_protocol_version_with_supported_data() {
+        let (app, _db_path) = crate::server::handlers::admin::test_helpers::test_app().await;
+        let response = app
+            .oneshot(mcp_post(
+                4,
+                "tools/list",
+                "2025-11-25",
+                "2025-11-25",
+                json!({}),
+                None,
+                None,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = mcp_json(response).await;
+        assert_eq!(body["error"]["code"], -32022);
+        assert_eq!(
+            body["error"]["data"]["supported"],
+            json!([MCP_PROTOCOL_VERSION])
+        );
+    }
+
+    #[tokio::test]
+    async fn modern_mcp_rejects_header_body_protocol_mismatch() {
+        let (app, _db_path) = crate::server::handlers::admin::test_helpers::test_app().await;
+        let response = app
+            .oneshot(mcp_post(
+                5,
+                "tools/list",
+                MCP_PROTOCOL_VERSION,
+                "2025-11-25",
+                json!({}),
+                None,
+                None,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = mcp_json(response).await;
+        assert_eq!(body["error"]["code"], -32020);
+    }
+
+    #[tokio::test]
+    async fn modern_mcp_get_and_delete_are_not_allowed() {
+        let (app, _db_path) = crate::server::handlers::admin::test_helpers::test_app().await;
+
+        for method in [Method::GET, Method::DELETE] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method(method)
+                        .uri("/mcp")
+                        .header("Host", "localhost")
+                        .header("Authorization", format!("Bearer {MCP_TEST_TOKEN}"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+        }
+    }
+
+    #[tokio::test]
+    async fn modern_mcp_origin_policy_rejects_bad_origin_and_allows_missing_origin() {
+        let (app, _db_path) = crate::server::handlers::admin::test_helpers::test_app().await;
+
+        let bad_origin = app
+            .clone()
+            .oneshot(mcp_post(
+                6,
+                "tools/list",
+                MCP_PROTOCOL_VERSION,
+                MCP_PROTOCOL_VERSION,
+                json!({}),
+                None,
+                Some("https://evil.example"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(bad_origin.status(), StatusCode::FORBIDDEN);
+
+        let missing_origin = app.oneshot(tools_list_request(7)).await.unwrap();
+        assert_eq!(missing_origin.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn modern_mcp_origin_policy_allows_configured_local_admin_port() {
+        let (app, _db_path) = crate::server::handlers::admin::test_helpers::test_app().await;
+        let response = app
+            .oneshot(mcp_post(
+                8,
+                "tools/list",
+                MCP_PROTOCOL_VERSION,
+                MCP_PROTOCOL_VERSION,
+                json!({}),
+                None,
+                Some("http://localhost:8082"),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/apps/remi/src/server/routes/mcp.rs
+++ b/apps/remi/src/server/routes/mcp.rs
@@ -7,6 +7,21 @@ pub(super) fn create_mcp_router(
     state: Arc<RwLock<ServerState>>,
 ) -> Router<Arc<RwLock<ServerState>>> {
     let state_for_mcp = state;
+    // Remi deliberately exposes only the modern, stateless MCP transport.
+    // Keep rmcp's loopback host default; Origin is separately restricted to
+    // local browser origins and the two configured admin-port variants.
+    let config = rmcp::transport::streamable_http_server::StreamableHttpServerConfig::default()
+        .with_legacy_session_mode(false)
+        .with_json_response(true)
+        .with_allowed_origins([
+            "http://127.0.0.1",
+            "http://localhost",
+            "http://127.0.0.1:8081",
+            "http://localhost:8081",
+            "http://127.0.0.1:8082",
+            "http://localhost:8082",
+        ])
+        .with_stateless_protocol_metadata_required(true);
     let mcp_service = rmcp::transport::streamable_http_server::StreamableHttpService::new(
         move || {
             Ok(crate::server::mcp::RemiMcpServer::new(
@@ -14,9 +29,9 @@ pub(super) fn create_mcp_router(
             ))
         },
         Arc::new(
-            rmcp::transport::streamable_http_server::session::local::LocalSessionManager::default(),
+            rmcp::transport::streamable_http_server::session::never::NeverSessionManager::default(),
         ),
-        Default::default(),
+        config,
     );
     let mcp_service = tower::service_fn(move |request: Request<Body>| {
         let mut service = mcp_service.clone();

--- a/crates/conary-mcp/src/tools.rs
+++ b/crates/conary-mcp/src/tools.rs
@@ -5,7 +5,7 @@ use rmcp::{ErrorData as McpError, model::*};
 
 pub fn contract_tool_result<T: serde::Serialize>(value: &T) -> Result<CallToolResult, McpError> {
     let text = crate::contract_json_text(value)?;
-    Ok(CallToolResult::success(vec![Content::text(text)]))
+    Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
 }
 
 #[cfg(test)]

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-08
-revision: 18
+revision: 19
 summary: Document Remi source, sparse sync, signing, canonical-map, repository trust, conversion, publication, and serving authority
 ---
 
@@ -442,3 +442,25 @@ MCP tool `chunk_gc` is the agent surface, and `POST /v1/admin/chunk-gc` on the
 external admin router is the operator surface; both require the `admin` scope.
 Deletion requires an explicit `dry_run: false`, so an omitted body, an omitted
 field, or an absent MCP parameter previews the run instead of deleting.
+
+## MCP
+
+The external admin `/mcp` endpoint is a modern-only, stateless Streamable HTTP
+surface using rmcp 3.1.2 and protocol revision `2026-07-28`. Every POST carries
+the protocol version and client metadata in `_meta`; Remi does not negotiate an
+`initialize` session, issue `Mcp-Session-Id`, retain session state, or serve the
+MCP GET and DELETE operations. The per-request handler shares Remi's state
+through the existing `Arc<RwLock<ServerState>>`, and every request remains
+behind the admin Bearer-token middleware.
+
+Origin validation permits `http://localhost` and `http://127.0.0.1`, including
+the default internal `8081` and external `8082` admin-port variants. The
+allowlist is fixed at these defaults; an operator who moves the admin ports in
+`remi.toml` must extend it in `create_mcp_router` (browser origins on other
+ports are rejected; CLI and curl clients send no `Origin` and are
+unaffected). A
+missing `Origin` is accepted for CLI and curl clients. Host validation keeps
+rmcp's default loopback allowlist; public hostnames are intentionally not added
+without a separately reviewed exposure decision. Changes to this MCP contract
+must update this module's frontmatter `revision` and its router-level protocol
+tests together.

--- a/docs/operations/agent-mcp-adapter-decision.md
+++ b/docs/operations/agent-mcp-adapter-decision.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-25
-revision: 9
+last_updated: 2026-08-09
+revision: 10
 summary: Decision record for Conary's stateless MCP adapter path and its current code and test evidence
 ---
 
@@ -14,13 +14,14 @@ discovery behavior on the existing session-based `rmcp` path.
 
 ## Current State
 
-- Workspace requirement: `rmcp = "1.7.0"` in `Cargo.toml`
-- Resolved dependency: `rmcp 1.7.0` in `Cargo.lock`
-- Latest public `rmcp` docs checked on 2026-05-24 list `rmcp 1.7.0`, but still
-  document session/initialize-era types such as `LocalSessionManager` and
-  `InitializeResult`
-- Current Remi and conary-test wiring uses `RoleServer`, `ServerHandler`,
-  `StreamableHttpService`, and `LocalSessionManager`
+- Workspace requirement: `rmcp = "3.1.2"` in `Cargo.toml` (bumped by the
+  #306 stateless migration; resolved to `rmcp 3.1.2` in `Cargo.lock`)
+- Remi's `/mcp` is modern-only stateless Streamable HTTP (protocol revision
+  `2026-07-28`, `NeverSessionManager`, no legacy session mode); the
+  authoritative description is `docs/modules/remi.md`
+- conary-test wiring still uses `RoleServer`, `ServerHandler`,
+  `StreamableHttpService`, and `LocalSessionManager`; that server layer is
+  slated for deletion in the #306 follow-up slice
 - Current live MCP surfaces are tool-only from Conary's product perspective
 - `crates/conary-mcp::stateless` contains the non-live compliance harness for
   request validation, discovery result modeling, cacheable result modeling, and


### PR DESCRIPTION
## Problem

Remi's external admin `/mcp` endpoint ran rmcp 1.7.0's session-era transport: `initialize` negotiation, `Mcp-Session-Id`, `LocalSessionManager` state, and GET/DELETE session operations — all superseded by the stateless posture in the MCP 2026-07-28 revision (decisions on record in #305/#306).

## Fix

- Workspace rmcp 1.7.0 → 3.1.2. `/mcp` now speaks only protocol revision `2026-07-28`: `NeverSessionManager`, `with_legacy_session_mode(false)`, JSON responses, per-request stateless `_meta` required, GET/DELETE → 405.
- Origin validation ON with a fixed loopback allowlist (no-port + `:8081`/`:8082` variants); rmcp's default loopback `allowed_hosts` unchanged — **this closes #305**. Bearer/admin-scope middleware boundary untouched.
- rmcp 3.x fallout: `Content` → `ContentBlock` (49 sites in conary-mcp, remi, conary-test); `ToolRouter::call` returns `CallToolResponse` directly, so the three hand-written `call_tool` boundaries drop their conversions. The 18 remi `#[tool]` handlers are untouched.
- Router-level protocol tests pin the contract: stateless POSTs, deterministic sorted `tools/list`, end-to-end `tools/call` with `resultType: complete` (wire-probed during review), unsupported-version and header/body-mismatch rejections, method rejection, Origin policy, 401/403 auth.
- **Fixture defect found by the new tool-call test:** `ServerState` defaults `test_db_path` to the production `/conary/test-data.db` and the admin `test_app` fixture inherited it — any test exercising a test-data handler depended on host state (this PR's test was the first). The fixture now provisions its test-data DB inside the fixture tempdir. Kept in this slice because the slice's own test is what exposes it and fails without it.
- Docs: `docs/modules/remi.md` revision 19 documents the modern posture; `docs/operations/agent-mcp-adapter-decision.md` revision 10 drops the stale rmcp 1.7.0 claim (DeepSeek review nit).

## Accepted, not fixed

- Origin allowlist is fixed at the default admin ports rather than derived from `remi.toml`; deriving needs state access at sync router-construction time. Documented in remi.md with the operator instruction. CLI/curl clients send no Origin and are unaffected.
- conary-test's own MCP server layer still uses the session-era API (compiles and passes under 3.1.2); it is slated for deletion in the follow-up slice (#306 decision record).

## Breaking (deliberate)

Clients negotiating older protocol revisions are rejected with a supported-versions error. Post-deploy empirical check planned: whether our own claude-code client negotiates `2026-07-28`; dual-era is a one-line revert per the decision comment if not.

## Verification

- `cargo check --workspace --all-targets` — exit 0
- `cargo test -p remi` (641 tests), `-p conary-test`, `-p conary mcp`, `-p conary-mcp` — 0 failures
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, `check-doc-truth.sh` — clean
- Wire probe: tools/call response body contains `"resultType":"complete","isError":false`
- Cross-review: Luna implemented (sandboxed, could not compile — honestly reported); verification here found the three compile/test defects above; DeepSeek reviewed the committed diff — verdict OK-to-ship pending green build (now green), stale-doc nit fixed, scope note answered above

Closes #306
Closes #305