### PR TITLE
fix: lock selected-root authority reads

### DIFF
--- a/apps/conary/src/commands/install/ccs_transaction.rs
+++ b/apps/conary/src/commands/install/ccs_transaction.rs
@@ -359,6 +359,14 @@ fn install_ccs_package_transactionally_inner(
     let progress = InstallProgress::single("Installing");
     let semantics = install_semantics_for_ccs_manifest(pkg.manifest())?;
     enforce_ccs_scriptlet_capability_gate(pkg)?;
+    // A caller-owned selected root already owns the runtime mutation lock.
+    // Standalone real installs acquire it before resolving upgrade authority;
+    // dry runs remain read-only and do not serialize with mutations.
+    let locked_root = if !opts.dry_run && !caller_owned_selected_root {
+        Some(crate::commands::generation::selected_root::LockedRuntimeRoot::acquire(opts.db_path)?)
+    } else {
+        None
+    };
     let upgrade = check_ccs_upgrade_status(
         conn,
         pkg,
@@ -383,17 +391,11 @@ fn install_ccs_package_transactionally_inner(
     };
     // Dry-run remains filesystem-read-only. Every real CCS mutation receives
     // either its caller-owned try root or a freshly materialized selected root.
-    let mut owned_selected_root = if !opts.dry_run && selected_root.is_none() {
-        Some(
-            crate::commands::generation::selected_root::SelectedRootSession::begin(
-                conn,
-                opts.db_path,
-                format!("Install {}-{}", pkg.name(), pkg.version()),
-            )?,
-        )
-    } else {
-        None
-    };
+    let mut owned_selected_root = locked_root
+        .map(|locked_root| {
+            locked_root.materialize(conn, format!("Install {}-{}", pkg.name(), pkg.version()))
+        })
+        .transpose()?;
     let selected_root = match selected_root {
         Some(selected_root) => Some(selected_root),
         None => owned_selected_root.as_mut(),
@@ -805,3 +807,7 @@ mod tests {
 #[cfg(test)]
 #[path = "ccs_transaction/converted_directory_tests.rs"]
 mod converted_directory_tests;
+
+#[cfg(test)]
+#[path = "ccs_transaction/mutation_lock_tests.rs"]
+mod mutation_lock_tests;

--- a/apps/conary/src/commands/install/ccs_transaction/mutation_lock_tests.rs
+++ b/apps/conary/src/commands/install/ccs_transaction/mutation_lock_tests.rs
@@ -1,0 +1,129 @@
+// apps/conary/src/commands/install/ccs_transaction/mutation_lock_tests.rs
+
+use super::super::*;
+use conary_core::ccs::builder::write_signed_current_ccs_package;
+use conary_core::ccs::{BuildResult, CcsManifest, CcsPackage, SigningKeyPair};
+use conary_core::db::models::{InstallSource, Trove, TroveType};
+use conary_core::packages::PackageFormat;
+use conary_core::repository::versioning::VersionScheme;
+use std::collections::HashMap;
+
+fn metadata_only_ccs(temp: &std::path::Path) -> (CcsPackage, SigningKeyPair) {
+    let package_path = temp.join("ccs-lock-fixture.ccs");
+    let manifest = CcsManifest::new_minimal("ccs-lock-fixture", "2.0.0");
+    let result = BuildResult {
+        manifest,
+        components: HashMap::new(),
+        files: Vec::new(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &[],
+            HashMap::new(),
+        )
+        .unwrap(),
+        total_size: 0,
+        chunked: false,
+        chunk_stats: None,
+    };
+    let signing_key = SigningKeyPair::generate().with_key_id("ccs-lock-fixture");
+    write_signed_current_ccs_package(&result, &package_path, &signing_key, true).unwrap();
+    let verification = crate::commands::install::verify_ccs_package_authority(
+        temp.join("conary.db").to_str().unwrap(),
+        &package_path,
+        &crate::commands::install::CcsEnvelopeAuthority::ExactKey(signing_key.public_key_base64()),
+        None,
+    )
+    .unwrap();
+    let package =
+        CcsPackage::from_verified_archive(package_path.to_str().unwrap(), &verification).unwrap();
+    (package, signing_key)
+}
+
+#[test]
+fn standalone_ccs_install_resolves_upgrade_identity_under_the_mutation_lock() {
+    let _mount_skip = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let db_path = temp.path().join("conary.db");
+    let install_root = temp.path().join("install-root");
+    std::fs::create_dir_all(&install_root).unwrap();
+    conary_core::db::init(&db_path).unwrap();
+    crate::commands::test_helpers::seed_test_bootable_runtime(&db_path);
+    let (package, _signing_key) = metadata_only_ccs(temp.path());
+
+    let conn = conary_core::db::open(&db_path).unwrap();
+    let mut installed = Trove::new_with_source(
+        package.name().to_string(),
+        "1.0.0".to_string(),
+        TroveType::Package,
+        InstallSource::Repository,
+        VersionScheme::Conary,
+    );
+    installed.architecture = package.architecture().map(str::to_string);
+    installed.package_release = package.package_release().map(str::to_string);
+    let installed_id = installed.insert(&conn).unwrap();
+    drop(conn);
+
+    let db_path_string = db_path.to_string_lossy().into_owned();
+    let install_root_string = install_root.to_string_lossy().into_owned();
+    let incoming_version = package.version().to_string();
+    let locked =
+        crate::commands::generation::selected_root::LockedRuntimeRoot::acquire(&db_path_string)
+            .unwrap();
+    let (attempt_tx, attempt_rx) = std::sync::mpsc::sync_channel(0);
+    let (result_tx, result_rx) = std::sync::mpsc::sync_channel(0);
+    let waiter_db_path = db_path_string.clone();
+    let waiter = std::thread::spawn(move || {
+        let mut conn = conary_core::db::open(&waiter_db_path).unwrap();
+        attempt_tx.send(()).unwrap();
+        let result = install_ccs_package_transactionally(
+            &mut conn,
+            &package,
+            CcsTransactionInstallOptions {
+                db_path: &waiter_db_path,
+                root: &install_root_string,
+                dry_run: false,
+                defer_generation: false,
+                quiet: true,
+                sandbox_mode: conary_core::scriptlet::SandboxMode::Always,
+                allow_downgrade: false,
+                intent: InstallIntent::PackageChange,
+                reinstall: false,
+                selection_reason: None,
+                selected_manifest_components: None,
+                repository_provenance: None,
+            },
+        )
+        .map_err(|error| format!("{error:#}"));
+        result_tx.send(result).unwrap();
+    });
+
+    attempt_rx.recv().unwrap();
+    assert!(
+        matches!(
+            result_rx.recv_timeout(std::time::Duration::from_millis(250)),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        ),
+        "CCS install reached a verdict while another transaction held the mutation lock"
+    );
+
+    let conn = conary_core::db::open(&db_path).unwrap();
+    assert_eq!(
+        conn.execute(
+            "UPDATE troves SET version = ?1 WHERE id = ?2",
+            rusqlite::params![incoming_version, installed_id],
+        )
+        .unwrap(),
+        1
+    );
+    drop(conn);
+    drop(locked);
+
+    let result = result_rx
+        .recv_timeout(std::time::Duration::from_secs(60))
+        .expect("CCS install must finish once the mutation lock is released");
+    waiter.join().unwrap();
+    let error = match result {
+        Ok(_) => panic!("CCS install accepted upgrade authority changed before it locked"),
+        Err(error) => error,
+    };
+    assert!(error.contains("is already installed"), "{error}");
+}

--- a/apps/conary/src/commands/install/command.rs
+++ b/apps/conary/src/commands/install/command.rs
@@ -13,6 +13,7 @@ use super::{
     extract_and_classify_files, finalize_install, preflight_extracted_file_ownership,
     resolve_canonical_name, show_dry_run_summary,
 };
+use crate::commands::generation::selected_root::LockedRuntimeRoot;
 use crate::commands::open_db;
 use anyhow::{Context, Result};
 use conary_core::components::parse_component_spec;
@@ -165,6 +166,15 @@ async fn cmd_install_with_intent(
         policy: &policy,
     };
     handle_dependencies(&dep_ctx).await?;
+
+    // Dry-run planning is read-only and does not participate in the runtime
+    // mutation serialization boundary. A real install takes that boundary
+    // before reading any installed authority its transaction will certify.
+    let locked_root = if dry_run {
+        None
+    } else {
+        Some(LockedRuntimeRoot::acquire(db_path)?)
+    };
     let relation_plan = plan_package_relations(&conn, pkg.as_ref(), semantics.version_scheme)
         .context("Failed to plan package conflicts and replacements")?;
     validate_package_relation_plan(&conn, &relation_plan)
@@ -233,11 +243,9 @@ async fn cmd_install_with_intent(
             .as_deref()
             .map(|trove| trove.version.as_str()),
     );
-    let mut selected_root = crate::commands::generation::selected_root::SelectedRootSession::begin(
-        &conn,
-        db_path,
-        format!("Install {}-{}", pkg.name(), pkg.version()),
-    )?;
+    let mut selected_root = locked_root
+        .context("real install has no locked runtime root")?
+        .materialize(&conn, format!("Install {}-{}", pkg.name(), pkg.version()))?;
     let transaction_root = selected_root.selected_root().to_string_lossy().into_owned();
     native_transaction.preflight(Path::new(&transaction_root), &native_execution_mode)?;
     let preflighted_ccs_removal_hooks =
@@ -293,3 +301,7 @@ fn show_relation_removals(plan: &conary_core::transaction::PackageRelationPlan) 
         );
     }
 }
+
+#[cfg(test)]
+#[path = "command_mutation_lock_tests.rs"]
+mod mutation_lock_tests;

--- a/apps/conary/src/commands/install/command_mutation_lock_tests.rs
+++ b/apps/conary/src/commands/install/command_mutation_lock_tests.rs
@@ -1,0 +1,106 @@
+// apps/conary/src/commands/install/command_mutation_lock_tests.rs
+
+use super::*;
+use conary_core::db::models::{InstallSource, Trove, TroveType};
+use conary_core::packages::PackageFormat;
+use conary_core::repository::versioning::VersionScheme;
+
+#[test]
+fn native_install_resolves_upgrade_identity_under_the_mutation_lock() {
+    let _mount_skip = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let db_path = temp.path().join("conary.db");
+    let install_root = temp.path().join("install-root");
+    std::fs::create_dir_all(&install_root).unwrap();
+    conary_core::db::init(&db_path).unwrap();
+    crate::commands::test_helpers::seed_test_bootable_runtime(&db_path);
+
+    let mut builder = rpm::PackageBuilder::new(
+        "native-lock-fixture",
+        "2.0.0",
+        "MIT",
+        "x86_64",
+        "native install mutation-lock fixture",
+    );
+    builder
+        .with_file_contents(
+            b"fixture\n".to_vec(),
+            rpm::FileOptions::new("/usr/lib/native-lock-fixture/payload").permissions(0o644),
+        )
+        .unwrap();
+    let rpm_path = temp.path().join("native-lock-fixture.rpm");
+    builder.build().unwrap().write_file(&rpm_path).unwrap();
+    let incoming =
+        conary_core::packages::rpm::RpmPackage::parse(rpm_path.to_str().unwrap()).unwrap();
+    let incoming_version = incoming.version().to_string();
+
+    let conn = conary_core::db::open(&db_path).unwrap();
+    let mut installed = Trove::new_with_source(
+        "native-lock-fixture".to_string(),
+        "1.0.0-1".to_string(),
+        TroveType::Package,
+        InstallSource::Repository,
+        VersionScheme::Rpm,
+    );
+    installed.architecture = Some("x86_64".to_string());
+    let installed_id = installed.insert(&conn).unwrap();
+    drop(conn);
+
+    let db_path_string = db_path.to_string_lossy().into_owned();
+    let install_root_string = install_root.to_string_lossy().into_owned();
+    let rpm_path_string = rpm_path.to_string_lossy().into_owned();
+    let locked = LockedRuntimeRoot::acquire(&db_path_string).unwrap();
+    let (attempt_tx, attempt_rx) = std::sync::mpsc::sync_channel(0);
+    let (result_tx, result_rx) = std::sync::mpsc::sync_channel(0);
+    let waiter_db_path = db_path_string.clone();
+    let waiter = std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        attempt_tx.send(()).unwrap();
+        let result = runtime
+            .block_on(cmd_install(
+                &rpm_path_string,
+                InstallOptions {
+                    db_path: &waiter_db_path,
+                    root: &install_root_string,
+                    architecture: Some("x86_64".to_string()),
+                    no_deps: true,
+                    sandbox_mode: crate::commands::SandboxMode::Always,
+                    yes: true,
+                    ..InstallOptions::default()
+                },
+            ))
+            .map_err(|error| format!("{error:#}"));
+        result_tx.send(result).unwrap();
+    });
+
+    attempt_rx.recv().unwrap();
+    assert!(
+        matches!(
+            result_rx.recv_timeout(std::time::Duration::from_secs(1)),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        ),
+        "native install reached a verdict while another transaction held the mutation lock"
+    );
+
+    let conn = conary_core::db::open(&db_path).unwrap();
+    assert_eq!(
+        conn.execute(
+            "UPDATE troves SET version = ?1 WHERE id = ?2",
+            rusqlite::params![incoming_version, installed_id],
+        )
+        .unwrap(),
+        1
+    );
+    drop(conn);
+    drop(locked);
+
+    let error = result_rx
+        .recv_timeout(std::time::Duration::from_secs(60))
+        .expect("native install must finish once the mutation lock is released")
+        .expect_err("native install accepted upgrade authority changed before it locked");
+    waiter.join().unwrap();
+    assert!(error.contains("is already installed"), "{error}");
+}

