### PR TITLE
fix(install): CCS dependent validation evaluates the transaction end state

### DIFF
--- a/apps/conary/src/commands/ccs/install/command.rs
+++ b/apps/conary/src/commands/ccs/install/command.rs
@@ -8,9 +8,30 @@ use std::path::Path;
 use super::super::payload_paths::validate_ccs_payload_paths;
 use super::capability_declaration::validate_ccs_capability_declaration;
 use super::component_selection::select_ccs_components;
-use super::dependency::validate_incoming_version_against_dependents;
-use crate::commands::install::{CcsTransactionInstallOptions, install_ccs_package_transactionally};
+use super::dependency::{incoming_package_identity, validate_incoming_version_against_dependents};
+use crate::commands::install::{
+    CcsTransactionInstallOptions, InstallIntent, UpgradeCheck, check_ccs_upgrade_status,
+    install_ccs_package_transactionally, install_semantics_for_ccs_manifest,
+};
 use crate::commands::open_db;
+
+/// Resolve the replacement trove through the same CCS upgrade authority used
+/// by the transaction, including its exact already-installed rule.
+pub(super) fn check_ccs_install_upgrade_status(
+    conn: &rusqlite::Connection,
+    pkg: &CcsPackage,
+    reinstall: bool,
+) -> Result<UpgradeCheck> {
+    let semantics = install_semantics_for_ccs_manifest(pkg.manifest())?;
+    check_ccs_upgrade_status(
+        conn,
+        pkg,
+        &semantics,
+        false,
+        InstallIntent::PackageChange,
+        reinstall,
+    )
+}
 
 /// Install a CCS package
 #[allow(clippy::too_many_arguments)]
