### PR TITLE
fix(install): read transaction authority under the mutation lock

### DIFF
--- a/apps/conary/src/commands/generation/selected_root.rs
+++ b/apps/conary/src/commands/generation/selected_root.rs
@@ -32,6 +32,109 @@ pub(crate) struct SelectedRootSession {
     deferred_ima: DeferredImaAuthority,
 }
 
+/// The runtime mutation lock, held before any package authority is read.
+///
+/// [`SelectedRootSession::begin`] takes this lock and materializes the selected
+/// root in one step, which is what a caller whose planning is already complete
+/// wants. A caller that must certify a transaction against installed state --
+/// requirement satisfaction, promise reliance, negative relation effects --
+/// acquires this first and reads those facts with the lock already held, so
+/// nothing it certifies can change before it commits. Materialization is the
+/// expensive half, so keeping it separate also lets a rejected transaction fail
+/// without paying for a root it will never mutate.
+///
+/// Dropping without materializing releases the lock and leaves no session
+/// directory behind, because the directory is created by `materialize`.
+pub(crate) struct LockedRuntimeRoot {
+    runtime_root: ConaryRuntimeRoot,
+    session_dir: PathBuf,
+    session_id: String,
+    transaction_engine: TransactionEngine,
+}
+
+impl LockedRuntimeRoot {
+    /// Acquire the runtime mutation lock for the runtime root owning `db_path`.
+    pub(crate) fn acquire(db_path: &str) -> Result<Self> {
+        Self::acquire_for_runtime(ConaryRuntimeRoot::from_db_path(PathBuf::from(db_path)))
+    }
+
+    fn acquire_for_runtime(runtime_root: ConaryRuntimeRoot) -> Result<Self> {
+        let session_id = uuid::Uuid::new_v4().to_string();
+        let session_dir = runtime_root
+            .root()
+            .join("selected-root-sessions")
+            .join(&session_id);
+        Self::acquire_in_session_dir(runtime_root, session_dir, session_id)
+    }
+
+    fn acquire_in_session_dir(
+        runtime_root: ConaryRuntimeRoot,
+        session_dir: PathBuf,
+        session_id: String,
+    ) -> Result<Self> {
+        // The runtime transaction lock is acquired before reading either
+        // SQLite package authority or the selected generation. Holding it
+        // through candidate persistence and the caller-owned DB commit makes
+        // the materialized root a serializable mutation base.
+        let mut transaction_engine =
+            TransactionEngine::new(TransactionConfig::for_runtime_root(&runtime_root))?;
+        transaction_engine.begin()?;
+        Ok(Self {
+            runtime_root,
+            session_dir,
+            session_id,
+            transaction_engine,
+        })
+    }
+
+    /// Materialize installed package state into a writable selected root.
+    ///
+    /// Consumes the lock holder: the lock is not released here, it moves into
+    /// the returned session and is released when that session finishes.
+    pub(crate) fn materialize(
+        self,
+        conn: &rusqlite::Connection,
+        operation: impl Into<String>,
+    ) -> Result<SelectedRootSession> {
+        let Self {
+            runtime_root,
+            session_dir,
+            session_id,
+            transaction_engine,
+        } = self;
+        let selected_root = session_dir.join("root");
+        fs::create_dir_all(&selected_root).with_context(|| {
+            format!(
+                "failed to create selected generation root {}",
+                selected_root.display()
+            )
+        })?;
+        let materialized = match materialize_current_root(conn, &runtime_root, &selected_root) {
+            Ok(materialized) => materialized,
+            Err(error) => {
+                let _ = fs::remove_dir_all(&session_dir);
+                return Err(error);
+            }
+        };
+        let deferred_ima = match DeferredImaAuthority::from_captured(&materialized) {
+            Ok(authority) => authority,
+            Err(error) => {
+                let _ = fs::remove_dir_all(&session_dir);
+                return Err(error);
+            }
+        };
+        let transaction =
+            LiveRootTransaction::begin(runtime_root.root(), &selected_root, session_id, operation)?;
+        Ok(SelectedRootSession {
+            session_dir,
+            selected_root,
+            transaction: Some(transaction),
+            transaction_engine,
+            deferred_ima,
+        })
+    }
+}
+
 impl SelectedRootSession {
     pub(crate) fn begin(
         conn: &rusqlite::Connection,
@@ -79,43 +182,8 @@ impl SelectedRootSession {
         session_id: String,
         operation: impl Into<String>,
     ) -> Result<Self> {
-        // The runtime transaction lock is acquired before reading either
-        // SQLite package authority or the selected generation. Holding it
-        // through candidate persistence and the caller-owned DB commit makes
-        // the materialized root a serializable mutation base.
-        let mut transaction_engine =
-            TransactionEngine::new(TransactionConfig::for_runtime_root(runtime_root))?;
-        transaction_engine.begin()?;
-        let selected_root = session_dir.join("root");
-        fs::create_dir_all(&selected_root).with_context(|| {
-            format!(
-                "failed to create selected generation root {}",
-                selected_root.display()
-            )
-        })?;
-        let materialized = match materialize_current_root(conn, runtime_root, &selected_root) {
-            Ok(materialized) => materialized,
-            Err(error) => {
-                let _ = fs::remove_dir_all(&session_dir);
-                return Err(error);
-            }
-        };
-        let deferred_ima = match DeferredImaAuthority::from_captured(&materialized) {
-            Ok(authority) => authority,
-            Err(error) => {
-                let _ = fs::remove_dir_all(&session_dir);
-                return Err(error);
-            }
-        };
-        let transaction =
-            LiveRootTransaction::begin(runtime_root.root(), &selected_root, session_id, operation)?;
-        Ok(Self {
-            session_dir,
-            selected_root,
-            transaction: Some(transaction),
-            transaction_engine,
-            deferred_ima,
-        })
+        LockedRuntimeRoot::acquire_in_session_dir(runtime_root.clone(), session_dir, session_id)?
+            .materialize(conn, operation)
     }
 
     pub(crate) fn selected_root(&self) -> &Path {

--- a/apps/conary/src/commands/generation/selected_root.rs
+++ b/apps/conary/src/commands/generation/selected_root.rs
@@ -123,8 +123,18 @@ impl LockedRuntimeRoot {
                 return Err(error);
             }
         };
-        let transaction =
-            LiveRootTransaction::begin(runtime_root.root(), &selected_root, session_id, operation)?;
+        let transaction = match LiveRootTransaction::begin(
+            runtime_root.root(),
+            &selected_root,
+            session_id,
+            operation,
+        ) {
+            Ok(transaction) => transaction,
+            Err(error) => {
+                let _ = fs::remove_dir_all(&session_dir);
+                return Err(error);
+            }
+        };
         Ok(SelectedRootSession {
             session_dir,
             selected_root,

--- a/apps/conary/src/commands/install/batch.rs
+++ b/apps/conary/src/commands/install/batch.rs
@@ -287,8 +287,6 @@ impl<'a> BatchInstaller<'a> {
 
         // Open database connection
         let mut conn = open_db(self.db_path)?;
-        let mut promise_plan = ordering::order_packages_for_transaction(&conn, &mut packages)?;
-        self.plan_package_relations_for_batch(&conn, &mut packages)?;
         // Build transaction description
         let tx_description = if package_count == 1 {
             format!("Install {}-{}", packages[0].name, packages[0].version)
@@ -299,12 +297,19 @@ impl<'a> BatchInstaller<'a> {
                 package_count - 1
             )
         };
-        let mut selected_root =
-            crate::commands::generation::selected_root::SelectedRootSession::begin(
-                &conn,
-                self.db_path,
-                &tx_description,
-            )?;
+
+        // Every fact this transaction certifies is read from installed state:
+        // requirement satisfaction against the end-state universe, promise
+        // reliance, and the negative relation effects of the incoming set. All
+        // of it is read with the runtime mutation lock already held. Certifying
+        // first and locking second would let another transaction remove a
+        // provider this certification relied on, and the database would commit
+        // an end state missing a capability the batch was admitted on.
+        let locked_root =
+            crate::commands::generation::selected_root::LockedRuntimeRoot::acquire(self.db_path)?;
+        let mut promise_plan = ordering::order_packages_for_transaction(&conn, &mut packages)?;
+        self.plan_package_relations_for_batch(&conn, &mut packages)?;
+        let mut selected_root = locked_root.materialize(&conn, &tx_description)?;
         let selected_path = selected_root.selected_root().to_path_buf();
         for package in &mut packages {
             package.normalize_ccs_for_selected_root(&selected_path)?;
@@ -355,23 +360,6 @@ impl<'a> BatchInstaller<'a> {
         let cas = selected_root.cas().clone();
 
         info!("Started batch transaction for {}", tx_description);
-
-        // Planning began before we waited for the runtime mutation lock. The
-        // selected-root session now owns that lock, so revalidate every exact
-        // relation transition against the serialized database state.
-        for package in &packages {
-            conary_core::transaction::validate_package_relation_transitions(
-                &conn,
-                &package.relation_removals,
-                &package.relation_deconfigurations,
-            )
-            .with_context(|| {
-                format!(
-                    "package relation transaction preflight changed for {}",
-                    package.name
-                )
-            })?;
-        }
 
         // Phase 1: Unified planning across all packages
         // Collect all files and detect cross-package conflicts

--- a/apps/conary/src/commands/install/batch/tests.rs
+++ b/apps/conary/src/commands/install/batch/tests.rs
@@ -11,6 +11,12 @@ use conary_core::payload::{
 };
 use std::collections::BTreeMap;
 
+// Both children need an explicit path: `tests` is itself loaded through a
+// `#[path]` attribute, so its submodules resolve against `batch/` rather than
+// `batch/tests/`. Without this, `mod witness_universe;` silently binds to the
+// source module of the same name instead of the test file.
+#[path = "tests/mutation_lock.rs"]
+mod mutation_lock;
 #[path = "tests/witness_universe.rs"]
 mod witness_universe;
 

--- a/apps/conary/src/commands/install/batch/tests/mutation_lock.rs
+++ b/apps/conary/src/commands/install/batch/tests/mutation_lock.rs
@@ -1,0 +1,85 @@
+// apps/conary/src/commands/install/batch/tests/mutation_lock.rs
+
+//! Certification reads installed state with the mutation lock already held.
+//!
+//! A batch is admitted on facts it reads from installed state: which
+//! requirements the end-state universe satisfies, which promises it relies on,
+//! which installed packages the incoming relations remove. Reading those facts
+//! before waiting for the runtime mutation lock leaves a window -- another
+//! transaction can delete a provider the certification leaned on, and this
+//! batch still commits against a universe that no longer exists. The lock is
+//! what closes that window, so the facts have to be read on its far side.
+
+use super::*;
+
+/// Delete the only provider while the batch waits for the mutation lock.
+///
+/// The deletion lands after the batch has started and before it holds the
+/// lock, which is exactly the interval a pre-lock snapshot would have read
+/// across. Certification must see the deletion, because the database it is
+/// about to commit into is the one without the provider.
+#[test]
+fn a_batch_certifies_against_the_installed_state_the_mutation_lock_protects() {
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let (db_path, db_path_string) = db_with_prior_transaction(
+        temp.path(),
+        vec![prepared_test_package(
+            "provider",
+            "/usr/lib64/libprovided.so.1",
+            b"provided",
+        )],
+    );
+
+    // Hold the mutation lock without materializing a root, which is the state
+    // the installer itself is in while it certifies.
+    let locked =
+        crate::commands::generation::selected_root::LockedRuntimeRoot::acquire(&db_path_string)
+            .unwrap();
+
+    let (attempt_tx, attempt_rx) = std::sync::mpsc::sync_channel(0);
+    let (result_tx, result_rx) = std::sync::mpsc::sync_channel(0);
+    let waiter_db_path = db_path_string.clone();
+    let waiter = std::thread::spawn(move || {
+        let mut dependent = prepared_test_package("dependent", "/usr/bin/dependent", b"dependent");
+        dependent.requirements = vec![depends_on("provider")];
+        attempt_tx.send(()).unwrap();
+        let result = BatchInstaller::new(&waiter_db_path, SandboxMode::Always)
+            .install_batch(vec![dependent])
+            .map_err(|error| format!("{error:#}"));
+        result_tx.send(result).unwrap();
+    });
+
+    // No verdict is reachable while another holder owns the lock.
+    attempt_rx.recv().unwrap();
+    assert!(
+        matches!(
+            result_rx.recv_timeout(std::time::Duration::from_millis(250)),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        ),
+        "a batch reached a verdict while another transaction held the mutation lock"
+    );
+
+    // Remove the only provider under the held lock. Nothing this batch will
+    // certify has been read yet, so this is the state it is obliged to see.
+    let conn = conary_core::db::open(&db_path).unwrap();
+    let deleted = conn
+        .execute("DELETE FROM troves WHERE name = 'provider'", [])
+        .unwrap();
+    assert_eq!(
+        deleted, 1,
+        "the prior transaction must have installed exactly one provider"
+    );
+    drop(conn);
+    drop(locked);
+
+    let error = result_rx
+        .recv_timeout(std::time::Duration::from_secs(60))
+        .expect("the batch must reach a verdict once the mutation lock is released")
+        .expect_err("a batch certified a requirement against a provider deleted before it locked");
+    waiter.join().unwrap();
+    assert!(
+        error.contains("does not satisfy exact depends requirement for dependent"),
+        "{error}"
+    );
+}


### PR DESCRIPTION
## Problem

`install_batch_with_result` certified its transaction against installed state it
read before waiting for the runtime mutation lock. Requirement certification
against the end-state universe, promise planning, and negative relation planning
all ran above `SelectedRootSession::begin`. Another transaction could remove a
provider the certification relied on inside that window, and this batch would
still commit an end state missing a capability it was admitted on.

This was never a #345 regression: multi-package batches had validated at that
pipeline position all along.

The contract it violated is stated in the code it calls, in `selected_root.rs`:
"The runtime transaction lock is acquired before reading either SQLite package
authority or the selected generation." Nothing made that boundary reachable on
its own, so callers were free to break it.

## Fix

Split lock acquisition from root materialization. `LockedRuntimeRoot::acquire`
takes the runtime mutation lock and does nothing else; `materialize` consumes it
into the `SelectedRootSession`. Batch install acquires, certifies, then
materializes.

Moving the reads below an unsplit `begin` would have worked too, but
materialization is the expensive half -- it rebuilds the root from CAS -- so a
batch rejected on certification would have paid for a root it never mutates.
Re-running certification under the lock was the other option and is worse:
`surviving_installed_identities` is the expensive universe load, and paying it
twice on every successful install to defend a rare race also leaves the same
fact certified in two places.

The post-lock relation revalidation loop is deleted rather than kept. It was a
second call to `validate_package_relation_transitions`; the first call, inside
`plan_package_relations_for_batch`, now runs under the lock. The whole-plan
call is also strictly stronger, since it catches cross-package duplicates the
per-package slices could not see.

`SelectedRootSession::begin` is unchanged for its other seven callers.

## Proof

`a_batch_certifies_against_the_installed_state_the_mutation_lock_protects` holds
the mutation lock, deletes the only provider under it, releases, and asserts the
batch refuses. It mirrors the serialization test already in `selected_root.rs`.

Three mutations, each run:

| Mutation | Result |
| --- | --- |
| Authority reads moved back above the lock | FAILS -- batch commits an install whose `Depends` has no provider |
| `DELETE` matching no row | FAILS -- the `deleted == 1` guard catches it |
| No deletion at all | FAILS -- install succeeds, `expect_err` trips |

The first is #356 reproduced. The third also shows the test is not passing
because installs always fail.

## Verification

- `cargo test -p conary` -- 1294 passed, 0 failed, 5 ignored, 38 binaries
- All 12 focused-proof commands from the `install` ownership card -- green
- `cargo clippy --workspace --all-targets -- -D warnings` -- clean
- `cargo fmt --check` -- clean

## Notes

Both test submodules now carry explicit `#[path]` attributes. `batch/tests.rs`
is itself loaded through `#[path]`, so its children resolve against `batch/`
rather than `batch/tests/`, and a bare `mod witness_universe;` there binds to
the *source* module of the same name and compiles clean. That misfire produced
a green run with the new test never compiled, which is why the attributes now
carry a comment.

#356 turned out to be one instance of a class. `command.rs:236`,
`ccs_transaction.rs:388`, `native_graph.rs:45`, and `autoremove.rs:177` all read
installed authority above their `begin` call. Filed as #368 with line-level
evidence and left out of this PR deliberately.

Closes #356.
