### PR TITLE
fix(container): bound and reap sandbox children

### DIFF
--- a/crates/conary-core/src/capability/enforcement/landlock_enforce.rs
+++ b/crates/conary-core/src/capability/enforcement/landlock_enforce.rs
@@ -21,7 +21,6 @@ use landlock::{
     ABI, Access, AccessFs, AccessNet, CompatLevel, Compatible, NetPort, Ruleset, RulesetAttr,
     RulesetCreatedAttr, RulesetStatus, path_beneath_rules,
 };
-use tracing::{debug, warn};
 
 /// Apply Landlock filesystem and exact TCP restrictions.
 ///
@@ -33,14 +32,22 @@ pub fn apply_landlock_rules(
     network: Option<&NetworkCapabilities>,
     mode: EnforcementMode,
 ) -> Result<(), EnforcementError> {
-    let has_network_rules =
-        network.is_some_and(|caps| !caps.connect_tcp.is_empty() || !caps.bind_tcp.is_empty());
-    let abi = if has_network_rules { ABI::V4 } else { ABI::V3 };
-
     if let Some(caps) = network {
         caps.validate()
             .map_err(|error| EnforcementError::Landlock(error.to_string()))?;
     }
+    apply_prepared_landlock_rules(filesystem, network, mode)
+}
+
+/// Apply rules whose declarations were validated by the parent before fork.
+pub(super) fn apply_prepared_landlock_rules(
+    filesystem: Option<&FilesystemCapabilities>,
+    network: Option<&NetworkCapabilities>,
+    mode: EnforcementMode,
+) -> Result<(), EnforcementError> {
+    let has_network_rules =
+        network.is_some_and(|caps| !caps.connect_tcp.is_empty() || !caps.bind_tcp.is_empty());
+    let abi = if has_network_rules { ABI::V4 } else { ABI::V3 };
 
     let read_paths = paths_for_rules(
         filesystem.map_or(&[], |caps| caps.read.as_slice()),
@@ -63,8 +70,6 @@ pub fn apply_landlock_rules(
         return Err(EnforcementError::DenyConflict {
             count: deny_conflicts,
         });
-    } else if let Some(caps) = filesystem.filter(|_| deny_conflicts > 0) {
-        check_deny_conflicts(caps);
     }
 
     let mut ruleset = Ruleset::default().set_compatibility(CompatLevel::HardRequirement);
@@ -126,8 +131,6 @@ pub fn apply_landlock_rules(
         .map_err(|e| EnforcementError::Landlock(format!("Failed to restrict self: {e}")))?;
 
     require_fully_enforced(status.ruleset)?;
-    debug!("Landlock fully enforced");
-
     Ok(())
 }
 
@@ -144,8 +147,6 @@ fn paths_for_rules<'a>(
             return Err(EnforcementError::Landlock(format!(
                 "declared {context} path does not exist: {path}"
             )));
-        } else {
-            debug!("Skipping non-existent {} path: {}", context, path);
         }
     }
     Ok(existing)
@@ -197,17 +198,6 @@ fn find_deny_conflicts(caps: &FilesystemCapabilities) -> Vec<(&str, &str, &'stat
         }
     }
     conflicts
-}
-
-/// Warn about deny paths that cannot be enforced due to overlapping allow rules
-fn check_deny_conflicts(caps: &FilesystemCapabilities) {
-    for (deny_path, allowed_path, access_type) in find_deny_conflicts(caps) {
-        warn!(
-            "Deny path '{}' is under allowed {} path '{}' - \
-             landlock cannot enforce sub-path denials (limitation)",
-            deny_path, access_type, allowed_path
-        );
-    }
 }
 
 /// Check if the kernel supports landlock

--- a/crates/conary-core/src/capability/enforcement/mod.rs
+++ b/crates/conary-core/src/capability/enforcement/mod.rs
@@ -20,6 +20,7 @@ pub mod landlock_enforce;
 pub mod seccomp_enforce;
 
 use crate::capability::{FilesystemCapabilities, NetworkCapabilities, SyscallCapabilities};
+use seccompiler::BpfProgram;
 use std::fmt;
 
 /// Enforcement mode for capability restrictions
@@ -92,6 +93,24 @@ pub struct EnforcementWarning {
     pub message: String,
 }
 
+/// Enforcement work prepared in the parent before `fork()`.
+///
+/// Syscall validation, native-name resolution, and BPF compilation may touch
+/// process-global library state, so none of them belongs in the child. The
+/// child retains only the compiled program and the policy facts Landlock must
+/// apply after its mount namespace exists.
+pub(crate) struct PreparedEnforcement<'a> {
+    policy: &'a EnforcementPolicy,
+    seccomp_filter: Option<BpfProgram>,
+    warnings: Vec<EnforcementWarning>,
+}
+
+impl PreparedEnforcement<'_> {
+    pub(crate) fn mode(&self) -> EnforcementMode {
+        self.policy.mode
+    }
+}
+
 impl fmt::Display for EnforcementWarning {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "[{}] {}", self.category, self.message)