@@ -76,37 +97,69 @@ pub async fn cmd_ccs_install(
     // Step 3: Check for existing installation
     let mut conn = open_db(db_path)?;
 
-    let existing = conary_core::db::models::Trove::find_by_name(&conn, ccs_pkg.name())?;
-    if !existing.is_empty() {
-        let old = &existing[0];
-        if old.version == ccs_pkg.version() {
-            if reinstall {
+    let upgrade = check_ccs_install_upgrade_status(&conn, &ccs_pkg, reinstall)?;
+    let replacing = match &upgrade {
+        UpgradeCheck::FreshInstall => None,
+        UpgradeCheck::AlreadyInstalled(trove) => {
+            anyhow::bail!(
+                "Package {} version {} ({}) is already installed",
+                trove.name,
+                trove.version,
+                trove.architecture.as_deref().unwrap_or("no-arch")
+            )
+        }
+        UpgradeCheck::Upgrade(trove)
+        | UpgradeCheck::Downgrade(trove)
+        | UpgradeCheck::Replatform(trove) => {
+            if reinstall
+                && trove.version == ccs_pkg.version()
+                && trove.package_release.as_deref() == ccs_pkg.package_release()
+                && trove.architecture.as_deref() == ccs_pkg.architecture()
+            {
                 println!(
                     "Reinstalling {} {} (--reinstall)",
                     ccs_pkg.name(),
                     ccs_pkg.version()
                 );
             } else {
-                anyhow::bail!(
-                    "Package {} version {} is already installed",
+                println!(
+                    "Upgrading {} from {} to {}",
                     ccs_pkg.name(),
+                    trove.version,
                     ccs_pkg.version()
                 );
             }
+            Some(trove.as_ref())
         }
-        println!(
-            "Upgrading {} from {} to {}",
-            ccs_pkg.name(),
-            old.version,
-            ccs_pkg.version()
-        );
-    }
-    validate_incoming_version_against_dependents(
+    };
+
+    // The validator and the transaction must reason about the same exact
+    // outgoing identities. Upgrade selection is architecture-slot based for a
+    // CCS install; relation removals are already planned by exact trove ID.
+    let relation_plan = conary_core::transaction::plan_package_relations(
         &conn,
-        ccs_pkg.name(),
-        ccs_pkg.version(),
+        &ccs_pkg,
         ccs_pkg.manifest().package.version_scheme,
     )?;
+    let mut outgoing_trove_ids = relation_plan
+        .removals
+        .iter()
+        .map(|removal| removal.trove_id)
+        .collect::<Vec<_>>();
+    if let Some(trove) = replacing {
+        // Relation removal and replacement may duplicate an ID intentionally; the validator deduplicates it.
+        let trove_id = trove.id.ok_or_else(|| {
+            anyhow::anyhow!(
+                "CCS replacement trove '{} {} ({})' has no database id",
+                trove.name,
+                trove.version,
+                trove.architecture.as_deref().unwrap_or("no-arch")
+            )
+        })?;
+        outgoing_trove_ids.push(trove_id);
+    }
+    let incoming_identity = incoming_package_identity(&ccs_pkg)?;
+    validate_incoming_version_against_dependents(&conn, &outgoing_trove_ids, &incoming_identity)?;
 
     // Step 4: Check dependencies
     if no_deps {

--- a/apps/conary/src/commands/ccs/install/command_reinstall_tests.rs
+++ b/apps/conary/src/commands/ccs/install/command_reinstall_tests.rs
@@ -68,6 +68,184 @@ async fn ccs_install_reinstall_dry_run_does_not_mutate_db() {
 }
 
 #[tokio::test]
+async fn ccs_noarch_replacement_uses_transaction_trove_for_dependent_validation() {
+    use conary_core::ccs::{BuildResult, CcsManifest, TrustPolicy};
+    use conary_core::db::models::{InstalledRequirementGroup, ProvideEntry, Trove, TroveType};
+    use conary_core::repository::dependency_model::{
+        ProvideArchitectureQualifier, RepositoryCapabilityKind, RepositoryRequirementKind,
+    };
+    use conary_core::repository::versioning::VersionScheme;
+
+    fn upgrade_trove_id(upgrade: &crate::commands::install::UpgradeCheck) -> i64 {
+        match upgrade {
+            crate::commands::install::UpgradeCheck::Upgrade(trove)
+            | crate::commands::install::UpgradeCheck::Downgrade(trove)
+            | crate::commands::install::UpgradeCheck::Replatform(trove) => {
+                trove.id.expect("upgrade trove must have a database id")
+            }
+            crate::commands::install::UpgradeCheck::FreshInstall
+            | crate::commands::install::UpgradeCheck::AlreadyInstalled(_) => {
+                panic!("expected a replacing upgrade trove")
+            }
+        }
+    }
+
+    fn insert_provider(
+        conn: &rusqlite::Connection,
+        name: &str,
+        version: &str,
+        architecture: &str,
+        capability: Option<&str>,
+    ) -> i64 {
+        let mut trove = Trove::new(
+            name.to_string(),
+            version.to_string(),
+            TroveType::Package,
+            VersionScheme::Conary,
+        );
+        trove.package_release = Some("1".to_string());
+        trove.architecture = Some(architecture.to_string());
+        let trove_id = trove.insert(conn).unwrap();
+
+        let mut identity = ProvideEntry::new(
+            trove_id,
+            name.to_string(),
+            Some(version.to_string()),
+            VersionScheme::Conary,
+        );
+        identity.insert(conn).unwrap();
+        if let Some(capability) = capability {
+            let mut declared = ProvideEntry::new_typed(
+                trove_id,
+                RepositoryCapabilityKind::Generic,
+                capability.to_string(),
+                None,
+                VersionScheme::Conary,
+                ProvideArchitectureQualifier::Implicit,
+            );
+            declared.insert(conn).unwrap();
+        }
+        trove_id
+    }
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let install_root = temp_dir.path().join("root");
+    let package_path = temp_dir.path().join("same-name-noarch.ccs");
+    let db_path = temp_dir.path().join("conary.db");
+    let db_path_str = db_path.to_str().unwrap();
+    std::fs::create_dir_all(&install_root).unwrap();
+    conary_core::db::init(db_path_str).unwrap();
+
+    let native_architecture = conary_core::repository::registry::detect_system_arch();
+    let conn = conary_core::db::open(db_path_str).unwrap();
+    // Insert the native slot first so the old first-compatible-row selection
+    // chooses the wrong trove; the exact noarch rule must choose the second.
+    let native_id = insert_provider(
+        &conn,
+        "same-name-provider",
+        "1.0.0",
+        &native_architecture,
+        None,
+    );
+    let noarch_id = insert_provider(
+        &conn,
+        "same-name-provider",
+        "2.0.0",
+        conary_core::ccs::manifest::DEFAULT_CONARY_ARCHITECTURE,
+        Some("review-capability"),
+    );
+    let existing = Trove::find_by_name(&conn, "same-name-provider").unwrap();
+    assert_eq!(
+        existing.iter().map(|trove| trove.id).collect::<Vec<_>>(),
+        vec![Some(native_id), Some(noarch_id)],
+        "fixture must preserve the DB order that made the old selector wrong"
+    );
+
+    let mut dependent = Trove::new(
+        "same-name-dependent".to_string(),
+        "1.0.0".to_string(),
+        TroveType::Package,
+        VersionScheme::Conary,
+    );
+    dependent.architecture = Some(native_architecture.clone());
+    let dependent_id = dependent.insert(&conn).unwrap();
+    let requirement = conary_core::repository::requirement::parse_native_requirement(
+        RepositoryRequirementKind::Depends,
+        VersionScheme::Conary,
+        "review-capability",
+    )
+    .unwrap();
+    InstalledRequirementGroup::insert_groups(
+        &conn,
+        dependent_id,
+        VersionScheme::Conary,
+        &[requirement],
+    )
+    .unwrap();
+
+    let result = BuildResult {
+        manifest: CcsManifest::new_minimal("same-name-provider", "2.0.0"),
+        components: HashMap::new(),
+        files: Vec::new(),
+        payloads: Vec::new(),
+        total_size: 0,
+        chunked: false,
+        chunk_stats: None,
+    };
+    let trust_policy_path = super::test_support::write_signed_test_package(&result, &package_path);
+    let trust_policy = TrustPolicy::from_file(&trust_policy_path).unwrap();
+    let verification =
+        conary_core::ccs::verify::verify_package(&package_path, &trust_policy).unwrap();
+    let ccs_package = conary_core::ccs::CcsPackage::from_verified_archive(
+        package_path.to_str().unwrap(),
+        &verification,
+    )
+    .unwrap();
+
+    let command_upgrade =
+        super::command::check_ccs_install_upgrade_status(&conn, &ccs_package, true).unwrap();
+    let semantics =
+        crate::commands::install::install_semantics_for_ccs_manifest(ccs_package.manifest())
+            .unwrap();
+    let transaction_upgrade = crate::commands::install::check_ccs_upgrade_status(
+        &conn,
+        &ccs_package,
+        &semantics,
+        false,
+        crate::commands::install::InstallIntent::PackageChange,
+        true,
+    )
+    .unwrap();
+    assert_eq!(upgrade_trove_id(&command_upgrade), noarch_id);
+    assert_eq!(
+        upgrade_trove_id(&command_upgrade),
+        upgrade_trove_id(&transaction_upgrade),
+        "command validation and transaction must replace the same trove"
+    );
+    drop(conn);
+
+    let error = cmd_ccs_install(
+        package_path.to_str().unwrap(),
+        db_path_str,
+        install_root.to_str().unwrap(),
+        true,
+        Some(trust_policy_path.to_string_lossy().into_owned()),
+        None,
+        crate::commands::SandboxMode::Always,
+        true,
+        true,
+    )
+    .await
+    .expect_err("dropping the exact noarch provider must fail dependent validation");
+    assert!(
+        error
+            .to_string()
+            .contains("same-name-dependent requires review-capability"),
+        "unexpected validation error: {error:#}"
+    );
+}
+
+#[tokio::test]
 async fn default_authored_package_upgrades_with_explicit_architecture_authority() {
     use conary_core::ccs::{BuildResult, CcsManifest};
     use conary_core::db::models::InstalledRequirementGroup;

--- a/apps/conary/src/commands/ccs/install/dependency.rs
+++ b/apps/conary/src/commands/ccs/install/dependency.rs
@@ -4,28 +4,64 @@
 
 use anyhow::Result;
 use conary_core::db::models::InstalledRequirementGroup;
+use conary_core::packages::traits::PackageFormat;
 use conary_core::repository::dependency_model::RepositoryRequirementKind;
-use conary_core::repository::versioning::VersionScheme;
+use conary_core::resolver::identity::PackageIdentity;
 
+/// Project the signed/source package facts used by the end-state validator.
+pub(super) fn incoming_package_identity(incoming: &dyn PackageFormat) -> Result<PackageIdentity> {
+    Ok(PackageIdentity {
+        repo_package_id: None,
+        name: incoming.name().to_string(),
+        version: incoming.version().to_string(),
+        package_release: incoming.package_release().map(str::to_string),
+        architecture: incoming.architecture().map(str::to_string),
+        debian_multi_arch: incoming.debian_multi_arch(),
+        version_scheme: incoming.version_scheme(),
+        repository_id: None,
+        repository_name: String::new(),
+        repository_profile: None,
+        repository_priority: 0,
+        canonical_id: None,
+        canonical_name: None,
+        installed_trove_id: None,
+        installed_pinned: false,
+        provided_capabilities: incoming.resolution_capabilities()?,
+    })
+}
+
+/// Validate installed dependents against the transaction's exact end state.
+///
+/// The admitted universe is `(installed - outgoing) + incoming`. Outgoing
+/// identities are selected by exact trove ID by the caller; package names are
+/// not identity, because parallel-installed same-name packages that remain in
+/// place must keep their original versions and capabilities.
 pub(super) fn validate_incoming_version_against_dependents(
     conn: &rusqlite::Connection,
-    package_name: &str,
-    incoming_version: &str,
-    incoming_version_scheme: VersionScheme,
+    outgoing_trove_ids: &[i64],
+    incoming: &PackageIdentity,
 ) -> Result<()> {
     let before = conary_core::resolver::load_installed_package_identities(conn)?;
-    let mut after = before.clone();
+    let outgoing_trove_ids = outgoing_trove_ids
+        .iter()
+        .copied()
+        .collect::<std::collections::HashSet<_>>();
     let mut replaced = false;
-    for package in &mut after {
-        if package.name == package_name {
-            package.version = incoming_version.to_string();
-            package.version_scheme = incoming_version_scheme;
+    let mut after = Vec::with_capacity(before.len() + 1);
+    for package in &before {
+        if package
+            .installed_trove_id
+            .is_some_and(|trove_id| outgoing_trove_ids.contains(&trove_id))
+        {
             replaced = true;
+        } else {
+            after.push(package.clone());
         }
     }
     if !replaced {
         return Ok(());
     }
+    after.push(incoming.clone());
 
     let native_architecture = conary_core::repository::registry::detect_system_arch();
     let mut violations = Vec::new();
@@ -80,8 +116,8 @@ pub(super) fn validate_incoming_version_against_dependents(
     }
     anyhow::bail!(
         "dependency version mismatch: {} {} would break {}",
-        package_name,
-        incoming_version,
+        incoming.name,
+        incoming.version,
         violations.join(", ")
     )
 }
@@ -89,10 +125,14 @@ pub(super) fn validate_incoming_version_against_dependents(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use conary_core::db::models::{Trove, TroveType};
+    use conary_core::db::models::{ProvideEntry, Trove, TroveType};
     use conary_core::repository::dependency_model::{
-        RepositoryRequirementClause, RepositoryRequirementExpression, RepositoryRequirementGroup,
+        CapabilityProvenance, ProvideArchitectureQualifier, ProvideVersionRelation,
+        RepositoryCapabilityKind, RepositoryRequirementClause, RepositoryRequirementExpression,
+        RepositoryRequirementGroup,
     };
+    use conary_core::repository::versioning::VersionScheme;
+    use conary_core::resolver::identity::ProvidedCapability;
 
     fn database() -> (tempfile::TempDir, rusqlite::Connection) {
         let temp = tempfile::tempdir().unwrap();
@@ -117,6 +157,97 @@ mod tests {
         trove.insert(conn).unwrap()
     }
 
+    fn package_with_capability(
+        conn: &rusqlite::Connection,
+        name: &str,
+        version: &str,
+        architecture: &str,
+        capability: &str,
+    ) -> i64 {
+        let mut trove = Trove::new(
+            name.to_string(),
+            version.to_string(),
+            TroveType::Package,
+            VersionScheme::Rpm,
+        );
+        trove.architecture = Some(architecture.to_string());
+        let trove_id = trove.insert(conn).unwrap();
+        let exact_identity = exact_identity_capability(name, version);
+        let declared = ProvidedCapability {
+            kind: RepositoryCapabilityKind::Generic,
+            name: capability.to_string(),
+            version: None,
+            version_relation: None,
+            version_scheme: VersionScheme::Rpm,
+            architecture_qualifier: ProvideArchitectureQualifier::Implicit,
+            provenance: CapabilityProvenance::AuthorDeclared,
+        };
+        ProvideEntry::insert_package_capabilities(
+            conn,
+            trove_id,
+            name,
+            version,
+            VersionScheme::Rpm,
+            &[exact_identity, declared],
+        )
+        .unwrap();
+        trove_id
+    }
+
+    fn exact_identity_capability(name: &str, version: &str) -> ProvidedCapability {
+        ProvidedCapability {
+            kind: RepositoryCapabilityKind::PackageName,
+            name: name.to_string(),
+            version: Some(version.to_string()),
+            version_relation: Some(ProvideVersionRelation::Equal),
+            version_scheme: VersionScheme::Rpm,
+            architecture_qualifier: ProvideArchitectureQualifier::Implicit,
+            provenance: CapabilityProvenance::ExactIdentity,
+        }
+    }
+
+    fn incoming_identity(
+        name: &str,
+        version: &str,
+        architecture: &str,
+        version_scheme: VersionScheme,
+        provided_capabilities: Vec<ProvidedCapability>,
+    ) -> PackageIdentity {
+        PackageIdentity {
+            repo_package_id: None,
+            name: name.to_string(),
+            version: version.to_string(),
+            package_release: None,
+            architecture: Some(architecture.to_string()),
+            debian_multi_arch: None,
+            version_scheme,
+            repository_id: None,
+            repository_name: String::new(),
+            repository_profile: None,
+            repository_priority: 0,
+            canonical_id: None,
+            canonical_name: None,
+            installed_trove_id: None,
+            installed_pinned: false,
+            provided_capabilities,
+        }
+    }
+
+    fn depends_on(capability: &str) -> RepositoryRequirementGroup {
+        RepositoryRequirementGroup::simple(
+            RepositoryRequirementKind::Depends,
+            RepositoryRequirementClause::name_only(capability.to_string()),
+        )
+    }
+
+    fn alternate_architecture(native: &str) -> &'static str {
+        if native == "aarch64" {
+            "x86_64"
+        } else {
+            "aarch64"
+        }
+    }
+
     #[test]
     fn incoming_version_is_checked_against_typed_installed_groups() {
         let (_temp, conn) = database();
@@ -131,25 +262,34 @@ mod tests {
         InstalledRequirementGroup::insert_groups(&conn, app, VersionScheme::Conary, &[requirement])
             .unwrap();
 
-        let error = validate_incoming_version_against_dependents(
-            &conn,
+        let old_id = Trove::find_by_name(&conn, "dep-liba")
+            .unwrap()
+            .first()
+            .and_then(|trove| trove.id)
+            .unwrap();
+        let native_architecture = conary_core::repository::registry::detect_system_arch();
+        let incoming = incoming_identity(
             "dep-liba",
             "2.0.0",
+            &native_architecture,
             VersionScheme::Conary,
-        )
-        .unwrap_err();
+            Vec::new(),
+        );
+        let error =
+            validate_incoming_version_against_dependents(&conn, &[old_id], &incoming).unwrap_err();
         assert!(
             error
                 .to_string()
                 .contains("dep-app requires dep-liba < 2.0.0")
         );
-        validate_incoming_version_against_dependents(
-            &conn,
+        let incoming = incoming_identity(
             "dep-liba",
             "1.9.0",
+            &native_architecture,
             VersionScheme::Conary,
-        )
-        .unwrap();
+            Vec::new(),
+        );
+        validate_incoming_version_against_dependents(&conn, &[old_id], &incoming).unwrap();
     }
 
     #[test]
@@ -172,8 +312,100 @@ mod tests {
         InstalledRequirementGroup::insert_groups(&conn, app, VersionScheme::Rpm, &[requirement])
             .unwrap();
 
-        validate_incoming_version_against_dependents(&conn, "dep-liba", "2.0", VersionScheme::Rpm)
+        let old_id = Trove::find_by_name(&conn, "dep-liba")
+            .unwrap()
+            .first()
+            .and_then(|trove| trove.id)
             .unwrap();
+        let native_architecture = conary_core::repository::registry::detect_system_arch();
+        let incoming = incoming_identity(
+            "dep-liba",
+            "2.0",
+            &native_architecture,
+            VersionScheme::Rpm,
+            Vec::new(),
+        );
+        validate_incoming_version_against_dependents(&conn, &[old_id], &incoming).unwrap();
+    }
+
+    #[test]
+    fn incoming_ccs_that_drops_an_old_capability_breaks_its_installed_dependent() {
+        let (_temp, conn) = database();
+        let native_architecture = conary_core::repository::registry::detect_system_arch();
+        let old_id = package_with_capability(
+            &conn,
+            "parallel-provider",
+            "1",
+            &native_architecture,
+            "feature-dropped",
+        );
+        let dependent_id = package(&conn, "dependent", "1", VersionScheme::Rpm);
+        InstalledRequirementGroup::insert_groups(
+            &conn,
+            dependent_id,
+            VersionScheme::Rpm,
+            &[depends_on("feature-dropped")],
+        )
+        .unwrap();
+
+        // The incoming CCS identity carries its exact self-provider but
+        // deliberately drops the capability its outgoing version provided.
+        let incoming = incoming_identity(
+            "parallel-provider",
+            "2",
+            &native_architecture,
+            VersionScheme::Rpm,
+            vec![exact_identity_capability("parallel-provider", "2")],
+        );
+        let error = validate_incoming_version_against_dependents(&conn, &[old_id], &incoming)
+            .expect_err("dropping the only provider must fail dependent validation");
+        assert!(
+            error.to_string().contains("dependent requires")
+                && error.to_string().contains("feature-dropped"),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn untouched_parallel_same_name_capability_survives_an_exact_replacement() {
+        let (_temp, conn) = database();
+        let native_architecture = conary_core::repository::registry::detect_system_arch();
+        let parallel_architecture = alternate_architecture(&native_architecture);
+        let outgoing_id = package_with_capability(
+            &conn,
+            "parallel-provider",
+            "1",
+            parallel_architecture,
+            "feature-kept-by-other-identity",
+        );
+        package_with_capability(
+            &conn,
+            "parallel-provider",
+            "9",
+            &native_architecture,
+            "feature-kept-by-other-identity",
+        );
+        let dependent_id = package(&conn, "dependent", "1", VersionScheme::Rpm);
+        InstalledRequirementGroup::insert_groups(
+            &conn,
+            dependent_id,
+            VersionScheme::Rpm,
+            &[depends_on("feature-kept-by-other-identity")],
+        )
+        .unwrap();
+
+        // Only the non-native identity is outgoing. The incoming CCS drops the
+        // capability, so success proves the untouched native identity remains
+        // in the end-state universe with its own persisted capabilities.
+        let incoming = incoming_identity(
+            "parallel-provider",
+            "2",
+            parallel_architecture,
+            VersionScheme::Rpm,
+            vec![exact_identity_capability("parallel-provider", "2")],
+        );
+        validate_incoming_version_against_dependents(&conn, &[outgoing_id], &incoming)
+            .expect("the untouched same-name provider must still satisfy the dependent");
     }
 
     #[test]

--- a/apps/conary/src/commands/install/ccs_transaction.rs
+++ b/apps/conary/src/commands/install/ccs_transaction.rs
@@ -152,7 +152,7 @@ fn show_ccs_dry_run_summary(pkg: &conary_core::ccs::CcsPackage, extraction: &Ext
     println!("\nDry run complete. No changes made.");
 }
 
-pub(super) fn check_ccs_upgrade_status(
+pub(crate) fn check_ccs_upgrade_status(
     conn: &rusqlite::Connection,
     pkg: &conary_core::ccs::CcsPackage,
     semantics: &InstallSemantics,
@@ -186,7 +186,7 @@ pub(super) fn check_ccs_upgrade_status(
 /// Recover the package-manager semantics carried through a converted CCS
 /// archive. CCS is a transport here; it must not erase the source package
 /// manager's version, config, or directory-materialization contract.
-pub(super) fn install_semantics_for_ccs_manifest(
+pub(crate) fn install_semantics_for_ccs_manifest(
     manifest: &conary_core::ccs::manifest::CcsManifest,
 ) -> Result<InstallSemantics> {
     let Some(native) = manifest.native_lifecycle.as_ref() else {

--- a/apps/conary/src/commands/install/mod.rs
+++ b/apps/conary/src/commands/install/mod.rs
@@ -40,8 +40,9 @@ pub(crate) use package_set::{PackageSetRequest, install_package_set};
 
 #[allow(unused_imports)]
 pub(crate) use ccs_transaction::{
-    CcsTransactionInstallOptions, CcsTransactionInstallResult, install_ccs_package_transactionally,
-    install_ccs_package_transactionally_in_selected_root,
+    CcsTransactionInstallOptions, CcsTransactionInstallResult, check_ccs_upgrade_status,
+    install_ccs_package_transactionally, install_ccs_package_transactionally_in_selected_root,
+    install_semantics_for_ccs_manifest,
 };
 
 #[allow(unused_imports)]

--- a/apps/conary/src/commands/install/semantics.rs
+++ b/apps/conary/src/commands/install/semantics.rs
@@ -18,7 +18,7 @@ pub(crate) enum InstallIntent {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) struct InstallSemantics {
+pub(crate) struct InstallSemantics {
     pub(super) source: PreparedSourceKind,
     pub(super) version_scheme: VersionScheme,
 }


### PR DESCRIPTION
## Problem

`validate_incoming_version_against_dependents` built its 'after' universe by rewriting the installed identity's version string **in place, matched by name**, keeping the old version's provided capabilities. An incoming CCS that drops a capability a dependent requires was invisible to it, and parallel-installed same-name identities were all rewritten (#344, same class as #334).

## Fix

- End-state doctrine per #348: the universe is now **(installed identities − exact outgoing trove ids) + the incoming identity carrying the incoming CCS's own resolution capabilities**. Name matching only locates candidate rows; it never rewrites the universe.
- **One owner for 'which trove does this install replace'** (DeepSeek review should-fix): the command's hand-rolled first-slot-match-in-DB-order selection is deleted; the command now consumes the transaction's own `check_ccs_upgrade_status` result (exact arch+version+release already-installed rule first, then slot matching), and the bail/upgrade output derive from the same `UpgradeCheck`. Deliberate behavior alignment: a version-equal package with a different architecture or release is no longer mis-treated as already installed, and the already-installed diagnostic names the architecture.
- An outgoing replacement trove without a DB id now fails closed with a named error instead of silently skipping validation (review should-fix #2). Duplicate outgoing ids (relation removal + replacement) are intentional and deduped by the validator, now commented.

## Tests (all mutation-reasoned)

- Incoming CCS drops a required capability → validation fails naming the missing capability (retaining the outgoing identity or copying its capabilities flips it)
- Untouched parallel same-name identity keeps satisfying its dependent (a by-name filter flips it)
- `ccs_noarch_replacement_uses_transaction_trove_for_dependent_validation`: native trove inserted first, exact noarch second — command and transaction selections must agree on trove id, and dropping the noarch provider rejects the dependent. Reverting to first-row slot match selects the native trove and fails it.

## Verification

Reviewer-run (Luna's sandbox verification was environmental-failure-limited, honestly reported): `cargo test -p conary` full — 0 FAILED; `cargo test -p conary-core` full — 0 FAILED; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo fmt --check` — all clean.

Chain: Luna implemented + revised; DeepSeek cross-reviewed (2 should-fixes, both implemented; nit on pre-existing dependent-without-architecture error noted, unchanged). Review also confirmed sound: dedup, capability projection, fresh-install skip semantics.

Closes #344