--- a/apps/conary/src/commands/remove/autoremove.rs
+++ b/apps/conary/src/commands/remove/autoremove.rs
@@ -152,6 +152,8 @@ fn preflight_autoremove_round(
                 trove.version
             );
         };
+        let locked_root =
+            crate::commands::generation::selected_root::LockedRuntimeRoot::acquire(db_path)?;
         let paths = PackagePayloadOwnership::load(conn, trove_id)?
             .lifecycle_paths()
             .to_vec();
@@ -174,9 +176,8 @@ fn preflight_autoremove_round(
                 );
             }
         };
-        let selected = crate::commands::generation::selected_root::SelectedRootSession::begin(
+        let selected = locked_root.materialize(
             conn,
-            db_path,
             format!("Autoremove preflight {}-{}", trove.name, trove.version),
         )?;
         if let Err(error) =
@@ -425,6 +426,78 @@ mod tests {
                 .retrieve(&content.sha256)
                 .unwrap(),
             b"zz-native-orphan"
+        );
+    }
+
+    #[test]
+    fn autoremove_preflight_reads_package_identity_under_the_mutation_lock() {
+        let _mount_skip = crate::commands::composefs_ops::test_mount_skip_guard();
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("conary.db");
+        conary_core::db::init(&db_path).unwrap();
+        crate::commands::test_helpers::seed_test_bootable_runtime(&db_path);
+
+        let conn = conary_core::db::open(&db_path).unwrap();
+        let trove_id = seed_dependency_trove(
+            &conn,
+            "autoremove-lock-fixture",
+            "1.0.0",
+            conary_core::repository::versioning::VersionScheme::Conary,
+        );
+        let trove = Trove::find_by_id(&conn, trove_id).unwrap().unwrap();
+        drop(conn);
+
+        let db_path_string = db_path.to_string_lossy().into_owned();
+        let locked =
+            crate::commands::generation::selected_root::LockedRuntimeRoot::acquire(&db_path_string)
+                .unwrap();
+        let (attempt_tx, attempt_rx) = std::sync::mpsc::sync_channel(0);
+        let (result_tx, result_rx) = std::sync::mpsc::sync_channel(0);
+        let waiter_db_path = db_path_string.clone();
+        let waiter = std::thread::spawn(move || {
+            let conn = conary_core::db::open(&waiter_db_path).unwrap();
+            attempt_tx.send(()).unwrap();
+            let result = preflight_autoremove_round(
+                &conn,
+                &[trove],
+                &waiter_db_path,
+                RemoveLifecycleOptions::new(SandboxMode::Always),
+            )
+            .map_err(|error| format!("{error:#}"));
+            result_tx.send(result).unwrap();
+        });
+
+        attempt_rx.recv().unwrap();
+        assert!(
+            matches!(
+                result_rx.recv_timeout(std::time::Duration::from_millis(250)),
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+            ),
+            "autoremove preflight reached a verdict while another transaction held the mutation lock"
+        );
+
+        let conn = conary_core::db::open(&db_path).unwrap();
+        assert_eq!(
+            conn.execute(
+                "UPDATE troves SET version = '2.0.0' WHERE id = ?1",
+                [trove_id],
+            )
+            .unwrap(),
+            1
+        );
+        drop(conn);
+        drop(locked);
+
+        let error = result_rx
+            .recv_timeout(std::time::Duration::from_secs(60))
+            .expect("autoremove preflight must finish once the mutation lock is released")
+            .expect_err(
+                "autoremove preflight accepted a package identity changed before it locked",
+            );
+        waiter.join().unwrap();
+        assert!(
+            error.contains("identity changed during removal preparation"),
+            "{error}"
         );
     }
 

