### PR TITLE
fix(ccs): persist the typed scriptlet slot class, delete the redundant critical bool

### DIFF
--- a/apps/conary/src/commands/install/conversion/tests/dependencies.rs
+++ b/apps/conary/src/commands/install/conversion/tests/dependencies.rs
@@ -78,7 +78,7 @@ fn rpm_pretransaction_absence_bundle(
         scriptlet_fidelity: ScriptletFidelity::NativeLifecycle,
         entries: vec![NativeLifecycleEntry {
             id: "rpm:%pretrans".to_string(),
-            native_slot: "%pretrans".to_string(),
+            native_slot: Some(conary_core::packages::native_abi::RpmScriptletSlot::PreTrans),
             kind: NativeLifecycleEntryKind::Executable,
             phase: LifecyclePath::PreTransaction,
             lifecycle_paths: vec![LifecyclePath::PreTransaction.as_str().to_string()],
@@ -102,8 +102,7 @@ fn rpm_pretransaction_absence_bundle(
             rpm_runtime: Some(RpmRuntimeMetadata {
                 program: RpmProgram::EmbeddedLua,
                 body_transforms: Vec::new(),
-                critical: true,
-                criticality: RpmCriticality::Header,
+                criticality: RpmCriticality::SlotDefault,
                 raw_flags: 0,
                 unknown_flags: 0,
                 install_prefixes: Vec::new(),

--- a/apps/conary/src/commands/install/native_events/debian_runtime/admin_projection/tests.rs
+++ b/apps/conary/src/commands/install/native_events/debian_runtime/admin_projection/tests.rs
@@ -29,7 +29,7 @@ fn bundle_with_interest() -> NativeLifecycleBundle {
         scriptlet_fidelity: ScriptletFidelity::NativeLifecycle,
         entries: vec![NativeLifecycleEntry {
             id: "deb:triggers".to_string(),
-            native_slot: "DEBIAN/triggers".to_string(),
+            native_slot: None,
             kind: NativeLifecycleEntryKind::ControlArtifact,
             phase: conary_core::ccs::native_lifecycle::LifecyclePath::Trigger,
             lifecycle_paths: vec!["trigger".to_string()],

--- a/apps/conary/src/commands/install/native_events/runtime.rs
+++ b/apps/conary/src/commands/install/native_events/runtime.rs
@@ -4,7 +4,7 @@
 
 use super::{NativeBundleOwner, debian_runtime};
 use anyhow::{Context, Result};
-use conary_core::ccs::native_lifecycle::NativeLifecycleEntry;
+use conary_core::ccs::native_lifecycle::{NativeLifecycleEntry, RPM_SCRIPTLET_FLAG_CRITICAL};
 use conary_core::scriptlet::{
     ExecutionMode, FailurePosture, LifecycleFailureClass, NativeInterpreterAvailability,
     NativeInvocationRuntime, NativeLifecycleExecution, ScriptletExecutor, ScriptletFailureOutcome,
@@ -79,11 +79,18 @@ pub(super) fn execute_entry(
             .map_err(anyhow::Error::from);
     };
     // The source format's own per-scriptlet-class table decides this, never the
-    // entry's name. See docs/specs/foreign-package-lifecycle-contracts.md,
-    // "RPM Scriptlet Failure Posture".
+    // entry's name. The runtime is told the typed class by the persisted
+    // contract and consults the current table through it, so posture
+    // corrections apply to already-converted artifacts without reconversion.
+    // See docs/specs/foreign-package-lifecycle-contracts.md, "RPM Scriptlet
+    // Failure Posture".
     let posture = FailurePosture::for_lifecycle_failure(LifecycleFailureClass {
         source_format: owner.bundle.source_format,
-        rpm_criticality: entry.rpm_runtime.as_ref().map(|rpm| rpm.criticality),
+        rpm_class: entry.rpm_class(),
+        header_critical: entry
+            .rpm_runtime
+            .as_ref()
+            .is_some_and(|rpm| rpm.raw_flags & RPM_SCRIPTLET_FLAG_CRITICAL != 0),
         failure_kind: failure.failure_kind,
     });
     match posture {

--- a/apps/conary/src/commands/install/native_events/tests.rs
+++ b/apps/conary/src/commands/install/native_events/tests.rs
@@ -36,7 +36,7 @@ fn pre_remove_bundle(package_name: &str, version: &str) -> NativeLifecycleBundle
     let body = "exit 0\n".to_string();
     let entry = NativeLifecycleEntry {
         id: "rpm:%preun".to_string(),
-        native_slot: "%preun".to_string(),
+        native_slot: Some(conary_core::packages::native_abi::RpmScriptletSlot::PreUn),
         kind: NativeLifecycleEntryKind::Executable,
         phase: LifecyclePath::PreRemove,
         lifecycle_paths: vec![LifecyclePath::PreRemove.as_str().to_string()],
@@ -59,7 +59,6 @@ fn pre_remove_bundle(package_name: &str, version: &str) -> NativeLifecycleBundle
         rpm_runtime: Some(RpmRuntimeMetadata {
             program: RpmProgram::External,
             body_transforms: Vec::new(),
-            critical: true,
             criticality: RpmCriticality::SlotDefault,
             raw_flags: 0,
             unknown_flags: 0,
@@ -105,11 +104,21 @@ fn rpm_bundle_for_phase(
     let mut bundle = pre_remove_bundle(package_name, version);
     let entry = &mut bundle.entries[0];
     entry.id = entry_id.to_string();
-    entry.native_slot = entry_id.trim_start_matches("rpm:").to_string();
+    // Fixture ids mix `rpm:<slot>` and `rpm:<slot>:<qualifier>` shapes; the
+    // slot is the `%`-prefixed segment.
+    entry.native_slot = entry_id
+        .strip_prefix("rpm:")
+        .and_then(|suffix| suffix.split(':').find(|part| part.starts_with('%')))
+        .and_then(conary_core::packages::native_abi::RpmScriptletSlot::from_tag);
     entry.phase = phase;
     entry.lifecycle_paths = vec![phase.as_str().to_string()];
     entry.interpreter = interpreter.to_string();
     entry.transaction_order.position = phase.as_str().to_string();
+    // Keep the persisted criticality stamp consistent with the typed class.
+    let entry_class = entry.rpm_class();
+    if let (Some(runtime), Some(class)) = (&mut entry.rpm_runtime, entry_class) {
+        runtime.criticality = class.effective_criticality(false);
+    }
     bundle
 }
 
@@ -191,15 +200,7 @@ fn deb_entry(
 ) -> NativeLifecycleEntry {
     let mut entry = pre_remove_bundle("fixture", "1").entries.remove(0);
     entry.id = id.to_string();
-    entry.native_slot = match control_member {
-        DebControlMember::Config => "config",
-        DebControlMember::Preinst => "preinst",
-        DebControlMember::Postinst => "postinst",
-        DebControlMember::Prerm => "prerm",
-        DebControlMember::Postrm => "postrm",
-        DebControlMember::Triggers => "triggers",
-    }
-    .to_string();
+    entry.native_slot = None;
     entry.phase = phase;
     entry.lifecycle_paths = vec![phase.as_str().to_string()];
     entry.interpreter = interpreter.to_string();
@@ -225,7 +226,7 @@ fn deb_entry(
 fn deb_triggers_entry(declarations: Vec<DebTriggerMetadata>) -> NativeLifecycleEntry {
     let mut entry = pre_remove_bundle("fixture", "1").entries.remove(0);
     entry.id = "deb:triggers".to_string();
-    entry.native_slot = "triggers".to_string();
+    entry.native_slot = None;
     entry.kind = NativeLifecycleEntryKind::ControlArtifact;
     entry.phase = LifecyclePath::Trigger;
     entry.lifecycle_paths = vec![LifecyclePath::Trigger.as_str().to_string()];

--- a/apps/conary/src/commands/install/native_events/tests/arch.rs
+++ b/apps/conary/src/commands/install/native_events/tests/arch.rs
@@ -15,7 +15,7 @@ fn arch_hook_bundle_with_dependency(package_name: &str, dependency: &str) -> Nat
 
     let entry = &mut bundle.entries[0];
     entry.id = "arch:alpm-hook:40-cache.hook".to_string();
-    entry.native_slot = "alpm-hook:40-cache.hook".to_string();
+    entry.native_slot = None;
     entry.kind = NativeLifecycleEntryKind::ControlArtifact;
     entry.phase = LifecyclePath::Trigger;
     entry.lifecycle_paths = vec![LifecyclePath::Trigger.as_str().to_string()];

--- a/apps/conary/src/commands/install/native_events/tests/rpm_warning.rs
+++ b/apps/conary/src/commands/install/native_events/tests/rpm_warning.rs
@@ -30,40 +30,29 @@ fn rpm_entry_event(bundle: &NativeLifecycleBundle) -> NativeTransactionEvent {
     }
 }
 
-fn failing_rpm_bundle(criticality: RpmCriticality, critical: bool) -> NativeLifecycleBundle {
-    let mut bundle = rpm_bundle_for_phase(
-        "rpm-warning-fixture",
-        "1",
-        "rpm:%post",
-        LifecyclePath::PostInstall,
-        "<lua>",
-    );
-    let entry = &mut bundle.entries[0];
-    entry.body = "error('typed fixture failure')\n".to_string();
-    entry.body_sha256 = conary_core::hash::sha256_prefixed(entry.body.as_bytes());
-    let runtime = entry.rpm_runtime.as_mut().unwrap();
-    runtime.program = RpmProgram::EmbeddedLua;
-    runtime.criticality = criticality;
-    runtime.critical = critical;
-    bundle
-}
-
 fn failing_rpm_bundle_for_slot(
     entry_id: &str,
     phase: LifecyclePath,
-    criticality: RpmCriticality,
+    header_critical: bool,
 ) -> NativeLifecycleBundle {
-    let mut bundle = failing_rpm_bundle(
-        criticality,
-        conary_core::scriptlet::FailurePosture::for_rpm_criticality(criticality)
-            .aborts_transaction(),
-    );
+    let mut bundle = rpm_bundle_for_phase("rpm-warning-fixture", "1", entry_id, phase, "<lua>");
     let entry = &mut bundle.entries[0];
-    entry.id = entry_id.to_string();
-    entry.native_slot = entry_id.trim_start_matches("rpm:").to_string();
-    entry.phase = phase;
-    entry.lifecycle_paths = vec![phase.as_str().to_string()];
-    entry.transaction_order.position = phase.as_str().to_string();
+    entry.body = "error('typed fixture failure')\n".to_string();
+    entry.body_sha256 = conary_core::hash::sha256_prefixed(entry.body.as_bytes());
+    // The stamp is derived exactly as conversion derives it: from the typed
+    // class and the header flag word. The runtime itself derives posture from
+    // the class alone, so the stamp is evidence, not the decision input.
+    // Trigger-slot entries cannot derive a class until the caller attaches
+    // rpm_trigger metadata; those callers re-stamp afterwards.
+    let class = entry.rpm_class();
+    let runtime = entry.rpm_runtime.as_mut().unwrap();
+    runtime.program = RpmProgram::EmbeddedLua;
+    if header_critical {
+        runtime.raw_flags |= conary_core::ccs::native_lifecycle::RPM_SCRIPTLET_FLAG_CRITICAL;
+    }
+    if let Some(class) = class {
+        runtime.criticality = class.effective_criticality(header_critical);
+    }
     bundle
 }
 
@@ -96,19 +85,61 @@ fn prepare_single_event(
     (prepared, result)
 }
 
+/// The runtime derives posture from the typed class and the header flag word
+/// alone, so every persisted criticality value lands on the posture the class
+/// declares -- including header promotion and the file-trigger refusal.
 #[test]
-fn rpm_script_execution_failure_follows_every_persisted_criticality_value() {
-    for (criticality, critical, expected_fatal) in [
-        (RpmCriticality::WarningOnly, false, false),
-        (RpmCriticality::ForcedWarningOnly, false, false),
-        (RpmCriticality::Header, true, true),
-        (RpmCriticality::SlotDefault, true, true),
-    ] {
-        let result = execute_single_event(failing_rpm_bundle(criticality, critical));
+fn rpm_runtime_derives_posture_from_typed_class_and_header_flag() {
+    // (bundle, expected fatal): one class/flag pair per persisted criticality
+    // value.
+    let mut cases: Vec<(NativeLifecycleBundle, bool)> = vec![
+        // WarningOnly: a promotable class without the header flag warns.
+        (
+            failing_rpm_bundle_for_slot("rpm:%post", LifecyclePath::PostInstall, false),
+            false,
+        ),
+        // Header: the same class with the header CRITICAL bit promotes to
+        // fatal.
+        (
+            failing_rpm_bundle_for_slot("rpm:%post", LifecyclePath::PostInstall, true),
+            true,
+        ),
+        // SlotDefault: a class whose default aborts, without the header flag.
+        (
+            failing_rpm_bundle_for_slot("rpm:%pre", LifecyclePath::PreInstall, false),
+            true,
+        ),
+    ];
+    // ForcedWarningOnly: a file trigger refuses promotion even with the
+    // header bit set.
+    let mut file_trigger =
+        failing_rpm_bundle_for_slot("rpm:%filetriggerin:0", LifecyclePath::Trigger, true);
+    let entry = &mut file_trigger.entries[0];
+    entry.rpm_trigger = Some(conary_core::ccs::native_lifecycle::RpmTriggerMetadata {
+        kind: conary_core::ccs::native_lifecycle::RpmTriggerKind::File,
+        target_constraints: vec![
+            conary_core::ccs::native_lifecycle::RpmTriggerTargetConstraint {
+                package: "/usr/share/cache".to_string(),
+                action: conary_core::ccs::native_lifecycle::RpmTriggerAction::Install,
+                operator: None,
+                version: None,
+                raw_flags: 0,
+            },
+        ],
+        priority: None,
+        path_prefixes: vec!["/usr/share/cache".to_string()],
+    });
+    let class = entry.rpm_class().expect("typed trigger class");
+    let runtime = entry.rpm_runtime.as_mut().unwrap();
+    runtime.criticality = class.effective_criticality(true);
+    cases.push((file_trigger, false));
+
+    for (bundle, expected_fatal) in cases {
+        let result = execute_single_event(bundle);
         assert_eq!(
             result.is_err(),
             expected_fatal,
-            "unexpected graph result for {criticality:?}: {result:#?}"
+            "unexpected graph result: {result:#?}"
         );
         if let Err(error) = result {
             assert!(
@@ -122,7 +153,7 @@ fn rpm_script_execution_failure_follows_every_persisted_criticality_value() {
 
 #[test]
 fn warning_only_rpm_contract_failure_remains_fatal() {
-    let mut bundle = failing_rpm_bundle(RpmCriticality::WarningOnly, false);
+    let mut bundle = failing_rpm_bundle_for_slot("rpm:%post", LifecyclePath::PostInstall, false);
     bundle.entries[0].interpreter = "/bin/sh".to_string();
 
     let error = execute_single_event(bundle)
@@ -182,15 +213,15 @@ fn every_declared_rpm_class_gets_its_declared_runtime_posture() {
             WarnAndContinue,
         ),
     ] {
-        // Only the persisted criticality comes from the table: it is what
-        // conversion would have stamped on an entry of this class.
-        let criticality =
-            conary_core::scriptlet::rpm_package_slot_authority(slot).effective_criticality(false);
-        let (prepared, result) = prepare_single_event(failing_rpm_bundle_for_slot(
-            entry_id,
-            phase,
-            criticality.persisted(),
-        ));
+        // The runtime is told only the typed class; the persisted stamp is
+        // derived from that class exactly as conversion derives it.
+        let bundle = failing_rpm_bundle_for_slot(entry_id, phase, false);
+        assert_eq!(
+            bundle.entries[0].native_slot,
+            Some(slot),
+            "{entry_id} must carry the declared typed slot"
+        );
+        let (prepared, result) = prepare_single_event(bundle);
         let continued = prepared.take_continued_lifecycle_failures();
         match expected {
             AbortsTransaction => {
@@ -237,11 +268,7 @@ fn a_pre_install_class_failure_aborts_before_the_payload_boundary() {
     let root = temp.path().join("selected-root");
     std::fs::create_dir(&root).unwrap();
 
-    let bundle = failing_rpm_bundle_for_slot(
-        "rpm:%pre",
-        LifecyclePath::PreInstall,
-        RpmCriticality::SlotDefault,
-    );
+    let bundle = failing_rpm_bundle_for_slot("rpm:%pre", LifecyclePath::PreInstall, false);
     let event = rpm_entry_event(&bundle);
     let mut prepared =
         prepared_with_projected_event(bundle, event, NativeEventPathProjection::CurrentRoot);
@@ -297,18 +324,10 @@ fn a_continued_failure_is_still_reported_when_a_later_graph_step_aborts() {
 
     // Entry 0 fails in a warn-and-continue class; entry 1 fails in an aborting
     // class later in the same graph.
-    let mut bundle = failing_rpm_bundle_for_slot(
-        "rpm:%post",
-        LifecyclePath::PostInstall,
-        RpmCriticality::WarningOnly,
-    );
-    let aborting = failing_rpm_bundle_for_slot(
-        "rpm:%pre",
-        LifecyclePath::PreInstall,
-        RpmCriticality::SlotDefault,
-    )
-    .entries
-    .remove(0);
+    let mut bundle = failing_rpm_bundle_for_slot("rpm:%post", LifecyclePath::PostInstall, false);
+    let aborting = failing_rpm_bundle_for_slot("rpm:%pre", LifecyclePath::PreInstall, false)
+        .entries
+        .remove(0);
     bundle.entries.push(aborting);
 
     let continuing_event = rpm_entry_event(&bundle);
@@ -389,11 +408,7 @@ fn a_lifecycle_evidence_persist_error_does_not_change_a_successful_graph_result(
         .update_status(&conn, ChangesetStatus::Applied)
         .unwrap();
 
-    let bundle = failing_rpm_bundle_for_slot(
-        "rpm:%post",
-        LifecyclePath::PostInstall,
-        RpmCriticality::WarningOnly,
-    );
+    let bundle = failing_rpm_bundle_for_slot("rpm:%post", LifecyclePath::PostInstall, false);
     let event = rpm_entry_event(&bundle);
     let mut prepared =
         prepared_with_projected_event(bundle, event, NativeEventPathProjection::CurrentRoot);
@@ -432,11 +447,7 @@ fn a_continued_failure_persists_once_on_the_success_exit() {
     std::fs::create_dir(&root).unwrap();
     let changeset_id = pending_changeset(&conn);
 
-    let bundle = failing_rpm_bundle_for_slot(
-        "rpm:%post",
-        LifecyclePath::PostInstall,
-        RpmCriticality::WarningOnly,
-    );
+    let bundle = failing_rpm_bundle_for_slot("rpm:%post", LifecyclePath::PostInstall, false);
     let event = rpm_entry_event(&bundle);
     let mut prepared =
         prepared_with_projected_event(bundle, event, NativeEventPathProjection::CurrentRoot);

--- a/apps/conary/src/commands/model/test_support.rs
+++ b/apps/conary/src/commands/model/test_support.rs
@@ -149,7 +149,7 @@ end
 "#;
     let entry = NativeLifecycleEntry {
         id: "rpm:%post".to_string(),
-        native_slot: "%post".to_string(),
+        native_slot: Some(conary_core::packages::native_abi::RpmScriptletSlot::Post),
         kind: NativeLifecycleEntryKind::Executable,
         phase: LifecyclePath::PostInstall,
         lifecycle_paths: vec!["install:post".to_string()],
@@ -179,9 +179,8 @@ end
         rpm_runtime: Some(RpmRuntimeMetadata {
             program: RpmProgram::EmbeddedLua,
             body_transforms: Vec::new(),
-            critical: true,
             criticality: RpmCriticality::Header,
-            raw_flags: 0,
+            raw_flags: conary_core::ccs::native_lifecycle::RPM_SCRIPTLET_FLAG_CRITICAL,
             unknown_flags: 0,
             install_prefixes: Vec::new(),
             macro_context: Default::default(),
@@ -286,7 +285,7 @@ fn typed_rpm_replatform_upgrade_entry() -> NativeLifecycleEntry {
     let body = "print('replatform-upgrade-new-pre')\n";
     NativeLifecycleEntry {
         id: "rpm:%pre".to_string(),
-        native_slot: "%pre".to_string(),
+        native_slot: Some(conary_core::packages::native_abi::RpmScriptletSlot::Pre),
         kind: NativeLifecycleEntryKind::Executable,
         phase: LifecyclePath::PreUpgrade,
         lifecycle_paths: vec!["upgrade:new-pre".to_string()],
@@ -312,9 +311,8 @@ fn typed_rpm_replatform_upgrade_entry() -> NativeLifecycleEntry {
         rpm_runtime: Some(RpmRuntimeMetadata {
             program: RpmProgram::EmbeddedLua,
             body_transforms: Vec::new(),
-            critical: true,
             criticality: RpmCriticality::Header,
-            raw_flags: 0,
+            raw_flags: conary_core::ccs::native_lifecycle::RPM_SCRIPTLET_FLAG_CRITICAL,
             unknown_flags: 0,
             install_prefixes: Vec::new(),
             macro_context: Default::default(),

--- a/apps/conary/src/commands/query/scripts.rs
+++ b/apps/conary/src/commands/query/scripts.rs
@@ -10,6 +10,7 @@ use conary_core::db::models::{InstalledCcsRemoveHook, InstalledNativeLifecycleBu
 use conary_core::packages::PackageFormat;
 use conary_core::packages::arch::ArchPackage;
 use conary_core::packages::deb::DebPackage;
+use conary_core::packages::native_abi::RpmScriptletSlot;
 use conary_core::packages::rpm::RpmPackage;
 use serde::Serialize;
 use std::path::Path;
@@ -86,7 +87,9 @@ struct BundleQuerySummary {
 #[derive(Debug, Serialize)]
 struct EntryQuerySummary {
     id: String,
-    native_slot: String,
+    /// The exact persisted typed slot class string, when the entry declares
+    /// one.
+    native_slot: Option<String>,
     phase: String,
     lifecycle_paths: Vec<String>,
     interpreter: String,
@@ -518,7 +521,10 @@ fn bundle_summary(bundle: &NativeLifecycleBundle) -> BundleQuerySummary {
 fn entry_summary(entry: &NativeLifecycleEntry) -> EntryQuerySummary {
     EntryQuerySummary {
         id: entry.id.clone(),
-        native_slot: entry.native_slot.clone(),
+        native_slot: entry
+            .native_slot
+            .map(RpmScriptletSlot::as_str)
+            .map(str::to_string),
         phase: entry.phase.as_str().to_string(),
         lifecycle_paths: entry.lifecycle_paths.clone(),
         interpreter: entry.interpreter.clone(),

--- a/apps/conary/src/commands/query/scripts/tests.rs
+++ b/apps/conary/src/commands/query/scripts/tests.rs
@@ -43,9 +43,11 @@ mod query_scripts {
     }
 
     fn entry_fixture(id: &str, body: &str) -> NativeLifecycleEntry {
-        NativeLifecycleEntry {
+        let mut entry = NativeLifecycleEntry {
             id: id.to_string(),
-            native_slot: id.split(':').nth(1).unwrap_or("%post").to_string(),
+            native_slot: conary_core::packages::native_abi::RpmScriptletSlot::from_tag(
+                id.split(':').nth(1).unwrap_or("%post"),
+            ),
             kind: NativeLifecycleEntryKind::Executable,
             phase: if id.ends_with("%preun") {
                 LifecyclePath::PreRemove
@@ -81,7 +83,6 @@ mod query_scripts {
             rpm_runtime: Some(conary_core::ccs::native_lifecycle::RpmRuntimeMetadata {
                 program: conary_core::ccs::native_lifecycle::RpmProgram::External,
                 body_transforms: Vec::new(),
-                critical: false,
                 criticality: conary_core::ccs::native_lifecycle::RpmCriticality::WarningOnly,
                 raw_flags: 0,
                 unknown_flags: 0,
@@ -95,7 +96,13 @@ mod query_scripts {
             arch_install: None,
             arch_hook: None,
             residual_lifecycle: None,
+        };
+        // Keep the persisted stamp consistent with the typed class authority.
+        let entry_class = entry.rpm_class();
+        if let (Some(runtime), Some(class)) = (&mut entry.rpm_runtime, entry_class) {
+            runtime.criticality = class.effective_criticality(false);
         }
+        entry
     }
 
     fn package_identity() -> PackageQueryIdentity {

--- a/apps/conary/src/commands/remove/autoremove.rs
+++ b/apps/conary/src/commands/remove/autoremove.rs
@@ -490,7 +490,7 @@ marker:close()
 "#;
         NativeLifecycleEntry {
             id: "rpm:%postun".to_string(),
-            native_slot: "%postun".to_string(),
+            native_slot: Some(conary_core::packages::native_abi::RpmScriptletSlot::PostUn),
             kind: NativeLifecycleEntryKind::Executable,
             phase: LifecyclePath::PostRemove,
             lifecycle_paths: vec!["remove:post".to_string()],
@@ -521,7 +521,6 @@ marker:close()
             rpm_runtime: Some(conary_core::ccs::native_lifecycle::RpmRuntimeMetadata {
                 program: conary_core::ccs::native_lifecycle::RpmProgram::EmbeddedLua,
                 body_transforms: Vec::new(),
-                critical: false,
                 criticality: conary_core::ccs::native_lifecycle::RpmCriticality::WarningOnly,
                 raw_flags: 0,
                 unknown_flags: 0,

--- a/apps/conary/src/commands/state/tests.rs
+++ b/apps/conary/src/commands/state/tests.rs
@@ -117,8 +117,12 @@ fn typed_rpm_entry(
             _ => unreachable!("test fixture only builds install and remove entries"),
         },
         native_slot: match phase {
-            LifecyclePath::PreInstall => "%pre".to_string(),
-            LifecyclePath::PostRemove => "%postun".to_string(),
+            LifecyclePath::PreInstall => {
+                Some(conary_core::packages::native_abi::RpmScriptletSlot::Pre)
+            }
+            LifecyclePath::PostRemove => {
+                Some(conary_core::packages::native_abi::RpmScriptletSlot::PostUn)
+            }
             _ => unreachable!("test fixture only builds install and remove entries"),
         },
         kind: NativeLifecycleEntryKind::Executable,
@@ -144,8 +148,11 @@ fn typed_rpm_entry(
         rpm_runtime: Some(RpmRuntimeMetadata {
             program: RpmProgram::EmbeddedLua,
             body_transforms: Vec::new(),
-            critical: true,
-            criticality: RpmCriticality::Header,
+            criticality: match phase {
+                LifecyclePath::PreInstall => RpmCriticality::SlotDefault,
+                LifecyclePath::PostRemove => RpmCriticality::WarningOnly,
+                _ => unreachable!("test fixture only builds install and remove entries"),
+            },
             raw_flags: 0,
             unknown_flags: 0,
             install_prefixes: Vec::new(),

--- a/apps/conary/src/commands/system/tests/rollback.rs
+++ b/apps/conary/src/commands/system/tests/rollback.rs
@@ -171,7 +171,7 @@ fn rollback_typed_rpm_entry() -> NativeLifecycleEntry {
     let body = "print('rollback-post-remove')\n";
     NativeLifecycleEntry {
         id: "rpm:%postun".to_string(),
-        native_slot: "%postun".to_string(),
+        native_slot: Some(conary_core::packages::native_abi::RpmScriptletSlot::PostUn),
         kind: NativeLifecycleEntryKind::Executable,
         phase: LifecyclePath::PostRemove,
         lifecycle_paths: vec!["remove:last".to_string()],
@@ -195,8 +195,7 @@ fn rollback_typed_rpm_entry() -> NativeLifecycleEntry {
         rpm_runtime: Some(RpmRuntimeMetadata {
             program: RpmProgram::EmbeddedLua,
             body_transforms: Vec::new(),
-            critical: true,
-            criticality: RpmCriticality::Header,
+            criticality: RpmCriticality::WarningOnly,
             raw_flags: 0,
             unknown_flags: 0,
             install_prefixes: Vec::new(),

--- a/apps/conary/src/commands/try_session/validation.rs
+++ b/apps/conary/src/commands/try_session/validation.rs
@@ -326,7 +326,7 @@ description = "native lifecycles"
 
 [native_lifecycle]
 schema = "conary.native-lifecycles.v1"
-schema_revision = 19
+schema_revision = 20
 source_format = "rpm"
 source_family = "fedora-rhel"
 source_profile = "fedora-44"
@@ -354,7 +354,7 @@ body = "{body}"
 native_invocation = {{ args = ["1"], environment = ["RPM_INSTALL_PREFIX=/"], stdin = "none", chroot = "install-root" }}
 transaction_order = {{ position = "after-payload", after = ["payload"] }}
 timeout_ms = 30000
-rpm_runtime = {{ program = "external", critical = false, criticality = "warning-only", raw_flags = 0 }}
+rpm_runtime = {{ program = "external", criticality = "warning-only", raw_flags = 0 }}
 "#
         );
 

--- a/apps/conary/src/commands/update/package/tests.rs
+++ b/apps/conary/src/commands/update/package/tests.rs
@@ -84,7 +84,7 @@ fn rpm_upgrade_entry() -> NativeLifecycleEntry {
     let body = "print('rpm-upgrade-new-pre')\n";
     NativeLifecycleEntry {
         id: "rpm:%pre".to_string(),
-        native_slot: "%pre".to_string(),
+        native_slot: Some(conary_core::packages::native_abi::RpmScriptletSlot::Pre),
         kind: NativeLifecycleEntryKind::Executable,
         phase: LifecyclePath::PreUpgrade,
         lifecycle_paths: vec!["upgrade:new-pre".to_string()],
@@ -108,8 +108,7 @@ fn rpm_upgrade_entry() -> NativeLifecycleEntry {
         rpm_runtime: Some(RpmRuntimeMetadata {
             program: RpmProgram::EmbeddedLua,
             body_transforms: Vec::new(),
-            critical: true,
-            criticality: RpmCriticality::Header,
+            criticality: RpmCriticality::SlotDefault,
             raw_flags: 0,
             unknown_flags: 0,
             install_prefixes: Vec::new(),

--- a/apps/conary/tests/conversion_integration.rs
+++ b/apps/conary/tests/conversion_integration.rs
@@ -123,14 +123,22 @@ fn rpm_lifecycle_entry(
             slot,
             runtime: RpmScriptletRuntimeMetadata {
                 program: RpmScriptletProgram::External,
-                flags: RpmScriptletFlagsMetadata {
-                    names: Vec::new(),
-                    raw_bits: 0,
-                    unknown_bits: 0,
-                    expand: false,
-                    query_format: false,
-                    critical: false,
-                    criticality: RpmScriptletCriticality::WarningOnly,
+                flags: {
+                    // Derive the stamp as the parser does: the slot's class
+                    // authority with no CRITICAL header flag. Hand-set
+                    // combinations the parser cannot emit are rejected by the
+                    // bundle's class cross-check.
+                    let criticality = conary_core::scriptlet::rpm_package_slot_authority(slot)
+                        .effective_criticality(false);
+                    RpmScriptletFlagsMetadata {
+                        names: Vec::new(),
+                        raw_bits: 0,
+                        unknown_bits: 0,
+                        expand: false,
+                        query_format: false,
+                        critical: criticality.is_critical(),
+                        criticality,
+                    }
                 },
                 install_prefixes: Vec::new(),
                 macro_context: Default::default(),

--- a/apps/conary/tests/native_pm_daily_driver.rs
+++ b/apps/conary/tests/native_pm_daily_driver.rs
@@ -164,7 +164,7 @@ fn missing_interpreter_remove_bundle(package: &str, version: &str) -> NativeLife
     let body = "exit 0\n".to_string();
     let entry = NativeLifecycleEntry {
         id: "rpm:%preun".to_string(),
-        native_slot: "%preun".to_string(),
+        native_slot: Some(conary_core::packages::native_abi::RpmScriptletSlot::PreUn),
         kind: NativeLifecycleEntryKind::Executable,
         phase: LifecyclePath::PreRemove,
         lifecycle_paths: vec![LifecyclePath::PreRemove.as_str().to_string()],
@@ -187,7 +187,6 @@ fn missing_interpreter_remove_bundle(package: &str, version: &str) -> NativeLife
         rpm_runtime: Some(RpmRuntimeMetadata {
             program: RpmProgram::External,
             body_transforms: Vec::new(),
-            critical: true,
             criticality: RpmCriticality::SlotDefault,
             raw_flags: 0,
             unknown_flags: 0,

--- a/apps/conary/tests/query_scripts.rs
+++ b/apps/conary/tests/query_scripts.rs
@@ -161,7 +161,7 @@ fn bundle_fixture() -> NativeLifecycleBundle {
         ),
         scriptlet_fidelity: ScriptletFidelity::NativeLifecycle,
         entries: vec![
-            entry_fixture("rpm:%preun", pre_remove_body, true),
+            entry_fixture("rpm:%filetriggerin:0", pre_remove_body, true),
             entry_fixture("rpm:%post", post_install_body, false),
         ],
     }
@@ -175,14 +175,19 @@ fn zero_entry_bundle_fixture() -> NativeLifecycleBundle {
 }
 
 fn entry_fixture(id: &str, body: &str, with_reserved_metadata: bool) -> NativeLifecycleEntry {
-    NativeLifecycleEntry {
+    let slot = conary_core::packages::native_abi::RpmScriptletSlot::from_tag(
+        id.split(':').nth(1).unwrap_or("%post"),
+    );
+    let mut entry = NativeLifecycleEntry {
         id: id.to_string(),
-        native_slot: id.split(':').nth(1).unwrap_or("%post").to_string(),
+        native_slot: slot,
         kind: NativeLifecycleEntryKind::Executable,
-        phase: if id.ends_with("%preun") {
-            LifecyclePath::PreRemove
-        } else {
-            LifecyclePath::PostInstall
+        phase: match slot {
+            Some(conary_core::packages::native_abi::RpmScriptletSlot::Trigger) => {
+                LifecyclePath::Trigger
+            }
+            _ if id.ends_with("%preun") => LifecyclePath::PreRemove,
+            _ => LifecyclePath::PostInstall,
         },
         lifecycle_paths: vec!["install:first".to_string()],
         interpreter: "/bin/sh".to_string(),
@@ -223,7 +228,6 @@ fn entry_fixture(id: &str, body: &str, with_reserved_metadata: bool) -> NativeLi
         rpm_runtime: Some(conary_core::ccs::native_lifecycle::RpmRuntimeMetadata {
             program: conary_core::ccs::native_lifecycle::RpmProgram::External,
             body_transforms: Vec::new(),
-            critical: false,
             criticality: conary_core::ccs::native_lifecycle::RpmCriticality::WarningOnly,
             raw_flags: 0,
             unknown_flags: 0,
@@ -237,7 +241,14 @@ fn entry_fixture(id: &str, body: &str, with_reserved_metadata: bool) -> NativeLi
         arch_install: None,
         arch_hook: None,
         residual_lifecycle: None,
+    };
+    // Keep the persisted stamp consistent with the typed class authority,
+    // including the trigger class carried by the reserved metadata.
+    let entry_class = entry.rpm_class();
+    if let (Some(runtime), Some(class)) = (&mut entry.rpm_runtime, entry_class) {
+        runtime.criticality = class.effective_criticality(false);
     }
+    entry
 }
 
 #[test]
@@ -460,7 +471,7 @@ fn query_scripts_ccs_bundle_entry_filter_prints_single_entry() {
     assert_success(&output);
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("rpm:%post"));
-    assert!(!stdout.contains("rpm:%preun"));
+    assert!(!stdout.contains("rpm:%filetriggerin:0"));
 }
 
 #[test]
@@ -502,7 +513,7 @@ fn query_scripts_ccs_bundle_json_is_stable() {
     assert_eq!(json["package"]["name"], "nginx");
     assert_eq!(json["bundle_present"], true);
     assert_eq!(json["bundle"]["schema"], "conary.native-lifecycles.v1");
-    assert_eq!(json["entries"][0]["id"], "rpm:%preun");
+    assert_eq!(json["entries"][0]["id"], "rpm:%filetriggerin:0");
     assert!(json["entries"][0]["body"].is_null());
     assert!(stdout.contains("body_sha256"));
     assert!(!stdout.contains("systemctl daemon-reload"));

--- a/crates/conary-core/src/ccs/convert/converter/tests.rs
+++ b/crates/conary-core/src/ccs/convert/converter/tests.rs
@@ -174,14 +174,22 @@ fn rpm_native_entry(
             slot,
             runtime: RpmScriptletRuntimeMetadata {
                 program: RpmScriptletProgram::External,
-                flags: RpmScriptletFlagsMetadata {
-                    names: Vec::new(),
-                    raw_bits: 0,
-                    unknown_bits: 0,
-                    expand: false,
-                    query_format: false,
-                    critical: false,
-                    criticality: RpmScriptletCriticality::WarningOnly,
+                flags: {
+                    // Derive the stamp exactly as the parser does: the slot's
+                    // class authority with no CRITICAL header flag. Hand-set
+                    // combinations the parser cannot emit are rejected by the
+                    // bundle's class cross-check.
+                    let criticality = crate::scriptlet::rpm_package_slot_authority(slot)
+                        .effective_criticality(false);
+                    RpmScriptletFlagsMetadata {
+                        names: Vec::new(),
+                        raw_bits: 0,
+                        unknown_bits: 0,
+                        expand: false,
+                        query_format: false,
+                        critical: criticality.is_critical(),
+                        criticality,
+                    }
                 },
                 install_prefixes: Vec::new(),
                 macro_context: Default::default(),

--- a/crates/conary-core/src/ccs/convert/scriptlet_bundle/builder.rs
+++ b/crates/conary-core/src/ccs/convert/scriptlet_bundle/builder.rs
@@ -55,7 +55,7 @@ pub fn build_native_lifecycle_bundle(
     for entry in &mut bundle.entries {
         entry.evidence_digest = Some(digest.clone());
     }
-    bundle.validate()?;
+    bundle.validate_as_conversion_output()?;
 
     Ok(ScriptletBundleBuild {
         summary: summary_from_bundle(&bundle),

--- a/crates/conary-core/src/ccs/convert/scriptlet_bundle/entries.rs
+++ b/crates/conary-core/src/ccs/convert/scriptlet_bundle/entries.rs
@@ -8,7 +8,8 @@ use super::native_contracts::{
 use super::types::ScriptletBundleInput;
 use crate::ccs::native_lifecycle::NativeLifecycleEntry;
 use crate::packages::native_abi::{
-    ArchNativeScriptletMetadata, NativeScriptletEntry, NativeScriptletMetadata,
+    ArchNativeScriptletMetadata, NativeScriptletEntry, NativeScriptletFormat,
+    NativeScriptletMetadata, RpmScriptletSlot,
 };
 use crate::repository::supported_profiles;
 
@@ -49,7 +50,7 @@ fn build_native_entry(
 
     Ok(NativeLifecycleEntry {
         id: native.id.clone(),
-        native_slot: native.native_slot.clone(),
+        native_slot: native_lifecycle_slot(native)?,
         kind: native_lifecycle_entry_kind(native.kind),
         phase,
         lifecycle_paths,
@@ -73,6 +74,25 @@ fn build_native_entry(
         arch_hook,
         residual_lifecycle: None,
     })
+}
+
+fn native_lifecycle_slot(
+    native: &NativeScriptletEntry,
+) -> anyhow::Result<Option<RpmScriptletSlot>> {
+    if native.format != NativeScriptletFormat::Rpm {
+        // Formats without a declared class table persist no slot; their typed
+        // class authority lives in their format metadata.
+        return Ok(None);
+    }
+    RpmScriptletSlot::from_tag(&native.native_slot)
+        .map(Some)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "RPM native lifecycle entry '{}' carries unknown scriptlet slot '{}'",
+                native.id,
+                native.native_slot
+            )
+        })
 }
 
 fn native_interpreter(

--- a/crates/conary-core/src/ccs/convert/scriptlet_bundle/format_metadata.rs
+++ b/crates/conary-core/src/ccs/convert/scriptlet_bundle/format_metadata.rs
@@ -114,7 +114,6 @@ fn project_rpm_metadata(
         .into_iter()
         .flatten()
         .collect(),
-        critical: metadata.runtime.flags.criticality.is_critical(),
         criticality: metadata.runtime.flags.criticality.persisted(),
         raw_flags: metadata.runtime.flags.raw_bits,
         unknown_flags: metadata.runtime.flags.unknown_bits,

--- a/crates/conary-core/src/ccs/manifest/tests.rs
+++ b/crates/conary-core/src/ccs/manifest/tests.rs
@@ -747,7 +747,7 @@ description = "nginx converted from RPM"
 
 [native_lifecycle]
 schema = "conary.native-lifecycles.v1"
-schema_revision = 19
+schema_revision = 20
 source_format = "rpm"
 source_family = "fedora-rhel"
 source_profile = "fedora-44"
@@ -775,7 +775,7 @@ body = "{body}"
 native_invocation = {{ args = ["1"], environment = ["RPM_INSTALL_PREFIX=/"], stdin = "none", chroot = "install-root" }}
 transaction_order = {{ position = "after-payload", after = ["payload"] }}
 timeout_ms = 30000
-rpm_runtime = {{ program = "external", critical = false, criticality = "warning-only", raw_flags = 0 }}
+rpm_runtime = {{ program = "external", criticality = "warning-only", raw_flags = 0 }}
 "#
     )
 }
@@ -795,6 +795,10 @@ fn manifest_toml_round_trips_native_lifecycle_bundle() {
     assert_eq!(bundle.source_package, "nginx");
     assert_eq!(bundle.entries.len(), 1);
     assert_eq!(bundle.entries[0].id, "rpm:%post");
+    assert_eq!(
+        bundle.entries[0].native_slot,
+        Some(crate::packages::native_abi::RpmScriptletSlot::Post)
+    );
 
     let encoded = manifest.to_toml().expect("serialize manifest");
     assert!(encoded.contains("[native_lifecycle]"));
@@ -811,6 +815,25 @@ fn manifest_toml_round_trips_native_lifecycle_bundle() {
 }
 
 #[test]
+fn manifest_carrying_the_deleted_critical_bool_fails_naming_the_unknown_field() {
+    let body = "ldconfig";
+    let body_sha256 = crate::hash::sha256_prefixed(body.as_bytes());
+    let toml = manifest_with_native_lifecycle_bundle(body, &body_sha256)
+        .replacen(
+            "rpm_runtime = { program = \"external\", criticality = \"warning-only\", raw_flags = 0 }",
+            "rpm_runtime = { program = \"external\", critical = false, criticality = \"warning-only\", raw_flags = 0 }",
+            1,
+        );
+
+    let error = CcsManifest::parse(&toml)
+        .expect_err("a manifest carrying the deleted critical bool must fail");
+    assert!(
+        error.to_string().contains("unknown field `critical`"),
+        "the rejection must name the deleted field, got: {error}"
+    );
+}
+
+#[test]
 fn manifest_rejects_removed_security_policy_intent_authority() {
     let toml = r#"
 [package]
@@ -823,7 +846,7 @@ description = "policy fixture"
 
 [native_lifecycle]
 schema = "conary.native-lifecycles.v1"
-schema_revision = 19
+schema_revision = 20
 source_format = "rpm"
 source_family = "rpm"
 source_profile = "fedora-44"

--- a/crates/conary-core/src/ccs/native_lifecycle.rs
+++ b/crates/conary-core/src/ccs/native_lifecycle.rs
@@ -1,6 +1,7 @@
 // conary-core/src/ccs/native_lifecycle.rs
 //! Preserved native package-manager lifecycle metadata for CCS packages.
 
+use crate::packages::native_abi::RpmScriptletSlot;
 use anyhow::{anyhow, bail};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
@@ -14,7 +15,7 @@ pub use rpm::*;
 pub use types::*;
 
 pub const NATIVE_LIFECYCLE_SCHEMA_V1: &str = "conary.native-lifecycles.v1";
-pub const NATIVE_LIFECYCLE_SCHEMA_REVISION: u16 = 19;
+pub const NATIVE_LIFECYCLE_SCHEMA_REVISION: u16 = 20;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -68,7 +69,12 @@ pub enum NativeLifecycleEntryKind {
 #[serde(deny_unknown_fields)]
 pub struct NativeLifecycleEntry {
     pub id: String,
-    pub native_slot: String,
+    /// The typed lifecycle slot class. RPM entries carry their exact typed
+    /// `RpmScriptletSlot` class (the persisted wire value is the exact RPM
+    /// scriptlet tag); formats without a declared class table persist no slot
+    /// and their class authority lives in their typed format metadata.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub native_slot: Option<RpmScriptletSlot>,
     pub kind: NativeLifecycleEntryKind,
     pub phase: LifecyclePath,
     pub lifecycle_paths: Vec<String>,
@@ -181,6 +187,35 @@ pub enum RpmTriggerAction {
     Install,
     Uninstall,
     PostUninstall,
+}
+
+impl RpmTriggerAction {
+    /// The persisted wire value of this trigger action.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::PreInstall => "pre-install",
+            Self::Install => "install",
+            Self::Uninstall => "uninstall",
+            Self::PostUninstall => "post-uninstall",
+        }
+    }
+}
+
+/// The typed RPM lifecycle class of a persisted entry.
+///
+/// This is the value the install runtime is told about: it keys the failure
+/// posture table, so format-posture corrections apply to already-converted
+/// artifacts without reconversion. A trigger entry's class carries its exact
+/// persisted trigger kind and its single target action; validation rejects
+/// target constraints with more than one distinct action, so the class is
+/// never constraint-order-dependent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RpmLifecycleClass {
+    PackageSlot(RpmScriptletSlot),
+    Trigger {
+        kind: RpmTriggerKind,
+        action: RpmTriggerAction,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
@@ -425,12 +460,26 @@ impl NativeLifecycleBundle {
 
         Ok(())
     }
+
+    /// Conversion-output validation: every contract-shape rule plus the
+    /// criticality-stamp agreement with the current posture-table derivation.
+    ///
+    /// Only the converter/publication path calls this, so nothing Conary
+    /// produces can carry a stale or disagreeing stamp. Load paths (installed
+    /// bundle rows, residual rows, manifests, transaction planning) use
+    /// [`Self::validate`], which treats the stamp as evidence only.
+    pub fn validate_as_conversion_output(&self) -> anyhow::Result<()> {
+        self.validate()?;
+        for entry in &self.entries {
+            entry.validate_as_conversion_output()?;
+        }
+        Ok(())
+    }
 }
 
 impl NativeLifecycleEntry {
     fn validate(&self) -> anyhow::Result<()> {
         required_string("entry.id", &self.id)?;
-        required_string("entry.native_slot", &self.native_slot)?;
         required_string("entry.interpreter", &self.interpreter)?;
         required_string("entry.body", &self.body)?;
         required_string(
@@ -518,10 +567,75 @@ impl NativeLifecycleEntry {
             ),
             (_, false) => {}
         }
+        if matches!(self.native_slot, Some(RpmScriptletSlot::Trigger))
+            && self
+                .rpm_trigger
+                .as_ref()
+                .is_some_and(|trigger| trigger.target_constraints.is_empty())
+        {
+            bail!(
+                "entry '{}' declares the RPM trigger class without a target constraint",
+                self.id
+            );
+        }
+        match self.rpm_class() {
+            Some(RpmLifecycleClass::PackageSlot(RpmScriptletSlot::Sysusers))
+                if self
+                    .rpm_runtime
+                    .as_ref()
+                    .is_none_or(|metadata| metadata.program != RpmProgram::Sysusers) =>
+            {
+                bail!(
+                    "entry '{}' declares the RPM sysusers class without the sysusers program",
+                    self.id
+                )
+            }
+            Some(RpmLifecycleClass::Trigger { .. }) if self.rpm_trigger.is_none() => bail!(
+                "entry '{}' declares the RPM trigger class without typed trigger metadata",
+                self.id
+            ),
+            Some(RpmLifecycleClass::PackageSlot(_)) if self.rpm_trigger.is_some() => bail!(
+                "entry '{}' declares typed RPM trigger metadata outside the trigger class",
+                self.id
+            ),
+            _ => {}
+        }
         if let Some(metadata) = &self.residual_lifecycle {
             metadata.validate(&self.id)?;
         }
 
+        Ok(())
+    }
+
+    /// The typed RPM lifecycle class of this entry, or `None` when the entry
+    /// carries no declared RPM class.
+    ///
+    /// Trigger entries project their persisted trigger kind and their single
+    /// target action; validation rejects target constraints with more than one
+    /// distinct action, so the first constraint is provably the only action.
+    pub fn rpm_class(&self) -> Option<RpmLifecycleClass> {
+        match self.native_slot {
+            Some(RpmScriptletSlot::Trigger) => {
+                let trigger = self.rpm_trigger.as_ref()?;
+                let action = trigger.target_constraints.first()?.action;
+                Some(RpmLifecycleClass::Trigger {
+                    kind: trigger.kind,
+                    action,
+                })
+            }
+            Some(slot) => Some(RpmLifecycleClass::PackageSlot(slot)),
+            None => None,
+        }
+    }
+
+    /// Conversion-output validation: everything [`Self::validate`] enforces
+    /// plus the criticality-stamp agreement with the current posture-table
+    /// derivation. Only the converter/publication path calls this.
+    fn validate_as_conversion_output(&self) -> anyhow::Result<()> {
+        self.validate()?;
+        if let Some(metadata) = &self.rpm_runtime {
+            metadata.validate_as_conversion_output(&self.id, self.rpm_class())?;
+        }
         Ok(())
     }
 
@@ -559,6 +673,24 @@ impl NativeLifecycleEntry {
 
 impl RpmTriggerMetadata {
     fn validate(&self, entry_id: &str) -> anyhow::Result<()> {
+        // RPM's model declares one action per trigger scriptlet entry: the
+        // scriptlet's flags word carries a single action. The class projection
+        // reads the first target constraint, so more than one distinct action
+        // would make the class (and therefore the failure posture)
+        // constraint-order-dependent.
+        let mut actions = self
+            .target_constraints
+            .iter()
+            .map(|constraint| constraint.action);
+        if let Some(first) = actions.next()
+            && let Some(other) = actions.find(|action| *action != first)
+        {
+            bail!(
+                "entry '{entry_id}' RPM trigger target constraints mix actions '{}' and '{}'",
+                first.as_str(),
+                other.as_str()
+            );
+        }
         if matches!(
             self.kind,
             RpmTriggerKind::File | RpmTriggerKind::TransactionFile

--- a/crates/conary-core/src/ccs/native_lifecycle/debconf.rs
+++ b/crates/conary-core/src/ccs/native_lifecycle/debconf.rs
@@ -6,9 +6,7 @@ use super::{
     LifecyclePath, NativeLifecycleBundle, NativeLifecycleEntry, NativeLifecycleEntryKind,
     SourceFormat,
 };
-use crate::packages::native_abi::{
-    DEBCONF_TEMPLATES_ENTRY_ID, DEBCONF_TEMPLATES_NATIVE_SLOT, DebconfTemplateRecord,
-};
+use crate::packages::native_abi::{DEBCONF_TEMPLATES_ENTRY_ID, DebconfTemplateRecord};
 use anyhow::{Result, bail};
 
 /// Exact package association and byte-preserving authority for a Debian
@@ -76,14 +74,19 @@ impl NativeLifecycleBundle {
 }
 
 pub(super) fn is_debconf_templates_candidate(entry: &NativeLifecycleEntry) -> bool {
-    entry.id == DEBCONF_TEMPLATES_ENTRY_ID || entry.native_slot == DEBCONF_TEMPLATES_NATIVE_SLOT
+    entry.id == DEBCONF_TEMPLATES_ENTRY_ID
 }
 
 fn validate_debconf_templates_entry(entry: &NativeLifecycleEntry) -> Result<()> {
-    if entry.id != DEBCONF_TEMPLATES_ENTRY_ID || entry.native_slot != DEBCONF_TEMPLATES_NATIVE_SLOT
-    {
+    if entry.id != DEBCONF_TEMPLATES_ENTRY_ID {
         bail!(
             "entry '{}' is an ambiguous partial declaration of debconf templates authority",
+            entry.id
+        );
+    }
+    if entry.native_slot.is_some() {
+        bail!(
+            "entry '{}' debconf templates artifact carries an RPM slot class",
             entry.id
         );
     }
@@ -145,7 +148,7 @@ mod tests {
     fn entry() -> NativeLifecycleEntry {
         NativeLifecycleEntry {
             id: DEBCONF_TEMPLATES_ENTRY_ID.to_string(),
-            native_slot: DEBCONF_TEMPLATES_NATIVE_SLOT.to_string(),
+            native_slot: None,
             kind: NativeLifecycleEntryKind::ControlArtifact,
             phase: LifecyclePath::PackageControl,
             lifecycle_paths: vec!["package-control".to_string()],

--- a/crates/conary-core/src/ccs/native_lifecycle/rpm.rs
+++ b/crates/conary-core/src/ccs/native_lifecycle/rpm.rs
@@ -12,7 +12,6 @@ pub struct RpmRuntimeMetadata {
     pub program: RpmProgram,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub body_transforms: Vec<RpmBodyTransform>,
-    pub critical: bool,
     pub criticality: RpmCriticality,
     pub raw_flags: u32,
     #[serde(default, skip_serializing_if = "is_zero")]
@@ -26,6 +25,16 @@ pub struct RpmRuntimeMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub package_rpm_version: Option<String>,
 }
+
+/// `RPMSCRIPT_FLAG_CRITICAL` bit within the persisted raw scriptlet flag word.
+///
+/// Pinned to RPM upstream `lib/rpmscript.hh` at
+/// a8f0192aee1c08bd1454ed2ac6ebaf506004b55c
+/// (`RPMSCRIPT_FLAG_CRITICAL = (1 << 2)`); the parser's `rpm::ScriptletFlags`
+/// uses the same value. The runtime re-derives header promotion from the
+/// persisted typed class and this bit instead of trusting a conversion-time
+/// stamp.
+pub const RPM_SCRIPTLET_FLAG_CRITICAL: u32 = 1 << 2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -49,6 +58,18 @@ pub enum RpmCriticality {
     SlotDefault,
     WarningOnly,
     ForcedWarningOnly,
+}
+
+impl RpmCriticality {
+    /// The persisted wire value of this criticality.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Header => "header",
+            Self::SlotDefault => "slot-default",
+            Self::WarningOnly => "warning-only",
+            Self::ForcedWarningOnly => "forced-warning-only",
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -197,14 +218,17 @@ pub enum RpmSysusersDirective {
 }
 
 impl RpmRuntimeMetadata {
+    /// Contract-shape validation of a persisted RPM runtime contract.
+    ///
+    /// This runs on every bundle load, including installed bundles that were
+    /// converted against an earlier posture table. The criticality stamp is
+    /// evidence only: it must be a valid value of the closed persisted enum
+    /// (serde enforces that at deserialization), but it is not cross-checked
+    /// against the current posture-table derivation here. The runtime derives
+    /// posture from the typed class and the persisted header flag word alone,
+    /// so a posture-table correction applies to already-converted artifacts
+    /// without reconversion.
     pub(super) fn validate(&self, entry_id: &str) -> Result<()> {
-        let expected_critical = !matches!(
-            self.criticality,
-            RpmCriticality::WarningOnly | RpmCriticality::ForcedWarningOnly
-        );
-        if self.critical != expected_critical {
-            bail!("entry '{entry_id}' RPM critical flag disagrees with its criticality authority");
-        }
         if self.unknown_flags != 0 {
             bail!(
                 "entry '{entry_id}' RPM scriptlet flags contain unknown bits {:#x}",
@@ -301,6 +325,35 @@ impl RpmRuntimeMetadata {
         }
         if let Some(version) = &self.package_rpm_version {
             required_string("RPM package RPM version", version)?;
+        }
+        Ok(())
+    }
+
+    /// Conversion-output validation: every contract-shape rule plus the
+    /// criticality-stamp agreement with the current posture-table derivation.
+    ///
+    /// Only the converter/publication path calls this, so nothing Conary
+    /// produces can carry a stale or disagreeing stamp. The effective
+    /// criticality is a projection of the typed class and the header flag
+    /// word; the stamp must agree with that derivation so a hand-edited
+    /// manifest cannot smuggle a posture the class does not declare.
+    pub(super) fn validate_as_conversion_output(
+        &self,
+        entry_id: &str,
+        class: Option<super::RpmLifecycleClass>,
+    ) -> Result<()> {
+        self.validate(entry_id)?;
+        let Some(class) = class else {
+            return Ok(());
+        };
+        let header_critical = self.raw_flags & RPM_SCRIPTLET_FLAG_CRITICAL != 0;
+        let expected = class.effective_criticality(header_critical);
+        if self.criticality != expected {
+            bail!(
+                "entry '{entry_id}' RPM criticality '{}' disagrees with its typed class authority '{}'",
+                self.criticality.as_str(),
+                expected.as_str()
+            );
         }
         Ok(())
     }

--- a/crates/conary-core/src/ccs/native_lifecycle/tests.rs
+++ b/crates/conary-core/src/ccs/native_lifecycle/tests.rs
@@ -1,15 +1,18 @@
 // conary-core/src/ccs/native_lifecycle/tests.rs
 
 use super::*;
+use crate::packages::native_abi::RpmScriptletSlot;
+use crate::scriptlet::ScriptletFailureKind;
+use crate::scriptlet::{FailurePosture, LifecycleFailureClass};
 
 fn sha256_prefixed(body: &str) -> String {
     crate::hash::sha256_prefixed(body.as_bytes())
 }
 
 fn sample_entry(id: &str, body: &str) -> NativeLifecycleEntry {
-    NativeLifecycleEntry {
+    let mut entry = NativeLifecycleEntry {
         id: id.to_string(),
-        native_slot: "%post".to_string(),
+        native_slot: id.strip_prefix("rpm:").and_then(RpmScriptletSlot::from_tag),
         kind: NativeLifecycleEntryKind::Executable,
         phase: LifecyclePath::PostInstall,
         lifecycle_paths: vec!["install:first".to_string()],
@@ -44,7 +47,6 @@ fn sample_entry(id: &str, body: &str) -> NativeLifecycleEntry {
         rpm_runtime: Some(RpmRuntimeMetadata {
             program: RpmProgram::External,
             body_transforms: Vec::new(),
-            critical: false,
             criticality: RpmCriticality::WarningOnly,
             raw_flags: 0,
             unknown_flags: 0,
@@ -58,7 +60,14 @@ fn sample_entry(id: &str, body: &str) -> NativeLifecycleEntry {
         arch_install: None,
         arch_hook: None,
         residual_lifecycle: None,
+    };
+    // Keep the persisted criticality stamp consistent with the typed class
+    // authority, exactly as conversion would stamp it.
+    let entry_class = entry.rpm_class();
+    if let (Some(runtime), Some(class)) = (&mut entry.rpm_runtime, entry_class) {
+        runtime.criticality = class.effective_criticality(false);
     }
+    entry
 }
 
 fn sample_bundle() -> NativeLifecycleBundle {
@@ -154,6 +163,8 @@ fn native_lifecycle_bundle_round_trips_core_fields() {
 fn native_lifecycle_bundle_round_trips_reserved_metadata() {
     let mut bundle = sample_bundle();
     let entry = bundle.entries.first_mut().expect("fixture entry");
+    entry.id = "rpm:%filetriggerin:0".to_string();
+    entry.native_slot = Some(RpmScriptletSlot::Trigger);
     entry.rpm_trigger = Some(RpmTriggerMetadata {
         kind: RpmTriggerKind::File,
         target_constraints: vec![RpmTriggerTargetConstraint {
@@ -166,6 +177,10 @@ fn native_lifecycle_bundle_round_trips_reserved_metadata() {
         priority: Some(100),
         path_prefixes: vec!["/usr/lib/systemd/system".to_string()],
     });
+    let entry_class = entry.rpm_class();
+    if let (Some(runtime), Some(class)) = (&mut entry.rpm_runtime, entry_class) {
+        runtime.criticality = class.effective_criticality(false);
+    }
     entry.residual_lifecycle = Some(ResidualLifecycleMetadata {
         superseded_effect_kinds: vec!["ldconfig".to_string()],
         wrapper_strategy: Some("source-and-suppress".to_string()),
@@ -500,4 +515,267 @@ fn native_lifecycle_entry_body_bytes_rejects_unknown_encoding() {
     let error = entry.body_bytes().expect_err("unknown encoding must fail");
 
     assert!(error.to_string().contains("body_encoding"));
+}
+
+/// Cut 1 conformance: the redundant `critical` boolean left the persisted
+/// contract entirely. `deny_unknown_fields` means a manifest still carrying it
+/// is rejected, naming the unknown field.
+#[test]
+fn manifest_carrying_the_deleted_critical_bool_is_rejected_naming_the_field() {
+    let encoded = toml::to_string_pretty(&sample_bundle()).expect("serialize bundle");
+    let with_bool = encoded.replacen(
+        "program = \"external\"",
+        "program = \"external\"\ncritical = false",
+        1,
+    );
+
+    let error = toml::from_str::<NativeLifecycleBundle>(&with_bool)
+        .expect_err("the deleted critical bool must fail deserialization");
+    assert!(
+        error.to_string().contains("unknown field `critical`"),
+        "the rejection must name the deleted field, got: {error}"
+    );
+}
+
+/// Cut 2 conformance: the typed slot persists with exact wire strings. Every
+/// class round-trips through serialize/deserialize byte-identically and no
+/// free string survives.
+#[test]
+fn typed_slot_round_trips_with_exact_wire_strings() {
+    for slot in [
+        RpmScriptletSlot::Pre,
+        RpmScriptletSlot::Post,
+        RpmScriptletSlot::PreUn,
+        RpmScriptletSlot::PostUn,
+        RpmScriptletSlot::PreTrans,
+        RpmScriptletSlot::PostTrans,
+        RpmScriptletSlot::PreUnTrans,
+        RpmScriptletSlot::PostUnTrans,
+        RpmScriptletSlot::Verify,
+        RpmScriptletSlot::Trigger,
+        RpmScriptletSlot::Sysusers,
+    ] {
+        let mut entry = sample_entry("rpm:%post", "exit 0\n");
+        entry.native_slot = Some(slot);
+
+        let encoded = toml::to_string_pretty(&entry).expect("serialize entry");
+        assert!(
+            encoded.contains(&format!("native_slot = \"{}\"", slot.as_str())),
+            "slot {slot:?} must persist as the exact string '{}', got:\n{encoded}",
+            slot.as_str()
+        );
+
+        let decoded: NativeLifecycleEntry = toml::from_str(&encoded).expect("deserialize entry");
+        assert_eq!(
+            decoded.native_slot,
+            Some(slot),
+            "slot {slot:?} must round-trip through the persisted contract"
+        );
+    }
+}
+
+/// Cut 2 conformance: unknown slot values and the retired per-trigger tag
+/// strings are rejected by the closed persisted enum; only the exact class
+/// strings parse.
+#[test]
+fn unknown_or_retired_slot_values_are_rejected() {
+    let encoded = toml::to_string_pretty(&sample_bundle()).expect("serialize bundle");
+
+    for unknown in ["%posst", "%triggerprein", "post", "rpm:%post"] {
+        let with_unknown = encoded.replacen(
+            "native_slot = \"%post\"",
+            &format!("native_slot = \"{unknown}\""),
+            1,
+        );
+        let error = toml::from_str::<NativeLifecycleBundle>(&with_unknown)
+            .expect_err("unknown slot values must fail deserialization");
+        assert!(
+            error.to_string().contains("unknown variant"),
+            "slot value {unknown:?} must be rejected as an unknown variant, got: {error}"
+        );
+    }
+}
+
+/// Every RPM trigger tag the parser can produce projects onto the Trigger
+/// class; the class persists as its canonical tag.
+#[test]
+fn every_parser_trigger_tag_projects_onto_the_trigger_class() {
+    for tag in [
+        "%triggerprein",
+        "%triggerin",
+        "%triggerun",
+        "%triggerpostun",
+        "%filetriggerin",
+        "%filetriggerun",
+        "%filetriggerpostun",
+        "%transfiletriggerin",
+        "%transfiletriggerun",
+        "%transfiletriggerpostun",
+    ] {
+        assert_eq!(
+            RpmScriptletSlot::from_tag(tag),
+            Some(RpmScriptletSlot::Trigger),
+            "tag {tag} must project onto the Trigger class"
+        );
+    }
+    assert_eq!(RpmScriptletSlot::Trigger.as_str(), "%triggerin");
+}
+
+/// The criticality stamp is evidence: an installed-style load (shape
+/// validation) accepts a stamp that disagrees with the current posture-table
+/// derivation, and the runtime derives posture from the typed class and
+/// header flag word alone -- the stale stamp is ignored.
+#[test]
+fn installed_style_load_accepts_a_stale_criticality_stamp_and_runtime_ignores_it() {
+    let mut bundle = sample_bundle();
+    let entry = bundle
+        .entries
+        .iter_mut()
+        .find(|entry| entry.id == "rpm:%post")
+        .expect("fixture post entry");
+    let class = entry.rpm_class().expect("typed class");
+    // A %post without the header flag derives warning-only; stamp it with a
+    // value the current table would never produce for this class.
+    assert_eq!(
+        class.effective_criticality(false),
+        RpmCriticality::WarningOnly
+    );
+    let runtime = entry.rpm_runtime.as_mut().expect("rpm runtime");
+    runtime.criticality = RpmCriticality::Header;
+
+    bundle
+        .validate()
+        .expect("an installed-style load must accept the stale stamp as evidence");
+
+    let posture = FailurePosture::for_lifecycle_failure(LifecycleFailureClass {
+        source_format: SourceFormat::Rpm,
+        rpm_class: Some(class),
+        header_critical: false,
+        failure_kind: ScriptletFailureKind::ScriptExited,
+    });
+    assert_eq!(
+        posture,
+        FailurePosture::WarnAndContinue,
+        "the runtime must derive posture from class + header flag, ignoring the stale stamp \
+         (the stamped Header value would abort the transaction)"
+    );
+}
+
+/// The converter/publication path additionally enforces stamp agreement: a
+/// criticality that disagrees with the typed class authority is rejected
+/// there, so nothing Conary produces can carry a stale or disagreeing stamp.
+#[test]
+fn criticality_stamp_must_agree_with_the_typed_class_on_the_conversion_path() {
+    let mut bundle = sample_bundle();
+    let entry = bundle.entries.first_mut().expect("fixture entry");
+    entry.rpm_runtime.as_mut().expect("rpm runtime").criticality = RpmCriticality::WarningOnly;
+
+    bundle
+        .validate()
+        .expect("shape validation treats the stamp as evidence only");
+
+    let error = bundle
+        .validate_as_conversion_output()
+        .expect_err("a criticality that disagrees with the class authority must fail conversion");
+    assert!(
+        error
+            .to_string()
+            .contains("disagrees with its typed class authority"),
+        "unexpected error: {error}"
+    );
+}
+
+/// RPM declares one action per trigger scriptlet entry. Validation must reject
+/// a persisted entry whose target constraints mix actions, naming the entry
+/// and both actions -- otherwise the class projection (which reads the first
+/// constraint) would be constraint-order-dependent and a publisher could
+/// smuggle one posture past validation with one ordering and get a different
+/// posture with the other.
+#[test]
+fn mixed_action_trigger_constraints_are_rejected_naming_both_actions() {
+    let constraint = |action| RpmTriggerTargetConstraint {
+        package: "owner-package".to_string(),
+        action,
+        operator: None,
+        version: None,
+        raw_flags: 0,
+    };
+    // The same constraint set in both orders must fail identically; with the
+    // rejection removed, one order would derive a warning class and the other
+    // a fatal class from the same persisted entry.
+    for constraints in [
+        vec![
+            constraint(RpmTriggerAction::Install),
+            constraint(RpmTriggerAction::PreInstall),
+        ],
+        vec![
+            constraint(RpmTriggerAction::PreInstall),
+            constraint(RpmTriggerAction::Install),
+        ],
+    ] {
+        let mut bundle = sample_bundle();
+        let entry = bundle.entries.first_mut().expect("fixture entry");
+        entry.id = "rpm:%triggerin:0".to_string();
+        entry.native_slot = Some(RpmScriptletSlot::Trigger);
+        entry.rpm_trigger = Some(RpmTriggerMetadata {
+            kind: RpmTriggerKind::Package,
+            target_constraints: constraints,
+            priority: None,
+            path_prefixes: Vec::new(),
+        });
+
+        let error = bundle
+            .validate()
+            .expect_err("mixed trigger actions must be rejected at validation");
+        let message = error.to_string();
+        assert!(message.contains("rpm:%triggerin:0"), "{message}");
+        assert!(message.contains("'install'"), "{message}");
+        assert!(message.contains("'pre-install'"), "{message}");
+    }
+}
+
+/// A trigger entry whose target constraints carry one uniform action
+/// validates, and the class projection is the same in either constraint
+/// order -- the class is never order-dependent for uniform sets.
+#[test]
+fn uniform_action_trigger_constraints_validate_in_any_order() {
+    let constraint = |package: &str, action| RpmTriggerTargetConstraint {
+        package: package.to_string(),
+        action,
+        operator: None,
+        version: None,
+        raw_flags: 0,
+    };
+    // The same two-constraint set in both orders: one action, two targets.
+    let order_flips = [
+        vec![
+            constraint("owner-a", RpmTriggerAction::Install),
+            constraint("owner-b", RpmTriggerAction::Install),
+        ],
+        vec![
+            constraint("owner-b", RpmTriggerAction::Install),
+            constraint("owner-a", RpmTriggerAction::Install),
+        ],
+    ];
+    for constraints in order_flips {
+        let mut bundle = sample_bundle();
+        let entry = bundle.entries.first_mut().expect("fixture entry");
+        entry.id = "rpm:%triggerin:0".to_string();
+        entry.native_slot = Some(RpmScriptletSlot::Trigger);
+        entry.rpm_trigger = Some(RpmTriggerMetadata {
+            kind: RpmTriggerKind::Package,
+            target_constraints: constraints,
+            priority: None,
+            path_prefixes: Vec::new(),
+        });
+
+        bundle.validate().expect("uniform actions validate");
+        assert_eq!(
+            bundle.entries[0].rpm_class(),
+            Some(RpmLifecycleClass::Trigger {
+                kind: RpmTriggerKind::Package,
+                action: RpmTriggerAction::Install,
+            })
+        );
+    }
 }

--- a/crates/conary-core/src/ccs/native_lifecycle/validation.rs
+++ b/crates/conary-core/src/ccs/native_lifecycle/validation.rs
@@ -35,6 +35,10 @@ impl NativeLifecycleEntry {
         }
 
         match source_format {
+            SourceFormat::Rpm if self.native_slot.is_none() => bail!(
+                "RPM native lifecycle entry '{}' has no typed RPM slot class",
+                self.id
+            ),
             SourceFormat::Rpm if self.rpm_runtime.is_none() => bail!(
                 "RPM native lifecycle entry '{}' has no typed RPM runtime contract",
                 self.id
@@ -47,12 +51,20 @@ impl NativeLifecycleEntry {
                 "DEB native lifecycle entry '{}' has no typed maintainer-script contract",
                 self.id
             ),
+            SourceFormat::Deb if self.native_slot.is_some() => bail!(
+                "DEB native lifecycle entry '{}' carries an RPM slot class without a declared class table",
+                self.id
+            ),
             SourceFormat::Deb if has_rpm || arch_metadata_count != 0 => bail!(
                 "DEB native lifecycle entry '{}' carries foreign format metadata",
                 self.id
             ),
             SourceFormat::Arch if arch_metadata_count != 1 => bail!(
                 "Arch native lifecycle entry '{}' must carry exactly one .INSTALL or ALPM hook contract",
+                self.id
+            ),
+            SourceFormat::Arch if self.native_slot.is_some() => bail!(
+                "Arch native lifecycle entry '{}' carries an RPM slot class without a declared class table",
                 self.id
             ),
             SourceFormat::Arch if has_rpm || has_deb => bail!(

--- a/crates/conary-core/src/ccs/native_transaction/rpm_tests.rs
+++ b/crates/conary-core/src/ccs/native_transaction/rpm_tests.rs
@@ -8,24 +8,29 @@ use crate::ccs::native_lifecycle::{
     RpmTriggerMetadata, RpmTriggerTargetConstraint, ScriptletFidelity, SourceFormat,
     TransactionOrder, VersionScheme as LifecycleVersionScheme,
 };
+use crate::packages::native_abi::RpmScriptletSlot;
 use std::collections::BTreeSet;
 
-fn runtime(program: RpmProgram, critical: bool) -> RpmRuntimeMetadata {
+fn runtime(program: RpmProgram) -> RpmRuntimeMetadata {
     RpmRuntimeMetadata {
         program,
         body_transforms: Vec::new(),
-        critical,
-        criticality: if critical {
-            RpmCriticality::SlotDefault
-        } else {
-            RpmCriticality::WarningOnly
-        },
+        criticality: RpmCriticality::WarningOnly,
         raw_flags: 0,
         unknown_flags: 0,
         install_prefixes: Vec::new(),
         macro_context: Default::default(),
         header_context: Default::default(),
         package_rpm_version: None,
+    }
+}
+
+/// Keep the persisted criticality stamp consistent with the entry's typed
+/// class authority, exactly as conversion would stamp it.
+fn stamp_criticality(entry: &mut NativeLifecycleEntry) {
+    let entry_class = entry.rpm_class();
+    if let (Some(runtime), Some(class)) = (&mut entry.rpm_runtime, entry_class) {
+        runtime.criticality = class.effective_criticality(false);
     }
 }
 
@@ -36,9 +41,15 @@ fn entry(id: &str, phase: LifecyclePath, runtime: RpmRuntimeMetadata) -> NativeL
         RpmProgram::External => "/bin/sh",
         RpmProgram::Sysusers => "/usr/bin/systemd-sysusers",
     };
-    NativeLifecycleEntry {
+    let mut entry = NativeLifecycleEntry {
         id: id.to_string(),
-        native_slot: id.to_string(),
+        // Fixture ids mix `rpm:<slot>`, `rpm:<pkg>:<slot>`, and
+        // `rpm:<slot>:<qualifier>` shapes; the slot is the `%`-prefixed
+        // segment wherever it sits.
+        native_slot: id
+            .strip_prefix("rpm:")
+            .and_then(|suffix| suffix.split(':').find(|part| part.starts_with('%')))
+            .and_then(RpmScriptletSlot::from_tag),
         kind: NativeLifecycleEntryKind::Executable,
         phase,
         lifecycle_paths: vec![phase.as_str().to_string()],
@@ -64,7 +75,9 @@ fn entry(id: &str, phase: LifecyclePath, runtime: RpmRuntimeMetadata) -> NativeL
         arch_install: None,
         arch_hook: None,
         residual_lifecycle: None,
-    }
+    };
+    stamp_criticality(&mut entry);
+    entry
 }
 
 fn bundle(entries: Vec<NativeLifecycleEntry>) -> NativeLifecycleBundle {
@@ -124,7 +137,7 @@ fn trigger_entry(
     let mut entry = entry(
         id,
         LifecyclePath::PostInstall,
-        runtime(RpmProgram::External, false),
+        runtime(RpmProgram::External),
     );
     entry.rpm_trigger = Some(RpmTriggerMetadata {
         kind,
@@ -140,6 +153,7 @@ fn trigger_entry(
             .then(|| vec![target.to_string()])
             .unwrap_or_default(),
     });
+    stamp_criticality(&mut entry);
     entry
 }
 
@@ -180,12 +194,12 @@ fn rpm_regular_events_do_not_delegate_transaction_failure_policy() {
         entry(
             "rpm:%pre",
             LifecyclePath::PreInstall,
-            runtime(RpmProgram::External, true),
+            runtime(RpmProgram::External),
         ),
         entry(
             "rpm:%post",
             LifecyclePath::PostInstall,
-            runtime(RpmProgram::External, false),
+            runtime(RpmProgram::External),
         ),
     ]);
 
@@ -206,7 +220,7 @@ fn rpm_sysusers_is_an_exact_pre_payload_target_interface_event() {
     let mut sysusers = entry(
         "rpm:%sysusers:0",
         LifecyclePath::RpmSysusers,
-        runtime(RpmProgram::Sysusers, true),
+        runtime(RpmProgram::Sysusers),
     );
     sysusers.interpreter = "/usr/bin/systemd-sysusers".to_string();
     sysusers.rpm_sysusers = Some(RpmSysusersMetadata {
@@ -247,7 +261,7 @@ fn rpm_sysusers_is_an_exact_pre_payload_target_interface_event() {
 
 #[test]
 fn rpm_owned_body_engines_are_planned_for_typed_runtime_execution() {
-    let mut transformed = runtime(RpmProgram::External, false);
+    let mut transformed = runtime(RpmProgram::External);
     transformed.body_transforms = vec![RpmBodyTransform::MacroExpand];
     let transformed_bundle = bundle(vec![entry(
         "rpm:%post",
@@ -265,7 +279,7 @@ fn rpm_owned_body_engines_are_planned_for_typed_runtime_execution() {
     let lua_bundle = bundle(vec![entry(
         "rpm:%post",
         LifecyclePath::PostInstall,
-        runtime(RpmProgram::EmbeddedLua, false),
+        runtime(RpmProgram::EmbeddedLua),
     )]);
     let lua_plan = plan_native_transaction(
         &[installing_view(&lua_bundle)],
@@ -795,24 +809,24 @@ fn rpm_transaction_graph_interleaves_each_payload_with_its_lifecycle() {
         entry(
             "rpm:a:%pre",
             LifecyclePath::PreInstall,
-            runtime(RpmProgram::External, true),
+            runtime(RpmProgram::External),
         ),
         entry(
             "rpm:a:%post",
             LifecyclePath::PostInstall,
-            runtime(RpmProgram::External, false),
+            runtime(RpmProgram::External),
         ),
     ]);
     let package_b = bundle(vec![
         entry(
             "rpm:b:%pre",
             LifecyclePath::PreInstall,
-            runtime(RpmProgram::External, true),
+            runtime(RpmProgram::External),
         ),
         entry(
             "rpm:b:%post",
             LifecyclePath::PostInstall,
-            runtime(RpmProgram::External, false),
+            runtime(RpmProgram::External),
         ),
     ]);
     let changes = [

--- a/crates/conary-core/src/ccs/native_transaction/tests.rs
+++ b/crates/conary-core/src/ccs/native_transaction/tests.rs
@@ -10,6 +10,7 @@ use crate::ccs::native_lifecycle::{
     RpmTriggerKind, RpmTriggerMetadata, RpmTriggerTargetConstraint, ScriptletFidelity,
     SourceFormat, TransactionOrder, VersionScheme,
 };
+use crate::packages::native_abi::RpmScriptletSlot;
 use std::collections::BTreeSet;
 
 #[path = "tests/arch_deconfiguration.rs"]
@@ -27,7 +28,6 @@ fn bundle(format: SourceFormat, entries: Vec<NativeLifecycleEntry>) -> NativeLif
             entry.rpm_runtime.get_or_insert_with(|| RpmRuntimeMetadata {
                 program: RpmProgram::External,
                 body_transforms: Vec::new(),
-                critical: true,
                 criticality: RpmCriticality::SlotDefault,
                 raw_flags: 0,
                 unknown_flags: 0,
@@ -36,6 +36,12 @@ fn bundle(format: SourceFormat, entries: Vec<NativeLifecycleEntry>) -> NativeLif
                 header_context: Default::default(),
                 package_rpm_version: None,
             });
+            // Keep the stamp consistent with the entry's typed class
+            // authority, exactly as conversion would stamp it.
+            let entry_class = entry.rpm_class();
+            if let (Some(runtime), Some(class)) = (&mut entry.rpm_runtime, entry_class) {
+                runtime.criticality = class.effective_criticality(false);
+            }
         }
     }
     NativeLifecycleBundle {
@@ -63,7 +69,7 @@ fn entry(id: &str) -> NativeLifecycleEntry {
     let body = "exit 0\n".to_string();
     NativeLifecycleEntry {
         id: id.to_string(),
-        native_slot: id.to_string(),
+        native_slot: slot_from_id(id),
         kind: NativeLifecycleEntryKind::Executable,
         phase: LifecyclePath::Trigger,
         lifecycle_paths: vec!["trigger".to_string()],
@@ -97,6 +103,14 @@ fn lifecycle_entry(id: &str, phase: LifecyclePath) -> NativeLifecycleEntry {
     entry.phase = phase;
     entry.lifecycle_paths = vec![phase.as_str().to_string()];
     entry
+}
+
+/// The typed slot class of a fixture entry id: `rpm:%post` and the bare
+/// `rpm:transfiletriggerin` form both project onto their class; non-RPM ids
+/// carry no persisted slot.
+fn slot_from_id(id: &str) -> Option<RpmScriptletSlot> {
+    let suffix = id.strip_prefix("rpm:")?;
+    RpmScriptletSlot::from_tag(suffix).or_else(|| RpmScriptletSlot::from_tag(&format!("%{suffix}")))
 }
 
 fn deb_entry(

--- a/crates/conary-core/src/db/models/converted.rs
+++ b/crates/conary-core/src/db/models/converted.rs
@@ -17,9 +17,12 @@ use strum_macros::{AsRefStr, Display, EnumString};
 /// Current conversion algorithm version
 /// Bump this when making changes that require re-conversion of existing packages.
 ///
-/// Revision 15 drops the duplicated path from every path-owning capability
-/// provenance, so a converted artifact states each owned path exactly once.
-pub const CONVERSION_VERSION: i32 = 15;
+/// Revision 16 cuts the persisted CCS scriptlet contract: the redundant
+/// `RpmRuntimeMetadata.critical` boolean leaves the contract entirely
+/// (`deny_unknown_fields` rejects old manifests naming it), and
+/// `NativeLifecycleEntry.native_slot` persists the typed `RpmScriptletSlot`
+/// class with exact wire strings instead of a free string.
+pub const CONVERSION_VERSION: i32 = 16;
 /// Canonical digest of an empty repository-provide projection.
 pub const EMPTY_REPOSITORY_PROVIDES_DIGEST: &str =
     "sha256:4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945";

--- a/crates/conary-core/src/db/models/installed_native_lifecycle_bundle.rs
+++ b/crates/conary-core/src/db/models/installed_native_lifecycle_bundle.rs
@@ -279,7 +279,9 @@ mod tests {
     fn fixture_entry(id: &str, body: &str) -> NativeLifecycleEntry {
         NativeLifecycleEntry {
             id: id.to_string(),
-            native_slot: "%post".to_string(),
+            native_slot: crate::packages::native_abi::RpmScriptletSlot::from_tag(
+                id.strip_prefix("rpm:").expect("fixture id"),
+            ),
             kind: NativeLifecycleEntryKind::Executable,
             phase: LifecyclePath::PostInstall,
             lifecycle_paths: vec!["install:last".to_string()],
@@ -307,7 +309,6 @@ mod tests {
             rpm_runtime: Some(crate::ccs::native_lifecycle::RpmRuntimeMetadata {
                 program: crate::ccs::native_lifecycle::RpmProgram::External,
                 body_transforms: Vec::new(),
-                critical: false,
                 criticality: crate::ccs::native_lifecycle::RpmCriticality::WarningOnly,
                 raw_flags: 0,
                 unknown_flags: 0,

--- a/crates/conary-core/src/packages/native_abi.rs
+++ b/crates/conary-core/src/packages/native_abi.rs
@@ -220,19 +220,90 @@ pub struct RpmNativeScriptletMetadata {
     pub sysusers: Option<RpmSysusersMetadata>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// The typed RPM scriptlet slot class.
+///
+/// This is the same typed value on both sides of the persisted CCS contract:
+/// serde renames pin the exact RPM scriptlet tag strings, so the persisted
+/// `native_slot` is a closed enum rather than a free string. RPM trigger
+/// entries of every family/action share the `Trigger` class; their exact tag
+/// (`%triggerprein`, `%filetriggerin`, ...) is preserved by the entry id and
+/// the typed `rpm_trigger` metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum RpmScriptletSlot {
+    #[serde(rename = "%pre")]
     Pre,
+    #[serde(rename = "%post")]
     Post,
+    #[serde(rename = "%preun")]
     PreUn,
+    #[serde(rename = "%postun")]
     PostUn,
+    #[serde(rename = "%pretrans")]
     PreTrans,
+    #[serde(rename = "%posttrans")]
     PostTrans,
+    #[serde(rename = "%preuntrans")]
     PreUnTrans,
+    #[serde(rename = "%postuntrans")]
     PostUnTrans,
+    #[serde(rename = "%verify")]
     Verify,
+    /// The canonical class tag for every RPM trigger. The exact trigger tag is
+    /// re-derivable from the persisted `rpm_trigger` family and action.
+    #[serde(rename = "%triggerin")]
     Trigger,
+    #[serde(rename = "%sysusers")]
     Sysusers,
+}
+
+impl RpmScriptletSlot {
+    /// The exact RPM scriptlet tag this class persists as.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pre => "%pre",
+            Self::Post => "%post",
+            Self::PreUn => "%preun",
+            Self::PostUn => "%postun",
+            Self::PreTrans => "%pretrans",
+            Self::PostTrans => "%posttrans",
+            Self::PreUnTrans => "%preuntrans",
+            Self::PostUnTrans => "%postuntrans",
+            Self::Verify => "%verify",
+            Self::Trigger => "%triggerin",
+            Self::Sysusers => "%sysusers",
+        }
+    }
+
+    /// Parse an exact RPM scriptlet tag into its typed class.
+    ///
+    /// Every tag RPM can carry for a scriptlet class is accepted; the ten
+    /// trigger tags all project onto the `Trigger` class. Unknown tags return
+    /// `None` and are a typed missing-semantic conversion failure.
+    pub fn from_tag(value: &str) -> Option<Self> {
+        match value {
+            "%pre" => Some(Self::Pre),
+            "%post" => Some(Self::Post),
+            "%preun" => Some(Self::PreUn),
+            "%postun" => Some(Self::PostUn),
+            "%pretrans" => Some(Self::PreTrans),
+            "%posttrans" => Some(Self::PostTrans),
+            "%preuntrans" => Some(Self::PreUnTrans),
+            "%postuntrans" => Some(Self::PostUnTrans),
+            "%verify" => Some(Self::Verify),
+            "%sysusers" => Some(Self::Sysusers),
+            "%triggerprein"
+            | "%triggerin"
+            | "%triggerun"
+            | "%triggerpostun"
+            | "%filetriggerin"
+            | "%filetriggerun"
+            | "%filetriggerpostun"
+            | "%transfiletriggerin"
+            | "%transfiletriggerun"
+            | "%transfiletriggerpostun" => Some(Self::Trigger),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/conary-core/src/scriptlet/failure_policy.rs
+++ b/crates/conary-core/src/scriptlet/failure_policy.rs
@@ -21,7 +21,10 @@
 //! sides of the persisted contract.
 
 use super::ScriptletFailureKind;
-use crate::ccs::native_lifecycle::{RpmCriticality, SourceFormat};
+use crate::ccs::native_lifecycle::{
+    RpmCriticality, RpmLifecycleClass, RpmTriggerAction as PersistedRpmTriggerAction,
+    RpmTriggerKind, SourceFormat,
+};
 use crate::packages::native_abi::{
     RpmScriptletCriticality, RpmScriptletSlot, RpmTriggerAction, RpmTriggerFamily,
 };
@@ -127,14 +130,55 @@ pub const fn rpm_trigger_authority(
     }
 }
 
+impl From<RpmTriggerKind> for RpmTriggerFamily {
+    fn from(kind: RpmTriggerKind) -> Self {
+        match kind {
+            RpmTriggerKind::Package => Self::Package,
+            RpmTriggerKind::File => Self::File,
+            RpmTriggerKind::TransactionFile => Self::TransactionFile,
+        }
+    }
+}
+
+impl From<PersistedRpmTriggerAction> for RpmTriggerAction {
+    fn from(action: PersistedRpmTriggerAction) -> Self {
+        match action {
+            PersistedRpmTriggerAction::PreInstall => Self::PreInstall,
+            PersistedRpmTriggerAction::Install => Self::Install,
+            PersistedRpmTriggerAction::Uninstall => Self::Uninstall,
+            PersistedRpmTriggerAction::PostUninstall => Self::PostUninstall,
+        }
+    }
+}
+
+impl RpmLifecycleClass {
+    /// The effective criticality this persisted class authority stamps for a
+    /// persisted header flag word carrying (or not carrying) the CRITICAL bit.
+    ///
+    /// This is the single derivation shared by contract validation and the
+    /// install runtime: both consult the current table through the typed
+    /// class, so a posture correction applies to already-converted artifacts
+    /// without reconversion.
+    pub fn effective_criticality(self, header_critical: bool) -> RpmCriticality {
+        let authority = match self {
+            Self::PackageSlot(slot) => rpm_package_slot_authority(slot),
+            Self::Trigger { kind, action } => rpm_trigger_authority(kind.into(), action.into()),
+        };
+        authority.effective_criticality(header_critical).persisted()
+    }
+}
+
 /// The typed inputs the runtime has when a native lifecycle entry fails.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LifecycleFailureClass {
     /// The source format whose lifecycle contract owns this entry.
     pub source_format: SourceFormat,
-    /// The persisted effective criticality of an RPM entry, or `None` for an
-    /// entry that declares no RPM runtime contract.
-    pub rpm_criticality: Option<RpmCriticality>,
+    /// The persisted typed RPM class of the entry, or `None` for an entry
+    /// that carries no declared RPM class.
+    pub rpm_class: Option<RpmLifecycleClass>,
+    /// Whether the persisted raw scriptlet flag word carries RPM's CRITICAL
+    /// bit, re-derived from `RpmRuntimeMetadata::raw_flags`.
+    pub header_critical: bool,
     /// How the entry failed.
     pub failure_kind: ScriptletFailureKind,
 }
@@ -148,15 +192,17 @@ impl FailurePosture {
     /// malformed contracts, and process or sandbox setup failures are Conary
     /// contract failures rather than source-program results, so they abort
     /// whatever the class says: criticality is not a security-boundary bypass.
-    pub const fn for_lifecycle_failure(class: LifecycleFailureClass) -> Self {
+    pub fn for_lifecycle_failure(class: LifecycleFailureClass) -> Self {
         if !class.failure_kind.is_source_program_result() {
             return Self::AbortsTransaction;
         }
         match class.source_format {
-            SourceFormat::Rpm => match class.rpm_criticality {
-                Some(criticality) => Self::for_rpm_criticality(criticality),
-                // An RPM entry with no persisted RPM runtime contract has no
-                // declared class, so it gets the strict posture.
+            SourceFormat::Rpm => match class.rpm_class {
+                Some(rpm_class) => Self::for_rpm_criticality(
+                    rpm_class.effective_criticality(class.header_critical),
+                ),
+                // An RPM entry with no persisted typed class has no declared
+                // class, so it gets the strict posture.
                 None => Self::AbortsTransaction,
             },
             // dpkg leaves a package whose maintainer script failed in an
@@ -185,14 +231,18 @@ impl FailurePosture {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ccs::native_lifecycle::{
+        RpmTriggerAction as PersistedRpmTriggerAction, RpmTriggerKind,
+    };
 
     fn rpm_class(
-        criticality: RpmCriticality,
+        rpm_class: RpmLifecycleClass,
         failure_kind: ScriptletFailureKind,
     ) -> LifecycleFailureClass {
         LifecycleFailureClass {
             source_format: SourceFormat::Rpm,
-            rpm_criticality: Some(criticality),
+            rpm_class: Some(rpm_class),
+            header_critical: false,
             failure_kind,
         }
     }
@@ -357,7 +407,8 @@ mod tests {
     }
 
     /// Every class the parser can produce, for every header flag value, must
-    /// land on the posture the pinned table declares.
+    /// land on the posture the pinned table declares -- through the persisted
+    /// typed class, exactly as the install runtime consults it.
     #[test]
     fn every_rpm_class_reaches_the_runtime_with_its_declared_posture() {
         let classes = [
@@ -385,13 +436,11 @@ mod tests {
             ),
         ];
         for (slot, without_header_flag) in classes {
-            let authority = rpm_package_slot_authority(slot);
             let posture = |header_critical| {
                 FailurePosture::for_lifecycle_failure(LifecycleFailureClass {
                     source_format: SourceFormat::Rpm,
-                    rpm_criticality: Some(
-                        authority.effective_criticality(header_critical).persisted(),
-                    ),
+                    rpm_class: Some(RpmLifecycleClass::PackageSlot(slot)),
+                    header_critical,
                     failure_kind: ScriptletFailureKind::ScriptExited,
                 })
             };
@@ -408,6 +457,122 @@ mod tests {
         }
     }
 
+    /// The #295 decision table, re-derived through the persisted typed class:
+    /// every pinned row of the RPM Scriptlet Failure Posture spec table lands
+    /// on its declared posture, with header promotion only where the table
+    /// allows it.
+    #[test]
+    fn persisted_typed_class_matches_the_pinned_decision_table() {
+        // Pinned rpm lib/rpmscript.cc scriptInfo[] deflags at
+        // a8f0192aee1c08bd1454ed2ac6ebaf506004b55c.
+        let package_slots = [
+            (
+                RpmScriptletSlot::PreTrans,
+                FailurePosture::AbortsTransaction,
+            ),
+            (RpmScriptletSlot::Pre, FailurePosture::AbortsTransaction),
+            (RpmScriptletSlot::Post, FailurePosture::WarnAndContinue),
+            (RpmScriptletSlot::PostTrans, FailurePosture::WarnAndContinue),
+            (
+                RpmScriptletSlot::PreUnTrans,
+                FailurePosture::AbortsTransaction,
+            ),
+            (RpmScriptletSlot::PreUn, FailurePosture::AbortsTransaction),
+            (RpmScriptletSlot::PostUn, FailurePosture::WarnAndContinue),
+            (
+                RpmScriptletSlot::PostUnTrans,
+                FailurePosture::WarnAndContinue,
+            ),
+            (RpmScriptletSlot::Verify, FailurePosture::AbortsTransaction),
+            (
+                RpmScriptletSlot::Sysusers,
+                FailurePosture::AbortsTransaction,
+            ),
+        ];
+        for (slot, expected) in package_slots {
+            let class = RpmLifecycleClass::PackageSlot(slot);
+            assert_eq!(
+                FailurePosture::for_lifecycle_failure(LifecycleFailureClass {
+                    source_format: SourceFormat::Rpm,
+                    rpm_class: Some(class),
+                    header_critical: false,
+                    failure_kind: ScriptletFailureKind::ScriptExited,
+                }),
+                expected,
+                "class {slot:?} without a header flag diverges from the pinned table"
+            );
+            assert_eq!(
+                FailurePosture::for_lifecycle_failure(LifecycleFailureClass {
+                    source_format: SourceFormat::Rpm,
+                    rpm_class: Some(class),
+                    header_critical: true,
+                    failure_kind: ScriptletFailureKind::ScriptExited,
+                }),
+                FailurePosture::AbortsTransaction,
+                "a header CRITICAL flag on class {slot:?} must promote to fatal"
+            );
+        }
+        // Package triggers: %triggerprein and %triggerun abort; %triggerin and
+        // %triggerpostun warn and continue.
+        for (action, expected) in [
+            (
+                PersistedRpmTriggerAction::PreInstall,
+                FailurePosture::AbortsTransaction,
+            ),
+            (
+                PersistedRpmTriggerAction::Uninstall,
+                FailurePosture::AbortsTransaction,
+            ),
+            (
+                PersistedRpmTriggerAction::Install,
+                FailurePosture::WarnAndContinue,
+            ),
+            (
+                PersistedRpmTriggerAction::PostUninstall,
+                FailurePosture::WarnAndContinue,
+            ),
+        ] {
+            let class = RpmLifecycleClass::Trigger {
+                kind: RpmTriggerKind::Package,
+                action,
+            };
+            assert_eq!(
+                FailurePosture::for_lifecycle_failure(LifecycleFailureClass {
+                    source_format: SourceFormat::Rpm,
+                    rpm_class: Some(class),
+                    header_critical: false,
+                    failure_kind: ScriptletFailureKind::ScriptExited,
+                }),
+                expected,
+                "package {action:?} trigger diverges from the pinned table"
+            );
+        }
+        // File and transaction-file triggers: CRITICAL is cleared, so no header
+        // flag can promote them; they never fail their transaction element.
+        for kind in [RpmTriggerKind::File, RpmTriggerKind::TransactionFile] {
+            for action in [
+                PersistedRpmTriggerAction::PreInstall,
+                PersistedRpmTriggerAction::Install,
+                PersistedRpmTriggerAction::Uninstall,
+                PersistedRpmTriggerAction::PostUninstall,
+            ] {
+                let class = RpmLifecycleClass::Trigger { kind, action };
+                for header_critical in [false, true] {
+                    assert_eq!(
+                        FailurePosture::for_lifecycle_failure(LifecycleFailureClass {
+                            source_format: SourceFormat::Rpm,
+                            rpm_class: Some(class),
+                            header_critical,
+                            failure_kind: ScriptletFailureKind::ScriptExited,
+                        }),
+                        FailurePosture::WarnAndContinue,
+                        "a {kind:?} {action:?} trigger must never fail its transaction element"
+                    );
+                }
+            }
+        }
+    }
+
     #[test]
     fn warn_and_continue_covers_only_source_program_results() {
         for failure_kind in [
@@ -416,7 +581,7 @@ mod tests {
         ] {
             assert_eq!(
                 FailurePosture::for_lifecycle_failure(rpm_class(
-                    RpmCriticality::WarningOnly,
+                    RpmLifecycleClass::PackageSlot(RpmScriptletSlot::Post),
                     failure_kind
                 )),
                 FailurePosture::WarnAndContinue
@@ -430,7 +595,7 @@ mod tests {
         ] {
             assert_eq!(
                 FailurePosture::for_lifecycle_failure(rpm_class(
-                    RpmCriticality::WarningOnly,
+                    RpmLifecycleClass::PackageSlot(RpmScriptletSlot::Post),
                     failure_kind
                 )),
                 FailurePosture::AbortsTransaction,
@@ -445,7 +610,8 @@ mod tests {
             assert_eq!(
                 FailurePosture::for_lifecycle_failure(LifecycleFailureClass {
                     source_format,
-                    rpm_criticality: None,
+                    rpm_class: None,
+                    header_critical: false,
                     failure_kind: ScriptletFailureKind::ScriptExited,
                 }),
                 FailurePosture::AbortsTransaction
@@ -454,7 +620,8 @@ mod tests {
         assert_eq!(
             FailurePosture::for_lifecycle_failure(LifecycleFailureClass {
                 source_format: SourceFormat::Rpm,
-                rpm_criticality: None,
+                rpm_class: None,
+                header_critical: false,
                 failure_kind: ScriptletFailureKind::ScriptExited,
             }),
             FailurePosture::AbortsTransaction

--- a/crates/conary-core/src/scriptlet/native_lifecycle.rs
+++ b/crates/conary-core/src/scriptlet/native_lifecycle.rs
@@ -897,7 +897,6 @@ mod tests {
         let rpm = RpmRuntimeMetadata {
             program: RpmProgram::External,
             body_transforms: vec![RpmBodyTransform::HeaderQueryFormat],
-            critical: false,
             criticality: RpmCriticality::WarningOnly,
             raw_flags: 0,
             unknown_flags: 0,

--- a/crates/conary-core/src/scriptlet/rpm_runtime/lua.rs
+++ b/crates/conary-core/src/scriptlet/rpm_runtime/lua.rs
@@ -198,7 +198,6 @@ mod tests {
         RpmRuntimeMetadata {
             program: RpmProgram::EmbeddedLua,
             body_transforms: Vec::new(),
-            critical: false,
             criticality: RpmCriticality::WarningOnly,
             raw_flags: 0,
             unknown_flags: 0,

--- a/crates/conary-core/src/scriptlet/rpm_runtime/macro_expand/tests.rs
+++ b/crates/conary-core/src/scriptlet/rpm_runtime/macro_expand/tests.rs
@@ -25,7 +25,6 @@ fn runtime() -> RpmRuntimeMetadata {
     RpmRuntimeMetadata {
         program: RpmProgram::External,
         body_transforms: Vec::new(),
-        critical: false,
         criticality: RpmCriticality::WarningOnly,
         raw_flags: 0,
         unknown_flags: 0,

--- a/crates/conary-core/src/scriptlet/rpm_runtime/mod.rs
+++ b/crates/conary-core/src/scriptlet/rpm_runtime/mod.rs
@@ -52,7 +52,6 @@ mod tests {
         RpmRuntimeMetadata {
             program: RpmProgram::External,
             body_transforms: transforms,
-            critical: false,
             criticality: RpmCriticality::WarningOnly,
             raw_flags: 0,
             unknown_flags: 0,

--- a/crates/conary-core/tests/native_abi.rs
+++ b/crates/conary-core/tests/native_abi.rs
@@ -547,7 +547,12 @@ fn assert_conversion_preserves_native_entries(
                     entry.id
                 )
             });
-        assert_eq!(bundle_entry.native_slot, entry.native_slot);
+        assert_eq!(
+            bundle_entry.native_slot,
+            conary_core::packages::native_abi::RpmScriptletSlot::from_tag(&entry.native_slot),
+            "bundle slot must be the typed projection of parser tag {}",
+            entry.native_slot
+        );
         assert_eq!(bundle_entry.body_sha256, entry.body.sha256);
         assert_eq!(
             bundle_entry.kind,

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -288,7 +288,7 @@ validation prove the replacement complete for every control-flow path. That is
 a new schema contract, not a partial suppression marker or a mixture of guessed
 diagnostics and partial source-program execution.
 
-Current native lifecycle schema revision 19 has no replacement marker,
+Current native lifecycle schema revision 20 has no replacement marker,
 arbitrary extension map, reason code, effect projection, unknown-command
 evidence, diagnostic-class list/count, adapter-registry digest, publication
 policy, or parallel security-policy intent. Every source entry carries an exact
@@ -300,9 +300,17 @@ artifact and requires an exact one-to-one match. Entry presence is the exact
 lifecycle authority; there is no single-value decision tag or duplicated
 preserved-entry counter. Only actual executed argv captured at the provider
 process boundary can become selected-root or generation mutation authority.
-Revision 18 accepts neither earlier nor unknown revisions: pre-alpha artifacts
-and installed rows must be reconverted, rebuilt, or discarded instead of
-migrated. Every executable source entry remains preserved; adding a lowering
+Revision 20 cuts the persisted scriptlet contract: `RpmRuntimeMetadata`
+carries no `critical` boolean (its effective `criticality` projection is the
+only stamp, and `deny_unknown_fields` rejects a manifest that still names the
+deleted field), and `native_slot` is the typed `RpmScriptletSlot` class with
+exact RPM scriptlet tag strings instead of a free string. Formats without a
+declared class table persist no slot: their class authority lives in their
+typed format metadata, and every RPM entry persists its typed class so the
+install runtime is told the class it needs.
+Revision 19 and earlier accept neither earlier nor unknown revisions: pre-alpha
+artifacts and installed rows must be reconverted, rebuilt, or discarded instead
+of migrated. Every executable source entry remains preserved; adding a lowering
 requires a later typed schema contract with its own execution proof.
 
 Revision 18 also names the exact package-origin authority `source_profile`.
@@ -973,8 +981,13 @@ the entry's name, body, or apparent importance.
 The table below is the declared authority. `conary-core`'s
 `scriptlet::failure_policy` module is its single implementation: conversion
 consults it to stamp each entry's effective criticality, and the install runtime
-consults it to decide whether a failed entry aborts its transaction. Neither
-side matches a scriptlet name at decision time.
+consults it to decide whether a failed entry aborts its transaction. The
+runtime is told the entry's typed class by the persisted contract (`native_slot`
+carries the typed `RpmScriptletSlot`, and a trigger entry carries its exact
+family and action) plus the persisted raw header flag word; it re-derives the
+posture through the current table at failure time, so a posture correction
+applies to already-converted artifacts without reconversion. Neither side
+matches a scriptlet name at decision time.
 
 #### RPM Scriptlet Failure Posture
 


### PR DESCRIPTION
## Problem

Two persisted-contract findings from #295 (#336): `RpmRuntimeMetadata.critical` stored one fact twice (the bool duplicated `.criticality`), and `NativeLifecycleEntry.native_slot` was a free String — the typed `RpmScriptletSlot` never persisted, so the runtime could not re-derive a class it was not told about, and posture-table corrections could not apply to already-converted artifacts without reconversion.

## Fix (CONVERSION_VERSION 15 → 16, NATIVE_LIFECYCLE_SCHEMA_REVISION 19 → 20)

- The bool is gone from the persisted contract; `deny_unknown_fields` rejects old manifests naming the field. Its cross-check is replaced by a stronger one: the stamp must equal the typed class authority's derivation from the persisted `raw_flags` header word (CRITICAL bit pinned to upstream `lib/rpmscript.hh`).
- `native_slot` persists the typed `RpmScriptletSlot` with exact RPM tag wire strings; all ten trigger tags project onto the one `Trigger` class (exact tag survives in entry id + typed `rpm_trigger`); unknown/retired slot strings are rejected as unknown variants. The runtime derives failure posture from the typed class + header flag alone — the stamp is persisted evidence.
- **Review round (Luna, both findings fixed):** (P1) the stamp-agreement check is enforced only on the conversion-output path (`validate_as_conversion_output`), never on installed-bundle load — otherwise the first posture-table correction would reject every installed bundle, defeating the no-reconversion goal. Eight-caller audit table in the report; the conversion funnel (`build_native_lifecycle_bundle`) is the single gate. (P2) mixed trigger actions are rejected at validation naming both actions, killing constraint-order-dependent posture; order-flip pinned by test. Re-review verdict: clean, no findings.

## Three-contract audit

CONVERSION_VERSION bumped (forces corpus reconversion via prewarm); static repository document major NOT bumped (documents embed only scriptlet_fidelity + evidence_digest, grep-verified); client DB SCHEMA_VERSION NOT bumped — DDL is unchanged, and installed revision-19 `bundle_toml` blobs are hard-rejected by the bundle's own revision gate. Rebuild impact stated in the commit.

## Verification

- Full `cargo test -p conary-core` / `-p conary` / `-p remi` — 0 failures, including after the rebase over #362 (the shared rpm_warning.rs fixture signature collision was resolved and re-proven)
- output_vocabulary_guard, clippy -D warnings, fmt, doc-truth — clean
- Conformance tests pin: deleted-bool rejection naming the field (bundle + manifest level), exact wire strings for all 11 slot classes, all ten parser trigger tags projecting onto Trigger, the full 15-row #295 decision table re-derived through the persisted class, stale-stamp loads validating while conversion output rejects the same disagreement
- Chain: DeepSeek implemented + revised (sandbox fully blind — every command honestly NOT RUN; reviewer ran all protocols and repaired compile/fixture fallout); Luna reviewed (2 correctness findings) and re-reviewed (clean)

Closes #336