### PR TITLE
chore: align first-party MSRV and builders on Rust 1.97.1

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          toolchain: 1.96.0
+          toolchain: 1.97.1
       - name: Cache cargo
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
@@ -227,7 +227,7 @@ jobs:
             -o /tmp/rustup-init
           echo '20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c  /tmp/rustup-init' | sha256sum -c -
           chmod +x /tmp/rustup-init
-          /tmp/rustup-init -y --default-toolchain 1.96.0 --profile minimal
+          /tmp/rustup-init -y --default-toolchain 1.97.1 --profile minimal
           rm -f /tmp/rustup-init
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -289,7 +289,7 @@ jobs:
             -o /tmp/rustup-init
           echo '20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c  /tmp/rustup-init' | sha256sum -c -
           chmod +x /tmp/rustup-init
-          /tmp/rustup-init -y --default-toolchain 1.96.0 --profile minimal
+          /tmp/rustup-init -y --default-toolchain 1.97.1 --profile minimal
           rm -f /tmp/rustup-init
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -345,8 +345,8 @@ jobs:
           echo 'builder ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
       - name: Install Rust toolchain
         run: |
-          rustup default 1.96.0
-          runuser -u builder -- rustup default 1.96.0
+          rustup default 1.97.1
+          runuser -u builder -- rustup default 1.97.1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Thank you for your interest in contributing to Conary. Whether you are fixing a 
 
 ### Prerequisites
 
