### PR TITLE
feat(conary-test): stream local run results to Remi and make the WAL contract real

### DIFF
--- a/apps/conary-test/src/cli.rs
+++ b/apps/conary-test/src/cli.rs
@@ -467,43 +467,58 @@ fn run_single_distro(
             conary_test::remi_stream::LocalRemiRun::start(&aggregate_suite_name, distro, phase)
                 .await;
 
-        for manifest_path in &manifest_paths {
-            let manifest = conary_test::config::load_manifest(manifest_path)
-                .with_context(|| format!("failed to load manifest: {}", manifest_path.display()))?;
-            initialize_container_state(
-                config,
-                distro,
-                manifest.suite.phase > 1,
-                &backend,
-                &container_id,
-            )
-            .await?;
-
-            let mut runner =
-                conary_test::engine::runner::TestRunner::new(config.clone(), distro.to_string());
-            let suite = runner
-                .run_with_cancel(
-                    &manifest,
+        // The manifest loop is fallible, and an acknowledged Remi run must be
+        // closed on that path too: a run left at its `pending` default reads as
+        // still in flight forever.
+        let manifest_outcome: Result<()> = async {
+            for manifest_path in &manifest_paths {
+                let manifest =
+                    conary_test::config::load_manifest(manifest_path).with_context(|| {
+                        format!("failed to load manifest: {}", manifest_path.display())
+                    })?;
+                initialize_container_state(
+                    config,
+                    distro,
+                    manifest.suite.phase > 1,
                     &backend,
                     &container_id,
-                    Some(&container_config),
-                    None,
-                    None,
-                    remi_run.as_ref().map(|run| run.context()),
                 )
                 .await?;
-            aggregate_suite.expect_corpus_cases(suite.corpus_expected());
-            for result in suite.results {
-                aggregate_suite.record(result);
+
+                let mut runner = conary_test::engine::runner::TestRunner::new(
+                    config.clone(),
+                    distro.to_string(),
+                );
+                let suite = runner
+                    .run_with_cancel(
+                        &manifest,
+                        &backend,
+                        &container_id,
+                        Some(&container_config),
+                        None,
+                        None,
+                        remi_run.as_ref().map(|run| run.context()),
+                    )
+                    .await?;
+                aggregate_suite.expect_corpus_cases(suite.corpus_expected());
+                for result in suite.results {
+                    aggregate_suite.record(result);
+                }
+                for case in suite.corpus_cases {
+                    aggregate_suite.record_corpus(case);
+                }
             }
-            for case in suite.corpus_cases {
-                aggregate_suite.record_corpus(case);
-            }
+            Ok(())
         }
+        .await;
+
         aggregate_suite.finish();
         if let Some(remi_run) = &remi_run {
-            remi_run.finish(&aggregate_suite).await;
+            remi_run
+                .finish(&aggregate_suite, manifest_outcome.is_err())
+                .await;
         }
+        manifest_outcome?;
 
         // Print JSON results.
         let json = conary_test::report::json::to_json_report(&aggregate_suite)?;
@@ -514,10 +529,7 @@ fn run_single_distro(
         conary_test::report::json::write_json_report(&aggregate_suite, &results_file)?;
         tracing::info!(path = %results_file.display(), "Results written");
 
-        let has_blocking_results = aggregate_suite.failed() > 0
-            || aggregate_suite.skipped() > 0
-            || aggregate_suite.cancelled() > 0
-            || !aggregate_suite.corpus_all_completed();
+        let has_blocking_results = aggregate_suite.has_blocking_results();
 
         // Cleanup container.
         let keep_container = std::env::var("CONARY_TEST_KEEP_CONTAINER")
@@ -570,35 +582,44 @@ async fn run_qemu_only_suite(
     let remi_run =
         conary_test::remi_stream::LocalRemiRun::start(&aggregate_suite_name, distro, phase).await;
 
-    for manifest_path in manifest_paths {
-        let manifest = conary_test::config::load_manifest(manifest_path)
-            .with_context(|| format!("failed to load manifest: {}", manifest_path.display()))?;
+    // Fallible loop, closed run on both exits — see the container path.
+    let manifest_outcome: Result<()> = async {
+        for manifest_path in manifest_paths {
+            let manifest = conary_test::config::load_manifest(manifest_path)
+                .with_context(|| format!("failed to load manifest: {}", manifest_path.display()))?;
 
-        let mut runner =
-            conary_test::engine::runner::TestRunner::new(config.clone(), distro.to_string());
-        let suite = runner
-            .run_with_cancel(
-                &manifest,
-                &dummy_backend,
-                &dummy_container_id,
-                Some(&dummy_config),
-                None,
-                None,
-                remi_run.as_ref().map(|run| run.context()),
-            )
-            .await?;
-        aggregate_suite.expect_corpus_cases(suite.corpus_expected());
-        for result in suite.results {
-            aggregate_suite.record(result);
+            let mut runner =
+                conary_test::engine::runner::TestRunner::new(config.clone(), distro.to_string());
+            let suite = runner
+                .run_with_cancel(
+                    &manifest,
+                    &dummy_backend,
+                    &dummy_container_id,
+                    Some(&dummy_config),
+                    None,
+                    None,
+                    remi_run.as_ref().map(|run| run.context()),
+                )
+                .await?;
+            aggregate_suite.expect_corpus_cases(suite.corpus_expected());
+            for result in suite.results {
+                aggregate_suite.record(result);
+            }
+            for case in suite.corpus_cases {
+                aggregate_suite.record_corpus(case);
+            }
         }
-        for case in suite.corpus_cases {
-            aggregate_suite.record_corpus(case);
-        }
+        Ok(())
     }
+    .await;
+
     aggregate_suite.finish();
     if let Some(remi_run) = &remi_run {
-        remi_run.finish(&aggregate_suite).await;
+        remi_run
+            .finish(&aggregate_suite, manifest_outcome.is_err())
+            .await;
     }
+    manifest_outcome?;
 
     let json = conary_test::report::json::to_json_report(&aggregate_suite)?;
     println!("{json}");
@@ -607,10 +628,7 @@ async fn run_qemu_only_suite(
     conary_test::report::json::write_json_report(&aggregate_suite, &results_file)?;
     tracing::info!(path = %results_file.display(), "Results written");
 
-    Ok(aggregate_suite.failed() == 0
-        && aggregate_suite.skipped() == 0
-        && aggregate_suite.cancelled() == 0
-        && aggregate_suite.corpus_all_completed())
+    Ok(!aggregate_suite.has_blocking_results())
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/conary-test/src/cli.rs
+++ b/apps/conary-test/src/cli.rs
@@ -459,9 +459,13 @@ fn run_single_distro(
         backend.start(&container_id).await?;
         tracing::info!(distro, id = %container_id, "Container started");
 
+        let aggregate_suite_name = format!("phase-{phase}");
         let mut aggregate_suite =
-            conary_test::engine::suite::TestSuite::new(&format!("phase-{phase}"), phase);
+            conary_test::engine::suite::TestSuite::new(&aggregate_suite_name, phase);
         aggregate_suite.status = conary_test::engine::suite::RunStatus::Running;
+        let remi_run =
+            conary_test::remi_stream::LocalRemiRun::start(&aggregate_suite_name, distro, phase)
+                .await;
 
         for manifest_path in &manifest_paths {
             let manifest = conary_test::config::load_manifest(manifest_path)
@@ -478,7 +482,15 @@ fn run_single_distro(
             let mut runner =
                 conary_test::engine::runner::TestRunner::new(config.clone(), distro.to_string());
             let suite = runner
-                .run(&manifest, &backend, &container_id, Some(&container_config))
+                .run_with_cancel(
+                    &manifest,
+                    &backend,
+                    &container_id,
+                    Some(&container_config),
+                    None,
+                    None,
+                    remi_run.as_ref().map(|run| run.context()),
+                )
                 .await?;
             aggregate_suite.expect_corpus_cases(suite.corpus_expected());
             for result in suite.results {
@@ -489,6 +501,9 @@ fn run_single_distro(
             }
         }
         aggregate_suite.finish();
+        if let Some(remi_run) = &remi_run {
+            remi_run.finish(&aggregate_suite).await;
+        }
 
         // Print JSON results.
         let json = conary_test::report::json::to_json_report(&aggregate_suite)?;
@@ -548,9 +563,12 @@ async fn run_qemu_only_suite(
     let dummy_container_id: conary_test::container::ContainerId = "qemu-standalone".to_string();
     let dummy_config = conary_test::container::ContainerConfig::default();
 
+    let aggregate_suite_name = format!("phase-{phase}");
     let mut aggregate_suite =
-        conary_test::engine::suite::TestSuite::new(&format!("phase-{phase}"), phase);
+        conary_test::engine::suite::TestSuite::new(&aggregate_suite_name, phase);
     aggregate_suite.status = conary_test::engine::suite::RunStatus::Running;
+    let remi_run =
+        conary_test::remi_stream::LocalRemiRun::start(&aggregate_suite_name, distro, phase).await;
 
     for manifest_path in manifest_paths {
         let manifest = conary_test::config::load_manifest(manifest_path)
@@ -559,11 +577,14 @@ async fn run_qemu_only_suite(
         let mut runner =
             conary_test::engine::runner::TestRunner::new(config.clone(), distro.to_string());
         let suite = runner
-            .run(
+            .run_with_cancel(
                 &manifest,
                 &dummy_backend,
                 &dummy_container_id,
                 Some(&dummy_config),
+                None,
+                None,
+                remi_run.as_ref().map(|run| run.context()),
             )
             .await?;
         aggregate_suite.expect_corpus_cases(suite.corpus_expected());
@@ -575,6 +596,9 @@ async fn run_qemu_only_suite(
         }
     }
     aggregate_suite.finish();
+    if let Some(remi_run) = &remi_run {
+        remi_run.finish(&aggregate_suite).await;
+    }
 
     let json = conary_test::report::json::to_json_report(&aggregate_suite)?;
     println!("{json}");

--- a/apps/conary-test/src/engine/runner.rs
+++ b/apps/conary-test/src/engine/runner.rs
@@ -31,7 +31,7 @@ pub struct RemiStreamCtx {
     /// Remi run ID returned by `create_run`.
     pub remi_run_id: i64,
     pub client: Arc<RemiClient>,
-    pub wal: Option<Arc<std::sync::Mutex<Wal>>>,
+    pub wal: Option<Arc<tokio::sync::Mutex<Wal>>>,
 }
 
 /// Executes tests from a manifest against a container.
@@ -800,12 +800,18 @@ async fn push_to_remi(ctx: &RemiStreamCtx, data: &PushResultData) {
                 error = %e,
                 "failed to push result to Remi, buffering to WAL"
             );
-            if let Some(ref wal) = ctx.wal
-                && let Ok(json) = serde_json::to_string(data)
-                && let Ok(wal_guard) = wal.lock()
-                && let Err(wal_err) = wal_guard.buffer(ctx.remi_run_id, &json)
-            {
-                warn!(error = %wal_err, "failed to buffer result in WAL");
+            if let Some(ref wal) = ctx.wal {
+                match serde_json::to_string(data) {
+                    Ok(json) => {
+                        let wal_guard = wal.lock().await;
+                        if let Err(wal_err) = wal_guard.buffer(ctx.remi_run_id, &json) {
+                            warn!(error = %wal_err, "failed to buffer result in WAL");
+                        }
+                    }
+                    Err(json_error) => {
+                        warn!(error = %json_error, "failed to serialize result for WAL");
+                    }
+                }
             }
         }
     }

--- a/apps/conary-test/src/engine/runner/tests.rs
+++ b/apps/conary-test/src/engine/runner/tests.rs
@@ -737,8 +737,8 @@ async fn remi_failure_does_not_change_exit_outcome_or_json_report() {
         .unwrap();
 
     assert_eq!(
-        has_blocking_results(&no_remi_suite),
-        has_blocking_results(&remi_suite)
+        no_remi_suite.has_blocking_results(),
+        remi_suite.has_blocking_results()
     );
     assert_eq!(
         comparable_json_report(&no_remi_suite),
@@ -806,13 +806,6 @@ fn every_runner_push_shape_round_trips_through_the_wal() {
     let item = wal.pending_items().unwrap().pop().unwrap();
     let decoded: PushResultData = serde_json::from_str(&item.payload).unwrap();
     assert_eq!(decoded, explicit_none);
-}
-
-fn has_blocking_results(suite: &TestSuite) -> bool {
-    suite.failed() > 0
-        || suite.skipped() > 0
-        || suite.cancelled() > 0
-        || !suite.corpus_all_completed()
 }
 
 fn comparable_json_report(suite: &TestSuite) -> serde_json::Value {

--- a/apps/conary-test/src/engine/runner/tests.rs
+++ b/apps/conary-test/src/engine/runner/tests.rs
@@ -634,3 +634,196 @@ async fn test_resource_scoped_flaky_retries_use_fresh_container() {
 }
 
 mod controls;
+
+#[tokio::test]
+async fn push_to_remi_buffers_failed_payload_that_round_trips() {
+    let wal = Arc::new(tokio::sync::Mutex::new(Wal::open(":memory:").unwrap()));
+    let data = build_push_result(
+        "T-BUFFER",
+        "buffer_failure",
+        TestStatus::Failed,
+        23,
+        Some("message\nwith é"),
+        Some(&ExecResult {
+            exit_code: 1,
+            stdout: "stdout\n多 byte".to_string(),
+            stderr: "stderr\nошибка".to_string(),
+        }),
+    );
+    let ctx = RemiStreamCtx {
+        remi_run_id: 41,
+        client: Arc::new(RemiClient::new(
+            "http://127.0.0.1:1".to_string(),
+            "test-token".to_string(),
+        )),
+        wal: Some(wal.clone()),
+    };
+
+    push_to_remi(&ctx, &data).await;
+
+    let wal_guard = wal.lock().await;
+    let items = wal_guard.pending_items().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].run_id, 41);
+    let stored: PushResultData = serde_json::from_str(&items[0].payload).unwrap();
+    assert_eq!(stored, data);
+}
+
+#[tokio::test]
+async fn remi_failure_does_not_change_exit_outcome_or_json_report() {
+    let manifest = make_manifest(vec![TestDef {
+        id: "T-ISOLATION".to_string(),
+        name: "failure_isolation".to_string(),
+        description: "streaming must be observational".to_string(),
+        timeout: 30,
+        flaky: None,
+        retries: None,
+        retry_delay_ms: None,
+        step: vec![simple_step_run(
+            "echo stable",
+            Some(make_assertion(Some(0), Some("stable"))),
+        )],
+        resources: None,
+        depends_on: None,
+        fatal: None,
+        group: None,
+        skip: None,
+        requires: Vec::new(),
+        corpus: None,
+    }]);
+
+    let no_remi_backend = MockBackend::new(vec![ExecResult {
+        exit_code: 0,
+        stdout: "stable".to_string(),
+        stderr: String::new(),
+    }]);
+    let mut no_remi_runner = TestRunner::new(test_config(), "fedora44".to_string());
+    let no_remi_suite = no_remi_runner
+        .run(
+            &manifest,
+            &no_remi_backend,
+            &"ctr-no-remi".to_string(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let remi_backend = MockBackend::new(vec![ExecResult {
+        exit_code: 0,
+        stdout: "stable".to_string(),
+        stderr: String::new(),
+    }]);
+    let wal = Arc::new(tokio::sync::Mutex::new(Wal::open(":memory:").unwrap()));
+    let ctx = RemiStreamCtx {
+        remi_run_id: 42,
+        client: Arc::new(RemiClient::new(
+            "http://127.0.0.1:1".to_string(),
+            "test-token".to_string(),
+        )),
+        wal: Some(wal.clone()),
+    };
+    let mut remi_runner = TestRunner::new(test_config(), "fedora44".to_string());
+    let remi_suite = remi_runner
+        .run_with_cancel(
+            &manifest,
+            &remi_backend,
+            &"ctr-remi".to_string(),
+            None,
+            None,
+            None,
+            Some(&ctx),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        has_blocking_results(&no_remi_suite),
+        has_blocking_results(&remi_suite)
+    );
+    assert_eq!(
+        comparable_json_report(&no_remi_suite),
+        comparable_json_report(&remi_suite)
+    );
+    assert_eq!(wal.lock().await.pending_count().unwrap(), 1);
+}
+
+#[test]
+fn every_runner_push_shape_round_trips_through_the_wal() {
+    let wal = Wal::open(":memory:").unwrap();
+    let statuses = [
+        TestStatus::Passed,
+        TestStatus::Failed,
+        TestStatus::Skipped,
+        TestStatus::Cancelled,
+    ];
+
+    for (index, status) in statuses.into_iter().enumerate() {
+        let cases = [
+            build_push_result(
+                &format!("T-NONE-{index}"),
+                "without execution",
+                status,
+                0,
+                None,
+                None,
+            ),
+            build_push_result(
+                &format!("T-EXEC-{index}"),
+                "with execution",
+                status,
+                17,
+                Some("message\n多字节"),
+                Some(&ExecResult {
+                    exit_code: -1,
+                    stdout: "stdout\né\n行".to_string(),
+                    stderr: "stderr\nошибка".to_string(),
+                }),
+            ),
+        ];
+
+        for (offset, data) in cases.into_iter().enumerate() {
+            let run_id = i64::try_from(index * 2 + offset).unwrap();
+            wal.buffer(run_id, &serde_json::to_string(&data).unwrap())
+                .unwrap();
+            let item = wal.pending_items().unwrap().pop().unwrap();
+            let decoded: PushResultData = serde_json::from_str(&item.payload).unwrap();
+            assert_eq!(decoded, data);
+            wal.remove(item.id).unwrap();
+        }
+    }
+
+    let explicit_none = PushResultData {
+        test_id: "T-OPTIONALS".to_string(),
+        name: "all optional fields absent".to_string(),
+        status: "passed".to_string(),
+        duration_ms: None,
+        message: None,
+        attempt: None,
+        steps: Vec::new(),
+    };
+    wal.buffer(99, &serde_json::to_string(&explicit_none).unwrap())
+        .unwrap();
+    let item = wal.pending_items().unwrap().pop().unwrap();
+    let decoded: PushResultData = serde_json::from_str(&item.payload).unwrap();
+    assert_eq!(decoded, explicit_none);
+}
+
+fn has_blocking_results(suite: &TestSuite) -> bool {
+    suite.failed() > 0
+        || suite.skipped() > 0
+        || suite.cancelled() > 0
+        || !suite.corpus_all_completed()
+}
+
+fn comparable_json_report(suite: &TestSuite) -> serde_json::Value {
+    let mut report = crate::report::json::to_json_value(suite).unwrap();
+    if let Some(results) = report["results"].as_array_mut() {
+        for result in results {
+            result
+                .as_object_mut()
+                .expect("result is an object")
+                .remove("duration_ms");
+        }
+    }
+    report
+}

--- a/apps/conary-test/src/engine/suite.rs
+++ b/apps/conary-test/src/engine/suite.rs
@@ -162,6 +162,17 @@ impl TestSuite {
             && conary_core::corpus::aggregate_cases(&self.corpus_cases).all_completed()
     }
 
+    /// Whether anything in this suite blocks calling the run a success.
+    ///
+    /// One owner for a rule the CLI exit status, the QEMU-only path, and the
+    /// Remi run status all have to agree on.
+    pub fn has_blocking_results(&self) -> bool {
+        self.failed() > 0
+            || self.skipped() > 0
+            || self.cancelled() > 0
+            || !self.corpus_all_completed()
+    }
+
     pub fn finish(&mut self) {
         // Preserve Cancelled status when every test was cancelled (the run
         // was stopped via cancel flag, not because tests naturally finished).

--- a/apps/conary-test/src/lib.rs
+++ b/apps/conary-test/src/lib.rs
@@ -9,7 +9,21 @@ pub mod engine;
 pub mod error;
 pub mod paths;
 pub mod remi_client;
+pub mod remi_stream;
 pub mod report;
 pub(crate) mod static_binary;
 pub mod suite_inventory;
 pub mod wal;
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::sync::{LazyLock, Mutex, MutexGuard};
+
+    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    pub fn lock_env() -> MutexGuard<'static, ()> {
+        ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}

--- a/apps/conary-test/src/remi_client.rs
+++ b/apps/conary-test/src/remi_client.rs
@@ -267,6 +267,23 @@ impl RemiClient {
     }
 }
 
+/// Result delivery seam used by the WAL replay path.
+///
+/// The production implementation is [`RemiClient`]. Keeping replay behind a
+/// small async trait also lets the WAL contract tests exercise success,
+/// failure, and retry-count behavior without a live Remi service.
+#[async_trait::async_trait]
+pub trait RemiResultPusher: Send + Sync {
+    async fn push_result(&self, run_id: i64, data: &PushResultData) -> Result<()>;
+}
+
+#[async_trait::async_trait]
+impl RemiResultPusher for RemiClient {
+    async fn push_result(&self, run_id: i64, data: &PushResultData) -> Result<()> {
+        RemiClient::push_result(self, run_id, data).await
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Data types
 // ---------------------------------------------------------------------------
@@ -275,7 +292,7 @@ impl RemiClient {
 ///
 /// Matches the `PushTestResultData` type on the Remi server side
 /// (see `apps/remi/src/server/admin_service.rs`).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PushResultData {
     pub test_id: String,
     pub name: String,
@@ -289,7 +306,7 @@ pub struct PushResultData {
 /// A single step within a test result.
 ///
 /// Matches the `PushStepData` type on the Remi server side.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PushStepData {
     pub step_type: String,
     pub command: Option<String>,
@@ -307,9 +324,7 @@ pub struct PushStepData {
 mod tests {
     use super::*;
     use std::ffi::OsString;
-    use std::sync::{LazyLock, Mutex, MutexGuard};
-
-    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+    use std::sync::MutexGuard;
 
     struct EnvVarGuard {
         _lock: MutexGuard<'static, ()>,
@@ -321,9 +336,7 @@ mod tests {
     impl EnvVarGuard {
         fn new() -> Self {
             Self {
-                _lock: ENV_LOCK
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner()),
+                _lock: crate::test_support::lock_env(),
                 admin_token: std::env::var_os("REMI_ADMIN_TOKEN"),
                 admin_endpoint: std::env::var_os("REMI_ADMIN_ENDPOINT"),
                 legacy_endpoint: std::env::var_os("REMI_ENDPOINT"),

--- a/apps/conary-test/src/remi_stream.rs
+++ b/apps/conary-test/src/remi_stream.rs
@@ -8,7 +8,7 @@ use tracing::{debug, info, warn};
 
 use crate::build_info::BuildInfo;
 use crate::engine::runner::RemiStreamCtx;
-use crate::engine::suite::TestSuite;
+use crate::engine::suite::{RunStatus, TestSuite};
 use crate::paths;
 use crate::remi_client::RemiClient;
 use crate::wal::{self, Wal};
@@ -68,13 +68,22 @@ impl LocalRemiRun {
         &self.context
     }
 
-    /// Flush this run's WAL before closing the acknowledged Remi run.
-    pub async fn finish(&self, suite: &TestSuite) {
-        // Do not mark a run terminal while its own failed result deliveries
-        // are still buffered.
+    /// Flush this run's WAL, then close the acknowledged Remi run.
+    ///
+    /// `aborted` marks an invocation that ended on an error before every
+    /// manifest ran. The run is still closed: an acknowledged run left at its
+    /// `pending` default is indistinguishable from one still in flight, which
+    /// is the opposite of what this surface exists to report.
+    ///
+    /// The flush runs first so a run is never marked terminal ahead of results
+    /// it could still have delivered. It is ordering, not a gate — the status
+    /// update is best-effort and proceeds whatever the flush outcome, because a
+    /// run left open forever is worse than one whose last results arrive on a
+    /// later flush.
+    pub async fn finish(&self, suite: &TestSuite, aborted: bool) {
         self.flush_wal("final").await;
 
-        let status = terminal_status(suite);
+        let status = terminal_status(suite, aborted);
         let total = count_as_u32(suite.total());
         let passed = count_as_u32(suite.passed());
         let failed = count_as_u32(suite.failed());
@@ -154,10 +163,22 @@ fn open_wal() -> Option<Arc<tokio::sync::Mutex<Wal>>> {
     }
 }
 
-fn terminal_status(suite: &TestSuite) -> &'static str {
-    if suite.cancelled() > 0 {
+/// Project a finished local suite onto Remi's run-status vocabulary.
+///
+/// An invocation that `aborted` never finished its manifests, so its counts
+/// describe only the part that ran and cannot say the run passed.
+///
+/// Whether a run counts as cancelled is [`TestSuite::finish`]'s decision, not a
+/// second rule here: it is deliberately narrower than "some test was
+/// cancelled", and two rules under one word would let the same run read
+/// `completed` locally and `cancelled` on Remi. What this function adds is the
+/// pass/fail judgement, which the local lifecycle status does not carry.
+fn terminal_status(suite: &TestSuite, aborted: bool) -> &'static str {
+    if aborted {
+        "failed"
+    } else if suite.status == RunStatus::Cancelled {
         "cancelled"
-    } else if suite.failed() > 0 || suite.skipped() > 0 || !suite.corpus_all_completed() {
+    } else if suite.has_blocking_results() {
         "failed"
     } else {
         "passed"
@@ -171,6 +192,7 @@ fn count_as_u32(value: usize) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::engine::suite::TestResult;
     use std::ffi::OsString;
 
     struct EnvGuard {
@@ -243,10 +265,79 @@ mod tests {
         assert!(!state_dir.join(WAL_FILENAME).exists());
     }
 
+    fn result(id: &str, status: crate::engine::suite::TestStatus) -> TestResult {
+        TestResult {
+            id: id.to_string(),
+            name: id.to_string(),
+            status,
+            duration_ms: 1,
+            message: None,
+            stdout: None,
+            stderr: None,
+            attempts: Vec::new(),
+        }
+    }
+
+    fn finished(results: Vec<TestResult>) -> TestSuite {
+        let mut suite = TestSuite::new("phase-1", 1);
+        for result in results {
+            suite.record(result);
+        }
+        suite.finish();
+        suite
+    }
+
     #[test]
     fn terminal_status_matches_cli_outcome_categories() {
-        let mut passed = TestSuite::new("phase-1", 1);
-        passed.finish();
-        assert_eq!(terminal_status(&passed), "passed");
+        use crate::engine::suite::TestStatus;
+
+        assert_eq!(terminal_status(&finished(Vec::new()), false), "passed");
+        assert_eq!(
+            terminal_status(&finished(vec![result("T1", TestStatus::Passed)]), false),
+            "passed"
+        );
+        assert_eq!(
+            terminal_status(&finished(vec![result("T1", TestStatus::Failed)]), false),
+            "failed"
+        );
+        assert_eq!(
+            terminal_status(&finished(vec![result("T1", TestStatus::Skipped)]), false),
+            "failed"
+        );
+    }
+
+    /// An invocation that died before running every manifest is closed as
+    /// failed, never left at the `pending` default where it is
+    /// indistinguishable from a run still in flight.
+    #[test]
+    fn an_aborted_invocation_is_closed_as_failed_whatever_ran() {
+        use crate::engine::suite::TestStatus;
+
+        let all_passed = finished(vec![result("T1", TestStatus::Passed)]);
+        assert_eq!(terminal_status(&all_passed, false), "passed");
+        assert_eq!(terminal_status(&all_passed, true), "failed");
+
+        let cancelled = finished(vec![result("T1", TestStatus::Cancelled)]);
+        assert_eq!(terminal_status(&cancelled, false), "cancelled");
+        assert_eq!(terminal_status(&cancelled, true), "failed");
+    }
+
+    /// A run is cancelled only when [`TestSuite::finish`] says so. Deriving
+    /// cancellation here from `cancelled() > 0` instead would report a run as
+    /// `cancelled` on Remi that the local report calls `completed`.
+    #[test]
+    fn a_partly_cancelled_run_is_not_reported_as_a_cancelled_run() {
+        use crate::engine::suite::{RunStatus, TestStatus};
+
+        let all_cancelled = finished(vec![result("T1", TestStatus::Cancelled)]);
+        assert_eq!(all_cancelled.status, RunStatus::Cancelled);
+        assert_eq!(terminal_status(&all_cancelled, false), "cancelled");
+
+        let partly_cancelled = finished(vec![
+            result("T1", TestStatus::Passed),
+            result("T2", TestStatus::Cancelled),
+        ]);
+        assert_eq!(partly_cancelled.status, RunStatus::Completed);
+        assert_eq!(terminal_status(&partly_cancelled, false), "failed");
     }
 }

--- a/apps/conary-test/src/remi_stream.rs
+++ b/apps/conary-test/src/remi_stream.rs
@@ -1,0 +1,252 @@
+// conary-test/src/remi_stream.rs
+
+//! Local CLI orchestration for Remi test-result streaming.
+
+use std::sync::Arc;
+
+use tracing::{debug, info, warn};
+
+use crate::build_info::BuildInfo;
+use crate::engine::runner::RemiStreamCtx;
+use crate::engine::suite::TestSuite;
+use crate::paths;
+use crate::remi_client::RemiClient;
+use crate::wal::{self, Wal};
+
+const WAL_FILENAME: &str = "results-wal.db";
+
+/// One acknowledged Remi run associated with one local CLI suite invocation.
+pub struct LocalRemiRun {
+    context: RemiStreamCtx,
+}
+
+impl LocalRemiRun {
+    /// Create and initialize a Remi run for a local CLI invocation.
+    ///
+    /// Missing Remi configuration and failed run creation are deliberately
+    /// treated as optional observability paths. The caller receives `None`
+    /// and continues with ordinary local test behavior in either case.
+    pub async fn start(suite: &str, distro: &str, phase: u32) -> Option<Self> {
+        let client = match RemiClient::from_env() {
+            Ok(client) => client,
+            Err(_) => {
+                info!("Remi streaming disabled: no Remi env configured");
+                return None;
+            }
+        };
+
+        let build_info = BuildInfo::current();
+        let source_commit = (!build_info.git_commit.is_empty()).then_some(build_info.git_commit);
+        let source_commit_ref = source_commit.as_deref();
+        let run_id = match client
+            .create_run(suite, distro, phase, Some("local-cli"), source_commit_ref)
+            .await
+        {
+            Ok(run_id) => run_id,
+            Err(error) => {
+                warn!(error = %error, "Remi streaming disabled: failed to create run");
+                return None;
+            }
+        };
+
+        let client = Arc::new(client);
+        let context = RemiStreamCtx {
+            remi_run_id: run_id,
+            client,
+            wal: open_wal(),
+        };
+        let local_run = Self { context };
+
+        // Acknowledged reachability is the only gate that permits replaying
+        // rows left by earlier invocations.
+        local_run.flush_wal("startup").await;
+        Some(local_run)
+    }
+
+    /// Return the runner context for per-test result streaming.
+    pub fn context(&self) -> &RemiStreamCtx {
+        &self.context
+    }
+
+    /// Flush this run's WAL before closing the acknowledged Remi run.
+    pub async fn finish(&self, suite: &TestSuite) {
+        // Do not mark a run terminal while its own failed result deliveries
+        // are still buffered.
+        self.flush_wal("final").await;
+
+        let status = terminal_status(suite);
+        let total = count_as_u32(suite.total());
+        let passed = count_as_u32(suite.passed());
+        let failed = count_as_u32(suite.failed());
+        let skipped = count_as_u32(suite.skipped());
+        if let Err(error) = self
+            .context
+            .client
+            .update_run(
+                self.context.remi_run_id,
+                status,
+                total,
+                passed,
+                failed,
+                skipped,
+            )
+            .await
+        {
+            warn!(
+                remi_run_id = self.context.remi_run_id,
+                error = %error,
+                "failed to update Remi run status"
+            );
+        }
+    }
+
+    async fn flush_wal(&self, reason: &str) {
+        let Some(wal) = &self.context.wal else {
+            return;
+        };
+
+        let outcome = {
+            let wal_guard = wal.lock().await;
+            wal::flush(&wal_guard, self.context.client.as_ref()).await
+        };
+        debug!(
+            remi_run_id = self.context.remi_run_id,
+            reason,
+            flushed = outcome.flushed,
+            failed = outcome.failed,
+            discarded = outcome.discarded,
+            purged = outcome.purged,
+            "completed Remi result WAL flush"
+        );
+    }
+}
+
+fn open_wal() -> Option<Arc<tokio::sync::Mutex<Wal>>> {
+    let state_dir = match paths::state_dir() {
+        Ok(path) => path,
+        Err(error) => {
+            warn!(error = %error, "failed to resolve Remi result WAL state directory");
+            return None;
+        }
+    };
+
+    if let Err(error) = std::fs::create_dir_all(&state_dir) {
+        warn!(
+            path = %state_dir.display(),
+            error = %error,
+            "failed to create Remi result WAL state directory"
+        );
+        return None;
+    }
+
+    let wal_path = state_dir.join(WAL_FILENAME);
+    info!(path = %wal_path.display(), "Remi result streaming enabled; using WAL");
+    match Wal::open(&wal_path) {
+        Ok(wal) => Some(Arc::new(tokio::sync::Mutex::new(wal))),
+        Err(error) => {
+            warn!(
+                path = %wal_path.display(),
+                error = %error,
+                "failed to open Remi result WAL; continuing without buffering"
+            );
+            None
+        }
+    }
+}
+
+fn terminal_status(suite: &TestSuite) -> &'static str {
+    if suite.cancelled() > 0 {
+        "cancelled"
+    } else if suite.failed() > 0 || suite.skipped() > 0 || !suite.corpus_all_completed() {
+        "failed"
+    } else {
+        "passed"
+    }
+}
+
+fn count_as_u32(value: usize) -> u32 {
+    u32::try_from(value).unwrap_or(u32::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+
+    struct EnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        values: Vec<(&'static str, Option<OsString>)>,
+    }
+
+    impl EnvGuard {
+        fn new(names: &[&'static str]) -> Self {
+            let lock = crate::test_support::lock_env();
+            let values = names
+                .iter()
+                .map(|name| (*name, std::env::var_os(name)))
+                .collect();
+            Self {
+                _lock: lock,
+                values,
+            }
+        }
+
+        fn clear(&self, name: &str) {
+            // Environment mutation is unsafe under Rust 2024 because other
+            // threads may observe the process environment concurrently. The
+            // shared test lock makes this test's mutation serialized.
+            unsafe {
+                std::env::remove_var(name);
+            }
+        }
+
+        fn set(&self, name: &str, value: &str) {
+            unsafe {
+                std::env::set_var(name, value);
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (name, value) in &self.values {
+                unsafe {
+                    match value {
+                        Some(value) => std::env::set_var(name, value),
+                        None => std::env::remove_var(name),
+                    }
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn no_remi_environment_does_not_create_a_wal() {
+        let env = EnvGuard::new(&[
+            "REMI_ADMIN_ENDPOINT",
+            "REMI_ADMIN_TOKEN",
+            "CONARY_TEST_STATE_DIR",
+        ]);
+        env.clear("REMI_ADMIN_ENDPOINT");
+        env.clear("REMI_ADMIN_TOKEN");
+        let state_dir = std::env::current_dir()
+            .unwrap()
+            .join(format!(".conary-test-remi-stream-{}", std::process::id()));
+        assert!(!state_dir.exists());
+        env.set("CONARY_TEST_STATE_DIR", state_dir.to_str().unwrap());
+
+        assert!(
+            LocalRemiRun::start("phase-1", "fedora44", 1)
+                .await
+                .is_none()
+        );
+        assert!(!state_dir.join(WAL_FILENAME).exists());
+    }
+
+    #[test]
+    fn terminal_status_matches_cli_outcome_categories() {
+        let mut passed = TestSuite::new("phase-1", 1);
+        passed.finish();
+        assert_eq!(terminal_status(&passed), "passed");
+    }
+}

--- a/apps/conary-test/src/wal.rs
+++ b/apps/conary-test/src/wal.rs
@@ -2,11 +2,32 @@
 //! SQLite-backed write-ahead log for buffering test results when Remi is
 //! unreachable.
 //!
-//! Failed POST payloads are stored locally and replayed on the next flush
-//! cycle. Items that exceed a configurable retry limit are purged.
+//! Failed per-test result POST payloads are stored locally and replayed only
+//! by an invocation whose `create_run` call was acknowledged by Remi. A flush
+//! removes successful and unparseable rows, records failed attempts, and
+//! purges rows after [`MAX_FLUSH_ATTEMPTS`] failed flush attempts, logging each
+//! purged row with its retry context. Run-status updates are deliberately not
+//! WAL-buffered; they are best-effort updates made after the aggregate result
+//! flush.
 
 use anyhow::{Context, Result};
 use rusqlite::Connection;
+use std::path::Path;
+use tracing::warn;
+
+use crate::remi_client::{PushResultData, RemiResultPusher};
+
+/// Number of failed flush attempts tolerated before a result is discarded.
+pub const MAX_FLUSH_ATTEMPTS: u32 = 5;
+
+/// Counts the work performed by one WAL replay pass.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FlushOutcome {
+    pub flushed: u64,
+    pub failed: u64,
+    pub discarded: u64,
+    pub purged: u64,
+}
 
 /// SQLite-backed buffer for test result payloads that failed to reach Remi.
 pub struct Wal {
@@ -21,6 +42,7 @@ pub struct PendingItem {
     pub payload: String,
     pub retry_count: u32,
     pub created_at: String,
+    pub last_error: Option<String>,
 }
 
 impl Wal {
@@ -28,7 +50,7 @@ impl Wal {
     ///
     /// Pass `":memory:"` for an ephemeral in-memory database (useful in
     /// tests).
-    pub fn open(path: &str) -> Result<Self> {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self> {
         let conn = Connection::open(path).context("failed to open WAL database")?;
 
         conn.execute_batch(
@@ -73,7 +95,7 @@ impl Wal {
         let mut stmt = self
             .conn
             .prepare(
-                "SELECT id, run_id, payload, retry_count, created_at \
+                "SELECT id, run_id, payload, retry_count, created_at, last_error \
                  FROM pending_results ORDER BY id ASC",
             )
             .context("failed to prepare pending_items query")?;
@@ -86,6 +108,7 @@ impl Wal {
                     payload: row.get(2)?,
                     retry_count: row.get(3)?,
                     created_at: row.get(4)?,
+                    last_error: row.get(5)?,
                 })
             })
             .context("failed to query pending WAL items")?
@@ -122,8 +145,25 @@ impl Wal {
 
     /// Delete items whose retry count exceeds `max_retries`.
     ///
-    /// Returns the number of purged rows.
+    /// The doomed rows are read and logged before deletion so result loss is
+    /// observable rather than a silent retry cap.
     pub fn purge_dead(&self, max_retries: u32) -> Result<u64> {
+        let doomed = self
+            .pending_items()?
+            .into_iter()
+            .filter(|item| item.retry_count > max_retries)
+            .collect::<Vec<_>>();
+
+        for item in &doomed {
+            warn!(
+                id = item.id,
+                run_id = item.run_id,
+                retry_count = item.retry_count,
+                last_error = ?item.last_error,
+                "purging WAL result after retry limit"
+            );
+        }
+
         let deleted = self
             .conn
             .execute(
@@ -137,36 +177,66 @@ impl Wal {
 
 /// Attempt to flush all pending WAL items to Remi.
 ///
-/// Returns `(flushed_count, failed_count)`. Items with unparseable payloads
-/// are silently removed rather than retried indefinitely.
-pub async fn flush(wal: &Wal, client: &crate::remi_client::RemiClient) -> (u64, u64) {
-    let items = wal.pending_items().unwrap_or_default();
-    let mut flushed = 0u64;
-    let mut failed = 0u64;
+/// Items with unparseable payloads are removed and counted as discarded. After
+/// the replay pass, failed rows beyond the retry threshold are purged.
+pub async fn flush<C>(wal: &Wal, client: &C) -> FlushOutcome
+where
+    C: RemiResultPusher + ?Sized,
+{
+    let items = match wal.pending_items() {
+        Ok(items) => items,
+        Err(error) => {
+            warn!(error = %error, "failed to read WAL items for flush");
+            return FlushOutcome::default();
+        }
+    };
+    let mut outcome = FlushOutcome::default();
 
     for item in items {
-        let data: crate::remi_client::PushResultData = match serde_json::from_str(&item.payload) {
+        let data: PushResultData = match serde_json::from_str(&item.payload) {
             Ok(d) => d,
             Err(e) => {
                 tracing::warn!("WAL item {} has invalid payload: {}", item.id, e);
-                let _ = wal.remove(item.id);
+                match wal.remove(item.id) {
+                    Ok(()) => outcome.discarded += 1,
+                    Err(remove_error) => warn!(
+                        id = item.id,
+                        error = %remove_error,
+                        "failed to discard invalid WAL item"
+                    ),
+                }
                 continue;
             }
         };
 
         match client.push_result(item.run_id, &data).await {
-            Ok(()) => {
-                let _ = wal.remove(item.id);
-                flushed += 1;
-            }
+            Ok(()) => match wal.remove(item.id) {
+                Ok(()) => outcome.flushed += 1,
+                Err(remove_error) => warn!(
+                    id = item.id,
+                    error = %remove_error,
+                    "failed to remove flushed WAL item"
+                ),
+            },
             Err(e) => {
-                let _ = wal.mark_retry(item.id, &e.to_string());
-                failed += 1;
+                outcome.failed += 1;
+                if let Err(mark_error) = wal.mark_retry(item.id, &e.to_string()) {
+                    warn!(
+                        id = item.id,
+                        error = %mark_error,
+                        "failed to record WAL retry"
+                    );
+                }
             }
         }
     }
 
-    (flushed, failed)
+    match wal.purge_dead(MAX_FLUSH_ATTEMPTS - 1) {
+        Ok(purged) => outcome.purged = purged,
+        Err(error) => warn!(error = %error, "failed to purge dead WAL items"),
+    }
+
+    outcome
 }
 
 // ---------------------------------------------------------------------------
@@ -176,6 +246,63 @@ pub async fn flush(wal: &Wal, client: &crate::remi_client::RemiClient) -> (u64, 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::remi_client::{PushStepData, RemiResultPusher};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    struct FakePusher {
+        calls: AtomicU64,
+        fail: bool,
+    }
+
+    impl FakePusher {
+        fn working() -> Self {
+            Self {
+                calls: AtomicU64::new(0),
+                fail: false,
+            }
+        }
+
+        fn failing() -> Self {
+            Self {
+                calls: AtomicU64::new(0),
+                fail: true,
+            }
+        }
+
+        fn calls(&self) -> u64 {
+            self.calls.load(Ordering::Relaxed)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl RemiResultPusher for FakePusher {
+        async fn push_result(&self, _run_id: i64, _data: &PushResultData) -> Result<()> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            if self.fail {
+                anyhow::bail!("fake Remi unavailable");
+            }
+            Ok(())
+        }
+    }
+
+    fn push_data() -> PushResultData {
+        PushResultData {
+            test_id: "T-WAL".to_string(),
+            name: "wal_replay".to_string(),
+            status: "failed".to_string(),
+            duration_ms: Some(12),
+            message: Some("failed once".to_string()),
+            attempt: Some(1),
+            steps: vec![PushStepData {
+                step_type: "exec".to_string(),
+                command: Some("true".to_string()),
+                exit_code: Some(1),
+                duration_ms: Some(12),
+                stdout: Some(String::new()),
+                stderr: Some("failure".to_string()),
+            }],
+        }
+    }
 
     #[test]
     fn test_buffer_and_retrieve() {
@@ -208,6 +335,65 @@ mod tests {
 
         let items = wal.pending_items().unwrap();
         assert_eq!(items[0].retry_count, 1);
+    }
+
+    #[tokio::test]
+    async fn flush_replays_buffered_result_and_removes_row() {
+        let wal = Wal::open(":memory:").unwrap();
+        let data = push_data();
+        wal.buffer(7, &serde_json::to_string(&data).unwrap())
+            .unwrap();
+        let client = FakePusher::working();
+
+        let outcome = flush(&wal, &client).await;
+
+        assert_eq!(outcome.flushed, 1);
+        assert_eq!(outcome.failed, 0);
+        assert_eq!(outcome.discarded, 0);
+        assert_eq!(outcome.purged, 0);
+        assert_eq!(wal.pending_count().unwrap(), 0);
+        assert_eq!(client.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn flush_purges_after_five_failed_attempts() {
+        let wal = Wal::open(":memory:").unwrap();
+        let data = push_data();
+        wal.buffer(7, &serde_json::to_string(&data).unwrap())
+            .unwrap();
+        let client = FakePusher::failing();
+
+        for attempt in 1..=MAX_FLUSH_ATTEMPTS {
+            let outcome = flush(&wal, &client).await;
+            assert_eq!(outcome.failed, 1);
+            assert_eq!(outcome.flushed, 0);
+            assert_eq!(outcome.discarded, 0);
+            if attempt < MAX_FLUSH_ATTEMPTS {
+                assert_eq!(outcome.purged, 0);
+                assert_eq!(wal.pending_count().unwrap(), 1);
+            } else {
+                assert_eq!(outcome.purged, 1);
+                assert_eq!(wal.pending_count().unwrap(), 0);
+            }
+        }
+
+        assert_eq!(client.calls(), u64::from(MAX_FLUSH_ATTEMPTS));
+    }
+
+    #[tokio::test]
+    async fn flush_counts_and_removes_unparseable_payloads() {
+        let wal = Wal::open(":memory:").unwrap();
+        wal.buffer(7, "not-json").unwrap();
+        let client = FakePusher::working();
+
+        let outcome = flush(&wal, &client).await;
+
+        assert_eq!(outcome.discarded, 1);
+        assert_eq!(outcome.flushed, 0);
+        assert_eq!(outcome.failed, 0);
+        assert_eq!(outcome.purged, 0);
+        assert_eq!(wal.pending_count().unwrap(), 0);
+        assert_eq!(client.calls(), 0);
     }
 
     #[test]

--- a/apps/conary-test/src/wal.rs
+++ b/apps/conary-test/src/wal.rs
@@ -13,12 +13,17 @@
 use anyhow::{Context, Result};
 use rusqlite::Connection;
 use std::path::Path;
+use std::time::Duration;
 use tracing::warn;
 
 use crate::remi_client::{PushResultData, RemiResultPusher};
 
 /// Number of failed flush attempts tolerated before a result is discarded.
 pub const MAX_FLUSH_ATTEMPTS: u32 = 5;
+
+/// How long a writer waits for a concurrent `conary-test` process to release
+/// the shared WAL file before giving up.
+const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Counts the work performed by one WAL replay pass.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -50,8 +55,15 @@ impl Wal {
     ///
     /// Pass `":memory:"` for an ephemeral in-memory database (useful in
     /// tests).
+    ///
+    /// The WAL path is shared by every `conary-test` process on the host, so a
+    /// second concurrent run would otherwise take an immediate `SQLITE_BUSY`
+    /// and drop the result it was trying to buffer. Waiting is always better
+    /// than losing the row this file exists to keep.
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
         let conn = Connection::open(path).context("failed to open WAL database")?;
+        conn.busy_timeout(BUSY_TIMEOUT)
+            .context("failed to set WAL busy timeout")?;
 
         conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS pending_results (
@@ -302,6 +314,22 @@ mod tests {
                 stderr: Some("failure".to_string()),
             }],
         }
+    }
+
+    /// Every `conary-test` process on the host shares one WAL file, so a
+    /// writer must wait for a concurrent one rather than take an immediate
+    /// `SQLITE_BUSY` and drop the result it was buffering.
+    #[test]
+    fn open_configures_a_busy_timeout_for_concurrent_writers() {
+        let wal = Wal::open(":memory:").unwrap();
+
+        let configured: i64 = wal
+            .conn
+            .query_row("PRAGMA busy_timeout", [], |row| row.get(0))
+            .unwrap();
+
+        assert_eq!(configured, BUSY_TIMEOUT.as_millis() as i64);
+        assert!(configured > 0);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The result-streaming path (`RemiStreamCtx`, `push_to_remi`, `Wal`) survived the
conary-test server deletion as a deliberate keeper under #306, but its only
production constructor **was** the deleted server. Local CLI runs call the
4-arg `TestRunner::run` and have never streamed anything, so Remi's test-data
surface — the `test_health` / `test_list_runs` tools kept in #306 precisely
because they are useful off-host — has only ever shown Forge-era runs.

Confirmed live against production remi 0.12.1 while scoping this:
`test_health` returns `total_runs: 0`.

Alongside that, `wal.rs`'s module doc claimed "Items that exceed a configurable
retry limit are purged" and `flush` never called `purge_dead`, so a row that
could never be delivered retried forever.

## Fix

`remi_stream::LocalRemiRun` is the new CLI-side coordinator, wired into both
aggregate run paths (container and QEMU-only). One Remi run record per CLI
invocation, labelled with the same `phase-{phase}` name the local aggregate
`TestSuite` already uses, so the remote record and the local
`{distro}-phase{phase}.json` describe the same run.

**Run-record lifecycle.** Streaming is gated on `RemiClient::from_env()`
succeeding **and** `create_run` being acknowledged. Either failure disables
streaming for the whole invocation, logged once — missing env at info (the
ordinary local case), a failed `create_run` at warn.

That gate is what settles the WAL's cross-restart semantics, which the issue
asked to be designed rather than improvised: **a buffered row can only ever
name a run id Remi already acknowledged.** No provisional ids, no
reconciliation, no idempotency keys. A row whose run record later disappears
(test-data DB rebuilt) fails forever and is reaped by the purge contract.

**Flush timing.** Reachability-gated, never speculative — a successful
`create_run` is the proof of reachability that earns a flush. Once immediately
after it, replaying the backlog left by earlier runs; once after the aggregate
suite finishes and before `update_run`, so a run is never marked terminal while
its own results are still buffered. An offline developer therefore never burns
retries against a backlog that cannot be delivered.

**Purge contract.** `flush` now owns the purge its doc always claimed. It
returns a typed `FlushOutcome { flushed, failed, discarded, purged }` instead
of a bare tuple — `discarded` counts the unparseable payloads that previously
vanished from the return value — and calls `purge_dead` after the replay pass.
`MAX_FLUSH_ATTEMPTS = 5` means a row is dropped once it has failed five flush
attempts, and `purge_dead` reads and logs each doomed row with its id, run id,
retry count and last error before deleting it, so result loss is observable
rather than a silent cap. Run-status updates are deliberately not WAL-buffered
and the module doc now says so.

**WAL location.** `paths::state_dir()/results-wal.db` — `CONARY_TEST_STATE_DIR`,
then `XDG_STATE_HOME/conary-test`, then `$HOME`. Not `/tmp`: a buffer that does
not survive a reboot defeats its own purpose.

**Isolation invariant.** No Remi or WAL error changes the exit status, the
printed JSON report, the written results file, or any test outcome.

The WAL mutex moves from `std` to `tokio` because `flush` and `buffer` are both
awaited across the lock.

## Tests — property, not instance

- **buffer-on-failure** (the branch was entirely uncovered): a failing push
  lands a row whose payload round-trips back to an equal `PushResultData`.
- **flush replays**: buffered row + working client → removed, `flushed == 1`.
- **purge-after-N**: counts *actual flush attempts* against an always-failing
  client rather than pinning a `retry_count`, asserting the row survives four
  and is purged with `purged == 1` on the fifth. The `purge_dead(max)` /
  `MAX_FLUSH_ATTEMPTS` off-by-one is the kind that rots silently.
- **unparseable payload**: counted as `discarded`, removed, no push attempted.
- **no-env gate**: no client, no `create_run`, and no WAL file created at all.
- **failure isolation**: the same manifest run with and without an unreachable
  Remi, asserting identical blocking-outcome and JSON report (modulo timing),
  and that the failure path really was exercised (one row buffered).
- **payload contract**: every status the runner can emit, with and without
  execution, plus absent optionals, empty steps, multi-byte UTF-8 and embedded
  newlines — everything one side can emit, the other admits.

## Verification

Run in the worktree with `CARGO_TARGET_DIR` inside it and
`TMPDIR=/var/tmp/wt354`:

```
cargo fmt --check                                          exit 0
cargo clippy -p conary-test --all-targets -- -D warnings   exit 0
cargo test -p conary-test                                  exit 0
                                                           290 passed, 0 failed, 1 ignored
                                                           + 11 cli tests, 0 failed
```

Not verified: no live Remi, container, or QEMU invocation was made, so the
production HTTP create/update ordering and the hosted test-data result are not
live-proven. Every WAL and runner property above is covered by deterministic
tests.

## Deliberately out of scope — filed as #365

Both are server-side and need `TEST_DATA_SCHEMA_VERSION` bumped plus
`/conary/test-data.db` rebuilt, so they must ride a deliberately timed remi
release rather than a client slice:

- `test_results` has no `UNIQUE(run_id, test_id, attempt)` and inserts plainly,
  so at-least-once replay into a non-idempotent sink can duplicate one row when
  a response is lost after the server committed. Same for two concurrent
  `conary-test` processes sharing one WAL.
- `test_runs.suite` is a single column, so an aggregate run cannot retain
  per-manifest suite attribution.

Refs #354, #306.
