### PR TITLE
fix(container): stop logging and spawning between fork() and exec()

### DIFF
--- a/crates/conary-core/src/container/child_fork_safety.rs
+++ b/crates/conary-core/src/container/child_fork_safety.rs
@@ -1,0 +1,96 @@
+// conary-core/src/container/child_fork_safety.rs
+
+//! The post-fork child path may not log or spawn.
+//!
+//! `fork()` gives the child the parent's lock state with none of its other
+//! threads. glibc re-initializes its own primitives in the child, so allocation
+//! survives; Rust-level locks do not. `tracing`'s dispatcher is a global
+//! `RwLock`, so a child that logs while another thread held that lock at fork
+//! time never returns, and the parent reports `Script timed out after ...`.
+//!
+//! That is not a hypothetical shape. `setup_mount_namespace` logged through
+//! `debug!` every time a bind-mount source was absent, which is most sandbox
+//! starts, and the CLI forks from a `#[tokio::main]` runtime with worker
+//! threads logging alongside it.
+//!
+//! Reviewing for this is unreliable, because the offending call looks like
+//! ordinary logging. So it is checked instead: the child-path sources are
+//! compiled into the test binary and scanned.
+
+/// Sources that run between `fork()` and `exec()`.
+const CHILD_PATH_SOURCES: &[(&str, &str)] = &[
+    (
+        "container/execution/root_setup.rs",
+        include_str!("execution/root_setup.rs"),
+    ),
+    ("container/child_safety.rs", include_str!("child_safety.rs")),
+];
+
+/// Constructs that take a Rust-level lock or start a process.
+///
+/// `Command::new` itself is allowed: the child's final act is `command.exec()`,
+/// which is `execve` and is the point of the whole path. What is banned is
+/// *running* a second process from the child, which drags the full
+/// `std::process` machinery through inherited lock state.
+const FORBIDDEN: &[(&str, &str)] = &[
+    ("warn!(", "tracing macro"),
+    ("debug!(", "tracing macro"),
+    ("info!(", "tracing macro"),
+    ("trace!(", "tracing macro"),
+    ("error!(", "tracing macro"),
+    ("println!(", "buffered stdio macro"),
+    ("eprintln!(", "buffered stdio macro"),
+    (".status()", "subprocess execution"),
+    (".spawn()", "subprocess execution"),
+    (".output()", "subprocess execution"),
+];
+
+#[test]
+fn child_fork_safety_forbids_logging_and_spawning_after_fork() {
+    let mut violations = Vec::new();
+    for (name, source) in CHILD_PATH_SOURCES {
+        for (line_number, line) in source.lines().enumerate() {
+            let code = line.trim_start();
+            // Doc comments and ordinary comments describe the rule; they do not
+            // execute it.
+            if code.starts_with("//") {
+                continue;
+            }
+            for (needle, why) in FORBIDDEN {
+                if code.contains(needle) {
+                    violations.push(format!(
+                        "{name}:{}: {needle} ({why}) is not fork-safe in the post-fork child",
+                        line_number + 1
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "post-fork child path is not fork-safe:\n  {}\n\nUse container::child_safety::child_diag \
+         for diagnostics, and a direct syscall instead of a subprocess.",
+        violations.join("\n  ")
+    );
+}
+
+#[test]
+fn format_int_renders_without_allocating() {
+    use super::child_safety::{format_int, int_buffer};
+
+    let mut buffer = int_buffer();
+    assert_eq!(format_int(&mut buffer, 0), b"0");
+    let mut buffer = int_buffer();
+    assert_eq!(format_int(&mut buffer, 7), b"7");
+    let mut buffer = int_buffer();
+    assert_eq!(format_int(&mut buffer, 12345), b"12345");
+    let mut buffer = int_buffer();
+    assert_eq!(format_int(&mut buffer, -13), b"-13");
+    // errno values arrive as i32 but the widest input the buffer must survive
+    // is i64::MIN, whose magnitude does not fit in i64.
+    let mut buffer = int_buffer();
+    assert_eq!(format_int(&mut buffer, i64::MIN), b"-9223372036854775808");
+    let mut buffer = int_buffer();
+    assert_eq!(format_int(&mut buffer, i64::MAX), b"9223372036854775807");
+}

--- a/crates/conary-core/src/container/child_safety.rs
+++ b/crates/conary-core/src/container/child_safety.rs
@@ -92,11 +92,13 @@ pub(in crate::container) fn format_int(buffer: &mut IntBuffer, value: i64) -> &[
     &buffer[end..]
 }
 
-// Kernel ABI for the loopback interface. These are stable `ioctl` numbers and
-// flag bits; they are spelled out rather than taken from `libc` so the layout
-// this code depends on is visible at the point of use.
-const SIOCGIFFLAGS: libc::c_ulong = 0x8913;
-const SIOCSIFFLAGS: libc::c_ulong = 0x8914;
+// Kernel ABI for the loopback interface. The request numbers and flag bits are
+// stable and spelled out here so the layout this code depends on is visible at
+// the point of use. The request *type* is not stable across libcs -- glibc
+// takes `c_ulong`, musl takes `c_int` -- so it comes from `libc::Ioctl` rather
+// than being written out, which is what the static-musl release legs caught.
+const SIOCGIFFLAGS: libc::Ioctl = 0x8913;
+const SIOCSIFFLAGS: libc::Ioctl = 0x8914;
 const IFF_UP: libc::c_short = 0x1;
 const IFF_RUNNING: libc::c_short = 0x40;
 

--- a/crates/conary-core/src/container/child_safety.rs
+++ b/crates/conary-core/src/container/child_safety.rs
@@ -1,0 +1,189 @@
+// conary-core/src/container/child_safety.rs
+
+//! Async-signal-safe primitives for the window between `fork()` and `exec()`.
+//!
+//! `fork()` copies the whole address space but only the calling thread. Every
+//! lock another thread held at that instant is inherited locked, with no owner
+//! left to release it. glibc protects its own primitives across fork -- malloc
+//! arenas and stdio `FILE` locks are re-initialized in the child -- so
+//! allocation is survivable. Rust-level locks are not protected: `tracing`'s
+//! global dispatcher is an `RwLock`, and a child that logs while another thread
+//! held that lock at fork time blocks forever. The parent then converts the
+//! stall into `Script timed out after ...`.
+//!
+//! So the child gets diagnostics that touch no lock and no allocator: a direct
+//! `write(2)` of caller-owned bytes. Callers pass already-owned slices --
+//! string literals, `OsStr` bytes from a path that exists, integers rendered
+//! into a caller-supplied stack buffer.
+//!
+//! Anything added to the post-fork path must hold to this. `child_fork_safety`
+//! in the container tests fails the build if a logging macro or a subprocess
+//! spawn reappears in the child sources.
+
+use std::os::fd::RawFd;
+
+/// The inherited stderr. After the child's `dup2`, this is the pipe the parent
+/// drains, so these diagnostics reach the caller as scriptlet stderr.
+const CHILD_STDERR: RawFd = 2;
+
+/// Every diagnostic is prefixed, because it lands in the sandboxed program's
+/// own stderr stream and must be attributable.
+const PREFIX: &[u8] = b"conary-sandbox: ";
+
+/// Write one diagnostic line to the inherited stderr.
+///
+/// Allocation-free and lock-free: the parts are already-owned bytes and go out
+/// in a single `write(2)` per segment. Short writes and errors are ignored --
+/// there is no recovery available to a child that cannot report, and retrying
+/// risks blocking on a full pipe the parent is no longer reading.
+pub(in crate::container) fn child_diag(parts: &[&[u8]]) {
+    write_all(PREFIX);
+    for part in parts {
+        write_all(part);
+    }
+    write_all(b"\n");
+}
+
+fn write_all(bytes: &[u8]) {
+    if bytes.is_empty() {
+        return;
+    }
+    // SAFETY: `write(2)` is async-signal-safe. The pointer and length come from
+    // a live borrow, and the return value is deliberately discarded.
+    unsafe {
+        libc::write(
+            CHILD_STDERR,
+            bytes.as_ptr() as *const libc::c_void,
+            bytes.len(),
+        );
+    }
+}
+
+/// A stack buffer wide enough for any `i64` rendered by [`format_int`].
+pub(in crate::container) type IntBuffer = [u8; 24];
+
+/// An empty [`IntBuffer`], for callers that need one at a `let` binding.
+pub(in crate::container) const fn int_buffer() -> IntBuffer {
+    [0; 24]
+}
+
+/// Render `value` into `buffer` without allocating, returning the digits.
+///
+/// The child cannot use `format!`, so integer diagnostics -- errno values,
+/// exit codes -- are rendered here into caller-owned storage.
+pub(in crate::container) fn format_int(buffer: &mut IntBuffer, value: i64) -> &[u8] {
+    if value == 0 {
+        buffer[0] = b'0';
+        return &buffer[..1];
+    }
+    let negative = value < 0;
+    // Accumulate magnitude in i128 so i64::MIN negates without overflowing.
+    let mut magnitude = (value as i128).unsigned_abs();
+    let mut end = buffer.len();
+    while magnitude > 0 {
+        end -= 1;
+        buffer[end] = b'0' + (magnitude % 10) as u8;
+        magnitude /= 10;
+    }
+    if negative {
+        end -= 1;
+        buffer[end] = b'-';
+    }
+    &buffer[end..]
+}
+
+// Kernel ABI for the loopback interface. These are stable `ioctl` numbers and
+// flag bits; they are spelled out rather than taken from `libc` so the layout
+// this code depends on is visible at the point of use.
+const SIOCGIFFLAGS: libc::c_ulong = 0x8913;
+const SIOCSIFFLAGS: libc::c_ulong = 0x8914;
+const IFF_UP: libc::c_short = 0x1;
+const IFF_RUNNING: libc::c_short = 0x40;
+
+/// The prefix of `struct ifreq` this code touches.
+///
+/// `ifreq` is a 16-byte name followed by a union; only the `short` flags arm is
+/// used here, and the tail is padded to the full 40-byte size the kernel
+/// expects on 64-bit Linux.
+#[repr(C)]
+struct IfReqFlags {
+    name: [u8; 16],
+    flags: libc::c_short,
+    _padding: [u8; 22],
+}
+
+/// Bring the loopback interface up inside a fresh network namespace.
+///
+/// This replaces spawning `ip link set lo up`. Creating a subprocess between
+/// `fork()` and `exec()` runs the whole `std::process` machinery in a child
+/// with inherited lock state; two `ioctl` calls do the same job with no
+/// allocation, no subprocess, and no dependency on `iproute2` being installed
+/// in the sandbox.
+///
+/// Returns the failing errno, so the caller can report without allocating.
+pub(in crate::container) fn bring_loopback_up() -> std::result::Result<(), i32> {
+    // SAFETY: every call below is a raw syscall on a locally owned descriptor
+    // and a zeroed, correctly sized `ifreq`.
+    unsafe {
+        let fd = libc::socket(
+            libc::AF_INET,
+            libc::SOCK_DGRAM | libc::SOCK_CLOEXEC,
+            libc::IPPROTO_IP,
+        );
+        if fd < 0 {
+            return Err(errno());
+        }
+
+        let mut request = IfReqFlags {
+            name: [0; 16],
+            flags: 0,
+            _padding: [0; 22],
+        };
+        request.name[0] = b'l';
+        request.name[1] = b'o';
+
+        if libc::ioctl(fd, SIOCGIFFLAGS, &raw mut request) < 0 {
+            let error = errno();
+            libc::close(fd);
+            return Err(error);
+        }
+
+        request.flags |= IFF_UP | IFF_RUNNING;
+
+        let result = if libc::ioctl(fd, SIOCSIFFLAGS, &raw const request) < 0 {
+            Err(errno())
+        } else {
+            Ok(())
+        };
+        libc::close(fd);
+        result
+    }
+}
+
+fn errno() -> i32 {
+    std::io::Error::last_os_error().raw_os_error().unwrap_or(-1)
+}
+
+/// Set a resource limit if the value is non-zero.
+///
+/// Lives here because it runs only in the forked child: it reports through
+/// [`child_diag`], and keeping it in this module puts it under the same
+/// fork-safety check as the rest of the post-fork path.
+pub(in crate::container) fn set_rlimit(resource: super::RlimitResource, value: u64, name: &str) {
+    if value == 0 {
+        return;
+    }
+    let limit = libc::rlimit {
+        rlim_cur: value,
+        rlim_max: value,
+    };
+    if let Err(err) = super::set_rlimit_syscall(resource, &limit) {
+        let mut digits = int_buffer();
+        child_diag(&[
+            b"setrlimit ",
+            name.as_bytes(),
+            b" failed: errno ",
+            format_int(&mut digits, err.raw_os_error().unwrap_or(-1) as i64),
+        ]);
+    }
+}

--- a/crates/conary-core/src/container/execution/root_setup.rs
+++ b/crates/conary-core/src/container/execution/root_setup.rs
@@ -1,8 +1,16 @@
 // conary-core/src/container/execution/root_setup.rs
 
 //! Selected-root, namespace, mount, and enforcement setup for sandboxed children.
+//!
+//! Everything below [`Sandbox::child_setup_and_execute`] runs after `fork()` and
+//! before `exec()`, in a process that inherited the parent's lock state. No
+//! `tracing` macro and no subprocess spawn may appear on that path: see
+//! [`crate::container::child_safety`] for why, and `child_fork_safety` in the
+//! container tests for the check that keeps it true.
 
 use super::*;
+use crate::container::child_safety::{bring_loopback_up, child_diag, format_int, int_buffer};
+use std::os::unix::ffi::OsStrExt;
 
 impl Sandbox {
     /// Set up the container filesystem with bind mounts.
@@ -66,10 +74,12 @@ impl Sandbox {
 
         if !flags_with_user.is_empty() {
             if let Err(userns_error) = unshare(flags_with_user) {
-                warn!(
-                    "User namespace isolation unavailable ({}); continuing with existing namespace isolation",
-                    userns_error
-                );
+                let mut digits = int_buffer();
+                child_diag(&[
+                    b"user namespace isolation unavailable (errno ",
+                    format_int(&mut digits, userns_error as i64),
+                    b"); continuing with existing namespace isolation",
+                ]);
                 unshare(flags).map_err(|e| sandbox_error(format!("Unshare failed: {e}")))?;
                 signal_parent_user_namespace_ready(userns_sync.as_ref(), false)?;
             } else {
@@ -100,12 +110,13 @@ impl Sandbox {
         }
 
         if self.config.isolate_network
-            && let Ok(status) = std::process::Command::new("ip")
-                .args(["link", "set", "lo", "up"])
-                .status()
-            && !status.success()
+            && let Err(errno) = bring_loopback_up()
         {
-            debug!("Failed to bring up loopback interface");
+            let mut digits = int_buffer();
+            child_diag(&[
+                b"failed to bring up loopback interface: errno ",
+                format_int(&mut digits, errno as i64),
+            ]);
         }
 
         if self.config.isolate_uts && !self.config.hostname.is_empty() {
@@ -116,7 +127,11 @@ impl Sandbox {
                 )
             })?;
             if let Err(err) = sethostname_syscall(&hostname, self.config.hostname.len()) {
-                warn!("sethostname failed: {err}");
+                let mut digits = int_buffer();
+                child_diag(&[
+                    b"sethostname failed: errno ",
+                    format_int(&mut digits, err.raw_os_error().unwrap_or(-1) as i64),
+                ]);
             }
         }
 
@@ -130,17 +145,12 @@ impl Sandbox {
             match enforcement::apply_enforcement(policy) {
                 Ok(report) => {
                     for warning in &report.warnings {
-                        warn!("Enforcement setup: {warning}");
-                    }
-                    if report.landlock_applied {
-                        debug!(
-                            connect_tcp = ?report.connect_tcp_rules,
-                            bind_tcp = ?report.bind_tcp_rules,
-                            "Landlock filesystem/network enforcement active"
-                        );
-                    }
-                    if report.seccomp_applied {
-                        debug!("Seccomp syscall enforcement active");
+                        child_diag(&[
+                            b"enforcement setup: [",
+                            warning.category.as_bytes(),
+                            b"] ",
+                            warning.message.as_bytes(),
+                        ]);
                     }
                 }
                 Err(error) => {
@@ -150,7 +160,7 @@ impl Sandbox {
                             format!("Capability enforcement failed: {error}"),
                         ));
                     }
-                    warn!("Capability enforcement skipped: {error}");
+                    child_diag(&[b"capability enforcement skipped"]);
                 }
             }
         }
@@ -192,10 +202,13 @@ impl Sandbox {
 
         for bind_mount in &self.config.bind_mounts {
             if !bind_mount.source.exists() {
-                debug!(
-                    "Skipping bind mount, source doesn't exist: {:?}",
-                    bind_mount.source
-                );
+                // The hot path: a missing optional bind source is ordinary, and
+                // this ran on essentially every sandbox start. It was the most
+                // frequently executed `tracing` call in the post-fork child.
+                child_diag(&[
+                    b"skipping bind mount, source does not exist: ",
+                    bind_mount.source.as_os_str().as_bytes(),
+                ]);
                 continue;
             }
 
@@ -224,10 +237,15 @@ impl Sandbox {
                 None,
             )
             .map_err(|e| {
-                debug!(
-                    "Bind mount {:?} -> {:?} failed: {}",
-                    bind_mount.source, target, e
-                );
+                let mut digits = int_buffer();
+                child_diag(&[
+                    b"bind mount ",
+                    bind_mount.source.as_os_str().as_bytes(),
+                    b" -> ",
+                    target.as_os_str().as_bytes(),
+                    b" failed: errno ",
+                    format_int(&mut digits, e as i64),
+                ]);
                 sandbox_error(format!("Bind mount failed: {e}"))
             })?;
 
@@ -260,10 +278,10 @@ impl Sandbox {
                     "pivot_root failed ({error}) and chroot fallback is not allowed in Enforce mode"
                 )));
             }
-            warn!(
-                "pivot_root failed ({error}), falling back to chroot. \
-                 This is less secure -- chroot can be escaped by a privileged process."
-            );
+            child_diag(&[
+                b"pivot_root failed, falling back to chroot. ",
+                b"This is less secure -- chroot can be escaped by a privileged process.",
+            ]);
             self.chroot_into(root)?;
         }
 
@@ -302,10 +320,11 @@ impl Sandbox {
         let mut permissions = fs::metadata(target)?.permissions();
         permissions.set_mode(0o444);
         fs::set_permissions(target, permissions)?;
-        warn!(
-            "Falling back to copied read-only {} inside sandbox",
-            target.display()
-        );
+        child_diag(&[
+            b"falling back to copied read-only ",
+            target.as_os_str().as_bytes(),
+            b" inside sandbox",
+        ]);
         Ok(true)
     }
 
@@ -321,7 +340,7 @@ impl Sandbox {
                 message,
             ));
         }
-        warn!("{message}");
+        child_diag(&[message.as_bytes()]);
         Ok(())
     }
 