-- **Rust 1.96+** (edition 2024) -- install via [rustup](https://rustup.rs/)
+- **Rust 1.97.1+** (edition 2024) -- install via [rustup](https://rustup.rs/)
 - **Git**
 - **Linux** -- Conary uses Linux-specific APIs (namespaces, landlock, seccomp) and does not currently build on macOS or Windows
 
@@ -170,7 +170,7 @@ cargo test -p conaryd
 
 ### Rust Specifics
 
-- Edition 2024, minimum supported Rust version 1.96
+- Edition 2024, minimum supported Rust version 1.97.1
 - Use `thiserror` for library/module error types
 - Use `anyhow` for application-level error propagation
 - Minimize `.unwrap()` in production code paths -- prefer `?` or explicit error handling

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ weight that a team's review would otherwise carry.
 
 | | |
 | --- | --- |
-| First-party Rust | 447,093 lines across 1,225 files, 8-crate workspace, edition 2024, Rust 1.96+ |
+| First-party Rust | 447,093 lines across 1,225 files, 8-crate workspace, edition 2024, Rust 1.97.1+ |
 | Unit tests | 5,499 `#[test]` and `#[tokio::test]` functions |
 | Integration tests | 324 tests in 29 suites across 4 phases |
 | Test targets | Real Fedora 44, Ubuntu 26.04 LTS, and Arch VMs driven by `apps/conary-test` |
@@ -222,7 +222,7 @@ Two of those deserve specific mention:
 
 ## Build From Source
 
-Conary requires Rust 1.96+ on Linux.
+Conary requires Rust 1.97.1+ on Linux.
 
 ```bash
 git clone https://github.com/ConaryLabs/Conary.git

--- a/apps/conary-test/Cargo.toml
+++ b/apps/conary-test/Cargo.toml
@@ -3,7 +3,7 @@ name = "conary-test"
 version = "0.9.0"
 # Canonical release track: conary-test-v*
 edition = "2024"
-rust-version = "1.96"
+rust-version = "1.97.1"
 authors = ["Conary Contributors"]
 license = "MIT"
 description = "Test infrastructure for Conary — declarative TOML test engine with container management"

--- a/apps/conary/Cargo.toml
+++ b/apps/conary/Cargo.toml
@@ -2,7 +2,7 @@
 name = "conary"
 version = "0.14.0"
 edition = "2024"
-rust-version = "1.96"
+rust-version = "1.97.1"
 authors = ["Conary Contributors"]
 description = "Early-preview Linux package manager with native-package adoption"
 repository = "https://github.com/ConaryLabs/Conary"

--- a/apps/conaryd/Cargo.toml
+++ b/apps/conaryd/Cargo.toml
@@ -2,7 +2,7 @@
 name = "conaryd"
 version = "0.7.0"
 edition = "2024"
-rust-version = "1.96"
+rust-version = "1.97.1"
 authors = ["Conary Contributors"]
 description = "Conary system daemon"
 license = "MIT"

--- a/apps/remi/Cargo.toml
+++ b/apps/remi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "remi"
 version = "0.12.1"
 edition = "2024"
-rust-version = "1.96"
+rust-version = "1.97.1"
 authors = ["Conary Contributors"]
 description = "Remi package server for Conary"
 license = "MIT"

--- a/crates/conary-agent-contract/Cargo.toml
+++ b/crates/conary-agent-contract/Cargo.toml
@@ -2,7 +2,7 @@
 name = "conary-agent-contract"
 version = "0.9.0"
 edition = "2024"
-rust-version = "1.96"
+rust-version = "1.97.1"
 authors = ["Conary Contributors"]
 description = "Transport-neutral agent operation contract for Conary"
 license = "MIT"

--- a/crates/conary-bootstrap/Cargo.toml
+++ b/crates/conary-bootstrap/Cargo.toml
@@ -2,7 +2,7 @@
 name = "conary-bootstrap"
 version = "0.14.0"
 edition = "2024"
-rust-version = "1.96"
+rust-version = "1.97.1"
 authors = ["Conary Contributors"]
 description = "Shared bootstrap helpers for Conary workspace binaries"
 license = "MIT"

--- a/crates/conary-core/Cargo.toml
+++ b/crates/conary-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "conary-core"
 version = "0.14.0"
 edition = "2024"
-rust-version = "1.96"
+rust-version = "1.97.1"
 authors = ["Conary Contributors"]
 description = "Core library for the Conary package manager"
 license = "MIT"

--- a/crates/conary-core/tests/bootstrap_tier2_recipe_policy.rs
+++ b/crates/conary-core/tests/bootstrap_tier2_recipe_policy.rs
@@ -47,7 +47,7 @@ fn expected_tier2_versions() -> BTreeMap<&'static str, &'static str> {
         ("curl", "8.19.0"),
         ("sudo", "1.9.17p2"),
         ("nano", "9.0"),
-        ("rust", "1.96.0"),
+        ("rust", "1.97.1"),
     ])
 }
 

--- a/crates/conary-mcp/Cargo.toml
+++ b/crates/conary-mcp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "conary-mcp"
 version = "0.9.0"
 edition = "2024"
-rust-version = "1.96"
+rust-version = "1.97.1"
 authors = ["Conary Contributors"]
 description = "Shared MCP adapter helpers for Conary workspace apps"
 license = "MIT"

--- a/docs/guides/self-hosted-remi.md
+++ b/docs/guides/self-hosted-remi.md
@@ -16,7 +16,7 @@ single Remi service is enough for a private test host.
 
 ## Requirements
 
-- A Linux host with Rust 1.96+
+- A Linux host with Rust 1.97.1+
 - At least 8 GiB RAM for the default release build
 - Disk sized to the `[storage] max_cache_size` you choose
 - Outbound HTTPS access to distro mirrors

--- a/docs/operations/bootstrap-selfhosting-vm.md
+++ b/docs/operations/bootstrap-selfhosting-vm.md
@@ -170,7 +170,7 @@ The first self-hosting milestone uses this audited package set:
 | `curl` | `8.19.0` | Matches current BLFS systemd page |
 | `sudo` | `1.9.17p2` | Matches current BLFS systemd page |
 | `nano` | `9.0` | Updated to the current BLFS page |
-| `rust` | `1.96.0` | Version matches current BLFS page |
+| `rust` | `1.97.1` | Version matches the first-party workspace MSRV |
 | `conary` | tracked workspace | Built from the staged `conary-workspace.tar.gz` snapshot |
 
 Additional prerequisite note:

--- a/docs/operations/infrastructure.md
+++ b/docs/operations/infrastructure.md
@@ -200,8 +200,8 @@ cache paths under `/conary/dev/cache`, install Rust through rustup, and install
 the assistant CLIs without version pinning:
 
 ```bash
-rustup toolchain install 1.96.0 --profile default
-rustup default 1.96.0
+rustup toolchain install 1.97.1 --profile default
+rustup default 1.97.1
 npm install -g @openai/codex @anthropic-ai/claude-code
 ```
 

--- a/packaging/arch/Containerfile.build
+++ b/packaging/arch/Containerfile.build
@@ -25,5 +25,5 @@ RUN useradd -m builder && \
 RUN mkdir -p /build /output && chown builder:builder /build /output
 
 USER builder
-RUN rustup default 1.96.0
+RUN rustup default 1.97.1
 WORKDIR /build

--- a/packaging/deb/Containerfile.build
+++ b/packaging/deb/Containerfile.build
@@ -1,7 +1,7 @@
 # packaging/deb/Containerfile.build
 #
 # Ubuntu 26.04 LTS build container for Conary DEBs.
-# Uses rustup for a current toolchain (distro Rust is too old for MSRV 1.96).
+# Uses rustup for a current toolchain (distro Rust is too old for MSRV 1.97.1).
 
 FROM docker.io/library/ubuntu@sha256:3131b4cc82a783df6c9df078f86e01819a13594b865c2cad47bd1bca2b7063bb
 
@@ -27,7 +27,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf \
         -o /tmp/rustup-init \
     && echo '20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c  /tmp/rustup-init' | sha256sum -c - \
     && chmod +x /tmp/rustup-init \
-    && /tmp/rustup-init -y --default-toolchain 1.96.0 --profile minimal \
+    && /tmp/rustup-init -y --default-toolchain 1.97.1 --profile minimal \
     && rm -f /tmp/rustup-init
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/packaging/rpm/Containerfile.build
+++ b/packaging/rpm/Containerfile.build
@@ -28,7 +28,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf \
         -o /tmp/rustup-init \
     && echo '20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c  /tmp/rustup-init' | sha256sum -c - \
     && chmod +x /tmp/rustup-init \
-    && /tmp/rustup-init -y --default-toolchain 1.96.0 --profile minimal \
+    && /tmp/rustup-init -y --default-toolchain 1.97.1 --profile minimal \
     && rm -f /tmp/rustup-init
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/recipes/tier2/rust.toml
+++ b/recipes/tier2/rust.toml
@@ -1,9 +1,9 @@
 # recipes/tier2/rust.toml
 #
-# BLFS — Rustc-1.96.0 (version alignment only)
+# BLFS — Rustc-1.97.1 (version alignment only)
 # https://www.linuxfromscratch.org/blfs/view/systemd/general/rust.html
 #
-# Downloads the official Rust 1.96.0 standalone binary distribution
+# Downloads the official Rust 1.97.1 standalone binary distribution
 # and installs it to the sysroot. NOT built from source. This
 # provides rustc and cargo needed to build Conary itself.
 #
@@ -13,7 +13,7 @@
 
 [package]
 name = "rust"
-version = "1.96.0"
+version = "1.97.1"
 release = "1"
 summary = "Rust programming language toolchain"
 description = """
@@ -26,7 +26,7 @@ homepage = "https://www.rust-lang.org/"
 
 [source]
 archive = "https://static.rust-lang.org/dist/rust-%(version)s-x86_64-unknown-linux-gnu.tar.xz"
-checksum = "sha256:c295047583a56238ea06b43f849f4b877fa12bfd4c7103f8d9a74c94c9c4e108"
+checksum = "sha256:88f28fa9af20594179f85d6df67078dfd6fa93e2f6da5e1e9b0ac4997988ca4f"
 
 [build]
 requires = ["glibc"]

--- a/recipes/versions.toml
+++ b/recipes/versions.toml
@@ -139,7 +139,7 @@ make-ca = "1.16.1"
 curl = "8.19.0"
 sudo = "1.9.17p2"
 nano = "9.0"
-rust = "1.96.0"
+rust = "1.97.1"
 
 [urls]
 gnu = "https://ftp.gnu.org/gnu"

--- a/scripts/check-release-matrix.sh
+++ b/scripts/check-release-matrix.sh
@@ -208,17 +208,17 @@ require_match "$rpm_spec" '^BuildRequires:[[:space:]]+systemd-rpm-macros$' 'RPM 
 require_job_match "$release_build" build-rpm 'dnf install -y[\s\S]*systemd-rpm-macros' 'release-build RPM systemd macro dependency'
 require_match "$rpm_containerfile" 'systemd-rpm-macros[\s\S]*rpm --eval '\''%\{_unitdir\}'\''[\s\S]*/usr/lib/systemd/system' 'RPM Containerfile systemd macro dependency and expansion proof'
 
-rustup_flow_pattern="${rustup_init_url}[\\s\\S]*${rustup_init_sha256}  /tmp/rustup-init[\\s\\S]*sha256sum -c -[\\s\\S]*/tmp/rustup-init -y --default-toolchain 1\\.96\\.0 --profile minimal[\\s\\S]*rm -f /tmp/rustup-init"
+rustup_flow_pattern="${rustup_init_url}[\\s\\S]*${rustup_init_sha256}  /tmp/rustup-init[\\s\\S]*sha256sum -c -[\\s\\S]*/tmp/rustup-init -y --default-toolchain 1\\.97\\.1 --profile minimal[\\s\\S]*rm -f /tmp/rustup-init"
 require_job_match "$release_build" build-rpm "$rustup_flow_pattern" 'release-build RPM builder checksum-pinned rustup-init flow'
 require_job_match "$release_build" build-deb "$rustup_flow_pattern" 'release-build DEB builder checksum-pinned rustup-init flow'
 require_match "$rpm_containerfile" "$rustup_flow_pattern" 'RPM Containerfile checksum-pinned rustup-init flow'
 require_match "$deb_containerfile" "$rustup_flow_pattern" 'DEB Containerfile checksum-pinned rustup-init flow'
-require_job_match "$release_build" build-ccs 'toolchain: 1\.96\.0' 'release-build CCS builder pinned Rust toolchain'
+require_job_match "$release_build" build-ccs 'toolchain: 1\.97\.1' 'release-build CCS builder pinned Rust toolchain'
 require_job_match "$release_build" build-ccs 'RELEASE_SIGNING_KEY: \$\{\{ secrets\.RELEASE_SIGNING_KEY \}\}[\s\S]*cargo build[\s\S]*--target-dir target[\s\S]*sign_hash --write-ccs-authority "\$authority_dir"[\s\S]*packaging/ccs/build\.sh[\s\S]*--version "\$VERSION"[\s\S]*--key "\$authority_dir/release\.private"' 'CCS build must derive embedded authority from the configured release seed'
 require_job_match "$release_build" build-ccs 'conary ccs verify[\s\S]*packaging/ccs/output/conary-\$\{VERSION\}\.ccs[\s\S]*--policy "\$authority_dir/trust-policy\.toml"' 'CCS build must verify its embedded release authority'
 require_job_match "$release_build" build-ccs 'RELEASE_SIGNING_KEY must be configured for embedded CCS release authority' 'live CCS build must fail without its release authority'
-require_job_match "$release_build" build-arch 'rustup default 1\.96\.0[\s\S]*runuser -u builder -- rustup default 1\.96\.0' 'release-build Arch builder pinned Rust toolchain'
-require_match "$arch_containerfile" '^RUN rustup default 1\.96\.0$' 'Arch Containerfile pinned Rust toolchain'
+require_job_match "$release_build" build-arch 'rustup default 1\.97\.1[\s\S]*runuser -u builder -- rustup default 1\.97\.1' 'release-build Arch builder pinned Rust toolchain'
+require_match "$arch_containerfile" '^RUN rustup default 1\.97\.1$' 'Arch Containerfile pinned Rust toolchain'
 require_literal_count "$release_build" 'uses: actions/upload-artifact@' 10 'release artifact upload actions'
 require_literal_count "$release_build" 'if-no-files-found: error' 10 'fail-closed release artifact uploads'
 require_job_match "$release_build" bundle-conary 'require_exact_asset CCS[\s\S]*release-packages/conary-\$\{VERSION\}\.ccs"[\s\S]*release-packages/\*\.ccs' 'exact version-matching CCS release asset assertion'

--- a/scripts/test-release-matrix.sh
+++ b/scripts/test-release-matrix.sh
@@ -697,7 +697,7 @@ test_check_release_matrix_rejects_unpinned_ccs_toolchain() {
     repo="$(create_release_policy_fixture)"
     replace_fixture_text_once \
         "$repo/.github/workflows/release-build.yml" \
-        'toolchain: 1.96.0' \
+        'toolchain: 1.97.1' \
         'toolchain: stable'
 
     assert_check_release_matrix_fails "$repo" "release-build CCS builder pinned Rust toolchain"
@@ -708,7 +708,7 @@ test_check_release_matrix_rejects_unpinned_arch_toolchain() {
     repo="$(create_release_policy_fixture)"
     replace_fixture_text_once \
         "$repo/.github/workflows/release-build.yml" \
-        'rustup default 1.96.0' \
+        'rustup default 1.97.1' \
         'rustup default stable'
 
     assert_check_release_matrix_fails "$repo" "release-build Arch builder pinned Rust toolchain"

--- a/site/src/routes/install/+page.svelte
+++ b/site/src/routes/install/+page.svelte
@@ -263,7 +263,7 @@
 					<h2>Build a debug binary from source</h2>
 					<p>
 						Use this path for development, not as a substitute for the packaged tester lane.
-						It requires Rust 1.96+, Git, and Linux; Conary does not currently build on macOS or Windows.
+						It requires Rust 1.97.1+, Git, and Linux; Conary does not currently build on macOS or Windows.
 					</p>
 				</div>
 


### PR DESCRIPTION
## What changed

- hard-cut all eight first-party workspace manifests to `rust-version = "1.97.1"`
- pin the CCS, RPM, DEB, and Arch release/build paths to Rust 1.97.1
- align the self-hosting recipe and its official distribution checksum, release policy tests, setup docs, and public install guidance
- preserve the vendored `resolvo` floor and the dated Rust 1.96.1 historical observation unchanged

## Why

First-party manifests, release builders, packaging images, self-hosting inputs, and operator guidance named different Rust versions. A release could therefore depend on which entry point built it instead of one declared first-party MSRV.

## Verification

- `cargo metadata --no-deps --format-version 1` (all eight first-party packages report 1.97.1)
- `cargo fmt --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p conary-core --test bootstrap_tier2_recipe_policy`
- `bash scripts/check-release-matrix.sh`
- `bash scripts/test-release-matrix.sh`
- `bash scripts/check-doc-truth.sh`

The exact-head dry-run `release-build` workflow will provide the RPM, DEB, and Arch packaging-builder proof because this host has no container builder installed.

Closes #275