### PR TITLE
chore: release remi-v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [remi-v0.12.1] - 2026-08-09
+
+### Changed
+- delete the Forge-shaped server layer (#355)
+- delete the consumerless ChunkFetcherBuilder (#339)
+
+### Fixed
+- serve MCP as modern-only stateless Streamable HTTP on rmcp 3.1.2 (#350)
+- ordering witnesses come from the transaction's end state (#348)
+- drop the redundant kind+capability index from repository_provides (#343)
+- declare scriptlet failure posture as typed authority, keep the evidence (#338)
+
+### Performance
+- seek the capability index in conary query provides; delete test-only lookup (#353)
+- load ProvidesIndex on demand instead of every provides row (#349)
+
 ## [remi-v0.12.0] - 2026-08-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4889,7 +4889,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remi"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/apps/remi/Cargo.toml
+++ b/apps/remi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remi"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 rust-version = "1.96"
 authors = ["Conary Contributors"]


### PR DESCRIPTION
Release PR for remi-v0.12.1 (version bump + release state). Tag is created on the merge commit after this lands, per the release flow.

## Changelog

### Changed
- delete the Forge-shaped server layer (#355)
- delete the consumerless ChunkFetcherBuilder (#339)

### Fixed
- serve MCP as modern-only stateless Streamable HTTP on rmcp 3.1.2 (#350)
- ordering witnesses come from the transaction's end state (#348)
- drop the redundant kind+capability index from repository_provides (#343)
- declare scriptlet failure posture as typed authority, keep the evidence (#338)

### Performance
- seek the capability index in conary query provides; delete test-only lookup (#353)
- load ProvidesIndex on demand instead of every provides row (#349)

## Deploy notes

This release carries **SCHEMA_VERSION 28** (#343's index drop): the deploy is rebuild-and-resync #2 (accepted 2026-08-08). deploy-and-verify waits for repopulation and gates readiness on the schema revision. Post-deploy manual steps on record: remint admin tokens (schema rebuild kills them), then the #306 empirical check — does our claude-code client negotiate protocol 2026-07-28 against production /mcp.