--- a/crates/conary-core/src/container/mod.rs
+++ b/crates/conary-core/src/container/mod.rs
@@ -44,10 +44,15 @@ use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
-use tracing::{debug, warn};
+use tracing::warn;
 
 mod analysis;
+#[cfg(test)]
+mod child_fork_safety;
+mod child_safety;
 mod namespaces;
+
+use child_safety::set_rlimit;
 
 pub use analysis::{ScriptAnalysis, ScriptRisk, analyze_script};
 use namespaces::{
@@ -525,18 +530,6 @@ pub struct Sandbox {
 }
 
 mod execution;
-/// Set a resource limit if the value is non-zero
-fn set_rlimit(resource: RlimitResource, value: u64, name: &str) {
-    if value > 0 {
-        let limit = libc::rlimit {
-            rlim_cur: value,
-            rlim_max: value,
-        };
-        if let Err(err) = set_rlimit_syscall(resource, &limit) {
-            warn!("setrlimit {} failed: {}", name, err);
-        }
-    }
-}
 
 /// Check if namespace isolation is available
 pub fn isolation_available() -> bool {


### PR DESCRIPTION
## Problem

The sandbox forks, then does a long stretch of ordinary Rust work before
`exec()`. Two things on that path are not fork-safe:

- it logs through `tracing`
- it spawned `ip link set lo up` as a subprocess

`fork()` copies the whole address space but only the calling thread. Every lock
another thread held at that instant is inherited locked, with no owner left to
release it. glibc re-initializes its own primitives in the child, so allocation
survives -- but `tracing`'s global dispatcher is an `RwLock` and is not
protected. A child that logs while another thread holds that lock never
returns. The parent's wall-clock budget starts immediately *before* the fork
(`let start = Instant::now();`), so the stall surfaces as
`Script timed out after 30s`.

The hot path was also the unsafe one: `setup_mount_namespace` called `debug!`
every time a bind-mount source was absent, which is most sandbox starts.

That is exactly #328's signature -- intermittent, only under full-suite parallel
load, never reproducible in isolation -- because it needs another thread
mid-log at the fork instant.

It also explains why the two failures in #328 looked unrelated. They are one
bug: `cook_hermetic_records_host_divergence...` sets `use_isolation: false`, but
`HermeticBuildPlan::apply_to_kitchen_config` overrides it to `true`
unconditionally, so both tests reach the same fork path.

## Not a test-only problem

The CLI is `#[tokio::main]`. A real scriptlet forks while tokio workers log
alongside it, and users get the same `Script timed out after 30s`. The test
harness supplies the multithreading; it does not supply the bug.

## Fix

`container::child_safety` gives the post-fork child diagnostics that touch no
allocator and no lock: `write(2)` of caller-owned bytes, with integers rendered
into a caller-supplied stack buffer. Every `tracing` call on the child path
moves to it.

Loopback comes up via two `ioctl`s instead of a subprocess, which also drops the
sandbox's dependency on `iproute2` being present. `set_rlimit` moves into the
same module because it runs only in the child.

`Command::new` stays: the child's final act is `command.exec()`, which is
`execve` and is the entire point. What is gone is *running* a second process
from the child.

## Proof

Reviewing for this is unreliable -- the offending call looks like ordinary
logging. So `child_fork_safety` compiles the child-path sources into the test
binary and scans them, failing on any logging macro or subprocess execution.

Mutation, run: reintroducing `warn!("applying resource limits")` on the child
path fails the guard with

```
container/execution/root_setup.rs:144: warn!( (tracing macro) is not fork-safe
```

`debug!` is now stronger than that -- it no longer compiles on that path at all,
because the import is gone.

## Verification

- `cargo test -p conary-core` -- 3511 passed, 0 failed (up 2: the new guards)
- `cargo test -p conary-core --lib container` -- 45 passed, including
  `test_pid_namespace_init_can_reap_multiple_child_processes`
- `cargo clippy --workspace --all-targets -- -D warnings` -- clean
- `cargo fmt --check` -- clean

## What this does not claim

I never reproduced the original failure. 6 clean full-suite runs before the
change (3 sequential, 3 concurrent at 3x oversubscription on 12 cores), so I
cannot show a red-to-green transition -- the race is rarer than this host
provokes. The argument is mechanical: the inherited-lock hazard is removed from
the path, and the guard keeps it removed.

Residual, not addressed here: `enforcement::apply_enforcement` (landlock +
seccomp) still runs in the child and is not audited for internal locking, and
`wait_for_child` SIGKILLs on timeout without reaping, leaking a zombie per
timeout. The userns handshake `read` also has no deadline, so a child stalling
before it writes `'U'` hangs the caller rather than timing out. Those are listed
on #328.

Refs #328.
