### PR TITLE
perf(install): stop cloning the installed universe inside ordering loops

### DIFF
--- a/apps/conary/src/commands/install/batch/ordering.rs
+++ b/apps/conary/src/commands/install/batch/ordering.rs
@@ -88,10 +88,19 @@ pub(super) fn order_packages_for_transaction(
     let mut edges = vec![BTreeSet::new(); packages.len()];
     let mut strong_edges = vec![BTreeSet::new(); packages.len()];
 
+    // One witness vector for the whole loop, seeded by moving the installed
+    // universe in rather than cloning it per requirement or per retained
+    // witness. Every evaluation reads this vector; each requirement truncates
+    // the tail back to its own dependent and grows it with candidate
+    // identities, and the reverse pass takes one candidate out around each
+    // counterfactual and restores it when it is load-bearing -- the same
+    // mutate-and-restore shape promises.rs uses for promised paths.
+    let installed_count = installed.len();
+    let mut witnesses = installed;
     for (dependent_index, package) in packages.iter().enumerate() {
         let depending_architecture = depending_architecture(package, &native_architecture);
         for requirement in dependency_requirements(package) {
-            let mut witnesses = installed.clone();
+            witnesses.truncate(installed_count);
             witnesses.push(selected[dependent_index].clone());
             if expression_satisfied(
                 requirement,
@@ -132,24 +141,23 @@ pub(super) fn order_packages_for_transaction(
             // Remove every dispensable witness in a deterministic reverse
             // pass. The retained set is exact expression authority for the
             // dependency edge; package names and solver trail order never are.
+            // The witness tail mirrors selected_witnesses one for one, so the
+            // counterfactual removes one candidate from the shared universe
+            // and restores it at the same position when it must stay -- no
+            // second universe is built for it.
             for position in (0..selected_witnesses.len()).rev() {
-                let mut without_candidate = installed.clone();
-                without_candidate.push(selected[dependent_index].clone());
-                without_candidate.extend(
-                    selected_witnesses
-                        .iter()
-                        .enumerate()
-                        .filter(|(index, _)| *index != position)
-                        .map(|(_, index)| selected[*index].clone()),
-                );
+                let tail_index = installed_count + 1 + position;
+                let removed = witnesses.remove(tail_index);
                 if expression_satisfied(
                     requirement,
                     package.semantics.version_scheme,
                     depending_architecture,
                     &native_architecture,
-                    &without_candidate,
+                    &witnesses,
                 )? {
                     selected_witnesses.remove(position);
+                } else {
+                    witnesses.insert(tail_index, removed);
                 }
             }
             for provider_index in selected_witnesses {
@@ -161,9 +169,13 @@ pub(super) fn order_packages_for_transaction(
         }
     }
 
+    // The promise planner rebuilds this same universe from the installed
+    // prefix and the selected identities, and decides holder side by position,
+    // so hand back the installed prefix rather than a second copy.
+    witnesses.truncate(installed_count);
     let plan = super::promises::plan_promise_witnesses(
         packages,
-        installed,
+        witnesses,
         &selected,
         &native_architecture,
     )?;


### PR DESCRIPTION
## Problem

`order_packages_for_transaction` cloned the entire installed identity universe inside its nested loops — per requirement and per retained-witness counterfactual. Post-#286 that universe is ~system-file-count sized (one provides row per payload file), making ordering validation O(edges × files) allocation on every multi-package transaction (#333).

## Fix

The promises.rs mutate-and-restore pattern (#301), applied to the ordered path: the universe is **moved** into one `witnesses` vector for the whole function — zero whole-universe clones. Each requirement truncates the tail back to its own dependent; each counterfactual `remove`s exactly its candidate from the tail and `insert`s it back on the not-satisfied branch. Soundness invariant (documented in code): the tail mirrors `selected_witnesses` one-for-one, reverse iteration keeps lower indices stable, and the installed prefix is never mutated — so every evaluated set is element-for-element identical to the old per-iteration clone, and the final truncate hands promise planning exactly the original installed vector.

New allocation profile: per batch 0 universe clones; per requirement an O(batch) truncate + one identity clone; per counterfactual one element move + optional insert, tail-only.

## Honest scope

Wall-clock measurement on a real adopted system's DB (the issue's suggested proof; ~150k+ file rows) is not included — no adopted-host fixture exists yet (#137 track). The claim shipped here is the allocation shape, proven by construction and pinned by the unchanged behavior suite.

## Verification

- Existing suites are the oracle, unmodified: full `cargo test -p conary` (1053+ tests) and `-p conary-core` — 0 failures; #345's byte-identical-diagnostic pin and witness_universe tests all green
- clippy -D warnings, fmt — clean
- One full-suite run hit the known #328 load-dependent publish-cook flake (passes standalone + on rerun; occurrence logged on #328)
- Chain: DeepSeek implemented (host declined all commands — hand-proven invariant, honestly marked NOT RUN); reviewer ran the full protocol; Luna cross-reviewed the commit — clean verdict, no findings

Closes #333