### PR TITLE
fix(model): validate dry-run package transactions

### DIFF
--- a/apps/conary/src/commands/install/batch.rs
+++ b/apps/conary/src/commands/install/batch.rs
@@ -265,6 +265,28 @@ impl<'a> BatchInstaller<'a> {
         self.install_batch_with_result(packages).map(|_| ())
     }
 
+    /// Run the read-only dependency ordering and relation validation shared
+    /// with [`Self::install_batch`] without materializing a selected root or
+    /// executing lifecycle and payload mutation.
+    pub(crate) fn validate_batch(self, mut packages: Vec<PreparedPackage>) -> Result<()> {
+        if packages.is_empty() {
+            return Ok(());
+        }
+        let conn = open_db(self.db_path)?;
+        self.validate_batch_transaction(&conn, &mut packages)?;
+        Ok(())
+    }
+
+    fn validate_batch_transaction(
+        &self,
+        conn: &Connection,
+        packages: &mut Vec<PreparedPackage>,
+    ) -> Result<promises::PromiseWitnessPlan> {
+        let promise_plan = ordering::order_packages_for_transaction(conn, packages)?;
+        self.plan_package_relations_for_batch(conn, packages)?;
+        Ok(promise_plan)
+    }
+
     pub(crate) fn install_batch_with_result(
         self,
         mut packages: Vec<PreparedPackage>,
@@ -307,8 +329,7 @@ impl<'a> BatchInstaller<'a> {
         // an end state missing a capability the batch was admitted on.
         let locked_root =
             crate::commands::generation::selected_root::LockedRuntimeRoot::acquire(self.db_path)?;
-        let mut promise_plan = ordering::order_packages_for_transaction(&conn, &mut packages)?;
-        self.plan_package_relations_for_batch(&conn, &mut packages)?;
+        let mut promise_plan = self.validate_batch_transaction(&conn, &mut packages)?;
         let mut selected_root = locked_root.materialize(&conn, &tx_description)?;
         let selected_path = selected_root.selected_root().to_path_buf();
         for package in &mut packages {
@@ -361,11 +382,9 @@ impl<'a> BatchInstaller<'a> {
 
         info!("Started batch transaction for {}", tx_description);
 
-        // Phase 1: Unified planning across all packages
-        // Collect all files and detect cross-package conflicts
+        // Phase 1: Unified planning across all packages after selected-root
+        // normalization. Collect all files and detect cross-package conflicts.
         let batch_plan = self.plan_batch(&packages, &conn)?;
-
-        // Check for conflicts
         if !batch_plan.conflicts.is_empty() {
             let conflict_msgs: Vec<String> =
                 batch_plan.conflicts.iter().map(|c| c.to_string()).collect();
@@ -374,12 +393,10 @@ impl<'a> BatchInstaller<'a> {
                 conflict_msgs.join("\n  ")
             ));
         }
-
         info!(
             "Batch plan: {} total files across {} packages",
             batch_plan.total_files, package_count
         );
-
         self.preflight_file_ownership_for_batch(&conn, &packages)?;
 
         // Phase 2: Run exact typed lifecycle events before payload mutation.

--- a/apps/conary/src/commands/install/mod.rs
+++ b/apps/conary/src/commands/install/mod.rs
@@ -36,7 +36,7 @@ pub use batch::{BatchInstaller, prepare_package_for_batch};
 pub use command::cmd_install;
 pub(crate) use command::cmd_install_replatform;
 pub use ownership_mode::OwnershipMode;
-pub(crate) use package_set::{PackageSetRequest, install_package_set};
+pub(crate) use package_set::{PackageSetRequest, install_package_set, validate_package_set};
 
 #[allow(unused_imports)]
 pub(crate) use ccs_transaction::{

--- a/apps/conary/src/commands/install/package_set.rs
+++ b/apps/conary/src/commands/install/package_set.rs
@@ -36,6 +36,31 @@ pub(crate) async fn install_package_set(
     sandbox_mode: SandboxMode,
     requests: Vec<PackageSetRequest>,
 ) -> Result<usize> {
+    process_package_set(
+        db_path,
+        requests,
+        PackageSetOperation::Install(sandbox_mode),
+    )
+    .await
+}
+
+pub(crate) async fn validate_package_set(
+    db_path: &str,
+    requests: Vec<PackageSetRequest>,
+) -> Result<usize> {
+    process_package_set(db_path, requests, PackageSetOperation::Validate).await
+}
+
+enum PackageSetOperation {
+    Validate,
+    Install(SandboxMode),
+}
+
+async fn process_package_set(
+    db_path: &str,
+    requests: Vec<PackageSetRequest>,
+    operation: PackageSetOperation,
+) -> Result<usize> {
     if requests.is_empty() {
         return Ok(0);
     }
@@ -108,11 +133,22 @@ pub(crate) async fn install_package_set(
         .collect();
     let prepared = prepare_repository_batch(db_path, selections).await?;
     let root_count = resolved_requests.len();
-    println!(
-        "Installing model package set ({} explicit roots)...",
-        root_count
-    );
-    prepared.install(BatchInstaller::new(db_path, sandbox_mode))?;
+    match operation {
+        PackageSetOperation::Validate => {
+            println!(
+                "Validating model package set ({} explicit roots)...",
+                root_count
+            );
+            prepared.validate(BatchInstaller::new(db_path, SandboxMode::Always))?;
+        }
+        PackageSetOperation::Install(sandbox_mode) => {
+            println!(
+                "Installing model package set ({} explicit roots)...",
+                root_count
+            );
+            prepared.install(BatchInstaller::new(db_path, sandbox_mode))?;
+        }
+    }
     Ok(root_count)
 }
 

--- a/apps/conary/src/commands/install/repository_batch.rs
+++ b/apps/conary/src/commands/install/repository_batch.rs
@@ -44,6 +44,10 @@ impl PreparedRepositoryBatch {
         installer.install_batch(self.packages)
     }
 
+    pub(super) fn validate(self, installer: BatchInstaller<'_>) -> Result<()> {
+        installer.validate_batch(self.packages)
+    }
+
     pub(super) fn install_with_result(
         self,
         installer: BatchInstaller<'_>,

--- a/apps/conary/src/commands/model/apply.rs
+++ b/apps/conary/src/commands/model/apply.rs
@@ -24,7 +24,7 @@ use conary_core::model::parser::SystemModel;
 use conary_core::model::{DiffAction, replatform_execution_plan};
 use conary_core::repository::SETTINGS_KEY_ALLOWED_DISTROS;
 use derived::{build_derived_package, create_derived_from_model};
-use packages::apply_package_changes;
+use packages::{apply_package_changes, validate_package_changes};
 use rusqlite::Connection;
 #[cfg(test)]
 use std::cell::Cell;
@@ -141,6 +141,7 @@ pub async fn cmd_model_apply(opts: ApplyOptions<'_>) -> Result<()> {
     }
 
     if dry_run {
+        validate_package_changes(db_path, &actions).await?;
         println!("[Dry run - no changes made]");
         return Ok(());
     }
@@ -759,5 +760,7 @@ pub(super) fn apply_metadata_changes(
     (applied, errors)
 }
 
+#[cfg(test)]
+mod dry_run_tests;
 #[cfg(test)]
 mod tests;

--- a/apps/conary/src/commands/model/apply/dry_run_tests.rs
+++ b/apps/conary/src/commands/model/apply/dry_run_tests.rs
@@ -1,0 +1,207 @@
+// apps/conary/src/commands/model/apply/dry_run_tests.rs
+
+use super::super::test_support::{
+    build_test_ccs_package_with_payloads_and_relations, insert_test_repository_package_resolution,
+    insert_test_static_ccs_repository, serve_test_file_n,
+};
+use super::*;
+use crate::commands::test_helpers::create_test_db;
+use conary_core::db::models::{DistroPin, RepositoryPackage};
+use conary_core::repository::dependency_model::{
+    RepositoryCapabilityKind, RepositoryRequirementClause, RepositoryRequirementGroup,
+    RepositoryRequirementKind,
+};
+use conary_core::repository::resolution_policy::DependencyMixingPolicy;
+use tempfile::tempdir;
+
+#[derive(Debug, PartialEq, Eq)]
+struct LogicalDatabaseSnapshot(Vec<(String, Vec<Vec<Vec<u8>>>)>);
+
+fn logical_database_snapshot(db_path: &str) -> LogicalDatabaseSnapshot {
+    use rusqlite::types::ValueRef;
+
+    let conn = rusqlite::Connection::open_with_flags(
+        db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .unwrap();
+    let table_names = conn
+        .prepare(
+            "SELECT name FROM sqlite_schema
+             WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+             ORDER BY name",
+        )
+        .unwrap()
+        .query_map([], |row| row.get::<_, String>(0))
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap();
+
+    let mut tables = Vec::with_capacity(table_names.len());
+    for table in table_names {
+        let quoted = table.replace('"', "\"\"");
+        let mut statement = conn
+            .prepare(&format!("SELECT * FROM \"{quoted}\""))
+            .unwrap();
+        let column_count = statement.column_count();
+        let mut rows = statement
+            .query_map([], |row| {
+                (0..column_count)
+                    .map(|column| {
+                        Ok(match row.get_ref(column)? {
+                            ValueRef::Null => vec![0],
+                            ValueRef::Integer(value) => {
+                                let mut encoded = vec![1];
+                                encoded.extend_from_slice(&value.to_be_bytes());
+                                encoded
+                            }
+                            ValueRef::Real(value) => {
+                                let mut encoded = vec![2];
+                                encoded.extend_from_slice(&value.to_bits().to_be_bytes());
+                                encoded
+                            }
+                            ValueRef::Text(value) => {
+                                let mut encoded = vec![3];
+                                encoded.extend_from_slice(value);
+                                encoded
+                            }
+                            ValueRef::Blob(value) => {
+                                let mut encoded = vec![4];
+                                encoded.extend_from_slice(value);
+                                encoded
+                            }
+                        })
+                    })
+                    .collect::<rusqlite::Result<Vec<_>>>()
+            })
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        rows.sort();
+        tables.push((table, rows));
+    }
+    LogicalDatabaseSnapshot(tables)
+}
+
+#[tokio::test]
+async fn model_apply_dry_run_rejects_the_same_invalid_package_transaction_as_apply() {
+    let (_temp_file, db_path) = create_test_db();
+    let temp_dir = tempdir().unwrap();
+    let package_name = "model-invalid-transaction";
+    let version = "1-1";
+    let missing_path = "/usr/lib/model-missing-provider.so";
+    let requirement = RepositoryRequirementGroup::simple(
+        RepositoryRequirementKind::Depends,
+        RepositoryRequirementClause {
+            name: missing_path.to_string(),
+            capability_kind: Some(RepositoryCapabilityKind::File),
+            version_constraint: None,
+            architecture_qualifier: Default::default(),
+            native_text: Some(missing_path.to_string()),
+        },
+    );
+    let package_path = build_test_ccs_package_with_payloads_and_relations(
+        temp_dir.path(),
+        package_name,
+        version,
+        conary_core::repository::versioning::VersionScheme::Rpm,
+        None,
+        vec![(
+            format!("/usr/bin/{package_name}"),
+            b"#!/bin/sh\nexit 0\n".to_vec(),
+            0o755,
+        )],
+        vec![requirement],
+        Vec::new(),
+    );
+    let (package_url, _server) = serve_test_file_n(package_path.clone(), 2);
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    DistroPin::set(&conn, "fedora-44", DependencyMixingPolicy::Strict).unwrap();
+    let repository_id = insert_test_static_ccs_repository(
+        &conn,
+        "fedora",
+        "https://example.test/fedora",
+        "fedora-44",
+    );
+    let checksum = conary_core::hash::sha256(&std::fs::read(&package_path).unwrap());
+    let mut package = RepositoryPackage::new(
+        repository_id,
+        package_name.to_string(),
+        version.to_string(),
+        conary_core::repository::versioning::VersionScheme::Rpm,
+        checksum,
+        std::fs::metadata(&package_path)
+            .unwrap()
+            .len()
+            .try_into()
+            .unwrap(),
+        package_url,
+    );
+    package.architecture = Some("x86_64".to_string());
+    package.source_profile = Some("fedora-44".to_string());
+    let package_id = package.insert(&conn).unwrap();
+    insert_test_repository_package_resolution(
+        &conn,
+        repository_id,
+        package_id,
+        package_name,
+        version,
+    );
+    drop(conn);
+
+    let model_path = temp_dir.path().join("system.toml");
+    std::fs::write(
+        &model_path,
+        format!(
+            r#"
+[model]
+version = 1
+install = ["{package_name}"]
+
+[system.pin]
+distro = "fedora-44"
+strength = "strict"
+"#,
+        ),
+    )
+    .unwrap();
+    let options = |dry_run| ApplyOptions {
+        model_path: model_path.to_str().unwrap(),
+        db_path: &db_path,
+        root: temp_dir.path().to_str().unwrap(),
+        dry_run,
+        skip_optional: false,
+        strict: true,
+        autoremove: false,
+        offline: true,
+    };
+
+    let before = logical_database_snapshot(&db_path);
+    let dry_run_error = cmd_model_apply(options(true))
+        .await
+        .expect_err("dry-run must validate the exact prepared package transaction");
+    assert_eq!(
+        logical_database_snapshot(&db_path),
+        before,
+        "dry-run must leave every persisted table unchanged"
+    );
+
+    let apply_error = cmd_model_apply(options(false))
+        .await
+        .expect_err("apply must reject the invalid package transaction");
+    assert_eq!(
+        logical_database_snapshot(&db_path),
+        before,
+        "rejected apply must fail before persisted mutation"
+    );
+
+    let dry_run_error = format!("{dry_run_error:#}");
+    assert!(
+        dry_run_error
+            .contains("selected package transaction does not satisfy exact depends requirement"),
+        "{dry_run_error}"
+    );
+    assert!(dry_run_error.contains(package_name), "{dry_run_error}");
+    assert_eq!(dry_run_error, format!("{apply_error:#}"));
+}

--- a/apps/conary/src/commands/model/apply/packages.rs
+++ b/apps/conary/src/commands/model/apply/packages.rs
@@ -5,7 +5,7 @@
 use anyhow::Result;
 use conary_core::model::DiffAction;
 
-use crate::commands::install::{PackageSetRequest, install_package_set};
+use crate::commands::install::{PackageSetRequest, install_package_set, validate_package_set};
 use crate::commands::{SandboxMode, cmd_remove};
 
 /// Apply removal actions, then one atomic install/update package set.
@@ -130,6 +130,19 @@ pub(super) async fn apply_package_changes(
     }
 
     Ok((applied, errors))
+}
+
+/// Resolve, authenticate, prepare, order, and relation-plan the complete
+/// incoming package set without executing lifecycle or payload mutation.
+pub(super) async fn validate_package_changes(db_path: &str, actions: &[&DiffAction]) -> Result<()> {
+    let requests = package_set_requests(actions);
+    if requests.is_empty() {
+        return Ok(());
+    }
+    validate_package_set(db_path, requests)
+        .await
+        .map(|_| ())
+        .map_err(|error| anyhow::anyhow!(model_package_set_error(&error)))
 }
 
 fn model_package_set_error(error: &anyhow::Error) -> String {

--- a/apps/conary/src/commands/model/test_support.rs
+++ b/apps/conary/src/commands/model/test_support.rs
@@ -328,20 +328,29 @@ fn typed_rpm_replatform_upgrade_entry() -> NativeLifecycleEntry {
 }
 
 pub(super) fn serve_test_file(file_path: PathBuf) -> (String, std::thread::JoinHandle<()>) {
+    serve_test_file_n(file_path, 1)
+}
+
+pub(super) fn serve_test_file_n(
+    file_path: PathBuf,
+    request_count: usize,
+) -> (String, std::thread::JoinHandle<()>) {
     let filename = file_path.file_name().unwrap().to_string_lossy().to_string();
     let bytes = std::fs::read(&file_path).unwrap();
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
     let handle = std::thread::spawn(move || {
-        let (mut stream, _) = listener.accept().unwrap();
-        let mut request = [0_u8; 1024];
-        let _ = stream.read(&mut request);
-        let headers = format!(
-            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/octet-stream\r\nConnection: close\r\n\r\n",
-            bytes.len()
-        );
-        stream.write_all(headers.as_bytes()).unwrap();
-        stream.write_all(&bytes).unwrap();
+        for _ in 0..request_count {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request);
+            let headers = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/octet-stream\r\nConnection: close\r\n\r\n",
+                bytes.len()
+            );
+            stream.write_all(headers.as_bytes()).unwrap();
+            stream.write_all(&bytes).unwrap();
+        }
     });
     (format!("http://{addr}/{filename}"), handle)
 }

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -636,6 +636,13 @@ replatform transactions that are actually executable through the shared install
 path. Blocked transactions remain visible in the rendered plan and in follow-up
 warnings.
 
+`model apply --dry-run` resolves the complete incoming package set, downloads
+and authenticates its exact artifacts, and runs the same read-only batch
+ordering and relation planning that apply consumes. It stops before
+selected-root materialization, selected-root-relative payload normalization,
+lifecycle execution, CAS storage, or database mutation, and returns the same
+typed ordering error apply would return for an invalid prepared transaction.
+
 ### Replatform Planning
 
 `model/replatform.rs` uses the shared source-selection and package-selection


### PR DESCRIPTION
## Primary Issue

Closes #284

Design / Plan / Roadmap: [Source Selection Module](https://github.com/ConaryLabs/Conary/blob/main/docs/modules/source-selection.md)

## Problem And Outcome

`model apply --dry-run` returned after rendering the model diff, before resolving or preparing the incoming package set. A transaction that apply rejected during exact dependency ordering therefore exited successfully in preview.

After merge, preview resolves, authenticates, prepares, orders, and relation-plans the same package set as apply. Invalid prepared transactions return the same typed ordering error, and preview stops before mutation.

## Changes

- route preview and apply through one package-set resolve/authenticate/prepare path
- expose batch dependency ordering and relation planning as a shared read-only validation boundary
- retain selected-root-relative normalization and file preflight in their existing apply-only position
- add a regression proving preview and apply return the identical typed error against the same database and artifact
- prove both rejected paths leave every persisted table unchanged
- document the exact preview boundary

## Scope

- In scope: incoming install/update package-set resolution, artifact preparation, ordering, relation planning, typed error parity, and non-mutation proof
- Out of scope: selected-root-relative payload normalization and file preflight, which require materializing the selected root; standalone removal preview semantics

## Ownership / Boundary

- Owning subsystem: `model`, neighboring the shared install package-set and batch planner
- Boundary changed or preserved: one shared pre-materialization ordering authority; selected-root-relative validation remains after normalization
- Persisted state or public surface impact: no schema impact; `model apply --dry-run` now fails for invalid prepared package transactions and prints a validation progress line
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code
- [x] Updated subsystem docs or maps when the "look here first" path changed
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs

```text
- cargo fmt --check
- git diff --check
- cargo test -p conary --lib commands::model
- cargo test -p conary model
- cargo test -p conary --test model_apply
- cargo test -p conary --test live_host_mutation_safety model
- cargo test -p conary --lib commands::install::batch
- cargo test -p conary
- cargo clippy --workspace --all-targets -- -D warnings
- bash scripts/check-doc-truth.sh
- bash scripts/agent-context.sh --validate
```

Observed: 34 focused model tests passed; 41 batch tests passed; the full `conary` unit, integration, and doctest suite passed; all lint, formatting, documentation-truth, and feature-card checks passed.

## Review And Merge Notes

- Review focus: the pre-materialization validation boundary and proof that commit-only CCS path normalization remains in its original order
- User or developer impact: dry-run now downloads exact artifacts and rejects transactions that apply cannot commit
- Required-check bypass: not used