### PR TITLE
fix(install): requirement validation runs for every batch size

### DIFF
--- a/apps/conary/src/commands/install/batch/ordering.rs
+++ b/apps/conary/src/commands/install/batch/ordering.rs
@@ -16,7 +16,8 @@ use std::collections::{BTreeMap, BTreeSet};
 /// facts. [`super::promises`] owns the second one for both holders -- incoming
 /// packages and already installed ones -- because a promise made by an earlier
 /// transaction can hold up this one's edge, and because a single-package batch
-/// has promises to answer for even though it has nothing to order.
+/// has requirements to certify and promises to answer for even though it has
+/// nothing to order.
 ///
 /// Both questions are asked of the transaction's end state, never of the
 /// database as it stands: [`super::witness_universe`] withholds every installed
@@ -26,18 +27,18 @@ pub(super) fn order_packages_for_transaction(
     conn: &Connection,
     packages: &mut Vec<PreparedPackage>,
 ) -> Result<PromiseWitnessPlan> {
-    let requirement_atoms = super::promises::batch_requirement_atom_names(packages);
-    if packages.len() < 2
-        && !super::promises::batch_requirements_can_lean_on_a_promise(
-            conn,
-            packages,
-            &requirement_atoms,
-        )?
-    {
-        return Ok(PromiseWitnessPlan::empty());
-    }
-
     let native_architecture = conary_core::repository::registry::detect_system_arch();
+    // A lone package with no hard requirements has nothing to certify and no
+    // edges to order, so the installed universe is not loaded for it. This is
+    // the only excused shape: one package, zero Depends/PreDepends. Every
+    // requirement-carrying batch of any size certifies below.
+    if packages.len() < 2
+        && packages
+            .iter()
+            .all(|package| dependency_requirements(package).next().is_none())
+    {
+        return Ok(PromiseWitnessPlan::default());
+    }
     let installed = super::witness_universe::surviving_installed_identities(
         conn,
         packages,
@@ -48,17 +49,17 @@ pub(super) fn order_packages_for_transaction(
         .map(|package| transaction_identity(package, &native_architecture))
         .collect::<Vec<_>>();
     if packages.len() < 2 {
-        // A single-package batch has no edges to order, but it still reasons
-        // against a universe its own execution shrinks. When the package it
-        // supersedes -- or relation-removes -- was the only provider of one of
-        // its own requirements, nothing downstream would notice: with no holder
-        // left, promise planning has no obligation to record and the post
-        // condition has nothing to re-ask. So the transaction asks here, with
+        // A single-package batch has no edges to order, but every requirement
+        // is still certified against the transaction's end state -- the
+        // package itself plus the installed identities that survive it -- with
         // the same expression evaluation and the same diagnostic the ordered
-        // path uses.
-        //
-        // This is exactly the withheld-identity case, not general single-package
-        // validation against installed state, which is its own open question.
+        // path uses. The transaction layer does not assume an upstream layer
+        // (the solver) already caught an unsatisfiable requirement, so a lone
+        // package is not excused from certification. When the package
+        // supersedes -- or relation-removes -- the only provider of one of its
+        // own requirements, nothing downstream would notice: with no holder
+        // left, promise planning has no obligation to record and the post
+        // condition has nothing to re-ask.
         let mut witnesses = installed;
         witnesses.extend(selected.iter().cloned());
         for package in packages.iter() {

--- a/apps/conary/src/commands/install/batch/promises.rs
+++ b/apps/conary/src/commands/install/batch/promises.rs
@@ -27,9 +27,8 @@
 //! materialize.
 
 use super::*;
-use conary_core::db::models::ProvideEntry;
 use conary_core::repository::dependency_model::{
-    CapabilityProvenance, ProvidedCapability, RepositoryRequirementGroup, RepositoryRequirementKind,
+    ProvidedCapability, RepositoryRequirementGroup, RepositoryRequirementKind,
 };
 use conary_core::repository::versioning::VersionScheme;
 use conary_core::resolver::identity::PackageIdentity;
@@ -104,12 +103,6 @@ pub(super) struct PromiseWitnessPlan {
     obligations: Vec<PromiseObligation>,
 }
 
-impl PromiseWitnessPlan {
-    pub(super) fn empty() -> Self {
-        Self::default()
-    }
-}
-
 /// The hard requirements a transaction must be able to certify.
 ///
 /// Shared with [`super::ordering`] so the edge validator and the promise
@@ -130,60 +123,6 @@ fn requirement_text(requirement: &RepositoryRequirementGroup) -> &str {
         .native_text
         .as_deref()
         .unwrap_or("<typed expression>")
-}
-
-/// Every capability name this batch names in a `Depends`/`PreDepends` atom.
-///
-/// This bounds which promises are even considered. It is exact data off the
-/// batch's own requirement expressions and decides nothing on its own: naming a
-/// path is not relying on it, which is what [`plan_promise_witnesses`] settles.
-pub(super) fn batch_requirement_atom_names(packages: &[PreparedPackage]) -> BTreeSet<String> {
-    let mut atoms = BTreeSet::new();
-    for package in packages {
-        for requirement in dependency_requirements(package) {
-            for clause in requirement.expression.atoms() {
-                atoms.insert(clause.name.clone());
-            }
-        }
-    }
-    atoms
-}
-
-/// Whether any package -- incoming or installed -- promises one of `atoms`.
-///
-/// A batch of two or more packages already loads the installed identity
-/// universe for ordering, so this exists for the single-package batch, which
-/// otherwise has no reason to load it at all. The incoming side is answered in
-/// memory; each installed probe is an indexed point lookup on
-/// `provides.capability` and the first hit ends the scan.
-pub(super) fn batch_requirements_can_lean_on_a_promise(
-    conn: &Connection,
-    packages: &[PreparedPackage],
-    atoms: &BTreeSet<String>,
-) -> Result<bool> {
-    let incoming = packages.iter().any(|package| {
-        package
-            .provides
-            .iter()
-            .any(|capability| capability.is_promised_path() && atoms.contains(&capability.name))
-    });
-    if incoming {
-        return Ok(true);
-    }
-    for atom in atoms {
-        let promised = ProvideEntry::find_all_by_capability(conn, atom)?
-            .iter()
-            .any(|entry| {
-                matches!(
-                    entry.provenance,
-                    CapabilityProvenance::SourcePromisedPath { .. }
-                )
-            });
-        if promised {
-            return Ok(true);
-        }
-    }
-    Ok(false)
 }
 
 /// Decide which requirements this transaction cannot satisfy without a promise.
@@ -225,9 +164,12 @@ pub(super) fn plan_promise_witnesses(
                 native_architecture,
                 &universe,
             )? {
-                // The ordering validator owns an unsatisfiable edge. Inventing a
-                // promise failure here would replace its diagnostic with a worse
-                // one.
+                // Requirement certification owns an unsatisfiable edge for
+                // every batch size: the ordered path certifies each
+                // requirement against the whole batch, and the single-package
+                // path certifies it against the same end state, both through
+                // the one typed diagnostic. Inventing a promise failure here
+                // would replace that diagnostic with a worse one.
                 continue;
             }
 

--- a/apps/conary/src/commands/install/batch/tests.rs
+++ b/apps/conary/src/commands/install/batch/tests.rs
@@ -644,7 +644,23 @@ fn no_current_generation_batch_materializes_db_state_and_publishes_selected_root
     let db_path = temp.path().join("conary.db");
     std::fs::create_dir_all(&root).unwrap();
     conary_core::db::init(&db_path).unwrap();
-    crate::commands::test_helpers::seed_test_bootable_runtime(&db_path);
+    let seeded_trove = crate::commands::test_helpers::seed_test_bootable_runtime(&db_path);
+
+    // The fixture requirement must be satisfiable: since #345, a single-package
+    // batch's requirements are certified against the end state like every other
+    // batch's, so the seeded runtime has to provide what the fixture depends
+    // on. The materialization assertions below are about batch state, not
+    // about requirement semantics, so the provider is seeded directly.
+    let conn = conary_core::db::open(&db_path).unwrap();
+    conary_core::db::models::ProvideEntry::new(
+        seeded_trove,
+        "libfixture".to_string(),
+        Some("2.0.0".to_string()),
+        conary_core::repository::versioning::VersionScheme::Rpm,
+    )
+    .insert(&conn)
+    .unwrap();
+    drop(conn);
 
     let db_path_string = db_path.to_string_lossy().into_owned();
     let mut package =
@@ -1057,6 +1073,85 @@ fn payload_file_provider_satisfies_an_exact_path_requirement_and_orders_provider
             .map(|package| package.name.as_str())
             .collect::<Vec<_>>(),
         vec!["bash", "systemd-udev"]
+    );
+}
+
+#[test]
+fn a_single_package_rejects_an_unsatisfiable_requirement_with_the_ordered_batches_diagnostic() {
+    let (_temp, conn) = empty_test_db();
+    let unsatisfiable = || {
+        let mut package = prepared_test_package("needy", "/usr/bin/needy", b"needy");
+        package.requirements = vec![depends_on("/usr/bin/never-provided")];
+        package
+    };
+
+    // The ordered path already fails this batch, naming the dependent and the
+    // exact requirement. A lone package must fail with the identical typed
+    // diagnostic: one owner for every batch size, so the two paths cannot
+    // drift. The solver never ran here -- the batch is prepared directly and
+    // handed to transaction validation, which is the only authority between
+    // the packages and the commit.
+    let mut ordered = vec![
+        unsatisfiable(),
+        prepared_test_package("other", "/usr/bin/other", b"other"),
+    ];
+    let ordered_error =
+        super::ordering::order_packages_for_transaction(&conn, &mut ordered).unwrap_err();
+    let mut lone = vec![unsatisfiable()];
+    let lone_error = super::ordering::order_packages_for_transaction(&conn, &mut lone).unwrap_err();
+
+    assert!(
+        ordered_error.to_string().contains(
+            "selected package transaction does not satisfy exact depends requirement for needy"
+        ),
+        "{ordered_error:#}"
+    );
+    assert!(
+        lone_error.to_string().contains(
+            "selected package transaction does not satisfy exact depends requirement for needy"
+        ),
+        "{lone_error:#}"
+    );
+    assert_eq!(
+        format!("{lone_error:#}"),
+        format!("{ordered_error:#}"),
+        "a single-package batch must fail with the same typed diagnostic as an ordered batch"
+    );
+}
+
+#[test]
+fn a_lone_package_install_batch_rejects_an_unsatisfiable_requirement_at_validation() {
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().join("root");
+    let db_path = temp.path().join("conary.db");
+    std::fs::create_dir_all(&root).unwrap();
+    conary_core::db::init(&db_path).unwrap();
+    crate::commands::test_helpers::seed_test_bootable_runtime(&db_path);
+    let db_path_string = db_path.to_string_lossy().into_owned();
+    let mut package = prepared_test_package("lone-tool", "/usr/bin/lone-tool", b"tool");
+    package.requirements = vec![depends_on("/usr/bin/never-provided")];
+
+    // Nothing upstream (no solver, no repository) ran on this package: the
+    // batch installer is the first authority to see it, so this is exactly the
+    // single-package install the len<2 early return used to wave through.
+    let error = BatchInstaller::new(&db_path_string, SandboxMode::Always)
+        .install_batch(vec![package])
+        .unwrap_err();
+
+    let message = format!("{error:#}");
+    assert!(
+        message.contains(
+            "selected package transaction does not satisfy exact depends requirement for lone-tool"
+        ),
+        "{message}"
+    );
+    let conn = conary_core::db::open(&db_path).unwrap();
+    assert!(
+        conary_core::db::models::Changeset::list_all(&conn)
+            .unwrap()
+            .is_empty(),
+        "validation must fail before any changeset applies"
     );
 }
 

--- a/apps/conary/src/commands/install/batch/tests/witness_universe.rs
+++ b/apps/conary/src/commands/install/batch/tests/witness_universe.rs
@@ -253,11 +253,10 @@ fn a_lone_package_that_upgrades_away_a_shipped_path_it_requires_fails() {
         vec![openssl, crypto_policies_with_promise(PROMISED_CONFIG)],
     );
 
-    // The withheld capability is an ordinary provide this time. The promised
-    // path is what gives a single-package batch a reason to compute a universe
-    // at all -- whether every single-package batch should validate against
-    // installed state is a separate open question -- and the requirement that
-    // fails is the shipped one the superseded version alone provided.
+    // The withheld capability is an ordinary provide this time. Every
+    // single-package batch is certified against the end-state universe since
+    // #345, promised path or not, and the requirement that fails is the
+    // shipped one the superseded version alone provided.
     let mut lone = vec![upgrade_of(
         &conn,
         "openssl-libs",
@@ -287,4 +286,26 @@ fn a_lone_package_whose_provider_survives_the_transaction_orders() {
 
     super::super::ordering::order_packages_for_transaction(&conn, &mut lone)
         .expect("a surviving installed holder must still certify a lone package's requirement");
+}
+
+#[test]
+fn a_lone_package_satisfied_by_surviving_installed_state_passes_validation() {
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let mut provider = prepared_test_package("libprovider", "/usr/lib64/libprovider.so.1", b"lib");
+    provider
+        .provides
+        .push(shipped("/usr/lib64/libprovider.so.1"));
+    let conn = database_after(temp.path(), vec![provider]);
+
+    // No promised path anywhere: since #345 the end-state universe is computed
+    // for every single-package batch, so an installed provider this batch
+    // leaves alone must certify the lone package's requirement exactly as it
+    // would certify an edge in an ordered batch. Uniform validation must not
+    // over-reject a correct lone install.
+    let mut lone = prepared_test_package("consumer", "/usr/bin/consumer", b"consumer");
+    lone.requirements = vec![depends_on("/usr/lib64/libprovider.so.1")];
+
+    super::super::ordering::order_packages_for_transaction(&conn, &mut vec![lone])
+        .expect("a surviving installed provider must certify a lone package's requirement");
 }

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -796,13 +796,15 @@ execution order, so relation planning answers that one against the ordered
 batch.
 
 Withholding an identity must never make a transaction quieter than admitting it
-would have been. Where the universe is computed, every `Depends`/`PreDepends`
-requirement of every incoming package is certified against it, and a requirement
-the end state cannot satisfy fails the transaction with one typed diagnostic --
-including a batch of one package, which has no edges to order but can still be
-the transaction that removes the sole provider of its own requirement. Nothing
-downstream would report that case: with no holder left there is no promised-path
-obligation to record, so the post-condition below would have nothing to re-ask.
+would have been. Every `Depends`/`PreDepends` requirement of every incoming
+package is certified against the end-state universe, and a requirement the end
+state cannot satisfy fails the transaction with one typed diagnostic. A batch of
+one package is not excused: it has no edges to order, but its requirements are
+certified against the same universe, whether or not any promised path is in
+play. Nothing downstream would report an unsatisfiable requirement instead --
+with no holder left there is no promised-path obligation to record, and the
+transaction layer does not assume an upstream layer (the solver) already caught
+it, so the post-condition below would have nothing to re-ask.
 
 The promised-path post-condition plans and re-evaluates against this same
 universe.


### PR DESCRIPTION
## Problem

`order_packages_for_transaction` gated single-package batches behind a promise-relevance check: a lone package whose requirement atoms could not lean on any promised path skipped transaction validation entirely. An unsatisfiable lone requirement was caught only by whatever ran earlier — and a direct install with no solver ran nothing at all. The comment at promises.rs claiming 'the ordering validator owns an unsatisfiable edge' was true only for len >= 2 (#345).

## Fix

- The promise gate is gone. Every incoming Depends/PreDepends requirement is certified against the transaction's end-state universe for every batch size; ordering (edges, SCC order) remains len >= 2. Both batch sizes fail through the same typed diagnostic — pinned **byte-identical** by test so the paths cannot drift.
- One excused shape, restored after review: a lone package with **zero** hard requirements skips the universe load entirely (nothing to certify, no edges) — the pre-slice fast path for dependency-free installs, without reopening the validation gap (Luna review P2).
- Hard cut of the gate's machinery in the same slice: `batch_requirement_atom_names`, `batch_requirements_can_lean_on_a_promise`, `PromiseWitnessPlan::empty` deleted; the false ownership comment corrected; the lifecycle spec's 'where the universe is computed' hedge replaced with an unconditional-certification statement.

## Review chain

DeepSeek implemented (environment declined all shell — every claim marked predicted/static, honestly). Reviewer verification: full conary (1000+ tests) + conary-core suites, clippy -D warnings, fmt, doc-truth — all green. **Mutation proof observed, not just static**: restoring the early return kills exactly the two new rejection tests (`unwrap_err` on `Ok`) and nothing else; the non-over-rejection test stays green. Luna cross-reviewed the commit: P2 (dependency-free singleton scan) fixed above; P1 — validation and promise planning run **before** `SelectedRootSession::begin` for every batch size, a pre-existing validate-then-lock TOCTOU this slice did not introduce — filed as #356 with the fix shape.

## Found, filed, or left

- #356: validate-before-lock TOCTOU (pre-existing, every batch size)
- `install_ccs_package_transactionally` is a separate transaction path whose requirement-validation story was not audited here (DeepSeek found-not-changed); #344's slice touches that neighborhood and its review should say whether a gap remains

Closes #345