--- a/apps/conary/src/commands/remove/native_graph.rs
+++ b/apps/conary/src/commands/remove/native_graph.rs
@@ -4,7 +4,7 @@
 
 use super::transaction::{commit_remove_db, prepare_remove};
 use super::types::{RemoveInnerResult, RemoveLifecycleOptions};
-use crate::commands::generation::selected_root::SelectedRootSession;
+use crate::commands::generation::selected_root::{LockedRuntimeRoot, SelectedRootSession};
 use crate::commands::install::native_events::PreparedNativeTransaction;
 use crate::commands::install::native_graph::{NativePayloadBoundary, drive_native_graph_with};
 use crate::commands::progress::{RemovePhase, RemoveProgress};
@@ -33,6 +33,7 @@ pub(crate) fn execute_installed_trove_remove_graph(
         .context("selected package has no installed trove id")?;
     let identity =
         NativePackageIdentity::new(&trove.name, &trove.version, trove.architecture.as_deref());
+    let locked_root = LockedRuntimeRoot::acquire(db_path)?;
     let ownership = super::PackagePayloadOwnership::load(conn, trove_id)?;
     let native_transaction = PreparedNativeTransaction::prepare_remove(
         conn,
@@ -42,11 +43,8 @@ pub(crate) fn execute_installed_trove_remove_graph(
         ownership.lifecycle_paths().to_vec(),
         lifecycle_options.purge_config_files,
     )?;
-    let selected = SelectedRootSession::begin(
-        conn,
-        db_path,
-        format!("Remove {}-{}", trove.name, trove.version),
-    )?;
+    let selected =
+        locked_root.materialize(conn, format!("Remove {}-{}", trove.name, trove.version))?;
     native_transaction.preflight(selected.selected_root(), &ExecutionMode::Remove)?;
 
     execute_selected_root_graph(
@@ -242,3 +240,7 @@ fn execute_selected_root_graph(
     }
     Ok(GraphRemoveResult { removal, stats })
 }
+
+#[cfg(test)]
+#[path = "native_graph_tests.rs"]
+mod tests;

--- a/apps/conary/src/commands/remove/native_graph_tests.rs
+++ b/apps/conary/src/commands/remove/native_graph_tests.rs
@@ -1,0 +1,88 @@
+// apps/conary/src/commands/remove/native_graph_tests.rs
+
+use super::*;
+use conary_core::db::models::{InstallSource, TroveType};
+use conary_core::repository::versioning::VersionScheme;
+
+#[test]
+fn remove_graph_resolves_package_identity_under_the_mutation_lock() {
+    let _mount_skip = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let db_path = temp.path().join("conary.db");
+    conary_core::db::init(&db_path).unwrap();
+    crate::commands::test_helpers::seed_test_bootable_runtime(&db_path);
+
+    let conn = conary_core::db::open(&db_path).unwrap();
+    let mut trove = Trove::new_with_source(
+        "remove-lock-fixture".to_string(),
+        "1.0.0".to_string(),
+        TroveType::Package,
+        InstallSource::Repository,
+        VersionScheme::Conary,
+    );
+    trove.architecture = Some("x86_64".to_string());
+    let trove_id = trove.insert(&conn).unwrap();
+    let trove = Trove::find_by_id(&conn, trove_id).unwrap().unwrap();
+    drop(conn);
+
+    let db_path_string = db_path.to_string_lossy().into_owned();
+    let locked = LockedRuntimeRoot::acquire(&db_path_string).unwrap();
+    let (attempt_tx, attempt_rx) = std::sync::mpsc::sync_channel(0);
+    let (result_tx, result_rx) = std::sync::mpsc::sync_channel(0);
+    let waiter_db_path = db_path_string.clone();
+    let waiter = std::thread::spawn(move || {
+        let conn = conary_core::db::open(&waiter_db_path).unwrap();
+        let progress = RemoveProgress::new("remove-lock-fixture");
+        attempt_tx.send(()).unwrap();
+        let result = execute_installed_trove_remove_graph(
+            &conn,
+            &trove,
+            &waiter_db_path,
+            "remove-lock-fixture",
+            RemoveLifecycleOptions::new(crate::commands::SandboxMode::Always),
+            &progress,
+        )
+        .map_err(|error| format!("{error:#}"));
+        result_tx.send(result).unwrap();
+    });
+
+    attempt_rx.recv().unwrap();
+    assert!(
+        matches!(
+            result_rx.recv_timeout(std::time::Duration::from_millis(250)),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        ),
+        "remove reached a verdict while another transaction held the mutation lock"
+    );
+
+    let conn = conary_core::db::open(&db_path).unwrap();
+    assert_eq!(
+        conn.execute(
+            "UPDATE troves SET version = '2.0.0' WHERE id = ?1",
+            [trove_id],
+        )
+        .unwrap(),
+        1
+    );
+    drop(conn);
+    drop(locked);
+
+    let result = result_rx
+        .recv_timeout(std::time::Duration::from_secs(60))
+        .expect("remove must finish once the mutation lock is released");
+    waiter.join().unwrap();
+    let error = match result {
+        Ok(_) => panic!("remove accepted package identity changed before it locked"),
+        Err(error) => error,
+    };
+    assert!(
+        error.contains("identity changed during removal preparation"),
+        "{error}"
+    );
+
+    let conn = conary_core::db::open(&db_path).unwrap();
+    assert_eq!(
+        Trove::find_by_id(&conn, trove_id).unwrap().unwrap().version,
+        "2.0.0"
+    );
+}


### PR DESCRIPTION
## Primary Issue

Closes #368

Design / Plan / Roadmap: issue-owned defect slice; no durable design or roadmap contract changes.

## Problem And Outcome

Four non-batch selected-root mutation paths read installed SQLite authority before acquiring the runtime mutation lock. Another transaction could therefore change the state being certified while an install, CCS install, direct removal, or autoremove waited to materialize its selected root.

After this change, each real mutation acquires `LockedRuntimeRoot` before the issue-identified authority reads and consumes it with `.materialize(...)` only after planning succeeds. Dry-run install paths remain read-only and do not acquire the mutation lock.

## Changes

- Acquire the lock before relation, upgrade-target, lifecycle, and removal-ownership planning in native install, standalone CCS install, direct removal, and autoremove preflight.
- Preserve caller-owned selected roots for nested CCS transactions.
- Add one concurrency regression per converted path. Each test holds the lock, changes installed authority, releases the lock, and requires the waiting operation to refuse.

## Scope

- In scope: the four `SelectedRootSession::begin` call sites named by #368 and their regression proof.
- Out of scope: batch install, which was fixed by #356; unrelated selected-root users; issue #328.

## Ownership / Boundary

- Owning subsystem: Native Package Install, Update, Remove, And Live-Root Mutation.
- Boundary changed or preserved: preserves the documented runtime transaction invariant that the mutation lock is acquired before reading SQLite package authority or the selected generation.
- Persisted state or public surface impact: no schema or CLI surface change; concurrent mutations now reject stale plans instead of certifying or applying them.
- [x] Checked `docs/modules/feature-ownership.md` through `scripts/agent-context.sh --feature install`; no user-visible capability routing changed.

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly
- [x] No subsystem map update required because the ownership path did not change
- [x] No broader interaction gate required by the ownership card
- [x] Acceptance criteria are contained in this PR

```text
PASS: CARGO_TARGET_DIR=/conary/dev/cache/target/codex-368 TMPDIR=/var/tmp/codex-368 cargo test -p conary --lib mutation_lock -- --list
  6 tests listed, including all four new #368 regressions

PASS: CARGO_TARGET_DIR=/conary/dev/cache/target/codex-368 TMPDIR=/var/tmp/codex-368 cargo test -p conary --lib mutation_lock -- --nocapture
  6 passed; 0 failed

RED/GREEN SENSITIVITY:
- native install: FAILED with the authority read moved above the lock; PASSED after restoring fixed ordering
- standalone CCS install: FAILED with the authority read moved above the lock; PASSED after restoring fixed ordering
- direct native removal: FAILED by accepting the changed package identity with the read above the lock; PASSED after restoring fixed ordering
- autoremove: FAILED by accepting the changed package identity with the read above the lock; PASSED after restoring fixed ordering

PASS: CARGO_TARGET_DIR=/conary/dev/cache/target/codex-368 TMPDIR=/var/tmp/codex-368 bash scripts/agent-context.sh --feature install --run focused
  All 12 focused commands passed

PASS: CARGO_TARGET_DIR=/conary/dev/cache/target/codex-368 TMPDIR=/var/tmp/codex-368 cargo test -p conary
  Library: 1062 passed; 0 failed; 2 ignored
  All integration targets passed
  Doc tests: 0 failed; 2 ignored

PASS: CARGO_TARGET_DIR=/conary/dev/cache/target/codex-368 TMPDIR=/var/tmp/codex-368 cargo test -p conary-core
  Library: 3410 passed; 0 failed; 3 ignored
  All integration targets passed
  Doc tests: 8 passed; 0 failed; 19 ignored

PASS: CARGO_TARGET_DIR=/conary/dev/cache/target/codex-368 TMPDIR=/var/tmp/codex-368 cargo clippy --workspace --all-targets -- -D warnings
  Finished dev profile successfully

PASS: cargo fmt --check
PASS: git diff --check
```

## Review And Merge Notes

- Review focus: whether every issue-identified authority read is below acquisition and above materialization, and whether caller-owned/dry-run CCS behavior remains unchanged.
- User or developer impact: concurrent selected-root mutations can no longer act on stale installed-state authority at these four paths.
- Required-check bypass: not used
