### PR TITLE
feat(install): persist continued lifecycle failures per changeset

### DIFF
--- a/apps/conary/src/commands/install/batch/execution.rs
+++ b/apps/conary/src/commands/install/batch/execution.rs
@@ -264,6 +264,7 @@ impl BatchInstaller<'_> {
         };
         super::super::native_graph::drive_native_graph(
             tx,
+            changeset_id,
             native_transaction,
             selected_root,
             native_execution_mode,

--- a/apps/conary/src/commands/install/native_events/tests/rpm_warning.rs
+++ b/apps/conary/src/commands/install/native_events/tests/rpm_warning.rs
@@ -4,6 +4,7 @@
 
 use super::*;
 use conary_core::ccs::native_transaction::{NativeTransactionGraph, NativeTransactionStep};
+use conary_core::db::models::{Changeset, ChangesetStatus, LifecycleEvent};
 use conary_core::packages::native_abi::RpmScriptletSlot;
 
 fn rpm_entry_event(bundle: &NativeLifecycleBundle) -> NativeTransactionEvent {
@@ -64,6 +65,12 @@ fn failing_rpm_bundle_for_slot(
     entry.lifecycle_paths = vec![phase.as_str().to_string()];
     entry.transaction_order.position = phase.as_str().to_string();
     bundle
+}
+
+fn pending_changeset(conn: &rusqlite::Connection) -> i64 {
+    Changeset::new("Install lifecycle warning fixture".to_string())
+        .insert(conn)
+        .unwrap()
 }
 
 fn execute_single_event(bundle: NativeLifecycleBundle) -> anyhow::Result<()> {
@@ -246,8 +253,10 @@ fn a_pre_install_class_failure_aborts_before_the_payload_boundary() {
     };
 
     let mut boundaries = Vec::new();
+    let changeset_id = pending_changeset(&conn);
     let error = crate::commands::install::native_graph::drive_native_graph_with(
         &conn,
+        changeset_id,
         &prepared,
         &root,
         &ExecutionMode::Install,
@@ -268,11 +277,13 @@ fn a_pre_install_class_failure_aborts_before_the_payload_boundary() {
     );
 }
 
-/// Evidence the transaction ran past must survive the transaction's own abort.
+/// Evidence the transaction ran past must still be reported on the abort exit.
 ///
-/// A `%post` that failed is most diagnostic precisely when a later step brings
-/// the transaction down, so the accumulator has to be drained and reported on
-/// the error exit as well as the success exit.
+/// Production callers write the event inside the same transaction as the
+/// changeset and roll that transaction back on a graph error. A `%post` that
+/// failed is most diagnostic precisely when a later step brings the transaction
+/// down, so the accumulator has to be drained and reported on the error exit;
+/// the persisted row is durable only on a committed changeset.
 #[test]
 fn a_continued_failure_is_still_reported_when_a_later_graph_step_aborts() {
     let temp = tempfile::tempdir().unwrap();
@@ -281,6 +292,8 @@ fn a_continued_failure_is_still_reported_when_a_later_graph_step_aborts() {
     let conn = conary_core::db::open(&db_path).unwrap();
     let root = temp.path().join("selected-root");
     std::fs::create_dir(&root).unwrap();
+    let tx = conn.unchecked_transaction().unwrap();
+    let changeset_id = pending_changeset(&tx);
 
     // Entry 0 fails in a warn-and-continue class; entry 1 fails in an aborting
     // class later in the same graph.
@@ -327,7 +340,8 @@ fn a_continued_failure_is_still_reported_when_a_later_graph_step_aborts() {
     // accumulator mid-graph without draining it.
     let mut pending_mid_graph = None;
     let error = crate::commands::install::native_graph::drive_native_graph_with(
-        &conn,
+        &tx,
+        changeset_id,
         &prepared,
         &root,
         &ExecutionMode::Install,
@@ -349,9 +363,102 @@ fn a_continued_failure_is_still_reported_when_a_later_graph_step_aborts() {
     );
     assert!(
         prepared.continued_lifecycle_failures.borrow().is_empty(),
-        "the continued failure must be drained and reported on the abort exit, \
-         not discarded with the transaction"
+        "the continued failure must be drained for the ui::warn abort-path \
+         evidence surface"
     );
+    tx.rollback().unwrap();
+    let events = LifecycleEvent::list_for_changeset(&conn, changeset_id).unwrap();
+    assert_eq!(
+        events.len(),
+        0,
+        "abort rollback must discard lifecycle evidence with the changeset"
+    );
+}
+
+#[test]
+fn a_lifecycle_evidence_persist_error_does_not_change_a_successful_graph_result() {
+    let temp = tempfile::tempdir().unwrap();
+    let db_path = temp.path().join("conary.db");
+    conary_core::db::init(&db_path).unwrap();
+    let conn = conary_core::db::open(&db_path).unwrap();
+    let root = temp.path().join("selected-root");
+    std::fs::create_dir(&root).unwrap();
+    let changeset_id = pending_changeset(&conn);
+    let mut changeset = Changeset::find_by_id(&conn, changeset_id).unwrap().unwrap();
+    changeset
+        .update_status(&conn, ChangesetStatus::Applied)
+        .unwrap();
+
+    let bundle = failing_rpm_bundle_for_slot(
+        "rpm:%post",
+        LifecyclePath::PostInstall,
+        RpmCriticality::WarningOnly,
+    );
+    let event = rpm_entry_event(&bundle);
+    let mut prepared =
+        prepared_with_projected_event(bundle, event, NativeEventPathProjection::CurrentRoot);
+    prepared.plan.graph = NativeTransactionGraph {
+        steps: vec![NativeTransactionStep::RunEvent { event_index: 0 }],
+    };
+
+    crate::commands::install::native_graph::drive_native_graph_with(
+        &conn,
+        changeset_id,
+        &prepared,
+        &root,
+        &ExecutionMode::Install,
+        |_, _| Ok(()),
+    )
+    .expect("evidence persistence failure must not escalate a warn-and-continue graph");
+    assert!(
+        prepared.continued_lifecycle_failures.borrow().is_empty(),
+        "the persist-error path must still drain the ui::warn evidence"
+    );
+    assert!(
+        LifecycleEvent::list_for_changeset(&conn, changeset_id)
+            .unwrap()
+            .is_empty(),
+        "the rejected Applied changeset must not receive lifecycle evidence"
+    );
+}
+
+#[test]
+fn a_continued_failure_persists_once_on_the_success_exit() {
+    let temp = tempfile::tempdir().unwrap();
+    let db_path = temp.path().join("conary.db");
+    conary_core::db::init(&db_path).unwrap();
+    let conn = conary_core::db::open(&db_path).unwrap();
+    let root = temp.path().join("selected-root");
+    std::fs::create_dir(&root).unwrap();
+    let changeset_id = pending_changeset(&conn);
+
+    let bundle = failing_rpm_bundle_for_slot(
+        "rpm:%post",
+        LifecyclePath::PostInstall,
+        RpmCriticality::WarningOnly,
+    );
+    let event = rpm_entry_event(&bundle);
+    let mut prepared =
+        prepared_with_projected_event(bundle, event, NativeEventPathProjection::CurrentRoot);
+    prepared.plan.graph = NativeTransactionGraph {
+        steps: vec![NativeTransactionStep::RunEvent { event_index: 0 }],
+    };
+
+    crate::commands::install::native_graph::drive_native_graph_with(
+        &conn,
+        changeset_id,
+        &prepared,
+        &root,
+        &ExecutionMode::Install,
+        |_, _| Ok(()),
+    )
+    .unwrap();
+
+    let events = LifecycleEvent::list_for_changeset(&conn, changeset_id).unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].source_entry, "rpm:%post");
+    assert_eq!(events[0].requested_sandbox_mode.as_str(), "always");
+    assert_eq!(events[0].effective_sandbox.as_str(), "target-root");
 }
 
 #[test]

--- a/apps/conary/src/commands/install/native_graph.rs
+++ b/apps/conary/src/commands/install/native_graph.rs
@@ -5,7 +5,7 @@
 use super::native_events::PreparedNativeTransaction;
 use anyhow::Result;
 use conary_core::ccs::native_transaction::{NativeEventStage, NativeTransactionStep};
-use conary_core::db::models::Trove;
+use conary_core::db::models::{LifecycleEvent, NewLifecycleEvent, Trove};
 use conary_core::scriptlet::ExecutionMode;
 use std::collections::BTreeSet;
 use std::path::Path;
@@ -83,6 +83,7 @@ pub(crate) enum NativePayloadBoundary {
 
 pub(crate) fn drive_native_graph_with(
     conn: &rusqlite::Connection,
+    changeset_id: i64,
     native_transaction: &PreparedNativeTransaction,
     selected_root: &Path,
     execution_mode: &ExecutionMode,
@@ -91,6 +92,7 @@ pub(crate) fn drive_native_graph_with(
     let mut payload = CallbackPayload { callback };
     drive_native_graph(
         conn,
+        changeset_id,
         native_transaction,
         selected_root,
         execution_mode,
@@ -129,6 +131,7 @@ where
 
 pub(crate) fn drive_native_graph(
     conn: &rusqlite::Connection,
+    changeset_id: i64,
     native_transaction: &PreparedNativeTransaction,
     selected_root: &Path,
     execution_mode: &ExecutionMode,
@@ -141,11 +144,23 @@ pub(crate) fn drive_native_graph(
         execution_mode,
         payload,
     );
-    // Both exits report, because a later abort is exactly when "this package's
-    // %post already failed" is most diagnostic. Reporting only on success would
-    // discard that evidence with the transaction it explains. The abort error
-    // itself is untouched; these lines simply precede it.
-    report_continued_lifecycle_failures(native_transaction);
+    // Both exits drain and warn, because a later abort is exactly when "this
+    // package's %post already failed" is most diagnostic. Persisted evidence
+    // survives only with a committed changeset, so the write is attempted
+    // only on the success exit: on an abort the caller rolls the transaction
+    // back, the typed graph error and these ui::warn lines are the evidence
+    // surface, and skipping the doomed insert avoids a misleading
+    // evidence-loss warning from a connection the failure may have poisoned.
+    let report_result =
+        report_continued_lifecycle_failures(conn, changeset_id, native_transaction, result.is_ok());
+    if let Err(error) = report_result {
+        // The source format's warn-and-continue posture is authoritative:
+        // evidence persistence is diagnostic, so its failure must not escalate
+        // a graph that already succeeded.
+        crate::ui::warn(&format!(
+            "continued lifecycle failure evidence was not persisted: {error:#}"
+        ));
+    }
     result
 }
 
@@ -208,8 +223,32 @@ fn drive_native_graph_steps(
 /// The source format's failure table says the transaction proceeds, but the
 /// operator is still told, through the user-facing channel rather than an
 /// internal log record, that a package's own lifecycle did not complete.
-fn report_continued_lifecycle_failures(native_transaction: &PreparedNativeTransaction) {
-    for record in native_transaction.take_continued_lifecycle_failures() {
+fn report_continued_lifecycle_failures(
+    conn: &rusqlite::Connection,
+    changeset_id: i64,
+    native_transaction: &PreparedNativeTransaction,
+    persist: bool,
+) -> Result<()> {
+    let records = native_transaction.take_continued_lifecycle_failures();
+    let persist_result = if persist && !records.is_empty() {
+        let events = records
+            .iter()
+            .map(|record| NewLifecycleEvent {
+                source_package: record.package.clone(),
+                source_version: record.version.clone(),
+                source_entry: record.entry.clone(),
+                failure: record.failure.clone(),
+            })
+            .collect::<Vec<_>>();
+        LifecycleEvent::append_batch(conn, changeset_id, &events)
+            .map(|_| ())
+            .map_err(anyhow::Error::from)
+            .map_err(|error| error.context("failed to persist continued lifecycle failures"))
+    } else {
+        Ok(())
+    };
+
+    for record in records {
         crate::ui::warn(&format!(
             "{} {} lifecycle entry {} failed ({}) and the transaction continued: {}",
             record.package,
@@ -219,6 +258,8 @@ fn report_continued_lifecycle_failures(native_transaction: &PreparedNativeTransa
             record.failure.message
         ));
     }
+
+    persist_result
 }
 
 pub(crate) fn finalize_owned_trove(

--- a/apps/conary/src/commands/install/restore/transaction.rs
+++ b/apps/conary/src/commands/install/restore/transaction.rs
@@ -409,6 +409,7 @@ fn execute_removal_graph(graph: RestoreRemovalGraph<'_, '_>) -> Result<()> {
     };
     drive_native_graph(
         tx,
+        changeset_id,
         native_transaction,
         &selected_path,
         &ExecutionMode::Remove,
@@ -688,6 +689,7 @@ fn execute_install_graph(
     };
     drive_native_graph(
         tx,
+        changeset_id,
         native_transaction,
         &selected_path,
         native_mode,

--- a/apps/conary/src/commands/install/transaction/selected_root.rs
+++ b/apps/conary/src/commands/install/transaction/selected_root.rs
@@ -200,6 +200,7 @@ where
     };
     drive_native_graph(
         &tx,
+        changeset_id,
         native_transaction,
         &selected_path,
         native_execution_mode,

--- a/apps/conary/src/commands/query/history.rs
+++ b/apps/conary/src/commands/query/history.rs
@@ -88,6 +88,21 @@ fn publication_marker_for_changeset(
         .unwrap_or("")
 }
 
+fn format_lifecycle_event_line(event: &conary_core::db::models::LifecycleEvent) -> String {
+    let details = format!(
+        "lifecycle failure {} {} {} ({}) phase={} sandbox={} effective={}: {}",
+        event.source_package,
+        event.source_version,
+        event.source_entry,
+        event.failure_kind.as_str(),
+        event.phase,
+        event.requested_sandbox_mode.as_str(),
+        event.effective_sandbox.as_str(),
+        event.message,
+    );
+    crate::ui::row_line(crate::ui::Status::Warn, &[&details])
+}
+
 /// Show changeset history
 pub async fn cmd_history(db_path: &str) -> Result<()> {
     let conn = open_db(db_path)?;
@@ -103,6 +118,14 @@ pub async fn cmd_history(db_path: &str) -> Result<()> {
             for line in format_deferred_follow_up_lines(changeset)? {
                 println!("{line}");
             }
+            if let Some(changeset_id) = changeset.id {
+                for event in conary_core::db::models::LifecycleEvent::list_for_changeset(
+                    &conn,
+                    changeset_id,
+                )? {
+                    println!("      {}", format_lifecycle_event_line(&event));
+                }
+            }
         }
         println!("\nTotal: {} changeset(s)", changesets.len());
     }
@@ -114,6 +137,7 @@ pub async fn cmd_history(db_path: &str) -> Result<()> {
 mod tests {
     use super::*;
     use conary_core::db::models::{Changeset, ChangesetStatus};
+    use conary_core::scriptlet::{EffectiveSandbox, SandboxMode, ScriptletFailureKind};
 
     #[test]
     fn clean_applied_changeset_has_no_deferred_marker() {
@@ -186,5 +210,30 @@ mod tests {
             publication_marker_for_changeset(&[publication], Some(8)),
             " [publication-failed]"
         );
+    }
+
+    #[test]
+    fn lifecycle_failure_history_line_uses_warn_vocabulary_and_typed_fields() {
+        let event = conary_core::db::models::LifecycleEvent {
+            id: 1,
+            changeset_id: 8,
+            sequence: 0,
+            source_package: "fixture".to_string(),
+            source_version: "1.0.0".to_string(),
+            source_entry: "rpm:%post".to_string(),
+            failure_kind: ScriptletFailureKind::ScriptExited,
+            requested_sandbox_mode: SandboxMode::Always,
+            effective_sandbox: EffectiveSandbox::TargetRoot,
+            phase: "post-install".to_string(),
+            message: "script returned 42".to_string(),
+            created_at: "2026-08-09 12:00:00".to_string(),
+        };
+
+        let line = format_lifecycle_event_line(&event);
+        assert!(line.starts_with(&crate::ui::tag(crate::ui::Status::Warn)));
+        assert!(line.contains("fixture 1.0.0 rpm:%post"));
+        assert!(line.contains("ScriptExited"));
+        assert!(line.contains("phase=post-install"));
+        assert!(line.contains("script returned 42"));
     }
 }

--- a/apps/conary/src/commands/remove/native_graph.rs
+++ b/apps/conary/src/commands/remove/native_graph.rs
@@ -102,6 +102,7 @@ fn execute_selected_root_graph(
     let mut purge_plan = None;
     let graph_result = drive_native_graph_with(
         &tx,
+        changeset_id,
         native_transaction,
         &selected_path,
         &ExecutionMode::Remove,

--- a/apps/conary/tests/query.rs
+++ b/apps/conary/tests/query.rs
@@ -842,6 +842,49 @@ fn test_changeset_history() {
     assert_eq!(cs_by_id.unwrap().description, nginx_cs.description);
 }
 
+#[test]
+fn test_history_reports_persisted_lifecycle_failure() {
+    use conary_core::db::models::{Changeset, ChangesetStatus, LifecycleEvent, NewLifecycleEvent};
+    use conary_core::scriptlet::{EffectiveSandbox, SandboxMode, ScriptletFailureKind};
+
+    let (_temp_dir, db_path) = common::setup_command_test_db();
+    let conn = db::open(&db_path).unwrap();
+    let mut changeset = Changeset::new("Install lifecycle-fixture-1.0.0".to_string());
+    let changeset_id = changeset.insert(&conn).unwrap();
+    LifecycleEvent::append_batch(
+        &conn,
+        changeset_id,
+        &[NewLifecycleEvent {
+            source_package: "lifecycle-fixture".to_string(),
+            source_version: "1.0.0".to_string(),
+            source_entry: "rpm:%post".to_string(),
+            failure: conary_core::scriptlet::ScriptletFailureOutcome {
+                phase: "post-install".to_string(),
+                failure_kind: ScriptletFailureKind::ScriptExited,
+                requested_sandbox_mode: SandboxMode::Always,
+                effective_sandbox: EffectiveSandbox::TargetRoot,
+                message: "script returned 42".to_string(),
+            },
+        }],
+    )
+    .unwrap();
+    changeset
+        .update_status(&conn, ChangesetStatus::Applied)
+        .unwrap();
+    drop(conn);
+
+    let output = run_conary(&["system", "history", "--db-path", &db_path]);
+    assert!(output.status.success(), "{}", output_text(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("[warn]"), "{stdout}");
+    assert!(
+        stdout.contains("lifecycle-fixture 1.0.0 rpm:%post"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("ScriptExited"), "{stdout}");
+    assert!(stdout.contains("script returned 42"), "{stdout}");
+}
+
 /// Test whatprovides functionality
 #[test]
 fn test_whatprovides_operations() {

--- a/crates/conary-core/src/db/current_schema/sql/package_manager.sql
+++ b/crates/conary-core/src/db/current_schema/sql/package_manager.sql
@@ -820,6 +820,35 @@ CREATE INDEX idx_activation_requests_changeset
             ON activation_requests(changeset_id, sequence);
 CREATE INDEX idx_activation_requests_digest
             ON activation_requests(invocation_sha256);
+CREATE TABLE lifecycle_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            changeset_id INTEGER NOT NULL REFERENCES changesets(id) ON DELETE CASCADE,
+            sequence INTEGER NOT NULL CHECK(sequence >= 0),
+            source_package TEXT NOT NULL,
+            source_version TEXT NOT NULL,
+            source_entry TEXT NOT NULL,
+            failure_kind TEXT NOT NULL CHECK(failure_kind IN (
+                'ScriptExited',
+                'ScriptTimedOut',
+                'ContractViolation',
+                'ProgramUnavailable',
+                'ProcessSetupFailed',
+                'SandboxSetupUnavailable',
+                'EnforcementSetupFailed'
+            )),
+            requested_sandbox_mode TEXT NOT NULL CHECK(
+                requested_sandbox_mode IN ('always')
+            ),
+            effective_sandbox TEXT NOT NULL CHECK(
+                effective_sandbox IN ('target-root')
+            ),
+            phase TEXT NOT NULL,
+            message TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(changeset_id, sequence)
+        );
+CREATE INDEX idx_lifecycle_events_changeset
+            ON lifecycle_events(changeset_id, sequence);
 CREATE TABLE generation_activation_intents (
             generation_number INTEGER NOT NULL
                 REFERENCES system_states(state_number) ON DELETE CASCADE,

--- a/crates/conary-core/src/db/models/lifecycle_event.rs
+++ b/crates/conary-core/src/db/models/lifecycle_event.rs
@@ -1,0 +1,321 @@
+// conary-core/src/db/models/lifecycle_event.rs
+
+//! Persisted per-changeset evidence for lifecycle failures the source format
+//! allowed the transaction to continue past.
+
+use crate::error::{Error, Result, ScriptletFailureKind};
+use crate::scriptlet::{EffectiveSandbox, SandboxMode, ScriptletFailureOutcome};
+use rusqlite::{Connection, OptionalExtension, Row, params};
+
+/// Typed lifecycle-failure evidence ready to append to one pending changeset.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewLifecycleEvent {
+    pub source_package: String,
+    pub source_version: String,
+    pub source_entry: String,
+    pub failure: ScriptletFailureOutcome,
+}
+
+impl NewLifecycleEvent {
+    fn validate(&self) -> Result<()> {
+        for (field, value) in [
+            ("source_package", self.source_package.as_str()),
+            ("source_version", self.source_version.as_str()),
+            ("source_entry", self.source_entry.as_str()),
+        ] {
+            if value.is_empty() {
+                return Err(Error::InternalError(format!(
+                    "lifecycle event {field} is empty"
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// One typed continued-lifecycle-failure event attached to a changeset.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LifecycleEvent {
+    pub id: i64,
+    pub changeset_id: i64,
+    pub sequence: i64,
+    pub source_package: String,
+    pub source_version: String,
+    pub source_entry: String,
+    pub failure_kind: ScriptletFailureKind,
+    pub requested_sandbox_mode: SandboxMode,
+    pub effective_sandbox: EffectiveSandbox,
+    pub phase: String,
+    pub message: String,
+    pub created_at: String,
+}
+
+impl LifecycleEvent {
+    const COLUMNS: &'static str = "id, changeset_id, sequence, source_package, \
+        source_version, source_entry, failure_kind, requested_sandbox_mode, \
+        effective_sandbox, phase, message, created_at";
+
+    /// Append typed lifecycle failures to a still-pending changeset.
+    pub fn append_batch(
+        conn: &Connection,
+        changeset_id: i64,
+        events: &[NewLifecycleEvent],
+    ) -> Result<Vec<i64>> {
+        if events.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // This pending-only guard is coupled to the four production callers
+        // inserting the changeset immediately before driving the graph. A
+        // future caller that drives after update_status(Applied) will reject
+        // evidence here; native_graph treats that as evidence loss and warns
+        // without changing the graph's posture.
+        let status: Option<String> = conn
+            .query_row(
+                "SELECT status FROM changesets WHERE id = ?1",
+                [changeset_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        match status.as_deref() {
+            Some(status) if status == super::changeset::ChangesetStatus::Pending.as_str() => {}
+            Some(other) => {
+                return Err(Error::ConflictError(format!(
+                    "lifecycle events cannot be appended to changeset {changeset_id} in status '{other}'"
+                )));
+            }
+            None => {
+                return Err(Error::NotFound(format!(
+                    "lifecycle event changeset {changeset_id}"
+                )));
+            }
+        }
+
+        let next_sequence: i64 = conn.query_row(
+            "SELECT COALESCE(MAX(sequence), -1) + 1
+             FROM lifecycle_events
+             WHERE changeset_id = ?1",
+            [changeset_id],
+            |row| row.get(0),
+        )?;
+
+        // Validate the whole batch before the first insert: a mid-batch
+        // validation failure must not commit a prefix of the evidence while
+        // the caller's warn-and-continue handling drops the rest.
+        for event in events {
+            event.validate()?;
+        }
+
+        let mut ids = Vec::with_capacity(events.len());
+        for (sequence, event) in (next_sequence..).zip(events) {
+            conn.execute(
+                "INSERT INTO lifecycle_events (
+                    changeset_id, sequence, source_package, source_version, source_entry,
+                    failure_kind, requested_sandbox_mode, effective_sandbox, phase, message
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                params![
+                    changeset_id,
+                    sequence,
+                    &event.source_package,
+                    &event.source_version,
+                    &event.source_entry,
+                    event.failure.failure_kind.as_str(),
+                    event.failure.requested_sandbox_mode.as_str(),
+                    event.failure.effective_sandbox.as_str(),
+                    &event.failure.phase,
+                    &event.failure.message,
+                ],
+            )?;
+            ids.push(conn.last_insert_rowid());
+        }
+        Ok(ids)
+    }
+
+    pub fn find_by_id(conn: &Connection, id: i64) -> Result<Option<Self>> {
+        let sql = format!(
+            "SELECT {} FROM lifecycle_events WHERE id = ?1",
+            Self::COLUMNS
+        );
+        conn.prepare(&sql)?
+            .query_row([id], Self::from_row)
+            .optional()
+            .map_err(Into::into)
+    }
+
+    /// Return events in the exact order the native graph observed them.
+    pub fn list_for_changeset(conn: &Connection, changeset_id: i64) -> Result<Vec<Self>> {
+        let sql = format!(
+            "SELECT {} FROM lifecycle_events
+             WHERE changeset_id = ?1
+             ORDER BY sequence, id",
+            Self::COLUMNS
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map([changeset_id], Self::from_row)?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
+    fn from_row(row: &Row<'_>) -> rusqlite::Result<Self> {
+        Ok(Self {
+            id: row.get(0)?,
+            changeset_id: row.get(1)?,
+            sequence: row.get(2)?,
+            source_package: row.get(3)?,
+            source_version: row.get(4)?,
+            source_entry: row.get(5)?,
+            failure_kind: parse_failure_kind(row.get(6)?, 6)?,
+            requested_sandbox_mode: parse_sandbox_mode(row.get(7)?, 7)?,
+            effective_sandbox: parse_effective_sandbox(row.get(8)?, 8)?,
+            phase: row.get(9)?,
+            message: row.get(10)?,
+            created_at: row.get(11)?,
+        })
+    }
+}
+
+fn parse_failure_kind(value: String, column: usize) -> rusqlite::Result<ScriptletFailureKind> {
+    let parsed = match value.as_str() {
+        "ScriptExited" => ScriptletFailureKind::ScriptExited,
+        "ScriptTimedOut" => ScriptletFailureKind::ScriptTimedOut,
+        "ContractViolation" => ScriptletFailureKind::ContractViolation,
+        "ProgramUnavailable" => ScriptletFailureKind::ProgramUnavailable,
+        "ProcessSetupFailed" => ScriptletFailureKind::ProcessSetupFailed,
+        "SandboxSetupUnavailable" => ScriptletFailureKind::SandboxSetupUnavailable,
+        "EnforcementSetupFailed" => ScriptletFailureKind::EnforcementSetupFailed,
+        _ => {
+            return Err(rusqlite::Error::FromSqlConversionFailure(
+                column,
+                rusqlite::types::Type::Text,
+                Box::new(Error::InternalError(format!(
+                    "persisted lifecycle event has unknown failure kind '{value}'"
+                ))),
+            ));
+        }
+    };
+    Ok(parsed)
+}
+
+fn parse_sandbox_mode(value: String, column: usize) -> rusqlite::Result<SandboxMode> {
+    match value.as_str() {
+        "always" => Ok(SandboxMode::Always),
+        _ => Err(rusqlite::Error::FromSqlConversionFailure(
+            column,
+            rusqlite::types::Type::Text,
+            Box::new(Error::InternalError(format!(
+                "persisted lifecycle event has unknown requested sandbox mode '{value}'"
+            ))),
+        )),
+    }
+}
+
+fn parse_effective_sandbox(value: String, column: usize) -> rusqlite::Result<EffectiveSandbox> {
+    match value.as_str() {
+        "target-root" => Ok(EffectiveSandbox::TargetRoot),
+        _ => Err(rusqlite::Error::FromSqlConversionFailure(
+            column,
+            rusqlite::types::Type::Text,
+            Box::new(Error::InternalError(format!(
+                "persisted lifecycle event has unknown effective sandbox '{value}'"
+            ))),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::models::{Changeset, ChangesetStatus};
+    use crate::db::testing::create_test_db;
+
+    fn pending_changeset(conn: &Connection) -> i64 {
+        Changeset::new("Install lifecycle fixture".to_string())
+            .insert(conn)
+            .expect("insert pending changeset")
+    }
+
+    fn event() -> NewLifecycleEvent {
+        NewLifecycleEvent {
+            source_package: "fixture".to_string(),
+            source_version: "1.0.0".to_string(),
+            source_entry: "rpm:%post".to_string(),
+            failure: ScriptletFailureOutcome {
+                phase: "post-install".to_string(),
+                failure_kind: ScriptletFailureKind::ScriptExited,
+                requested_sandbox_mode: SandboxMode::Always,
+                effective_sandbox: EffectiveSandbox::TargetRoot,
+                message: "script returned 42: stderr excerpt".to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn lifecycle_event_round_trips_all_typed_failure_fields() {
+        let (_temp, conn) = create_test_db();
+        let changeset_id = pending_changeset(&conn);
+
+        let ids = LifecycleEvent::append_batch(&conn, changeset_id, &[event()]).unwrap();
+        assert_eq!(ids.len(), 1);
+
+        let events = LifecycleEvent::list_for_changeset(&conn, changeset_id).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].id, ids[0]);
+        assert_eq!(events[0].changeset_id, changeset_id);
+        assert_eq!(events[0].sequence, 0);
+        assert_eq!(events[0].source_package, "fixture");
+        assert_eq!(events[0].source_version, "1.0.0");
+        assert_eq!(events[0].source_entry, "rpm:%post");
+        assert_eq!(events[0].failure_kind, ScriptletFailureKind::ScriptExited);
+        assert_eq!(events[0].requested_sandbox_mode, SandboxMode::Always);
+        assert_eq!(events[0].effective_sandbox, EffectiveSandbox::TargetRoot);
+        assert_eq!(events[0].phase, "post-install");
+        assert_eq!(events[0].message, "script returned 42: stderr excerpt");
+        assert!(!events[0].created_at.is_empty());
+    }
+
+    #[test]
+    fn a_mid_batch_validation_failure_persists_nothing() {
+        let (_temp, conn) = create_test_db();
+        let changeset_id = pending_changeset(&conn);
+
+        let mut invalid = event();
+        invalid.source_entry = String::new();
+        // Two valid events ahead of the invalid one: the batch must be
+        // all-or-nothing, not a committed prefix with a dropped tail.
+        let error = LifecycleEvent::append_batch(&conn, changeset_id, &[event(), event(), invalid])
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("source_entry is empty"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            LifecycleEvent::list_for_changeset(&conn, changeset_id)
+                .unwrap()
+                .is_empty(),
+            "a rejected batch must not commit a prefix"
+        );
+    }
+
+    #[test]
+    fn lifecycle_events_cascade_with_their_changeset() {
+        let (_temp, conn) = create_test_db();
+        let changeset_id = pending_changeset(&conn);
+        LifecycleEvent::append_batch(&conn, changeset_id, &[event()]).unwrap();
+        conn.execute(
+            "UPDATE changesets SET status = ?1 WHERE id = ?2",
+            params![ChangesetStatus::Applied.as_str(), changeset_id],
+        )
+        .unwrap();
+
+        conn.execute("DELETE FROM changesets WHERE id = ?1", [changeset_id])
+            .unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM lifecycle_events WHERE changeset_id = ?1",
+                [changeset_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+}

--- a/crates/conary-core/src/db/models/mod.rs
+++ b/crates/conary-core/src/db/models/mod.rs
@@ -45,6 +45,7 @@ mod installed_native_lifecycle_bundle;
 mod installed_requirement_atom;
 mod installed_requirement_group;
 mod label;
+mod lifecycle_event;
 mod metadata;
 mod native_lifecycle_residual_state;
 mod native_publication;
@@ -105,6 +106,7 @@ pub use installed_native_lifecycle_bundle::InstalledNativeLifecycleBundle;
 pub use installed_requirement_atom::InstalledRequirementAtom;
 pub use installed_requirement_group::InstalledRequirementGroup;
 pub use label::{LabelEntry, LabelPathEntry, add_to_path, get_label_path, remove_from_path};
+pub use lifecycle_event::{LifecycleEvent, NewLifecycleEvent};
 pub use metadata::{MetadataTable, get_metadata, set_metadata};
 pub use native_lifecycle_residual_state::NativeLifecycleResidualState;
 pub use native_publication::{

--- a/crates/conary-core/src/db/schema.rs
+++ b/crates/conary-core/src/db/schema.rs
@@ -12,21 +12,14 @@ use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 use std::path::Path;
 use tracing::info;
 
-/// Revision 28 of the current-only schema epoch.
+/// Revision 29 of the current-only schema epoch.
 ///
-/// Revision 28 retains revision 27's fail-closed persisted states, explicit
-/// dependency-mixing policy, and path-free capability provenance, and carries
-/// one capability index on `repository_provides` instead of two. `capability`
-/// was the second column of the retired `(kind, capability)` composite, so that
-/// index could never serve the capability-only seek every provider lookup
-/// issues; the single-column index serves those seeks, and the one statement
-/// that also filters `kind` seeks the same index and filters the rows a single
-/// capability holds. An index is physical schema that a database keeps for the
-/// life of the file, so a revision-27 database still carries the retired index
-/// and reports a schema its build no longer defines. The revision gate is what
-/// keeps the two apart. Earlier pre-alpha databases must be rebuilt; no
-/// compatibility migration is provided.
-pub const SCHEMA_VERSION: i32 = 28;
+/// Revision 29 retains revision 28's fail-closed persisted states, explicit
+/// dependency-mixing policy, path-free capability provenance, and physical
+/// repository-provide index shape. It adds `lifecycle_events`, the ordered
+/// per-changeset store for typed warn-and-continue lifecycle failures. Earlier
+/// pre-alpha databases must be rebuilt; no compatibility migration is provided.
+pub const SCHEMA_VERSION: i32 = 29;
 /// Stable identity that distinguishes this epoch from retired schema revisions.
 pub const SCHEMA_EPOCH: &str = "conary-current-v1";
 
@@ -205,6 +198,7 @@ mod tests {
             "installed_file_capabilities",
             "generation_publications",
             "activation_requests",
+            "lifecycle_events",
             "generation_activation_intents",
             "debian_alternative_groups",
         ] {
@@ -221,7 +215,7 @@ mod tests {
     }
 
     #[test]
-    fn revision_27_requires_rebuild_for_revision_28() {
+    fn revision_28_requires_rebuild_for_revision_29() {
         let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(
             "CREATE TABLE schema_identity (
@@ -229,19 +223,19 @@ mod tests {
                 revision INTEGER NOT NULL
             );
             INSERT INTO schema_identity (epoch, revision)
-                VALUES ('conary-current-v1', 27);
+                VALUES ('conary-current-v1', 28);
             CREATE TABLE schema_version (
                 version INTEGER PRIMARY KEY,
                 applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             );
-            INSERT INTO schema_version (version) VALUES (27);",
+            INSERT INTO schema_version (version) VALUES (28);",
         )
         .unwrap();
 
         let error = ensure_current(&conn).unwrap_err();
         assert_eq!(
             error.to_string(),
-            "Database schema rebuild required: database uses schema epoch conary-current-v1 revision 27; this pre-alpha build supports only schema epoch conary-current-v1 revision 28"
+            "Database schema rebuild required: database uses schema epoch conary-current-v1 revision 28; this pre-alpha build supports only schema epoch conary-current-v1 revision 29"
         );
     }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -582,18 +582,15 @@ The schema itself is split by ownership under
 `crates/conary-core/src/db/current_schema/sql/`: local package-manager state,
 repository/service state, and Remi conversion/administration state.
 
-Schema revision 28 retains revision 27's fail-closed persisted-state
+Schema revision 29 retains revision 28's fail-closed persisted-state
 constraints, explicit `strict`, `guarded`, or `permissive` dependency-mixing
-policy on every persisted source pin, and path-free capability provenance, and
-carries one capability index on `repository_provides` instead of two. Neither
-change moves a table definition, so the revision is the only thing separating
-the shapes. Revision 27's cut was correctness: `provides.provenance` is JSON
-text inside a UNIQUE contract index and no resync rebuilds installed rows, so a
-database mixing both provenance shapes would admit one path twice as two
-distinct providers. Revision 28's cut is physical: an index lives in the
-database file for its lifetime, so a revision-27 database would keep serving a
-`(kind, capability)` index the build no longer defines, and its physical schema
-would disagree with the revision it reports.
+policy on every persisted source pin, path-free capability provenance, and
+physical repository-provide index shape. It adds `lifecycle_events`, an
+ordered per-changeset table that records each typed warn-and-continue native
+lifecycle failure before the changeset can become applied. The event stores
+only fields carried by `ContinuedLifecycleFailure` and its
+`ScriptletFailureOutcome`; it does not infer an exit code or stderr field that
+the source type does not expose.
 
 Databases from retired schema revisions are rejected with an exact recovery
 command. `conary system rebuild-db --discard-state --yes` consolidates the
@@ -606,7 +603,7 @@ not carry a compatibility chain or silently reset an existing database.
 
 The stable table families are:
 
-- Installed state: troves, changesets, files, components, dependencies, and provides
+- Installed state: troves, changesets, lifecycle events, files, components, dependencies, and provides
 - Repository and resolution state: repositories, synced package metadata, capability inputs, labels, and canonical mapping data
 - System state and configuration: state snapshots, config tracking, triggers, redirects, and settings
 - Try state: active/kept/rolled-back package try sessions and selected generation metadata

--- a/docs/modules/query.md
+++ b/docs/modules/query.md
@@ -32,6 +32,7 @@ conary query <subcommand> [args]
   +-- repquery               -> repo.rs         (RepositoryPackage table)
   +-- component / components -> components.rs   (Component + FileEntry tables)
   +-- scripts                -> scripts.rs      (package files plus installed scriptlet/bundle state)
+  +-- system history        -> commands/query/history.rs (changesets plus lifecycle_events)
   +-- conflicts              -> dependency.rs   (file ownership overlap detection)
   +-- delta-stats            -> dependency.rs   (delta update statistics)
   +-- label                  -> cli/label.rs + dispatch/query.rs   (label path, delegation, and provenance management)
@@ -63,6 +64,7 @@ conary system sbom <package|all> [--format cyclonedx]
 | `RepositoryPackage` | db/models/ | Available package from synced repo metadata |
 | `InstalledCcsRemoveHook` | db/models/ | Exact persisted CCS-authored pre-remove hook |
 | `InstalledNativeLifecycleBundle` | db/models/ | Persisted source-ABI lifecycle authority for later query and transaction planning |
+| `LifecycleEvent` | db/models/ | Typed per-changeset warn-and-continue lifecycle failure evidence |
 
 ## Database Tables
 
@@ -79,6 +81,7 @@ Primary tables hit by queries:
 | `repository_packages` | name, repository_id | repquery |
 | `installed_ccs_remove_hooks` | trove_id | scripts |
 | `installed_native_lifecycle_bundles` | trove_id, evidence_digest | scripts |
+| `lifecycle_events` | changeset_id, sequence | system history |
 
 ## Query Patterns
 
@@ -100,6 +103,12 @@ Primary tables hit by queries:
   and evidence digest without printing preserved raw script bodies by default.
   The JSON bundle summary exposes `diagnostic_class_counts`; these counts are
   evidence for implementation prioritization and never lifecycle authority.
+
+## Lifecycle Failure History
+
+`conary system history` reads the ordered `lifecycle_events` rows attached to
+each changeset and displays their typed package, entry, failure class, phase,
+sandbox, and message fields.
 
 ## Related SBOM Commands
 

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -276,13 +276,14 @@ the authenticated source artifact. Public, OCI, index, search, chunk, and
 garbage-collection paths validate that typed artifact instead of filling
 missing fields with guesses or empty values. Architecture and the repository
 provide digest are required constructor and API-view fields, and the current
-schema rejects missing, empty, or malformed values. Schema revision 28 retains
-revision 27's source-authority, fail-closed state constraints, explicit mixing
-policy for every persisted source pin, and path-free capability provenance, and
-carries one capability index on `repository_provides` instead of two. It is a
-pre-alpha hard cut: prior databases are rebuilt and re-ingested from configured
-repository authority rather than migrated. Local conversion tracking is
-written only after the CCS install transaction commits.
+schema rejects missing, empty, or malformed values. Schema revision 29 retains
+revision 28's source-authority, fail-closed state constraints, explicit mixing
+policy for every persisted source pin, path-free capability provenance, and
+physical `repository_provides` index shape, and adds ordered per-changeset
+`lifecycle_events` for typed continued lifecycle failures. It is a pre-alpha
+hard cut: prior databases are rebuilt and re-ingested from configured repository
+authority rather than migrated. Local conversion tracking is written only after
+the CCS install transaction commits.
 
 Ready conversion means the artifact carries a source-independent Conary
 lifecycle contract. A client may install it on any target whose typed

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -211,6 +211,13 @@ a live binary or an operator queue.
 Each successful selected-root transaction appends the canonical invocation,
 source package/version/entry, source kind, exact sequence, canonical JSON, and
 SHA-256 to `activation_requests` before its changeset can become applied.
+When a source format explicitly permits a lifecycle class to fail while the
+transaction continues, the same transaction appends one ordered row per typed
+`ContinuedLifecycleFailure` to `lifecycle_events` before the changeset can
+become applied. The row mirrors the current evidence type: source
+package/version/entry, failure kind, phase, requested and effective sandbox,
+and message. It does not synthesize an exit-code or stderr column absent from
+`ScriptletFailureOutcome`; `conary system history` is the read surface.
 Security-policy requests also retain the exact invoked path, canonical path,
 and executable SHA-256 observed inside that selected root. Current-only
 database schema revision 9 stores the tagged systemd/SELinux/AppArmor union;


### PR DESCRIPTION
## Problem

A warn-and-continue scriptlet failure produced typed `ContinuedLifecycleFailure` evidence surfaced via `ui::warn` during the transaction — but nothing persisted it, so conary could not report after the fact that an installed package's %post failed (#337).

## Fix

- New `lifecycle_events` table (**SCHEMA_VERSION 28 → 29**, pre-alpha hard cut, no migration chain), modeled on `activation_requests`: changeset FK with cascade, per-changeset monotonic sequence, and exactly the typed fields the evidence carries — no invented exit-code/stderr columns.
- `drive_native_graph` drains the typed accumulator once on **both** graph exits (#338 doctrine) and `ui::warn`s every record. Persistence is **honestly commit-only**: writes ride the caller's transaction, every production caller rolls back on graph error, and an aborted transaction installs nothing to report on — the typed error is the abort-path evidence surface (DeepSeek review finding; the original test modeled a bare-autocommit path production cannot take, now rewritten against a real rolled-back transaction asserting zero rows).
- **Posture outranks evidence**: a persistence failure degrades to a warn naming the evidence loss and never fails a graph that succeeded (review finding — the original code inverted the failure-posture doctrine).
- Re-review fixes: `append_batch` validates the whole batch before the first insert (mid-batch failure persists nothing — pinned by test); the persist attempt is gated on the success exit; the pending-only guard uses the typed `ChangesetStatus` and documents its caller coupling.
- `conary system history` renders persisted events as `[warn]` rows with the typed fields.

## Rebuild impact

Revision-28 databases are rejected until `conary system rebuild-db --discard-state` runs; the rebuild retires a snapshot and discards active installed-state/evidence records — operators resync metadata and re-adopt native packages.

## Verification

- Focused: lifecycle_event model 3/3 (incl. batch atomicity), native_events 58/58, history integration 2/2
- Full `cargo test -p conary` / `-p conary-core`: 0 failures (one known #328 load flake, standalone-green, logged)
- clippy -D warnings, fmt, doc-truth — clean
- Chain: Luna implemented + revised; DeepSeek reviewed twice (round 1: two behavioral-contract findings, both fixed; round 2: OK-to-ship with two small fixes, applied by reviewer with tests); all five `drive_native_graph` call sites audited by both reviewers

Closes #337