@@ -106,6 +125,82 @@ impl fmt::Display for EnforcementWarning {
 pub fn apply_enforcement(
     policy: &EnforcementPolicy,
 ) -> std::result::Result<EnforcementReport, EnforcementError> {
+    apply_prepared_enforcement(prepare_enforcement(policy)?)
+}
+
+/// Validate and compile every enforcement fact that does not depend on the
+/// child's completed mount namespace.
+pub(crate) fn prepare_enforcement(
+    policy: &EnforcementPolicy,
+) -> std::result::Result<PreparedEnforcement<'_>, EnforcementError> {
+    let mut warnings = Vec::new();
+    if let Some(network) = &policy.network
+        && let Err(error) = network.validate()
+    {
+        let error = EnforcementError::Landlock(error.to_string());
+        if policy.mode == EnforcementMode::Enforce {
+            return Err(error);
+        }
+        warnings.push(EnforcementWarning {
+            category: "landlock".to_string(),
+            message: format!("Landlock not applied: {error}"),
+        });
+    }
+    if (policy.filesystem.is_some() || policy.network.is_some())
+        && policy.mode != EnforcementMode::Enforce
+    {
+        warnings.push(EnforcementWarning {
+            category: "landlock".to_string(),
+            message: "Landlock has no non-blocking audit mode; exact filesystem/TCP rules were described but not applied".to_string(),
+        });
+    }
+
+    let seccomp_filter = if let Some(syscalls) = &policy.syscalls {
+        if !seccomp_enforce::check_seccomp_support() {
+            let error = EnforcementError::Unsupported {
+                feature: "seccomp".to_string(),
+            };
+            if policy.mode == EnforcementMode::Enforce {
+                return Err(error);
+            }
+            warnings.push(EnforcementWarning {
+                category: "seccomp".to_string(),
+                message: error.to_string(),
+            });
+            None
+        } else {
+            match seccomp_enforce::build_seccomp_filter(syscalls, policy.mode) {
+                Ok(filter) => Some(filter),
+                Err(error) if policy.mode != EnforcementMode::Enforce => {
+                    warnings.push(EnforcementWarning {
+                        category: "seccomp".to_string(),
+                        message: format!("Seccomp not applied: {error}"),
+                    });
+                    None
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    } else {
+        None
+    };
+
+    Ok(PreparedEnforcement {
+        policy,
+        seccomp_filter,
+        warnings,
+    })
+}
+
+/// Apply a parent-prepared policy after namespace setup and before `exec()`.
+pub(crate) fn apply_prepared_enforcement(
+    prepared: PreparedEnforcement<'_>,
+) -> std::result::Result<EnforcementReport, EnforcementError> {
+    let PreparedEnforcement {
+        policy,
+        seccomp_filter,
+        warnings,
+    } = prepared;
     let mut report = EnforcementReport {
         mode: policy.mode,
         landlock_applied: false,
@@ -115,19 +210,14 @@ pub fn apply_enforcement(
         connect_tcp_rules: Vec::new(),
         bind_tcp_rules: Vec::new(),
         deny_conflicts_count: 0,
-        warnings: Vec::new(),
+        warnings,
     };
 
     // Apply one Landlock ruleset for filesystem and exact TCP restrictions.
     if (policy.filesystem.is_some() || policy.network.is_some())
-        && policy.mode != EnforcementMode::Enforce
+        && policy.mode == EnforcementMode::Enforce
     {
-        report.warnings.push(EnforcementWarning {
-            category: "landlock".to_string(),
-            message: "Landlock has no non-blocking audit mode; exact filesystem/TCP rules were described but not applied".to_string(),
-        });
-    } else if policy.filesystem.is_some() || policy.network.is_some() {
-        match landlock_enforce::apply_landlock_rules(
+        match landlock_enforce::apply_prepared_landlock_rules(
             policy.filesystem.as_ref(),
             policy.network.as_ref(),
             policy.mode,
@@ -153,8 +243,8 @@ pub fn apply_enforcement(
 
     // Apply seccomp syscall filter LAST — once active, some syscalls
     // needed for landlock setup would be blocked
-    if let Some(ref syscall_caps) = policy.syscalls {
-        match seccomp_enforce::apply_seccomp_filter(syscall_caps, policy.mode) {
+    if let Some(filter) = seccomp_filter {
+        match seccomp_enforce::install_seccomp_filter(&filter) {
             Ok(()) => {
                 report.seccomp_applied = true;
             }
@@ -330,5 +420,26 @@ mod tests {
 
         let error = apply_enforcement(&policy).expect_err("enforce mode should fail closed");
         assert!(error.to_string().contains("not an exact name"));
+    }
+
+    #[test]
+    fn seccomp_filter_is_compiled_during_parent_preparation() {
+        if !seccomp_enforce::check_seccomp_support() {
+            return;
+        }
+        let policy = EnforcementPolicy {
+            mode: EnforcementMode::Audit,
+            filesystem: None,
+            network: None,
+            syscalls: Some(SyscallCapabilities {
+                allow: vec!["read".to_string()],
+                deny: Vec::new(),
+            }),
+            syscall_contract: None,
+            network_isolation: false,
+        };
+
+        let prepared = prepare_enforcement(&policy).expect("preparation should compile BPF");
+        assert!(prepared.seccomp_filter.is_some());
     }
 }

--- a/crates/conary-core/src/capability/enforcement/seccomp_enforce.rs
+++ b/crates/conary-core/src/capability/enforcement/seccomp_enforce.rs
@@ -12,7 +12,6 @@ use super::{EnforcementError, EnforcementMode};
 use crate::capability::SyscallCapabilities;
 use seccompiler::{BpfProgram, SeccompAction, SeccompFilter, SeccompRule};
 use std::collections::{BTreeMap, HashSet};
-use tracing::{debug, warn};
 
 /// `conary capability run` uses this executor-owned launch contract.
 pub const CAPABILITY_RUN_EXECUTOR_ABI_V1: &str = "capability-run-v1";
@@ -142,28 +141,18 @@ pub fn apply_seccomp_filter(
                 feature: "seccomp".to_string(),
             });
         }
-        warn!("Seccomp not supported, skipping syscall enforcement");
         return Ok(());
     }
 
     let bpf = build_seccomp_filter(caps, mode)?;
 
-    // Ensure NO_NEW_PRIVS is set (required for unprivileged seccomp)
-    // This is idempotent — landlock's restrict_self() may have already set it
-    unsafe {
-        let ret = libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
-        if ret != 0 {
-            return Err(EnforcementError::Seccomp(
-                "Failed to set PR_SET_NO_NEW_PRIVS".to_string(),
-            ));
-        }
-    }
+    install_seccomp_filter(&bpf)
+}
 
-    seccompiler::apply_filter(&bpf)
-        .map_err(|e| EnforcementError::Seccomp(format!("Failed to install filter: {e}")))?;
-
-    debug!("Seccomp filter applied in {} mode", mode);
-    Ok(())
+/// Install a filter already validated and compiled by the parent process.
+pub(super) fn install_seccomp_filter(bpf: &BpfProgram) -> Result<(), EnforcementError> {
+    seccompiler::apply_filter(bpf)
+        .map_err(|error| EnforcementError::Seccomp(format!("Failed to install filter: {error}")))
 }
 
 /// Resolve exact package-declared allow/deny inputs.
@@ -237,12 +226,6 @@ pub fn build_seccomp_filter(
             std::env::consts::ARCH
         ))
     })?;
-
-    debug!(
-        "Building seccomp filter: {} allowed syscalls, mode: {}",
-        allowed.len(),
-        mode
-    );
 
     let filter = SeccompFilter::new(
         rules,

--- a/crates/conary-core/src/container/child_fork_safety.rs
+++ b/crates/conary-core/src/container/child_fork_safety.rs
@@ -16,6 +16,12 @@
 //! Reviewing for this is unreliable, because the offending call looks like
 //! ordinary logging. So it is checked instead: the child-path sources are
 //! compiled into the test binary and scanned.
+//!
+//! The remaining third-party calls were audited at their exact Cargo.lock
+//! checksums: landlock 0.4.5's production path is direct ruleset/file/syscall
+//! machinery with no lazy global, and seccompiler 0.5.0's post-fork operation
+//! is only `apply_filter` (prctl + seccomp). A dependency change deliberately
+//! fails the checksum test below and requires a new source audit.
 
 /// Sources that run between `fork()` and `exec()`.
 const CHILD_PATH_SOURCES: &[(&str, &str)] = &[
@@ -24,6 +30,23 @@ const CHILD_PATH_SOURCES: &[(&str, &str)] = &[
         include_str!("execution/root_setup.rs"),
     ),
     ("container/child_safety.rs", include_str!("child_safety.rs")),
+    ("container/namespaces.rs", include_str!("namespaces.rs")),
+    (
+        "container/execution/process_wait.rs",
+        include_str!("execution/process_wait.rs"),
+    ),
+    (
+        "capability/enforcement/mod.rs",
+        include_str!("../capability/enforcement/mod.rs"),
+    ),
+    (
+        "capability/enforcement/landlock_enforce.rs",
+        include_str!("../capability/enforcement/landlock_enforce.rs"),
+    ),
+    (
+        "capability/enforcement/seccomp_enforce.rs",
+        include_str!("../capability/enforcement/seccomp_enforce.rs"),
+    ),
 ];
 
 /// Constructs that take a Rust-level lock or start a process.
@@ -43,13 +66,22 @@ const FORBIDDEN: &[(&str, &str)] = &[
     (".status()", "subprocess execution"),
     (".spawn()", "subprocess execution"),
     (".output()", "subprocess execution"),
+    ("Mutex", "process-global lock"),
+    ("RwLock", "process-global lock"),
+    ("OnceLock", "lazy process-global lock"),
+    ("LazyLock", "lazy process-global lock"),
+    ("lazy_static!", "lazy process-global lock"),
+    ("thread_local!", "thread-local initialization"),
 ];
 
 #[test]
 fn child_fork_safety_forbids_logging_and_spawning_after_fork() {
     let mut violations = Vec::new();
     for (name, source) in CHILD_PATH_SOURCES {
-        for (line_number, line) in source.lines().enumerate() {
+        let production_source = source
+            .split_once("\n#[cfg(test)]\nmod tests")
+            .map_or(*source, |(production, _)| production);
+        for (line_number, line) in production_source.lines().enumerate() {
             let code = line.trim_start();
             // Doc comments and ordinary comments describe the rule; they do not
             // execute it.
@@ -73,6 +105,20 @@ fn child_fork_safety_forbids_logging_and_spawning_after_fork() {
          for diagnostics, and a direct syscall instead of a subprocess.",
         violations.join("\n  ")
     );
+}
+
+#[test]
+fn post_fork_enforcement_dependencies_match_the_audited_sources() {
+    let lockfile = include_str!("../../../../Cargo.lock");
+    for audited in [
+        "name = \"landlock\"\nversion = \"0.4.5\"\nsource = \"registry+https://github.com/rust-lang/crates.io-index\"\nchecksum = \"635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d\"",
+        "name = \"seccompiler\"\nversion = \"0.5.0\"\nsource = \"registry+https://github.com/rust-lang/crates.io-index\"\nchecksum = \"a4ae55de56877481d112a559bbc12667635fdaf5e005712fd4e2b2fa50ffc884\"",
+    ] {
+        assert!(
+            lockfile.contains(audited),
+            "a post-fork enforcement dependency changed; audit its production source for locks and lazy initialization before updating this pin"
+        );
+    }
 }
 
 #[test]

--- a/crates/conary-core/src/container/execution.rs
+++ b/crates/conary-core/src/container/execution.rs
@@ -2,7 +2,12 @@
 
 use super::*;
 
+mod process_wait;
 mod root_setup;
+
+use process_wait::{
+    ChildWaitOutcome, terminate_and_reap, wait_for_child_until, wait_until_readable,
+};
 
 fn execution_error(kind: ScriptletFailureKind, message: impl Into<String>) -> Error {
     Error::scriptlet(kind, message)
@@ -20,9 +25,36 @@ struct ChildExecution<'a> {
     args: &'a [String],
     env: &'a [(&'a str, &'a str)],
     userns_sync: Option<UserNamespaceSync>,
+    deadline: Instant,
+    enforcement: Option<enforcement::PreparedEnforcement<'a>>,
+}
+
+struct ForkedChild<'a> {
+    stdin_fd: std::os::fd::RawFd,
+    stdout_read_fd: std::os::fd::OwnedFd,
+    stdout_write_fd: std::os::fd::OwnedFd,
+    stderr_read_fd: std::os::fd::OwnedFd,
+    stderr_write_fd: std::os::fd::OwnedFd,
+    userns_request_read_fd: std::os::fd::OwnedFd,
+    userns_ack_write_fd: std::os::fd::OwnedFd,
+    execution: ChildExecution<'a>,
 }
 
 impl Sandbox {
+    fn prepare_enforcement(&self) -> Result<Option<enforcement::PreparedEnforcement<'_>>> {
+        self.config
+            .capability_policy
+            .as_ref()
+            .map(enforcement::prepare_enforcement)
+            .transpose()
+            .map_err(|error| {
+                execution_error(
+                    ScriptletFailureKind::EnforcementSetupFailed,
+                    format!("Capability enforcement preparation failed: {error}"),
+                )
+            })
+    }
+
     /// Create a new sandbox with the given configuration
     pub fn new(config: ContainerConfig) -> Self {
         Self { config }
@@ -227,6 +259,7 @@ impl Sandbox {
         let stdin_path = root_dir.path().join(".conary-stdin");
         fs::write(&stdin_path, stdin)?;
         let stdin_file = File::open(&stdin_path)?;
+        let prepared_enforcement = self.prepare_enforcement()?;
 
         // Set up pipes before fork to capture child stdout/stderr
         let (stdout_read_fd, stdout_write_fd) = nix::unistd::pipe()
@@ -240,6 +273,7 @@ impl Sandbox {
 
         // Fork and execute in isolated namespaces
         let start = Instant::now();
+        let deadline = start.checked_add(self.config.timeout).unwrap_or(start);
 
         match fork_process() {
             Ok(ForkResult::Parent { child }) => {
@@ -253,12 +287,13 @@ impl Sandbox {
                     child,
                     &userns_request_read_fd,
                     &userns_ack_write_fd,
+                    deadline,
                 )?;
                 drop(userns_request_read_fd);
                 drop(userns_ack_write_fd);
 
                 // Wait for child, then read captured output
-                let (code, _, _) = self.wait_for_child(child, start)?;
+                let (code, _, _) = self.wait_for_child(child, deadline)?;
 
                 // Read stdout from pipe
                 let mut stdout_str = String::new();
@@ -273,65 +308,29 @@ impl Sandbox {
                 Ok((code, stdout_str, stderr_str))
             }
             Ok(ForkResult::Child) => {
-                // Child: close read ends of pipes
-                drop(stdout_read_fd);
-                drop(stderr_read_fd);
-                drop(userns_request_read_fd);
-                drop(userns_ack_write_fd);
-
-                if unsafe { libc::dup2(stdin_file.as_raw_fd(), 0) } < 0 {
-                    eprintln!(
-                        "failed to attach sandbox stdin: {}",
-                        std::io::Error::last_os_error()
-                    );
-                    std::process::exit(127);
-                }
-
-                // Redirect stdout and stderr to pipe write ends
-                let mut stdout_target = match adopt_raw_fd(1) {
-                    Ok(fd) => fd,
-                    Err(err) => {
-                        eprintln!("{err}");
-                        std::process::exit(127);
-                    }
-                };
-                let mut stderr_target = match adopt_raw_fd(2) {
-                    Ok(fd) => fd,
-                    Err(err) => {
-                        eprintln!("{err}");
-                        std::process::exit(127);
-                    }
-                };
-                let _ = nix::unistd::dup2(&stdout_write_fd, &mut stdout_target);
-                let _ = nix::unistd::dup2(&stderr_write_fd, &mut stderr_target);
-                // Prevent OwnedFd from closing stdout/stderr when dropped
-                std::mem::forget(stdout_target);
-                std::mem::forget(stderr_target);
-                drop(stdout_write_fd);
-                drop(stderr_write_fd);
-
-                // Child: set up namespaces and execute
-                let result = self.child_setup_and_execute(ChildExecution {
-                    root: root_dir.path(),
-                    program: interpreter,
-                    interpreter_args,
-                    script_path: Some(&script_path),
-                    args,
-                    env,
-                    userns_sync: Some(UserNamespaceSync {
-                        request_fd: userns_request_write_fd,
-                        ack_fd: userns_ack_read_fd,
-                    }),
+                self.run_forked_child(ForkedChild {
+                    stdin_fd: stdin_file.as_raw_fd(),
+                    stdout_read_fd,
+                    stdout_write_fd,
+                    stderr_read_fd,
+                    stderr_write_fd,
+                    userns_request_read_fd,
+                    userns_ack_write_fd,
+                    execution: ChildExecution {
+                        root: root_dir.path(),
+                        program: interpreter,
+                        interpreter_args,
+                        script_path: Some(&script_path),
+                        args,
+                        env,
+                        userns_sync: Some(UserNamespaceSync {
+                            request_fd: userns_request_write_fd,
+                            ack_fd: userns_ack_read_fd,
+                        }),
+                        deadline,
+                        enforcement: prepared_enforcement,
+                    },
                 });
-
-                // Exit with appropriate code
-                match result {
-                    Ok(code) => std::process::exit(code),
-                    Err(err) => {
-                        eprintln!("{err}");
-                        std::process::exit(127);
-                    }
-                }
             }
             Err(e) => {
                 drop(stdout_read_fd);
@@ -360,6 +359,7 @@ impl Sandbox {
         let stdin_path = root_dir.path().join(".conary-stdin");
         fs::write(&stdin_path, stdin)?;
         let stdin_file = File::open(&stdin_path)?;
+        let prepared_enforcement = self.prepare_enforcement()?;
 
         let (stdout_read_fd, stdout_write_fd) = nix::unistd::pipe()
             .map_err(|e| sandbox_error(format!("Failed to create stdout pipe: {e}")))?;
@@ -371,6 +371,7 @@ impl Sandbox {
             .map_err(|e| sandbox_error(format!("Failed to create userns ack pipe: {e}")))?;
 
         let start = Instant::now();
+        let deadline = start.checked_add(self.config.timeout).unwrap_or(start);
 
         match fork_process() {
             Ok(ForkResult::Parent { child }) => {
@@ -383,11 +384,12 @@ impl Sandbox {
                     child,
                     &userns_request_read_fd,
                     &userns_ack_write_fd,
+                    deadline,
                 )?;
                 drop(userns_request_read_fd);
                 drop(userns_ack_write_fd);
 
-                let (code, _, _) = self.wait_for_child(child, start)?;
+                let (code, _, _) = self.wait_for_child(child, deadline)?;
 
                 let mut stdout_str = String::new();
                 let mut stdout_file = std::fs::File::from(stdout_read_fd);
@@ -400,60 +402,29 @@ impl Sandbox {
                 Ok((code, stdout_str, stderr_str))
             }
             Ok(ForkResult::Child) => {
-                drop(stdout_read_fd);
-                drop(stderr_read_fd);
-                drop(userns_request_read_fd);
-                drop(userns_ack_write_fd);
-
-                if unsafe { libc::dup2(stdin_file.as_raw_fd(), 0) } < 0 {
-                    eprintln!(
-                        "failed to attach sandbox stdin: {}",
-                        std::io::Error::last_os_error()
-                    );
-                    std::process::exit(127);
-                }
-
-                let mut stdout_target = match adopt_raw_fd(1) {
-                    Ok(fd) => fd,
-                    Err(err) => {
-                        eprintln!("{err}");
-                        std::process::exit(127);
-                    }
-                };
-                let mut stderr_target = match adopt_raw_fd(2) {
-                    Ok(fd) => fd,
-                    Err(err) => {
-                        eprintln!("{err}");
-                        std::process::exit(127);
-                    }
-                };
-                let _ = nix::unistd::dup2(&stdout_write_fd, &mut stdout_target);
-                let _ = nix::unistd::dup2(&stderr_write_fd, &mut stderr_target);
-                std::mem::forget(stdout_target);
-                std::mem::forget(stderr_target);
-                drop(stdout_write_fd);
-                drop(stderr_write_fd);
-
-                let result = self.child_setup_and_execute(ChildExecution {
-                    root: root_dir.path(),
-                    program,
-                    interpreter_args: &[],
-                    script_path: None,
-                    args,
-                    env,
-                    userns_sync: Some(UserNamespaceSync {
-                        request_fd: userns_request_write_fd,
-                        ack_fd: userns_ack_read_fd,
-                    }),
+                self.run_forked_child(ForkedChild {
+                    stdin_fd: stdin_file.as_raw_fd(),
+                    stdout_read_fd,
+                    stdout_write_fd,
+                    stderr_read_fd,
+                    stderr_write_fd,
+                    userns_request_read_fd,
+                    userns_ack_write_fd,
+                    execution: ChildExecution {
+                        root: root_dir.path(),
+                        program,
+                        interpreter_args: &[],
+                        script_path: None,
+                        args,
+                        env,
+                        userns_sync: Some(UserNamespaceSync {
+                            request_fd: userns_request_write_fd,
+                            ack_fd: userns_ack_read_fd,
+                        }),
+                        deadline,
+                        enforcement: prepared_enforcement,
+                    },
                 });
-
-                match result {
-                    Ok(code) => std::process::exit(code),
-                    Err(err) => {
-                        eprintln!("{err}");
-                        std::process::exit(127);
-                    }
-                }
             }
             Err(e) => {
                 drop(stdout_read_fd);
@@ -596,39 +567,21 @@ impl Sandbox {
     }
 
     /// Wait for child process with timeout
-    fn wait_for_child(&self, child: Pid, start: Instant) -> Result<(i32, String, String)> {
-        loop {
-            // Check timeout
-            if start.elapsed() > self.config.timeout {
-                // Kill the child
-                let _ = kill(child, Signal::SIGKILL);
-                return Err(execution_error(
-                    ScriptletFailureKind::ScriptTimedOut,
-                    format!("Script timed out after {:?}", self.config.timeout),
-                ));
-            }
-
-            // Non-blocking wait
-            match waitpid(child, Some(nix::sys::wait::WaitPidFlag::WNOHANG)) {
-                Ok(WaitStatus::Exited(_, code)) => {
-                    return Ok((code, String::new(), String::new()));
-                }
-                Ok(WaitStatus::Signaled(_, sig, _)) => {
-                    return Err(execution_error(
-                        ScriptletFailureKind::ScriptExited,
-                        format!("Script killed by signal {sig:?}"),
-                    ));
-                }
-                Ok(WaitStatus::StillAlive) | Ok(_) => {
-                    std::thread::sleep(Duration::from_millis(10));
-                }
-                Err(e) => {
-                    return Err(execution_error(
-                        ScriptletFailureKind::ProcessSetupFailed,
-                        format!("Wait failed: {e}"),
-                    ));
-                }
-            }
+    fn wait_for_child(&self, child: Pid, deadline: Instant) -> Result<(i32, String, String)> {
+        match wait_for_child_until(child, deadline) {
+            Ok(ChildWaitOutcome::Exited(code)) => Ok((code, String::new(), String::new())),
+            Ok(ChildWaitOutcome::Signaled(signal)) => Err(execution_error(
+                ScriptletFailureKind::ScriptExited,
+                format!("Script killed by signal {signal:?}"),
+            )),
+            Ok(ChildWaitOutcome::TimedOut) => Err(execution_error(
+                ScriptletFailureKind::ScriptTimedOut,
+                format!("Script timed out after {:?}", self.config.timeout),
+            )),
+            Err(error) => Err(execution_error(
+                ScriptletFailureKind::ProcessSetupFailed,
+                format!("Wait failed: {error}"),
+            )),
         }
     }
 
@@ -637,7 +590,39 @@ impl Sandbox {
         child: Pid,
         request_fd: &std::os::fd::OwnedFd,
         ack_fd: &std::os::fd::OwnedFd,
+        deadline: Instant,
     ) -> Result<()> {
+        let result =
+            self.complete_user_namespace_handshake_inner(child, request_fd, ack_fd, deadline);
+        if let Err(error) = result {
+            if let Err(cleanup_error) = terminate_and_reap(child) {
+                return Err(execution_error(
+                    ScriptletFailureKind::ProcessSetupFailed,
+                    format!(
+                        "{error}; additionally failed to terminate and reap sandbox child: {cleanup_error}"
+                    ),
+                ));
+            }
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    fn complete_user_namespace_handshake_inner(
+        &self,
+        child: Pid,
+        request_fd: &std::os::fd::OwnedFd,
+        ack_fd: &std::os::fd::OwnedFd,
+        deadline: Instant,
+    ) -> Result<()> {
+        if !wait_until_readable(request_fd.as_fd(), deadline).map_err(|error| {
+            sandbox_error(format!("User namespace handshake poll failed: {error}"))
+        })? {
+            return Err(execution_error(
+                ScriptletFailureKind::ScriptTimedOut,
+                format!("Sandbox setup timed out after {:?}", self.config.timeout),
+            ));
+        }
         let mut message = [0_u8; 1];
         let bytes_read = nix::unistd::read(request_fd, &mut message)
             .map_err(|e| sandbox_error(format!("User namespace handshake failed: {e}")))?;
@@ -664,5 +649,47 @@ impl Sandbox {
         nix::unistd::write(ack_fd, b"O")
             .map_err(|e| sandbox_error(format!("User namespace handshake ack failed: {e}")))?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handshake_timeout_terminates_and_reaps_child() {
+        let sandbox = Sandbox::new(ContainerConfig::minimal(Duration::from_millis(20)));
+        let (request_read, request_write) = nix::unistd::pipe().expect("request pipe");
+        let (ack_read, ack_write) = nix::unistd::pipe().expect("ack pipe");
+
+        // SAFETY: the child closes owned descriptors, then performs only
+        // async-signal-safe pause/_exit calls.
+        match unsafe { nix::unistd::fork() }.expect("test fork should succeed") {
+            ForkResult::Child => {
+                drop(request_read);
+                drop(ack_write);
+                drop(ack_read);
+                loop {
+                    unsafe { libc::pause() };
+                }
+            }
+            ForkResult::Parent { child } => {
+                drop(request_write);
+                drop(ack_read);
+                let error = sandbox
+                    .complete_user_namespace_handshake(
+                        child,
+                        &request_read,
+                        &ack_write,
+                        Instant::now() + Duration::from_millis(20),
+                    )
+                    .expect_err("silent child must hit the handshake deadline");
+                assert!(error.to_string().contains("Sandbox setup timed out"));
+                assert_eq!(
+                    waitpid(child, Some(nix::sys::wait::WaitPidFlag::WNOHANG)),
+                    Err(nix::errno::Errno::ECHILD)
+                );
+            }
+        }
     }
 }

--- a/crates/conary-core/src/container/execution/process_wait.rs
+++ b/crates/conary-core/src/container/execution/process_wait.rs
@@ -1,0 +1,143 @@
+// conary-core/src/container/execution/process_wait.rs
+
+//! Deadline-aware child waiting and cleanup shared by sandbox monitors.
+//!
+//! The PID-namespace monitor calls this after `fork()` and before `exec()`, so
+//! this module must stay free of logging, global locks, and subprocess APIs.
+
+use nix::errno::Errno;
+use nix::sys::signal::{Signal, kill};
+use nix::sys::wait::{WaitPidFlag, WaitStatus, waitpid};
+use nix::unistd::Pid;
+use std::os::fd::{AsRawFd, BorrowedFd};
+use std::time::{Duration, Instant};
+
+const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ChildWaitOutcome {
+    Exited(i32),
+    Signaled(Signal),
+    TimedOut,
+}
+
+pub(super) fn wait_for_child_until(
+    child: Pid,
+    deadline: Instant,
+) -> std::result::Result<ChildWaitOutcome, Errno> {
+    loop {
+        let now = Instant::now();
+        if now >= deadline {
+            terminate_and_reap(child)?;
+            return Ok(ChildWaitOutcome::TimedOut);
+        }
+        match waitpid(child, Some(WaitPidFlag::WNOHANG)) {
+            Ok(WaitStatus::Exited(_, code)) => return Ok(ChildWaitOutcome::Exited(code)),
+            Ok(WaitStatus::Signaled(_, signal, _)) => {
+                return Ok(ChildWaitOutcome::Signaled(signal));
+            }
+            Ok(WaitStatus::StillAlive) | Ok(_) => {}
+            Err(Errno::EINTR) => continue,
+            Err(error) => return Err(error),
+        }
+
+        sleep_without_runtime_state(WAIT_POLL_INTERVAL.min(deadline.duration_since(now)));
+    }
+}
+
+fn sleep_without_runtime_state(duration: Duration) {
+    let timeout_ms = duration.as_millis().clamp(1, i32::MAX as u128) as i32;
+    // SAFETY: a poll with no descriptors is the kernel sleep primitive. It
+    // touches no inherited userspace synchronization state.
+    unsafe {
+        libc::poll(std::ptr::null_mut(), 0, timeout_ms);
+    }
+}
+
+/// Send SIGKILL and synchronously consume the child's terminal wait status.
+pub(super) fn terminate_and_reap(child: Pid) -> std::result::Result<(), Errno> {
+    match kill(child, Signal::SIGKILL) {
+        Ok(()) | Err(Errno::ESRCH) => {}
+        Err(error) => return Err(error),
+    }
+
+    loop {
+        match waitpid(child, None) {
+            Ok(WaitStatus::Exited(_, _)) | Ok(WaitStatus::Signaled(_, _, _)) => return Ok(()),
+            Ok(_) | Err(Errno::EINTR) => {}
+            // Another exact owner may have won a terminal-status race. Either
+            // way there is no child left for this process to leak as a zombie.
+            Err(Errno::ECHILD) => return Ok(()),
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+/// Wait until a pipe can be read without exceeding the sandbox deadline.
+pub(super) fn wait_until_readable(
+    fd: BorrowedFd<'_>,
+    deadline: Instant,
+) -> std::result::Result<bool, Errno> {
+    loop {
+        let now = Instant::now();
+        if now >= deadline {
+            return Ok(false);
+        }
+        let remaining = deadline.duration_since(now);
+        let timeout_ms = remaining.as_millis().clamp(1, i32::MAX as u128) as i32;
+        let mut descriptor = libc::pollfd {
+            fd: fd.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: `descriptor` points to one initialized pollfd for the duration
+        // of the call. poll only writes its `revents` field.
+        let result = unsafe { libc::poll(&mut descriptor, 1, timeout_ms) };
+        if result > 0 {
+            return Ok(true);
+        }
+        if result == 0 {
+            continue;
+        }
+        let error = Errno::last();
+        if error != Errno::EINTR {
+            return Err(error);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nix::unistd::{ForkResult, pipe};
+    use std::os::fd::AsFd;
+
+    #[test]
+    fn timeout_kills_and_reaps_child() {
+        // SAFETY: the child performs only async-signal-safe pause/_exit calls.
+        match unsafe { nix::unistd::fork() }.expect("test fork should succeed") {
+            ForkResult::Child => loop {
+                unsafe { libc::pause() };
+            },
+            ForkResult::Parent { child } => {
+                let outcome =
+                    wait_for_child_until(child, Instant::now() + Duration::from_millis(20))
+                        .expect("deadline wait should succeed");
+                assert_eq!(outcome, ChildWaitOutcome::TimedOut);
+                assert_eq!(
+                    waitpid(child, Some(WaitPidFlag::WNOHANG)),
+                    Err(Errno::ECHILD)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn unreadable_handshake_pipe_honors_deadline() {
+        let (read_fd, _write_fd) = pipe().expect("test pipe should open");
+        let readable =
+            wait_until_readable(read_fd.as_fd(), Instant::now() + Duration::from_millis(20))
+                .expect("poll should succeed");
+        assert!(!readable);
+    }
+}

--- a/crates/conary-core/src/container/execution/root_setup.rs
+++ b/crates/conary-core/src/container/execution/root_setup.rs
@@ -13,6 +13,47 @@ use crate::container::child_safety::{bring_loopback_up, child_diag, format_int, 
 use std::os::unix::ffi::OsStrExt;
 
 impl Sandbox {
+    pub(super) fn run_forked_child(&self, child: ForkedChild<'_>) -> ! {
+        let ForkedChild {
+            stdin_fd,
+            stdout_read_fd,
+            stdout_write_fd,
+            stderr_read_fd,
+            stderr_write_fd,
+            userns_request_read_fd,
+            userns_ack_write_fd,
+            execution,
+        } = child;
+        drop(stdout_read_fd);
+        drop(stderr_read_fd);
+        drop(userns_request_read_fd);
+        drop(userns_ack_write_fd);
+
+        if unsafe { libc::dup2(stdin_fd, 0) } < 0 {
+            child_diag(&[b"failed to attach sandbox stdin"]);
+            unsafe { libc::_exit(127) };
+        }
+        if unsafe { libc::dup2(stdout_write_fd.as_raw_fd(), 1) } < 0 {
+            child_diag(&[b"failed to attach sandbox stdout"]);
+            unsafe { libc::_exit(127) };
+        }
+        if unsafe { libc::dup2(stderr_write_fd.as_raw_fd(), 2) } < 0 {
+            child_diag(&[b"failed to attach sandbox stderr"]);
+            unsafe { libc::_exit(127) };
+        }
+        drop(stdout_write_fd);
+        drop(stderr_write_fd);
+
+        match self.child_setup_and_execute(execution) {
+            Ok(code) => unsafe { libc::_exit(code) },
+            Err(error) => {
+                let message = error.to_string();
+                child_diag(&[message.as_bytes()]);
+                unsafe { libc::_exit(127) };
+            }
+        }
+    }
+
     /// Set up the container filesystem with bind mounts.
     pub(super) fn setup_container_fs(&self, root: &Path) -> Result<()> {
         for dir in &[
@@ -52,6 +93,8 @@ impl Sandbox {
             args,
             env,
             userns_sync,
+            deadline,
+            enforcement,
         } = execution;
         let script_in_container = script_path.map(|path| {
             path.strip_prefix(root)
@@ -92,7 +135,9 @@ impl Sandbox {
             match fork_process()
                 .map_err(|error| sandbox_error(format!("PID namespace fork failed: {error}")))?
             {
-                ForkResult::Parent { child } => return wait_for_pid_namespace_init(child),
+                ForkResult::Parent { child } => {
+                    return wait_for_pid_namespace_init(child, deadline);
+                }
                 ForkResult::Child => {
                     let parent = unsafe { libc::getppid() };
                     set_parent_death_signal(libc::SIGKILL).map_err(|error| {
@@ -141,8 +186,9 @@ impl Sandbox {
 
         self.apply_resource_limits()?;
 
-        if let Some(ref policy) = self.config.capability_policy {
-            match enforcement::apply_enforcement(policy) {
+        if let Some(prepared) = enforcement {
+            let mode = prepared.mode();
+            match enforcement::apply_prepared_enforcement(prepared) {
                 Ok(report) => {
                     for warning in &report.warnings {
                         child_diag(&[
@@ -154,7 +200,7 @@ impl Sandbox {
                     }
                 }
                 Err(error) => {
-                    if policy.mode == EnforcementMode::Enforce {
+                    if mode == EnforcementMode::Enforce {
                         return Err(execution_error(
                             ScriptletFailureKind::EnforcementSetupFailed,
                             format!("Capability enforcement failed: {error}"),
@@ -387,18 +433,16 @@ impl Sandbox {
     }
 }
 
-fn wait_for_pid_namespace_init(child: Pid) -> Result<i32> {
-    loop {
-        match waitpid(child, None) {
-            Ok(WaitStatus::Exited(_, code)) => return Ok(code),
-            Ok(WaitStatus::Signaled(_, signal, _)) => return Ok(128 + signal as i32),
-            Ok(_) => {}
-            Err(nix::errno::Errno::EINTR) => {}
-            Err(error) => {
-                return Err(sandbox_error(format!(
-                    "failed to wait for PID namespace init: {error}"
-                )));
-            }
-        }
+fn wait_for_pid_namespace_init(child: Pid, deadline: Instant) -> Result<i32> {
+    match wait_for_child_until(child, deadline) {
+        Ok(ChildWaitOutcome::Exited(code)) => Ok(code),
+        Ok(ChildWaitOutcome::Signaled(signal)) => Ok(128 + signal as i32),
+        Ok(ChildWaitOutcome::TimedOut) => Err(execution_error(
+            ScriptletFailureKind::ScriptTimedOut,
+            "PID namespace init timed out",
+        )),
+        Err(error) => Err(sandbox_error(format!(
+            "failed to wait for PID namespace init: {error}"
+        ))),
     }
 }

--- a/crates/conary-core/src/container/mod.rs
+++ b/crates/conary-core/src/container/mod.rs
@@ -30,13 +30,11 @@ use crate::child_wait::wait_with_output;
 use crate::error::{Error, Result, ScriptletFailureKind};
 use nix::mount::{MntFlags, MsFlags, mount, umount2};
 use nix::sched::{CloneFlags, unshare};
-use nix::sys::signal::{Signal, kill};
-use nix::sys::wait::{WaitStatus, waitpid};
 use nix::unistd::{ForkResult, Gid, Pid, Uid};
 use std::ffi::CString;
 use std::fs::{self, File};
 use std::io::{Read, Seek, SeekFrom, Write};
-use std::os::fd::AsRawFd;
+use std::os::fd::{AsFd, AsRawFd};
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
@@ -45,6 +43,9 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
 use tracing::warn;
+
+#[cfg(test)]
+use nix::sys::wait::{WaitStatus, waitpid};
 
 mod analysis;
 #[cfg(test)]
@@ -56,7 +57,7 @@ use child_safety::set_rlimit;
 
 pub use analysis::{ScriptAnalysis, ScriptRisk, analyze_script};
 use namespaces::{
-    RlimitResource, UserNamespaceSync, adopt_raw_fd, chdir_syscall, chroot_syscall,
+    RlimitResource, UserNamespaceSync, chdir_syscall, chroot_syscall,
     configure_user_namespace_root_mapping_for_pid, fork_process, prepare_user_namespace_entrypoint,
     prepare_user_namespace_root, sandbox_host_gid, sandbox_host_uid, sandbox_namespace_flags,
     set_parent_death_signal, set_rlimit_syscall, sethostname_syscall,

--- a/crates/conary-core/src/container/namespaces.rs
+++ b/crates/conary-core/src/container/namespaces.rs
@@ -2,7 +2,7 @@
 
 use std::ffi::CStr;
 use std::fs;
-use std::os::fd::{FromRawFd, OwnedFd, RawFd};
+use std::os::fd::OwnedFd;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
@@ -31,18 +31,6 @@ pub(super) fn fork_process() -> nix::Result<ForkResult> {
     // SAFETY: This is a thin wrapper so callers can keep all fork-specific
     // handling in one place and exercise it in targeted tests.
     unsafe { fork() }
-}
-
-pub(super) fn adopt_raw_fd(raw_fd: RawFd) -> Result<OwnedFd> {
-    if raw_fd < 0 {
-        return Err(Error::scriptlet(
-            ScriptletFailureKind::SandboxSetupUnavailable,
-            format!("invalid stdio fd: {raw_fd}"),
-        ));
-    }
-
-    // SAFETY: The caller hands us ownership of a valid raw file descriptor.
-    Ok(unsafe { OwnedFd::from_raw_fd(raw_fd) })
 }
 
 pub(super) fn sethostname_syscall(hostname: &CStr, len: usize) -> std::io::Result<()> {

--- a/crates/conary-core/src/container/tests.rs
+++ b/crates/conary-core/src/container/tests.rs
@@ -2,7 +2,6 @@
 use super::namespaces::namespace_map_contents;
 use super::*;
 use crate::capability::enforcement::{EnforcementMode, EnforcementPolicy};
-use std::os::fd::IntoRawFd;
 
 #[test]
 fn test_script_analysis_safe() {
@@ -519,21 +518,6 @@ fn test_fork_process_returns_child_that_can_exit_cleanly() {
         }
         ForkResult::Child => std::process::exit(0),
     }
-}
-
-#[test]
-fn test_adopt_raw_fd_rejects_negative_fd() {
-    let err = adopt_raw_fd(-1).expect_err("negative fds should be rejected");
-    assert!(err.to_string().contains("invalid stdio fd"));
-}
-
-#[test]
-fn test_adopt_raw_fd_accepts_valid_fd() {
-    let (read_fd, write_fd) = nix::unistd::pipe().expect("pipe");
-    let raw_fd = write_fd.into_raw_fd();
-    let adopted = adopt_raw_fd(raw_fd).expect("valid pipe fd should be adoptable");
-    drop(adopted);
-    drop(read_fd);
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Sandbox execution had three unbounded or unsafe post-`fork()` paths:

- a wall-clock timeout sent `SIGKILL` but returned without consuming the child's terminal wait status, leaking a zombie;
- the user-namespace handshake and PID-namespace init monitor could block outside the configured timeout;
- capability enforcement still logged, resolved syscall names, and compiled seccomp BPF after `fork()`, where inherited Rust-level locks can deadlock the child.

Handshake setup failures also returned without terminating the child that was waiting for the acknowledgement.

## Fix

- Add one absolute deadline shared by the user-namespace handshake, PID-namespace init monitor, and final child wait.
- Poll the handshake pipe against that deadline.
- On timeout, send `SIGKILL` and synchronously reap the exact child before returning the typed timeout.
- Terminate and reap the child on every handshake error path.
- Move syscall validation, native-name resolution, and seccomp BPF compilation into parent-side enforcement preparation.
- Keep only Landlock ruleset application and compiled seccomp installation in the post-fork child.
- Move the duplicated child stdio/exit setup into the already-audited child module and use direct `dup2`/`_exit` operations.
- Extend the fork-safety guard across namespace, wait, and enforcement sources; reject logging, subprocesses, Rust locks, lazy globals, and thread-local initialization.
- Pin the audited Landlock 0.4.5 and seccompiler 0.5.0 Cargo.lock checksums so dependency changes require a new post-fork source audit.

## Impact

A stalled setup now respects the configured wall-clock budget, timed-out children do not accumulate as zombies in long-lived callers, and the capability path no longer performs known lock-bearing work after `fork()`.

Regression tests prove timeout reaping by observing `ECHILD` after both execution and handshake deadlines.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/conary/dev/cache/target/Conary-issue371 cargo test -p conary-core --lib container` — 47 passed
- `CARGO_TARGET_DIR=/conary/dev/cache/target/Conary-issue371 cargo test -p conary-core --lib capability::enforcement` — 36 passed, including the supported-kernel child probe
- `CARGO_TARGET_DIR=/conary/dev/cache/target/Conary-issue371 cargo test -p conary-core` — 3,413 unit tests passed, 3 ignored; integration targets and doc tests passed
- `CARGO_TARGET_DIR=/conary/dev/cache/target/Conary-issue371 cargo test -p conary` — 1,062 unit tests passed, 2 ignored; integration targets and doc tests passed
- `CARGO_TARGET_DIR=/conary/dev/cache/target/Conary-issue371 cargo clippy --workspace --all-targets -- -D warnings` — clean

Closes #371