### PR TITLE
feat(repository): add lossless native declarations

### DIFF
--- a/crates/conary-core/src/repository/declarations/alpm.rs
+++ b/crates/conary-core/src/repository/declarations/alpm.rs
@@ -1,0 +1,604 @@
+// conary-core/src/repository/declarations/alpm.rs
+
+//! ALPM/pacman repository declaration authority.
+
+use super::{
+    DeclarationEcosystem, DeclarationError, DeclarationErrorKind, DeclarationLocation, Result,
+    split_words,
+};
+use crate::filesystem::path::safe_join;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+const MAX_INCLUDE_DEPTH: usize = 10;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AlpmSection {
+    Options,
+    Repository(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AlpmRepositoryOptionName {
+    CacheServer,
+    Server,
+    SigLevel,
+    Usage,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum AlpmDirective {
+    Include {
+        pattern: String,
+        location: DeclarationLocation,
+    },
+    Architecture {
+        values: Vec<String>,
+        location: DeclarationLocation,
+    },
+    GlobalSigLevel {
+        values: Vec<String>,
+        location: DeclarationLocation,
+    },
+    RepositoryOption {
+        repository: String,
+        name: AlpmRepositoryOptionName,
+        raw_value: String,
+        values: Vec<String>,
+        location: DeclarationLocation,
+    },
+    /// An `[options]` directive that does not affect repository declaration.
+    OtherGlobal {
+        key: String,
+        raw_value: Option<String>,
+        location: DeclarationLocation,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AlpmConfigFile {
+    pub path: PathBuf,
+    pub source: String,
+    pub directives: Vec<AlpmDirective>,
+}
+
+impl AlpmConfigFile {
+    pub fn parse(path: impl Into<PathBuf>, source: &str) -> Result<Self> {
+        let path = path.into();
+        let mut section: Option<AlpmSection> = None;
+        let mut directives = Vec::new();
+        for (index, raw_line) in source.lines().enumerate() {
+            let line_number = index + 1;
+            match lex_line(&path, line_number, raw_line)? {
+                None => {}
+                Some(AlpmLine::Section(new_section)) => section = Some(new_section),
+                Some(AlpmLine::Directive {
+                    key,
+                    value,
+                    location,
+                }) => apply_directive(
+                    &path,
+                    line_number,
+                    section.as_ref(),
+                    &key,
+                    value,
+                    location,
+                    &mut directives,
+                )?,
+            }
+        }
+        Ok(Self {
+            path,
+            source: source.to_string(),
+            directives,
+        })
+    }
+
+    pub fn render_preserved(&self) -> &str {
+        &self.source
+    }
+}
+
+enum AlpmLine {
+    Section(AlpmSection),
+    Directive {
+        key: String,
+        value: Option<String>,
+        location: DeclarationLocation,
+    },
+}
+
+fn lex_line(path: &Path, line_number: usize, raw_line: &str) -> Result<Option<AlpmLine>> {
+    let line = raw_line.trim_end_matches('\r').trim();
+    if line.is_empty() || line.starts_with('#') {
+        return Ok(None);
+    }
+    if line.starts_with('[') {
+        let name = line
+            .strip_prefix('[')
+            .and_then(|value| value.strip_suffix(']'))
+            .ok_or_else(|| {
+                DeclarationError::syntax(
+                    DeclarationEcosystem::Alpm,
+                    path,
+                    line_number,
+                    "section header must end with ']'",
+                )
+            })?;
+        if name.is_empty() {
+            return Err(DeclarationError::syntax(
+                DeclarationEcosystem::Alpm,
+                path,
+                line_number,
+                "section name is empty",
+            ));
+        }
+        return Ok(Some(AlpmLine::Section(if name == "options" {
+            AlpmSection::Options
+        } else {
+            AlpmSection::Repository(name.to_string())
+        })));
+    }
+    let (key, value) = match line.split_once('=') {
+        Some((key, value)) => (key.trim(), Some(value.trim().to_string())),
+        None => (line, None),
+    };
+    if key.is_empty() {
+        return Err(DeclarationError::syntax(
+            DeclarationEcosystem::Alpm,
+            path,
+            line_number,
+            "directive name is empty",
+        ));
+    }
+    Ok(Some(AlpmLine::Directive {
+        key: key.to_string(),
+        value,
+        location: DeclarationLocation::new(path, line_number),
+    }))
+}
+
+fn apply_directive(
+    path: &Path,
+    line: usize,
+    section: Option<&AlpmSection>,
+    key: &str,
+    value: Option<String>,
+    location: DeclarationLocation,
+    directives: &mut Vec<AlpmDirective>,
+) -> Result<()> {
+    if key == "Include" {
+        let pattern = required_value(path, line, key, value)?;
+        directives.push(AlpmDirective::Include { pattern, location });
+        return Ok(());
+    }
+    match section {
+        Some(AlpmSection::Options) => parse_global(path, line, key, value, location, directives),
+        Some(AlpmSection::Repository(repository)) => {
+            parse_repository(path, line, repository, key, value, location, directives)
+        }
+        None => Err(DeclarationError::syntax(
+            DeclarationEcosystem::Alpm,
+            path,
+            line,
+            "directive appears before the first section",
+        )),
+    }
+}
+
+fn parse_global(
+    path: &Path,
+    line: usize,
+    key: &str,
+    value: Option<String>,
+    location: DeclarationLocation,
+    directives: &mut Vec<AlpmDirective>,
+) -> Result<()> {
+    match key {
+        "Architecture" => {
+            let value = required_value(path, line, key, value)?;
+            directives.push(AlpmDirective::Architecture {
+                values: split_words(&value),
+                location,
+            });
+        }
+        "SigLevel" => {
+            let value = required_value(path, line, key, value)?;
+            let values = split_words(&value);
+            validate_siglevel(path, line, &values)?;
+            directives.push(AlpmDirective::GlobalSigLevel { values, location });
+        }
+        _ => directives.push(AlpmDirective::OtherGlobal {
+            key: key.to_string(),
+            raw_value: value,
+            location,
+        }),
+    }
+    Ok(())
+}
+
+fn parse_repository(
+    path: &Path,
+    line: usize,
+    repository: &str,
+    key: &str,
+    value: Option<String>,
+    location: DeclarationLocation,
+    directives: &mut Vec<AlpmDirective>,
+) -> Result<()> {
+    let name = match key {
+        "CacheServer" => AlpmRepositoryOptionName::CacheServer,
+        "Server" => AlpmRepositoryOptionName::Server,
+        "SigLevel" => AlpmRepositoryOptionName::SigLevel,
+        "Usage" => AlpmRepositoryOptionName::Usage,
+        _ => {
+            return Err(DeclarationError::unknown(
+                DeclarationEcosystem::Alpm,
+                path,
+                line,
+                format!("unmodeled ALPM repository option '{key}'"),
+            ));
+        }
+    };
+    let raw_value = required_value(path, line, key, value)?;
+    let values = split_words(&raw_value);
+    match name {
+        AlpmRepositoryOptionName::SigLevel => validate_siglevel(path, line, &values)?,
+        AlpmRepositoryOptionName::Usage => validate_usage(path, line, &values)?,
+        _ => {}
+    }
+    directives.push(AlpmDirective::RepositoryOption {
+        repository: repository.to_string(),
+        name,
+        raw_value,
+        values,
+        location,
+    });
+    Ok(())
+}
+
+fn required_value(path: &Path, line: usize, key: &str, value: Option<String>) -> Result<String> {
+    value.filter(|value| !value.is_empty()).ok_or_else(|| {
+        DeclarationError::syntax(
+            DeclarationEcosystem::Alpm,
+            path,
+            line,
+            format!("directive '{key}' requires a value"),
+        )
+    })
+}
+
+fn validate_siglevel(path: &Path, line: usize, values: &[String]) -> Result<()> {
+    for value in values {
+        let base = value
+            .strip_prefix("Package")
+            .or_else(|| value.strip_prefix("Database"))
+            .unwrap_or(value);
+        if !matches!(
+            base,
+            "Never" | "Optional" | "Required" | "TrustedOnly" | "TrustAll"
+        ) {
+            return Err(DeclarationError::unknown(
+                DeclarationEcosystem::Alpm,
+                path,
+                line,
+                format!("unmodeled ALPM SigLevel token '{value}'"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_usage(path: &Path, line: usize, values: &[String]) -> Result<()> {
+    for value in values {
+        if !matches!(
+            value.as_str(),
+            "Sync" | "Search" | "Install" | "Upgrade" | "All"
+        ) {
+            return Err(DeclarationError::unknown(
+                DeclarationEcosystem::Alpm,
+                path,
+                line,
+                format!("unmodeled ALPM Usage token '{value}'"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AlpmConfigSet {
+    /// Files in the exact depth-first order pacman includes them.
+    pub files: Vec<AlpmConfigFile>,
+    /// Effective directives in exact include-expansion order.
+    pub directives: Vec<AlpmDirective>,
+}
+
+impl AlpmConfigSet {
+    pub fn parse_selected_root(root: &Path, entry_path: &Path) -> Result<Self> {
+        let mut files = Vec::new();
+        let mut directives = Vec::new();
+        let mut stack = HashSet::new();
+        let mut section = None;
+        parse_file_recursive(
+            root,
+            entry_path,
+            0,
+            &mut stack,
+            &mut section,
+            &mut files,
+            &mut directives,
+        )?;
+        Ok(Self { files, directives })
+    }
+}
+
+fn parse_file_recursive(
+    root: &Path,
+    guest_path: &Path,
+    depth: usize,
+    stack: &mut HashSet<PathBuf>,
+    section: &mut Option<AlpmSection>,
+    files: &mut Vec<AlpmConfigFile>,
+    directives: &mut Vec<AlpmDirective>,
+) -> Result<()> {
+    if depth >= MAX_INCLUDE_DEPTH {
+        return Err(DeclarationError::new(
+            DeclarationEcosystem::Alpm,
+            DeclarationErrorKind::IncludeDepth,
+            guest_path,
+            None,
+            format!("include nesting exceeds {MAX_INCLUDE_DEPTH}"),
+        ));
+    }
+    if !stack.insert(guest_path.to_path_buf()) {
+        return Err(DeclarationError::new(
+            DeclarationEcosystem::Alpm,
+            DeclarationErrorKind::IncludeDepth,
+            guest_path,
+            None,
+            "include cycle detected",
+        ));
+    }
+    let host_path = rooted_path(root, guest_path)?;
+    let bytes = fs::read(&host_path).map_err(|error| {
+        DeclarationError::new(
+            DeclarationEcosystem::Alpm,
+            DeclarationErrorKind::Io,
+            guest_path,
+            None,
+            error.to_string(),
+        )
+    })?;
+    let source = String::from_utf8(bytes).map_err(|error| {
+        DeclarationError::new(
+            DeclarationEcosystem::Alpm,
+            DeclarationErrorKind::InvalidUtf8,
+            guest_path,
+            None,
+            error.to_string(),
+        )
+    })?;
+    let file_index = files.len();
+    files.push(AlpmConfigFile {
+        path: guest_path.to_path_buf(),
+        source,
+        directives: Vec::new(),
+    });
+    let lines: Vec<String> = files[file_index]
+        .source
+        .lines()
+        .map(ToOwned::to_owned)
+        .collect();
+    for (index, raw_line) in lines.iter().enumerate() {
+        let line_number = index + 1;
+        match lex_line(guest_path, line_number, raw_line)? {
+            None => {}
+            Some(AlpmLine::Section(new_section)) => *section = Some(new_section),
+            Some(AlpmLine::Directive {
+                key,
+                value,
+                location,
+            }) if key == "Include" => {
+                let pattern = required_value(guest_path, line_number, &key, value)?;
+                let directive = AlpmDirective::Include {
+                    pattern: pattern.clone(),
+                    location: location.clone(),
+                };
+                files[file_index].directives.push(directive.clone());
+                directives.push(directive);
+                for included in expand_include(root, &pattern, &location)? {
+                    parse_file_recursive(
+                        root,
+                        &included,
+                        depth + 1,
+                        stack,
+                        section,
+                        files,
+                        directives,
+                    )?;
+                }
+            }
+            Some(AlpmLine::Directive {
+                key,
+                value,
+                location,
+            }) => {
+                let mut parsed = Vec::new();
+                apply_directive(
+                    guest_path,
+                    line_number,
+                    section.as_ref(),
+                    &key,
+                    value,
+                    location,
+                    &mut parsed,
+                )?;
+                files[file_index].directives.extend(parsed.iter().cloned());
+                directives.extend(parsed);
+            }
+        }
+    }
+    stack.remove(guest_path);
+    Ok(())
+}
+
+fn expand_include(
+    root: &Path,
+    pattern: &str,
+    location: &DeclarationLocation,
+) -> Result<Vec<PathBuf>> {
+    let guest_pattern = PathBuf::from(pattern);
+    if guest_pattern
+        .components()
+        .any(|component| component == Component::ParentDir)
+    {
+        return Err(DeclarationError::new(
+            DeclarationEcosystem::Alpm,
+            DeclarationErrorKind::PathEscape,
+            &location.path,
+            Some(location.line),
+            format!("include pattern escapes the selected root: '{pattern}'"),
+        ));
+    }
+    let host_pattern = root.join(guest_pattern.strip_prefix("/").unwrap_or(&guest_pattern));
+    let host_pattern = host_pattern.to_string_lossy();
+    let entries = glob::glob(&host_pattern).map_err(|error| {
+        DeclarationError::syntax(
+            DeclarationEcosystem::Alpm,
+            &location.path,
+            location.line,
+            format!("invalid include pattern '{pattern}': {error}"),
+        )
+    })?;
+    let mut paths = Vec::new();
+    for entry in entries {
+        let host_path = entry.map_err(|error| {
+            DeclarationError::new(
+                DeclarationEcosystem::Alpm,
+                DeclarationErrorKind::Io,
+                &location.path,
+                Some(location.line),
+                error.to_string(),
+            )
+        })?;
+        let relative = host_path.strip_prefix(root).map_err(|_| {
+            DeclarationError::new(
+                DeclarationEcosystem::Alpm,
+                DeclarationErrorKind::PathEscape,
+                &location.path,
+                Some(location.line),
+                format!(
+                    "include match escapes selected root: {}",
+                    host_path.display()
+                ),
+            )
+        })?;
+        let guest_path = Path::new("/").join(relative);
+        rooted_path(root, &guest_path)?;
+        paths.push(guest_path);
+    }
+    paths.sort();
+    if paths.is_empty() {
+        return Err(DeclarationError::new(
+            DeclarationEcosystem::Alpm,
+            DeclarationErrorKind::Io,
+            &location.path,
+            Some(location.line),
+            format!("include pattern matched no files: '{pattern}'"),
+        ));
+    }
+    Ok(paths)
+}
+
+fn rooted_path(root: &Path, guest_path: &Path) -> Result<PathBuf> {
+    safe_join(root, guest_path).map_err(|error| {
+        DeclarationError::new(
+            DeclarationEcosystem::Alpm,
+            DeclarationErrorKind::PathEscape,
+            guest_path,
+            None,
+            error.to_string(),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_variables_order_usage_and_global_options() {
+        let source = "# arch\n[options]\nArchitecture = auto\nColor\nSigLevel = Required DatabaseOptional\n[core]\nServer = https://mirror/$repo/os/$arch\nUsage = Sync Install\n";
+        let file = AlpmConfigFile::parse("/etc/pacman.conf", source).unwrap();
+        assert_eq!(file.render_preserved(), source);
+        assert_eq!(file.directives.len(), 5);
+    }
+
+    #[test]
+    fn unknown_repository_authority_fails_closed() {
+        let error =
+            AlpmConfigFile::parse("/etc/pacman.conf", "[core]\nFuture=value\n").unwrap_err();
+        assert_eq!(error.kind, DeclarationErrorKind::UnknownAuthority);
+    }
+
+    #[test]
+    fn selected_root_expands_includes_in_sorted_order() {
+        let root = tempfile::tempdir().unwrap();
+        fs::create_dir_all(root.path().join("etc/pacman.d")).unwrap();
+        fs::write(
+            root.path().join("etc/pacman.conf"),
+            "[options]\nInclude = /etc/pacman.d/*.conf\n",
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("etc/pacman.d/b.conf"),
+            "[b]\nServer=https://b\n",
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("etc/pacman.d/a.conf"),
+            "[a]\nServer=https://a\n",
+        )
+        .unwrap();
+        let set =
+            AlpmConfigSet::parse_selected_root(root.path(), Path::new("/etc/pacman.conf")).unwrap();
+        assert_eq!(set.files.len(), 3);
+        assert_eq!(set.files[1].path, Path::new("/etc/pacman.d/a.conf"));
+        assert_eq!(set.files[2].path, Path::new("/etc/pacman.d/b.conf"));
+    }
+
+    #[test]
+    fn included_files_inherit_and_update_the_current_section() {
+        let root = tempfile::tempdir().unwrap();
+        fs::create_dir_all(root.path().join("etc/pacman.d")).unwrap();
+        fs::write(
+            root.path().join("etc/pacman.conf"),
+            "[core]\nInclude = /etc/pacman.d/vendor.conf\nServer=https://after\n",
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("etc/pacman.d/vendor.conf"),
+            "Server=https://inherited\n[extra]\nServer=https://extra\n",
+        )
+        .unwrap();
+        let set =
+            AlpmConfigSet::parse_selected_root(root.path(), Path::new("/etc/pacman.conf")).unwrap();
+        let repositories: Vec<_> = set
+            .directives
+            .iter()
+            .filter_map(|directive| match directive {
+                AlpmDirective::RepositoryOption { repository, .. } => Some(repository.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(repositories, ["core", "extra", "extra"]);
+    }
+}

--- a/crates/conary-core/src/repository/declarations/apt.rs
+++ b/crates/conary-core/src/repository/declarations/apt.rs
@@ -1,0 +1,647 @@
+// conary-core/src/repository/declarations/apt.rs
+
+//! APT `sources.list` and deb822 `.sources` declaration authority.
+
+use super::{
+    DeclarationEcosystem, DeclarationError, DeclarationLocation, Result, parse_bool, split_words,
+};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AptSyntax {
+    OneLine,
+    Deb822,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AptSourceKind {
+    Deb,
+    DebSrc,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AptOptionOperation {
+    Set,
+    Add,
+    Remove,
+}
+
+/// Current options consumed by APT's source-list and Debian meta-index code.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AptOptionName {
+    Architectures,
+    Languages,
+    Targets,
+    Trusted,
+    CheckValidUntil,
+    ValidUntilMin,
+    ValidUntilMax,
+    CheckDate,
+    DateMaxFuture,
+    Snapshot,
+    SignedBy,
+    PDiffs,
+    ByHash,
+    Include,
+    Exclude,
+    AllowInsecure,
+    AllowWeak,
+    AllowDowngradeToInsecure,
+    InReleasePath,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AptOption {
+    pub name: AptOptionName,
+    pub operation: AptOptionOperation,
+    pub raw_value: String,
+    pub values: Vec<String>,
+    pub location: DeclarationLocation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AptAnnotation {
+    pub name: String,
+    pub raw_value: String,
+    pub location: DeclarationLocation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AptSourceEntry {
+    pub kinds: Vec<AptSourceKind>,
+    pub enabled: bool,
+    pub uris: Vec<String>,
+    pub suites: Vec<String>,
+    pub components: Vec<String>,
+    pub options: Vec<AptOption>,
+    pub annotations: Vec<AptAnnotation>,
+    pub location: DeclarationLocation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AptSourceDocument {
+    pub path: PathBuf,
+    pub syntax: AptSyntax,
+    /// Exact bytes after UTF-8 validation. Rendering returns this unchanged.
+    pub source: String,
+    pub entries: Vec<AptSourceEntry>,
+}
+
+impl AptSourceDocument {
+    pub fn parse(path: impl Into<PathBuf>, syntax: AptSyntax, source: &str) -> Result<Self> {
+        let path = path.into();
+        let entries = match syntax {
+            AptSyntax::OneLine => parse_one_line(&path, source)?,
+            AptSyntax::Deb822 => parse_deb822(&path, source)?,
+        };
+        Ok(Self {
+            path,
+            syntax,
+            source: source.to_string(),
+            entries,
+        })
+    }
+
+    pub fn render_preserved(&self) -> &str {
+        &self.source
+    }
+}
+
+fn parse_one_line(path: &Path, source: &str) -> Result<Vec<AptSourceEntry>> {
+    let mut entries = Vec::new();
+    for (index, raw_line) in source.lines().enumerate() {
+        let line_number = index + 1;
+        let mut line = raw_line.trim_end_matches('\r').trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let mut enabled = true;
+        if let Some(comment) = line.strip_prefix('#') {
+            let candidate = comment.trim_start();
+            if candidate.starts_with("deb ")
+                || candidate.starts_with("deb\t")
+                || candidate.starts_with("deb-src ")
+                || candidate.starts_with("deb-src\t")
+            {
+                enabled = false;
+                line = candidate;
+            } else {
+                continue;
+            }
+        }
+        let line = strip_one_line_comment(line).trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let (kind_text, mut remainder) = take_word(line).ok_or_else(|| {
+            DeclarationError::syntax(
+                DeclarationEcosystem::Apt,
+                path,
+                line_number,
+                "source entry has no type",
+            )
+        })?;
+        let kind = parse_kind(path, line_number, kind_text)?;
+        remainder = remainder.trim_start();
+
+        let mut options = Vec::new();
+        if remainder.starts_with('[') {
+            let closing = find_closing_bracket(remainder).ok_or_else(|| {
+                DeclarationError::syntax(
+                    DeclarationEcosystem::Apt,
+                    path,
+                    line_number,
+                    "option block is missing ']'",
+                )
+            })?;
+            let option_block = &remainder[1..closing];
+            for token in shell_words(option_block, path, line_number)? {
+                options.push(parse_one_line_option(path, line_number, &token)?);
+            }
+            remainder = remainder[closing + 1..].trim_start();
+        }
+
+        let words = shell_words(remainder, path, line_number)?;
+        if words.len() < 2 {
+            return Err(DeclarationError::syntax(
+                DeclarationEcosystem::Apt,
+                path,
+                line_number,
+                "source entry requires URI and suite",
+            ));
+        }
+        let suite = words[1].clone();
+        let components = words[2..].to_vec();
+        validate_components(path, line_number, &suite, &components)?;
+        entries.push(AptSourceEntry {
+            kinds: vec![kind],
+            enabled,
+            uris: vec![words[0].clone()],
+            suites: vec![suite],
+            components,
+            options,
+            annotations: Vec::new(),
+            location: DeclarationLocation::new(path, line_number),
+        });
+    }
+    Ok(entries)
+}
+
+fn parse_deb822(path: &Path, source: &str) -> Result<Vec<AptSourceEntry>> {
+    let stanzas = deb822_fields(path, source)?;
+    let mut entries = Vec::new();
+    for fields in stanzas {
+        let line = fields.first().map_or(1, |field| field.location.line);
+        let mut kinds = None;
+        let mut uris = None;
+        let mut suites = None;
+        let mut components = Vec::new();
+        let mut enabled = true;
+        let mut options = Vec::new();
+        let mut annotations = Vec::new();
+
+        for field in fields {
+            match field.name.as_str() {
+                "Types" => {
+                    kinds = Some(
+                        split_words(&field.value)
+                            .into_iter()
+                            .map(|value| parse_kind(path, field.location.line, &value))
+                            .collect::<Result<Vec<_>>>()?,
+                    );
+                }
+                "URIs" => uris = Some(split_words(&field.value)),
+                "Suites" => suites = Some(split_words(&field.value)),
+                "Components" => components = split_words(&field.value),
+                "Enabled" => {
+                    enabled = parse_bool(
+                        DeclarationEcosystem::Apt,
+                        path,
+                        field.location.line,
+                        &field.value,
+                    )?;
+                }
+                "Description" => annotations.push(AptAnnotation {
+                    name: field.name,
+                    raw_value: field.value,
+                    location: field.location,
+                }),
+                name if name.starts_with("X-") => annotations.push(AptAnnotation {
+                    name: field.name,
+                    raw_value: field.value,
+                    location: field.location,
+                }),
+                _ => options.push(parse_deb822_option(path, field)?),
+            }
+        }
+
+        let kinds = required_field(path, line, "Types", kinds)?;
+        let uris = required_field(path, line, "URIs", uris)?;
+        let suites = required_field(path, line, "Suites", suites)?;
+        if kinds.is_empty() || uris.is_empty() || suites.is_empty() {
+            return Err(DeclarationError::syntax(
+                DeclarationEcosystem::Apt,
+                path,
+                line,
+                "Types, URIs, and Suites must each contain at least one value",
+            ));
+        }
+        for suite in &suites {
+            validate_components(path, line, suite, &components)?;
+        }
+        entries.push(AptSourceEntry {
+            kinds,
+            enabled,
+            uris,
+            suites,
+            components,
+            options,
+            annotations,
+            location: DeclarationLocation::new(path, line),
+        });
+    }
+    Ok(entries)
+}
+
+#[derive(Debug)]
+struct Deb822Field {
+    name: String,
+    value: String,
+    location: DeclarationLocation,
+}
+
+fn deb822_fields(path: &Path, source: &str) -> Result<Vec<Vec<Deb822Field>>> {
+    let mut stanzas = Vec::new();
+    let mut current = Vec::<Deb822Field>::new();
+    for (index, raw_line) in source.lines().enumerate() {
+        let line_number = index + 1;
+        let line = raw_line.trim_end_matches('\r');
+        if line.is_empty() {
+            if !current.is_empty() {
+                stanzas.push(std::mem::take(&mut current));
+            }
+            continue;
+        }
+        if line.starts_with('#') {
+            continue;
+        }
+        if line.starts_with(' ') || line.starts_with('\t') {
+            let field = current.last_mut().ok_or_else(|| {
+                DeclarationError::syntax(
+                    DeclarationEcosystem::Apt,
+                    path,
+                    line_number,
+                    "continuation line has no field",
+                )
+            })?;
+            field.value.push('\n');
+            field.value.push_str(line.trim_start());
+            continue;
+        }
+        let (name, value) = line.split_once(':').ok_or_else(|| {
+            DeclarationError::syntax(
+                DeclarationEcosystem::Apt,
+                path,
+                line_number,
+                "deb822 field is missing ':'",
+            )
+        })?;
+        if name.is_empty()
+            || !name
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        {
+            return Err(DeclarationError::syntax(
+                DeclarationEcosystem::Apt,
+                path,
+                line_number,
+                format!("invalid deb822 field name '{name}'"),
+            ));
+        }
+        current.push(Deb822Field {
+            name: name.to_string(),
+            value: value.trim_start().to_string(),
+            location: DeclarationLocation::new(path, line_number),
+        });
+    }
+    if !current.is_empty() {
+        stanzas.push(current);
+    }
+    Ok(stanzas)
+}
+
+fn parse_kind(path: &Path, line: usize, value: &str) -> Result<AptSourceKind> {
+    match value {
+        "deb" => Ok(AptSourceKind::Deb),
+        "deb-src" => Ok(AptSourceKind::DebSrc),
+        _ => Err(DeclarationError::unknown(
+            DeclarationEcosystem::Apt,
+            path,
+            line,
+            format!("unknown APT source type '{value}'"),
+        )),
+    }
+}
+
+fn parse_one_line_option(path: &Path, line: usize, token: &str) -> Result<AptOption> {
+    let (name, value) = token.split_once('=').ok_or_else(|| {
+        DeclarationError::syntax(
+            DeclarationEcosystem::Apt,
+            path,
+            line,
+            format!("APT option '{token}' has no value separator"),
+        )
+    })?;
+    if name.is_empty() || value.is_empty() {
+        return Err(DeclarationError::syntax(
+            DeclarationEcosystem::Apt,
+            path,
+            line,
+            format!("APT option '{token}' requires a key and value"),
+        ));
+    }
+    let option_name = apt_option_name(path, line, name, true)?;
+    Ok(AptOption {
+        name: option_name,
+        operation: AptOptionOperation::Set,
+        raw_value: value.to_string(),
+        values: value.split(',').map(ToOwned::to_owned).collect(),
+        location: DeclarationLocation::new(path, line),
+    })
+}
+
+fn parse_deb822_option(path: &Path, field: Deb822Field) -> Result<AptOption> {
+    let (base, operation) = if let Some(base) = field.name.strip_suffix("-Add") {
+        (base, AptOptionOperation::Add)
+    } else if let Some(base) = field.name.strip_suffix("-Remove") {
+        (base, AptOptionOperation::Remove)
+    } else {
+        (field.name.as_str(), AptOptionOperation::Set)
+    };
+    let name = apt_option_name(path, field.location.line, base, false)?;
+    validate_option_operation(path, field.location.line, &name, operation, &field.name)?;
+    let values = if name == AptOptionName::SignedBy {
+        vec![field.value.clone()]
+    } else {
+        split_words(&field.value)
+    };
+    Ok(AptOption {
+        name,
+        operation,
+        raw_value: field.value,
+        values,
+        location: field.location,
+    })
+}
+
+fn apt_option_name(path: &Path, line: usize, name: &str, one_line: bool) -> Result<AptOptionName> {
+    let canonical = if one_line {
+        match name {
+            "arch" => "Architectures",
+            "lang" => "Languages",
+            "target" => "Targets",
+            "trusted" => "Trusted",
+            "check-valid-until" => "Check-Valid-Until",
+            "valid-until-min" => "Valid-Until-Min",
+            "valid-until-max" => "Valid-Until-Max",
+            "check-date" => "Check-Date",
+            "date-max-future" => "Date-Max-Future",
+            "snapshot" => "Snapshot",
+            "signed-by" => "Signed-By",
+            "pdiffs" => "PDiffs",
+            "by-hash" => "By-Hash",
+            "include" => "Include",
+            "exclude" => "Exclude",
+            "allow-insecure" => "Allow-Insecure",
+            "allow-weak" => "Allow-Weak",
+            "allow-downgrade-to-insecure" => "Allow-Downgrade-To-Insecure",
+            "inrelease-path" => "InRelease-Path",
+            other => other,
+        }
+    } else {
+        name
+    };
+    let option = match canonical {
+        "Architectures" => AptOptionName::Architectures,
+        "Languages" => AptOptionName::Languages,
+        "Targets" => AptOptionName::Targets,
+        "Trusted" => AptOptionName::Trusted,
+        "Check-Valid-Until" => AptOptionName::CheckValidUntil,
+        "Valid-Until-Min" => AptOptionName::ValidUntilMin,
+        "Valid-Until-Max" => AptOptionName::ValidUntilMax,
+        "Check-Date" => AptOptionName::CheckDate,
+        "Date-Max-Future" => AptOptionName::DateMaxFuture,
+        "Snapshot" => AptOptionName::Snapshot,
+        "Signed-By" => AptOptionName::SignedBy,
+        "PDiffs" => AptOptionName::PDiffs,
+        "By-Hash" => AptOptionName::ByHash,
+        "Include" => AptOptionName::Include,
+        "Exclude" => AptOptionName::Exclude,
+        "Allow-Insecure" if one_line => AptOptionName::AllowInsecure,
+        "Allow-Weak" if one_line => AptOptionName::AllowWeak,
+        "Allow-Downgrade-To-Insecure" if one_line => AptOptionName::AllowDowngradeToInsecure,
+        "InRelease-Path" if one_line => AptOptionName::InReleasePath,
+        _ => {
+            return Err(DeclarationError::unknown(
+                DeclarationEcosystem::Apt,
+                path,
+                line,
+                format!("unmodeled APT source option '{name}'"),
+            ));
+        }
+    };
+    Ok(option)
+}
+
+fn validate_option_operation(
+    path: &Path,
+    line: usize,
+    option: &AptOptionName,
+    operation: AptOptionOperation,
+    source_name: &str,
+) -> Result<()> {
+    if operation != AptOptionOperation::Set
+        && !matches!(
+            option,
+            AptOptionName::Architectures | AptOptionName::Languages | AptOptionName::Targets
+        )
+    {
+        return Err(DeclarationError::syntax(
+            DeclarationEcosystem::Apt,
+            path,
+            line,
+            format!("APT option '{source_name}' does not support add/remove semantics"),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_components(path: &Path, line: usize, suite: &str, components: &[String]) -> Result<()> {
+    if suite.ends_with('/') && !components.is_empty() {
+        return Err(DeclarationError::syntax(
+            DeclarationEcosystem::Apt,
+            path,
+            line,
+            "an absolute suite ending in '/' cannot declare components",
+        ));
+    }
+    if !suite.ends_with('/') && components.is_empty() {
+        return Err(DeclarationError::syntax(
+            DeclarationEcosystem::Apt,
+            path,
+            line,
+            "a distribution suite requires at least one component",
+        ));
+    }
+    Ok(())
+}
+
+fn required_field<T>(path: &Path, line: usize, name: &str, value: Option<T>) -> Result<T> {
+    value.ok_or_else(|| {
+        DeclarationError::syntax(
+            DeclarationEcosystem::Apt,
+            path,
+            line,
+            format!("deb822 stanza is missing {name}"),
+        )
+    })
+}
+
+fn strip_one_line_comment(line: &str) -> &str {
+    let mut bracket_depth = 0usize;
+    for (index, character) in line.char_indices() {
+        match character {
+            '[' => bracket_depth += 1,
+            ']' => bracket_depth = bracket_depth.saturating_sub(1),
+            '#' if bracket_depth == 0 => return &line[..index],
+            _ => {}
+        }
+    }
+    line
+}
+
+fn find_closing_bracket(value: &str) -> Option<usize> {
+    let mut quote = None;
+    for (index, character) in value.char_indices().skip(1) {
+        match character {
+            '\'' | '"' if quote == Some(character) => quote = None,
+            '\'' | '"' if quote.is_none() => quote = Some(character),
+            ']' if quote.is_none() => return Some(index),
+            _ => {}
+        }
+    }
+    None
+}
+
+fn take_word(value: &str) -> Option<(&str, &str)> {
+    let end = value.find(char::is_whitespace).unwrap_or(value.len());
+    (end != 0).then_some((&value[..end], &value[end..]))
+}
+
+fn shell_words(value: &str, path: &Path, line: usize) -> Result<Vec<String>> {
+    let mut words = Vec::new();
+    let mut current = String::new();
+    let mut quote = None;
+    for character in value.chars() {
+        match character {
+            '\'' | '"' if quote == Some(character) => quote = None,
+            '\'' | '"' if quote.is_none() => quote = Some(character),
+            c if c.is_whitespace() && quote.is_none() => {
+                if !current.is_empty() {
+                    words.push(std::mem::take(&mut current));
+                }
+            }
+            other => current.push(other),
+        }
+    }
+    if quote.is_some() {
+        return Err(DeclarationError::syntax(
+            DeclarationEcosystem::Apt,
+            path,
+            line,
+            "unterminated quoted word",
+        ));
+    }
+    if !current.is_empty() {
+        words.push(current);
+    }
+    Ok(words)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn one_line_preserves_disabled_and_ordered_authority() {
+        let source = "# heading\n# deb [arch=amd64 signed-by=/keys/vendor.gpg] https://example.test stable main\ndeb-src https://example.test stable main contrib # tail\n";
+        let document =
+            AptSourceDocument::parse("/etc/apt/sources.list", AptSyntax::OneLine, source).unwrap();
+        assert_eq!(document.render_preserved(), source);
+        assert_eq!(document.entries.len(), 2);
+        assert!(!document.entries[0].enabled);
+        assert_eq!(
+            document.entries[0].options[0].name,
+            AptOptionName::Architectures
+        );
+        assert_eq!(document.entries[1].kinds, vec![AptSourceKind::DebSrc]);
+        assert_eq!(document.entries[1].components, ["main", "contrib"]);
+    }
+
+    #[test]
+    fn deb822_preserves_disabled_multi_value_and_embedded_key() {
+        let source = "Types: deb deb-src\nURIs: https://deb.example.test\nSuites: stable testing\nComponents: main contrib\nEnabled: no\nArchitectures: amd64 arm64\nSigned-By:\n -----BEGIN PGP PUBLIC KEY BLOCK-----\n .\n body\nX-Repolib-Name: Vendor\n";
+        let document = AptSourceDocument::parse(
+            "/etc/apt/sources.list.d/vendor.sources",
+            AptSyntax::Deb822,
+            source,
+        )
+        .unwrap();
+        let entry = &document.entries[0];
+        assert!(!entry.enabled);
+        assert_eq!(entry.uris, ["https://deb.example.test"]);
+        assert_eq!(entry.suites, ["stable", "testing"]);
+        assert_eq!(entry.annotations[0].name, "X-Repolib-Name");
+        assert_eq!(document.render_preserved(), source);
+    }
+
+    #[test]
+    fn unknown_authority_fails_closed() {
+        let error = AptSourceDocument::parse(
+            "/etc/apt/sources.list",
+            AptSyntax::OneLine,
+            "deb [future-authority=yes] https://example.test stable main\n",
+        )
+        .unwrap_err();
+        assert_eq!(
+            error.kind,
+            super::super::DeclarationErrorKind::UnknownAuthority
+        );
+        assert_eq!(error.line, Some(1));
+    }
+
+    #[test]
+    fn one_line_does_not_invent_deb822_add_remove_operations() {
+        let error = AptSourceDocument::parse(
+            "/etc/apt/sources.list",
+            AptSyntax::OneLine,
+            "deb [arch+=arm64] https://example.test stable main\n",
+        )
+        .unwrap_err();
+        assert_eq!(
+            error.kind,
+            super::super::DeclarationErrorKind::UnknownAuthority
+        );
+    }
+}

--- a/crates/conary-core/src/repository/declarations/contract_tests.rs
+++ b/crates/conary-core/src/repository/declarations/contract_tests.rs
@@ -1,0 +1,120 @@
+// conary-core/src/repository/declarations/contract_tests.rs
+
+use super::alpm::AlpmConfigFile;
+use super::apt::{AptSourceDocument, AptSyntax};
+use super::dnf::{DnfEndpointKind, DnfRepoDocument};
+use super::zypper::{ZypperRepoDocument, ZypperServiceDocument};
+use super::{DeclarationEcosystem, DeclarationErrorKind};
+
+const FIXTURES: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/repository_declarations/"
+);
+
+fn fixture(name: &str) -> String {
+    std::fs::read_to_string(format!("{FIXTURES}{name}")).unwrap()
+}
+
+#[test]
+fn source_derived_fixtures_round_trip_byte_for_byte() {
+    let apt_list = fixture("apt-vendor.list");
+    assert_eq!(
+        AptSourceDocument::parse("apt-vendor.list", AptSyntax::OneLine, &apt_list)
+            .unwrap()
+            .render_preserved(),
+        apt_list
+    );
+    let apt_sources = fixture("apt-vendor.sources");
+    assert_eq!(
+        AptSourceDocument::parse("apt-vendor.sources", AptSyntax::Deb822, &apt_sources)
+            .unwrap()
+            .render_preserved(),
+        apt_sources
+    );
+    let dnf = fixture("dnf-vendor.repo");
+    assert_eq!(
+        DnfRepoDocument::parse("dnf-vendor.repo", &dnf)
+            .unwrap()
+            .render_preserved(),
+        dnf
+    );
+    let zypper = fixture("zypper-vendor.repo");
+    assert_eq!(
+        ZypperRepoDocument::parse("zypper-vendor.repo", &zypper)
+            .unwrap()
+            .render_preserved(),
+        zypper
+    );
+    let service = fixture("zypper-vendor.service");
+    assert_eq!(
+        ZypperServiceDocument::parse("zypper-vendor.service", &service)
+            .unwrap()
+            .render_preserved(),
+        service
+    );
+    let alpm = fixture("pacman.conf");
+    assert_eq!(
+        AlpmConfigFile::parse("pacman.conf", &alpm)
+            .unwrap()
+            .render_preserved(),
+        alpm
+    );
+}
+
+#[test]
+fn dnf_endpoint_combinations_follow_one_precedence_property() {
+    for bits in 0_u8..8 {
+        let mut source = String::from("[vendor]\n");
+        if bits & 1 != 0 {
+            source.push_str("baseurl=https://base/$basearch\n");
+        }
+        if bits & 2 != 0 {
+            source.push_str("mirrorlist=https://mirrors\n");
+        }
+        if bits & 4 != 0 {
+            source.push_str("metalink=https://meta\n");
+        }
+        let document = DnfRepoDocument::parse("vendor.repo", &source).unwrap();
+        assert_eq!(document.render_preserved(), source);
+        let expected = if bits & 4 != 0 {
+            Some(DnfEndpointKind::Metalink)
+        } else if bits & 2 != 0 {
+            Some(DnfEndpointKind::Mirrorlist)
+        } else if bits & 1 != 0 {
+            Some(DnfEndpointKind::Baseurl)
+        } else {
+            None
+        };
+        assert_eq!(
+            document.repositories[0]
+                .effective_endpoint()
+                .map(|(kind, _)| kind),
+            expected
+        );
+    }
+}
+
+#[test]
+fn authority_name_mutations_fail_closed_in_every_grammar() {
+    let cases = [
+        DnfRepoDocument::parse("vendor.repo", "[vendor]\nFutureEndpoint=https://x\n").unwrap_err(),
+        ZypperServiceDocument::parse("vendor.service", "[vendor]\nFutureEndpoint=https://x\n")
+            .unwrap_err(),
+        AlpmConfigFile::parse("pacman.conf", "[vendor]\nFutureEndpoint=https://x\n").unwrap_err(),
+        AptSourceDocument::parse(
+            "vendor.list",
+            AptSyntax::OneLine,
+            "deb [future-endpoint=https://x] https://repo stable main\n",
+        )
+        .unwrap_err(),
+    ];
+    for error in cases {
+        let expected_line = if error.ecosystem == DeclarationEcosystem::Apt {
+            1
+        } else {
+            2
+        };
+        assert_eq!(error.kind, DeclarationErrorKind::UnknownAuthority);
+        assert_eq!(error.line, Some(expected_line));
+    }
+}

--- a/crates/conary-core/src/repository/declarations/discovery.rs
+++ b/crates/conary-core/src/repository/declarations/discovery.rs
@@ -1,0 +1,329 @@
+// conary-core/src/repository/declarations/discovery.rs
+
+//! Selected-root discovery for native repository declarations.
+
+use super::alpm::AlpmConfigSet;
+use super::apt::{AptSourceDocument, AptSyntax};
+use super::dnf::DnfRepoDocument;
+use super::zypper::{ZypperRepoDocument, ZypperServiceDocument};
+use super::{DeclarationEcosystem, DeclarationError, DeclarationErrorKind, Result};
+use crate::filesystem::path::safe_join;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const APT_DIRECTORY: &str = "/etc/apt/sources.list.d";
+const DNF_DIRECTORIES: &[&str] = &[
+    "/etc/yum.repos.d",
+    "/etc/distro.repos.d",
+    "/usr/share/dnf5/repos.d",
+];
+const ZYPPER_REPOSITORY_DIRECTORY: &str = "/etc/zypp/repos.d";
+const ZYPPER_SERVICE_DIRECTORY: &str = "/etc/zypp/services.d";
+const ALPM_CONFIG: &str = "/etc/pacman.conf";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscoveredRepositoryDeclarations {
+    pub root: PathBuf,
+    pub apt: Vec<AptSourceDocument>,
+    pub dnf: Vec<DnfRepoDocument>,
+    pub zypper_repositories: Vec<ZypperRepoDocument>,
+    pub zypper_services: Vec<ZypperServiceDocument>,
+    pub alpm: Option<AlpmConfigSet>,
+}
+
+/// Discover only inside an explicit selected root; no native package-manager
+/// binary or database is read or invoked.
+pub fn discover_selected_root(root: impl AsRef<Path>) -> Result<DiscoveredRepositoryDeclarations> {
+    let root = root.as_ref();
+    let apt = discover_apt(root)?;
+    let dnf = discover_dnf(root)?;
+    let zypper_repositories = discover_zypper_repositories(root)?;
+    let zypper_services = discover_zypper_services(root)?;
+    let alpm = if selected_exists(root, Path::new(ALPM_CONFIG), DeclarationEcosystem::Alpm)? {
+        Some(AlpmConfigSet::parse_selected_root(
+            root,
+            Path::new(ALPM_CONFIG),
+        )?)
+    } else {
+        None
+    };
+    Ok(DiscoveredRepositoryDeclarations {
+        root: root.to_path_buf(),
+        apt,
+        dnf,
+        zypper_repositories,
+        zypper_services,
+        alpm,
+    })
+}
+
+fn discover_apt(root: &Path) -> Result<Vec<AptSourceDocument>> {
+    let mut paths = Vec::new();
+    let primary = PathBuf::from("/etc/apt/sources.list");
+    if selected_exists(root, &primary, DeclarationEcosystem::Apt)? {
+        paths.push((primary, AptSyntax::OneLine));
+    }
+    for path in directory_files(root, Path::new(APT_DIRECTORY), DeclarationEcosystem::Apt)? {
+        let Some(filename) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if !apt_filename_is_valid(filename) {
+            continue;
+        }
+        let syntax = if filename.ends_with(".list") {
+            AptSyntax::OneLine
+        } else {
+            AptSyntax::Deb822
+        };
+        paths.push((path, syntax));
+    }
+    paths
+        .into_iter()
+        .map(|(path, syntax)| {
+            let source = read_utf8(root, &path, DeclarationEcosystem::Apt)?;
+            AptSourceDocument::parse(path, syntax, &source)
+        })
+        .collect()
+}
+
+fn discover_dnf(root: &Path) -> Result<Vec<DnfRepoDocument>> {
+    let mut documents = Vec::new();
+    for directory in DNF_DIRECTORIES {
+        for path in directory_files(root, Path::new(directory), DeclarationEcosystem::Dnf)? {
+            if path.extension().and_then(|value| value.to_str()) != Some("repo") {
+                continue;
+            }
+            let source = read_utf8(root, &path, DeclarationEcosystem::Dnf)?;
+            documents.push(DnfRepoDocument::parse(path, &source)?);
+        }
+    }
+    Ok(documents)
+}
+
+fn discover_zypper_repositories(root: &Path) -> Result<Vec<ZypperRepoDocument>> {
+    directory_files(
+        root,
+        Path::new(ZYPPER_REPOSITORY_DIRECTORY),
+        DeclarationEcosystem::ZypperRepository,
+    )?
+    .into_iter()
+    .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("repo"))
+    .map(|path| {
+        let source = read_utf8(root, &path, DeclarationEcosystem::ZypperRepository)?;
+        let document = ZypperRepoDocument::parse(path, &source)?;
+        for repository in &document.repositories {
+            repository.require_interpreted_authority()?;
+        }
+        Ok(document)
+    })
+    .collect()
+}
+
+fn discover_zypper_services(root: &Path) -> Result<Vec<ZypperServiceDocument>> {
+    directory_files(
+        root,
+        Path::new(ZYPPER_SERVICE_DIRECTORY),
+        DeclarationEcosystem::ZypperService,
+    )?
+    .into_iter()
+    .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("service"))
+    .map(|path| {
+        let source = read_utf8(root, &path, DeclarationEcosystem::ZypperService)?;
+        ZypperServiceDocument::parse(path, &source)
+    })
+    .collect()
+}
+
+fn directory_files(
+    root: &Path,
+    guest_directory: &Path,
+    ecosystem: DeclarationEcosystem,
+) -> Result<Vec<PathBuf>> {
+    let host_directory = rooted_path(root, guest_directory, ecosystem)?;
+    let entries = match fs::read_dir(&host_directory) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(io_error(ecosystem, guest_directory, error)),
+    };
+    let mut files = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|error| io_error(ecosystem, guest_directory, error))?;
+        let guest_path = guest_directory.join(entry.file_name());
+        let host_path = rooted_path(root, &guest_path, ecosystem)?;
+        if host_path
+            .metadata()
+            .map_err(|error| io_error(ecosystem, &guest_path, error))?
+            .is_file()
+        {
+            files.push(guest_path);
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
+fn apt_filename_is_valid(filename: &str) -> bool {
+    (filename.ends_with(".list") || filename.ends_with(".sources"))
+        && filename
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
+}
+
+fn selected_exists(
+    root: &Path,
+    guest_path: &Path,
+    ecosystem: DeclarationEcosystem,
+) -> Result<bool> {
+    let host_path = rooted_path(root, guest_path, ecosystem)?;
+    match host_path.metadata() {
+        Ok(metadata) => Ok(metadata.is_file()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(io_error(ecosystem, guest_path, error)),
+    }
+}
+
+fn read_utf8(root: &Path, guest_path: &Path, ecosystem: DeclarationEcosystem) -> Result<String> {
+    let host_path = rooted_path(root, guest_path, ecosystem)?;
+    let bytes = fs::read(host_path).map_err(|error| io_error(ecosystem, guest_path, error))?;
+    String::from_utf8(bytes).map_err(|error| {
+        DeclarationError::new(
+            ecosystem,
+            DeclarationErrorKind::InvalidUtf8,
+            guest_path,
+            None,
+            error.to_string(),
+        )
+    })
+}
+
+fn rooted_path(root: &Path, guest_path: &Path, ecosystem: DeclarationEcosystem) -> Result<PathBuf> {
+    safe_join(root, guest_path).map_err(|error| {
+        DeclarationError::new(
+            ecosystem,
+            DeclarationErrorKind::PathEscape,
+            guest_path,
+            None,
+            error.to_string(),
+        )
+    })
+}
+
+fn io_error(
+    ecosystem: DeclarationEcosystem,
+    path: &Path,
+    error: std::io::Error,
+) -> DeclarationError {
+    DeclarationError::new(
+        ecosystem,
+        DeclarationErrorKind::Io,
+        path,
+        None,
+        error.to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discovers_each_ecosystem_only_below_selected_root() {
+        let root = tempfile::tempdir().unwrap();
+        let paths = [
+            "etc/apt/sources.list.d",
+            "etc/yum.repos.d",
+            "etc/zypp/repos.d",
+            "etc/zypp/services.d",
+        ];
+        for path in paths {
+            fs::create_dir_all(root.path().join(path)).unwrap();
+        }
+        fs::write(
+            root.path().join("etc/apt/sources.list.d/vendor.sources"),
+            "Types: deb\nURIs: https://apt.example\nSuites: stable\nComponents: main\n",
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("etc/yum.repos.d/vendor.repo"),
+            "[vendor]\nbaseurl=https://rpm.example\n",
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("etc/zypp/repos.d/vendor.repo"),
+            "[vendor]\nbaseurl=https://zypp.example\n",
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("etc/zypp/services.d/vendor.service"),
+            "[vendor]\nurl=https://service.example\n",
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("etc/pacman.conf"),
+            "[core]\nServer=https://alpm.example/$repo/$arch\n",
+        )
+        .unwrap();
+
+        let declarations = discover_selected_root(root.path()).unwrap();
+        assert_eq!(declarations.apt.len(), 1);
+        assert_eq!(declarations.dnf.len(), 1);
+        assert_eq!(declarations.zypper_repositories.len(), 1);
+        assert_eq!(declarations.zypper_services.len(), 1);
+        assert_eq!(declarations.alpm.unwrap().files.len(), 1);
+    }
+
+    #[test]
+    fn apt_ignores_names_upstream_would_ignore() {
+        let root = tempfile::tempdir().unwrap();
+        fs::create_dir_all(root.path().join("etc/apt/sources.list.d")).unwrap();
+        fs::write(
+            root.path().join("etc/apt/sources.list.d/vendor!.list"),
+            "deb https://outside.example stable main\n",
+        )
+        .unwrap();
+        assert!(discover_selected_root(root.path()).unwrap().apt.is_empty());
+    }
+
+    #[test]
+    fn invalid_utf8_is_source_attributed() {
+        let root = tempfile::tempdir().unwrap();
+        fs::create_dir_all(root.path().join("etc/yum.repos.d")).unwrap();
+        fs::write(
+            root.path().join("etc/yum.repos.d/vendor.repo"),
+            [b'[', 0xff, b']'],
+        )
+        .unwrap();
+        let error = discover_selected_root(root.path()).unwrap_err();
+        assert_eq!(error.ecosystem, DeclarationEcosystem::Dnf);
+        assert_eq!(error.kind, DeclarationErrorKind::InvalidUtf8);
+        assert_eq!(error.path, Path::new("/etc/yum.repos.d/vendor.repo"));
+    }
+
+    #[test]
+    fn zypper_extras_are_preserved_but_authoritative_discovery_refuses_them() {
+        let root = tempfile::tempdir().unwrap();
+        fs::create_dir_all(root.path().join("etc/zypp/repos.d")).unwrap();
+        fs::write(
+            root.path().join("etc/zypp/repos.d/vendor.repo"),
+            "[vendor]\nbaseurl=https://repo.example\nx-vendor=opaque\n",
+        )
+        .unwrap();
+        let error = discover_selected_root(root.path()).unwrap_err();
+        assert_eq!(error.ecosystem, DeclarationEcosystem::ZypperRepository);
+        assert_eq!(error.kind, DeclarationErrorKind::UnknownAuthority);
+        assert_eq!(error.line, Some(3));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_selected_root_symlink_escape() {
+        use std::os::unix::fs::symlink;
+        let root = tempfile::tempdir().unwrap();
+        fs::create_dir_all(root.path().join("etc/apt")).unwrap();
+        symlink("/etc", root.path().join("etc/apt/sources.list.d")).unwrap();
+        let error = discover_selected_root(root.path()).unwrap_err();
+        assert_eq!(error.kind, DeclarationErrorKind::PathEscape);
+    }
+}

--- a/crates/conary-core/src/repository/declarations/dnf.rs
+++ b/crates/conary-core/src/repository/declarations/dnf.rs
@@ -1,0 +1,358 @@
+// conary-core/src/repository/declarations/dnf.rs
+
+//! DNF5/YUM `.repo` declaration authority.
+
+use super::ini::IniDocument;
+use super::{DeclarationEcosystem, DeclarationError, DeclarationLocation, Result, parse_bool};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DnfOptionName {
+    Name,
+    Enabled,
+    Cachedir,
+    Baseurl,
+    Mirrorlist,
+    Metalink,
+    Type,
+    Mediaid,
+    Gpgkey,
+    Excludepkgs,
+    Exclude,
+    Includepkgs,
+    Fastestmirror,
+    Proxy,
+    ProxyUsername,
+    ProxyPassword,
+    ProxyAuthMethod,
+    Username,
+    Password,
+    ProtectedPackages,
+    PkgGpgcheck,
+    Gpgcheck,
+    RepoGpgcheck,
+    Enablegroups,
+    Retries,
+    Bandwidth,
+    Minrate,
+    IpResolve,
+    Throttle,
+    Timeout,
+    MaxParallelDownloads,
+    MaxDownloadsPerMirror,
+    MetadataExpire,
+    Cost,
+    Priority,
+    ModuleHotfixes,
+    Sslcacert,
+    Sslverify,
+    Sslclientcert,
+    Sslclientkey,
+    ProxySslcacert,
+    ProxySslverify,
+    ProxySslclientcert,
+    ProxySslclientkey,
+    Deltarpm,
+    DeltarpmPercentage,
+    SkipIfUnavailable,
+    EnabledMetadata,
+    UserAgent,
+    Countme,
+    BuildCache,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DnfOption {
+    pub name: DnfOptionName,
+    pub raw_value: String,
+    pub location: DeclarationLocation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DnfRepository {
+    pub id: String,
+    pub options: Vec<DnfOption>,
+    pub location: DeclarationLocation,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DnfEndpointKind {
+    Metalink,
+    Mirrorlist,
+    Baseurl,
+}
+
+impl DnfRepository {
+    /// DNF defaults to enabled when the declaration has no explicit value.
+    pub fn explicit_enabled(&self) -> Result<Option<bool>> {
+        let option = self
+            .options
+            .iter()
+            .rev()
+            .find(|option| option.name == DnfOptionName::Enabled);
+        option
+            .map(|option| {
+                parse_bool(
+                    DeclarationEcosystem::Dnf,
+                    &option.location.path,
+                    option.location.line,
+                    &option.raw_value,
+                )
+            })
+            .transpose()
+    }
+
+    pub fn endpoint_values(&self) -> impl Iterator<Item = &DnfOption> {
+        self.options.iter().filter(|option| {
+            matches!(
+                option.name,
+                DnfOptionName::Baseurl | DnfOptionName::Mirrorlist | DnfOptionName::Metalink
+            )
+        })
+    }
+
+    /// Mirrors DNF5's endpoint precedence: metalink, mirrorlist, then baseurl.
+    pub fn effective_endpoint(&self) -> Option<(DnfEndpointKind, &str)> {
+        [
+            (DnfEndpointKind::Metalink, DnfOptionName::Metalink),
+            (DnfEndpointKind::Mirrorlist, DnfOptionName::Mirrorlist),
+            (DnfEndpointKind::Baseurl, DnfOptionName::Baseurl),
+        ]
+        .into_iter()
+        .find_map(|(kind, name)| {
+            self.options
+                .iter()
+                .rev()
+                .find(|option| option.name == name && !option.raw_value.trim().is_empty())
+                .and_then(|option| {
+                    let value = if kind == DnfEndpointKind::Baseurl {
+                        option.raw_value.split_whitespace().next()
+                    } else {
+                        Some(option.raw_value.trim())
+                    }?;
+                    Some((kind, value))
+                })
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DnfRepoDocument {
+    pub path: PathBuf,
+    pub source: String,
+    pub repositories: Vec<DnfRepository>,
+}
+
+impl DnfRepoDocument {
+    pub fn parse(path: impl Into<PathBuf>, source: &str) -> Result<Self> {
+        let path = path.into();
+        let ini = IniDocument::parse(DeclarationEcosystem::Dnf, &path, source)?;
+        let mut repositories: Vec<DnfRepository> = Vec::new();
+        for section in ini.sections {
+            let target = if let Some(index) = repositories
+                .iter()
+                .position(|repository| repository.id == section.name)
+            {
+                &mut repositories[index]
+            } else {
+                repositories.push(DnfRepository {
+                    id: section.name,
+                    options: Vec::new(),
+                    location: section.location,
+                });
+                repositories.last_mut().expect("repository was pushed")
+            };
+            for entry in section.entries {
+                target.options.push(DnfOption {
+                    name: option_name(&path, &entry.key, entry.location.line)?,
+                    raw_value: entry.value,
+                    location: entry.location,
+                });
+            }
+        }
+        for repository in &repositories {
+            validate_booleans(repository)?;
+            validate_numeric(repository, DnfOptionName::Priority, "priority")?;
+            validate_numeric(repository, DnfOptionName::Cost, "cost")?;
+        }
+        Ok(Self {
+            path: ini.path,
+            source: ini.source,
+            repositories,
+        })
+    }
+
+    pub fn render_preserved(&self) -> &str {
+        &self.source
+    }
+}
+
+fn validate_numeric(repository: &DnfRepository, name: DnfOptionName, label: &str) -> Result<()> {
+    for option in repository
+        .options
+        .iter()
+        .filter(|option| option.name == name)
+    {
+        option.raw_value.parse::<i32>().map_err(|_| {
+            DeclarationError::syntax(
+                DeclarationEcosystem::Dnf,
+                &option.location.path,
+                option.location.line,
+                format!("invalid {label} value '{}'", option.raw_value),
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn validate_booleans(repository: &DnfRepository) -> Result<()> {
+    for option in &repository.options {
+        if matches!(
+            option.name,
+            DnfOptionName::Enabled
+                | DnfOptionName::Fastestmirror
+                | DnfOptionName::PkgGpgcheck
+                | DnfOptionName::Gpgcheck
+                | DnfOptionName::RepoGpgcheck
+                | DnfOptionName::Enablegroups
+                | DnfOptionName::ModuleHotfixes
+                | DnfOptionName::Sslverify
+                | DnfOptionName::ProxySslverify
+                | DnfOptionName::Deltarpm
+                | DnfOptionName::SkipIfUnavailable
+                | DnfOptionName::Countme
+                | DnfOptionName::BuildCache
+        ) {
+            parse_bool(
+                DeclarationEcosystem::Dnf,
+                &option.location.path,
+                option.location.line,
+                &option.raw_value,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn option_name(path: &Path, key: &str, line: usize) -> Result<DnfOptionName> {
+    let name = match key {
+        "name" => DnfOptionName::Name,
+        "enabled" => DnfOptionName::Enabled,
+        "cachedir" => DnfOptionName::Cachedir,
+        "baseurl" => DnfOptionName::Baseurl,
+        "mirrorlist" => DnfOptionName::Mirrorlist,
+        "metalink" => DnfOptionName::Metalink,
+        "type" => DnfOptionName::Type,
+        "mediaid" => DnfOptionName::Mediaid,
+        "gpgkey" => DnfOptionName::Gpgkey,
+        "excludepkgs" => DnfOptionName::Excludepkgs,
+        "exclude" => DnfOptionName::Exclude,
+        "includepkgs" => DnfOptionName::Includepkgs,
+        "fastestmirror" => DnfOptionName::Fastestmirror,
+        "proxy" => DnfOptionName::Proxy,
+        "proxy_username" => DnfOptionName::ProxyUsername,
+        "proxy_password" => DnfOptionName::ProxyPassword,
+        "proxy_auth_method" => DnfOptionName::ProxyAuthMethod,
+        "username" => DnfOptionName::Username,
+        "password" => DnfOptionName::Password,
+        "protected_packages" => DnfOptionName::ProtectedPackages,
+        "pkg_gpgcheck" => DnfOptionName::PkgGpgcheck,
+        "gpgcheck" => DnfOptionName::Gpgcheck,
+        "repo_gpgcheck" => DnfOptionName::RepoGpgcheck,
+        "enablegroups" => DnfOptionName::Enablegroups,
+        "retries" => DnfOptionName::Retries,
+        "bandwidth" => DnfOptionName::Bandwidth,
+        "minrate" => DnfOptionName::Minrate,
+        "ip_resolve" => DnfOptionName::IpResolve,
+        "throttle" => DnfOptionName::Throttle,
+        "timeout" => DnfOptionName::Timeout,
+        "max_parallel_downloads" => DnfOptionName::MaxParallelDownloads,
+        "max_downloads_per_mirror" => DnfOptionName::MaxDownloadsPerMirror,
+        "metadata_expire" => DnfOptionName::MetadataExpire,
+        "cost" => DnfOptionName::Cost,
+        "priority" => DnfOptionName::Priority,
+        "module_hotfixes" => DnfOptionName::ModuleHotfixes,
+        "sslcacert" => DnfOptionName::Sslcacert,
+        "sslverify" => DnfOptionName::Sslverify,
+        "sslclientcert" => DnfOptionName::Sslclientcert,
+        "sslclientkey" => DnfOptionName::Sslclientkey,
+        "proxy_sslcacert" => DnfOptionName::ProxySslcacert,
+        "proxy_sslverify" => DnfOptionName::ProxySslverify,
+        "proxy_sslclientcert" => DnfOptionName::ProxySslclientcert,
+        "proxy_sslclientkey" => DnfOptionName::ProxySslclientkey,
+        "deltarpm" => DnfOptionName::Deltarpm,
+        "deltarpm_percentage" => DnfOptionName::DeltarpmPercentage,
+        "skip_if_unavailable" => DnfOptionName::SkipIfUnavailable,
+        "enabled_metadata" => DnfOptionName::EnabledMetadata,
+        "user_agent" => DnfOptionName::UserAgent,
+        "countme" => DnfOptionName::Countme,
+        "build_cache" => DnfOptionName::BuildCache,
+        _ => {
+            return Err(DeclarationError::unknown(
+                DeclarationEcosystem::Dnf,
+                path,
+                line,
+                format!("unmodeled DNF repository option '{key}'"),
+            ));
+        }
+    };
+    Ok(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_comments_continuations_duplicates_and_disabled_state() {
+        let source = "# vendor\n[vendor]\nname = Vendor $releasever\nenabled = 0\nbaseurl = https://one.example/$basearch\n https://two.example/$basearch\nexclude = old-*\nexclude = broken-*\npriority = 20\n";
+        let document = DnfRepoDocument::parse("/etc/yum.repos.d/vendor.repo", source).unwrap();
+        assert_eq!(document.render_preserved(), source);
+        assert_eq!(document.repositories.len(), 1);
+        assert_eq!(
+            document.repositories[0].explicit_enabled().unwrap(),
+            Some(false)
+        );
+        assert_eq!(
+            document.repositories[0]
+                .options
+                .iter()
+                .filter(|option| matches!(option.name, DnfOptionName::Exclude))
+                .count(),
+            2
+        );
+        assert!(document.repositories[0].options[2].raw_value.contains('\n'));
+        assert_eq!(
+            document.repositories[0].effective_endpoint(),
+            Some((DnfEndpointKind::Baseurl, "https://one.example/$basearch"))
+        );
+    }
+
+    #[test]
+    fn unknown_option_fails_closed() {
+        let error =
+            DnfRepoDocument::parse("/etc/yum.repos.d/a.repo", "[a]\nfuture=1\n").unwrap_err();
+        assert_eq!(
+            error.kind,
+            super::super::DeclarationErrorKind::UnknownAuthority
+        );
+    }
+
+    #[test]
+    fn endpoint_precedence_matches_dnf5() {
+        let document = DnfRepoDocument::parse(
+            "/etc/yum.repos.d/a.repo",
+            "[a]\nbaseurl=https://a\nmetalink=https://m\n",
+        )
+        .unwrap();
+        assert_eq!(
+            document.repositories[0].effective_endpoint().unwrap().0,
+            DnfEndpointKind::Metalink
+        );
+    }
+}

--- a/crates/conary-core/src/repository/declarations/ini.rs
+++ b/crates/conary-core/src/repository/declarations/ini.rs
@@ -1,0 +1,170 @@
+// conary-core/src/repository/declarations/ini.rs
+
+//! Private lossless INI lexer shared by the distinct DNF and libzypp models.
+
+use super::{DeclarationEcosystem, DeclarationError, DeclarationLocation, Result};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IniDocument {
+    pub source: String,
+    pub path: PathBuf,
+    pub sections: Vec<IniSection>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IniSection {
+    pub name: String,
+    pub location: DeclarationLocation,
+    pub entries: Vec<IniEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IniEntry {
+    pub key: String,
+    pub value: String,
+    pub location: DeclarationLocation,
+}
+
+impl IniDocument {
+    pub fn parse(ecosystem: DeclarationEcosystem, path: &Path, source: &str) -> Result<Self> {
+        let mut sections: Vec<IniSection> = Vec::new();
+        let mut current_section: Option<usize> = None;
+        let mut current_entry: Option<(usize, usize)> = None;
+
+        for (index, raw_line) in source.lines().enumerate() {
+            let line_number = index + 1;
+            let line = raw_line.trim_end_matches('\r');
+            let trimmed = line.trim();
+            let zypper = matches!(
+                ecosystem,
+                DeclarationEcosystem::ZypperRepository | DeclarationEcosystem::ZypperService
+            );
+            if line.is_empty()
+                || line.starts_with('#')
+                || line.starts_with(';')
+                || (zypper && (trimmed.starts_with('#') || trimmed.starts_with(';')))
+            {
+                if !zypper {
+                    current_entry = None;
+                }
+                continue;
+            }
+
+            if trimmed.is_empty() {
+                if !zypper {
+                    current_entry = None;
+                }
+                continue;
+            }
+
+            if trimmed.starts_with('[') {
+                let closing = trimmed.find(']').ok_or_else(|| {
+                    DeclarationError::syntax(
+                        ecosystem,
+                        path,
+                        line_number,
+                        "section header is missing ']'",
+                    )
+                })?;
+                let name = &trimmed[1..closing];
+                if name.is_empty() {
+                    return Err(DeclarationError::syntax(
+                        ecosystem,
+                        path,
+                        line_number,
+                        "section name is empty",
+                    ));
+                }
+                let trailing = trimmed[closing + 1..].trim();
+                if !trailing.is_empty() && !trailing.starts_with('#') && !trailing.starts_with(';')
+                {
+                    return Err(DeclarationError::syntax(
+                        ecosystem,
+                        path,
+                        line_number,
+                        "non-comment text follows section header",
+                    ));
+                }
+                sections.push(IniSection {
+                    name: name.to_string(),
+                    location: DeclarationLocation::new(path, line_number),
+                    entries: Vec::new(),
+                });
+                current_section = Some(sections.len() - 1);
+                current_entry = None;
+                continue;
+            }
+
+            let zypper_url_continuation = ecosystem == DeclarationEcosystem::ZypperRepository
+                && !trimmed.contains('=')
+                && current_entry.is_some_and(|(section_index, entry_index)| {
+                    matches!(
+                        sections[section_index].entries[entry_index].key.as_str(),
+                        "baseurl" | "gpgkey" | "mirrorlist" | "metalink"
+                    )
+                });
+            if (!zypper && (line.starts_with(' ') || line.starts_with('\t')))
+                || zypper_url_continuation
+            {
+                let (section_index, entry_index) = current_entry.ok_or_else(|| {
+                    DeclarationError::syntax(
+                        ecosystem,
+                        path,
+                        line_number,
+                        "continuation line has no preceding option",
+                    )
+                })?;
+                sections[section_index].entries[entry_index]
+                    .value
+                    .push_str(&format!("\n{trimmed}"));
+                continue;
+            }
+
+            let section_index = current_section.ok_or_else(|| {
+                DeclarationError::syntax(
+                    ecosystem,
+                    path,
+                    line_number,
+                    "option appears before the first section",
+                )
+            })?;
+            let (key, value) = line.split_once('=').ok_or_else(|| {
+                DeclarationError::syntax(ecosystem, path, line_number, "option is missing '='")
+            })?;
+            let key = key.trim_end();
+            if key.is_empty() {
+                return Err(DeclarationError::syntax(
+                    ecosystem,
+                    path,
+                    line_number,
+                    "option name is empty",
+                ));
+            }
+            sections[section_index].entries.push(IniEntry {
+                key: key.to_string(),
+                value: trim_ini_value(value, ecosystem == DeclarationEcosystem::Dnf),
+                location: DeclarationLocation::new(path, line_number),
+            });
+            current_entry = Some((section_index, sections[section_index].entries.len() - 1));
+        }
+
+        Ok(Self {
+            source: source.to_string(),
+            path: path.to_path_buf(),
+            sections,
+        })
+    }
+}
+
+fn trim_ini_value(value: &str, strip_quotes: bool) -> String {
+    let value = value.trim();
+    if strip_quotes && value.len() >= 2 {
+        let first = value.as_bytes()[0];
+        let last = value.as_bytes()[value.len() - 1];
+        if matches!(first, b'\'' | b'"') && first == last {
+            return value[1..value.len() - 1].to_string();
+        }
+    }
+    value.to_string()
+}

--- a/crates/conary-core/src/repository/declarations/mod.rs
+++ b/crates/conary-core/src/repository/declarations/mod.rs
@@ -1,0 +1,176 @@
+// conary-core/src/repository/declarations/mod.rs
+
+//! Lossless, ecosystem-owned native repository declarations.
+//!
+//! These types are discovery inputs. They preserve source syntax and expose
+//! source-specific semantics, but they do not import trust, enable a
+//! repository, or persist takeover authority.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+pub mod alpm;
+pub mod apt;
+pub mod discovery;
+pub mod dnf;
+mod ini;
+pub mod zypper;
+
+#[cfg(test)]
+mod contract_tests;
+
+pub use discovery::{DiscoveredRepositoryDeclarations, discover_selected_root};
+
+/// The exact native grammar that rejected a declaration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DeclarationEcosystem {
+    Apt,
+    Dnf,
+    ZypperRepository,
+    ZypperService,
+    Alpm,
+}
+
+impl fmt::Display for DeclarationEcosystem {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Apt => "apt",
+            Self::Dnf => "dnf",
+            Self::ZypperRepository => "zypper-repository",
+            Self::ZypperService => "zypper-service",
+            Self::Alpm => "alpm",
+        })
+    }
+}
+
+/// Stable machine-readable declaration failure class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DeclarationErrorKind {
+    Io,
+    InvalidUtf8,
+    Syntax,
+    UnknownAuthority,
+    PathEscape,
+    IncludeDepth,
+}
+
+/// A source-attributed native declaration failure.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeclarationError {
+    pub ecosystem: DeclarationEcosystem,
+    pub kind: DeclarationErrorKind,
+    pub path: PathBuf,
+    pub line: Option<usize>,
+    pub message: String,
+}
+
+impl DeclarationError {
+    pub(crate) fn new(
+        ecosystem: DeclarationEcosystem,
+        kind: DeclarationErrorKind,
+        path: impl Into<PathBuf>,
+        line: Option<usize>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            ecosystem,
+            kind,
+            path: path.into(),
+            line,
+            message: message.into(),
+        }
+    }
+
+    pub(crate) fn syntax(
+        ecosystem: DeclarationEcosystem,
+        path: impl Into<PathBuf>,
+        line: usize,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::new(
+            ecosystem,
+            DeclarationErrorKind::Syntax,
+            path,
+            Some(line),
+            message,
+        )
+    }
+
+    pub(crate) fn unknown(
+        ecosystem: DeclarationEcosystem,
+        path: impl Into<PathBuf>,
+        line: usize,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::new(
+            ecosystem,
+            DeclarationErrorKind::UnknownAuthority,
+            path,
+            Some(line),
+            message,
+        )
+    }
+}
+
+impl fmt::Display for DeclarationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{} repository declaration {:?} error at {}",
+            self.ecosystem,
+            self.kind,
+            self.path.display()
+        )?;
+        if let Some(line) = self.line {
+            write!(formatter, ":{line}")?;
+        }
+        write!(formatter, ": {}", self.message)
+    }
+}
+
+impl std::error::Error for DeclarationError {}
+
+pub type Result<T> = std::result::Result<T, DeclarationError>;
+
+/// Exact source location for one authority-bearing declaration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeclarationLocation {
+    pub path: PathBuf,
+    pub line: usize,
+}
+
+impl DeclarationLocation {
+    pub(crate) fn new(path: &Path, line: usize) -> Self {
+        Self {
+            path: path.to_path_buf(),
+            line,
+        }
+    }
+}
+
+pub(crate) fn split_words(value: &str) -> Vec<String> {
+    value.split_whitespace().map(ToOwned::to_owned).collect()
+}
+
+pub(crate) fn parse_bool(
+    ecosystem: DeclarationEcosystem,
+    path: &Path,
+    line: usize,
+    value: &str,
+) -> Result<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "yes" | "true" | "on" => Ok(true),
+        "0" | "no" | "false" | "off" => Ok(false),
+        _ => Err(DeclarationError::syntax(
+            ecosystem,
+            path,
+            line,
+            format!("invalid boolean value '{value}'"),
+        )),
+    }
+}

--- a/crates/conary-core/src/repository/declarations/zypper.rs
+++ b/crates/conary-core/src/repository/declarations/zypper.rs
@@ -1,0 +1,401 @@
+// conary-core/src/repository/declarations/zypper.rs
+
+//! libzypp `.repo` and `.service` declaration authority.
+
+use super::ini::IniDocument;
+use super::{
+    DeclarationEcosystem, DeclarationError, DeclarationErrorKind, DeclarationLocation, Result,
+};
+use serde::{Deserialize, Serialize};
+use std::path::{Component, Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ZypperRepositoryOptionName {
+    Name,
+    Enabled,
+    Priority,
+    Path,
+    Type,
+    Autorefresh,
+    Gpgcheck,
+    RepoGpgcheck,
+    PkgGpgcheck,
+    Keeppackages,
+    Service,
+    Proxy,
+    Baseurl,
+    Gpgkey,
+    Mirrorlist,
+    Metalink,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "disposition", rename_all = "kebab-case")]
+pub enum ZypperRepositoryOption {
+    Known {
+        name: ZypperRepositoryOptionName,
+        raw_value: String,
+        location: DeclarationLocation,
+    },
+    /// libzypp preserves and re-emits unknown repository keys.
+    Uninterpreted {
+        key: String,
+        raw_value: String,
+        location: DeclarationLocation,
+    },
+}
+
+impl ZypperRepositoryOption {
+    fn known(&self) -> Option<(ZypperRepositoryOptionName, &str, &DeclarationLocation)> {
+        match self {
+            Self::Known {
+                name,
+                raw_value,
+                location,
+            } => Some((*name, raw_value, location)),
+            Self::Uninterpreted { .. } => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ZypperRepository {
+    pub alias: String,
+    pub options: Vec<ZypperRepositoryOption>,
+    pub location: DeclarationLocation,
+}
+
+impl ZypperRepository {
+    pub fn has_uninterpreted_authority(&self) -> bool {
+        self.options
+            .iter()
+            .any(|option| matches!(option, ZypperRepositoryOption::Uninterpreted { .. }))
+    }
+
+    pub fn explicit_enabled(&self) -> Result<Option<bool>> {
+        Ok(self
+            .options
+            .iter()
+            .rev()
+            .filter_map(ZypperRepositoryOption::known)
+            .find(|(name, _, _)| *name == ZypperRepositoryOptionName::Enabled)
+            .map(|(_, value, _)| zypper_true(value)))
+    }
+
+    pub fn require_interpreted_authority(&self) -> Result<()> {
+        if let Some(ZypperRepositoryOption::Uninterpreted { key, location, .. }) = self
+            .options
+            .iter()
+            .find(|option| matches!(option, ZypperRepositoryOption::Uninterpreted { .. }))
+        {
+            return Err(DeclarationError::unknown(
+                DeclarationEcosystem::ZypperRepository,
+                &location.path,
+                location.line,
+                format!("unmodeled libzypp repository option '{key}'"),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ZypperRepoDocument {
+    pub path: PathBuf,
+    pub source: String,
+    pub repositories: Vec<ZypperRepository>,
+}
+
+impl ZypperRepoDocument {
+    pub fn parse(path: impl Into<PathBuf>, source: &str) -> Result<Self> {
+        let path = path.into();
+        let ini = IniDocument::parse(DeclarationEcosystem::ZypperRepository, &path, source)?;
+        let mut repositories: Vec<ZypperRepository> = Vec::new();
+        for section in ini.sections {
+            let repository = if let Some(index) = repositories
+                .iter()
+                .position(|repository| repository.alias == section.name)
+            {
+                &mut repositories[index]
+            } else {
+                repositories.push(ZypperRepository {
+                    alias: section.name,
+                    options: Vec::new(),
+                    location: section.location,
+                });
+                repositories.last_mut().expect("repository was pushed")
+            };
+            for entry in section.entries {
+                let option = match repository_option_name(&entry.key) {
+                    Some(name) => ZypperRepositoryOption::Known {
+                        name,
+                        raw_value: entry.value,
+                        location: entry.location,
+                    },
+                    None => ZypperRepositoryOption::Uninterpreted {
+                        key: entry.key,
+                        raw_value: entry.value,
+                        location: entry.location,
+                    },
+                };
+                repository.options.push(option);
+            }
+        }
+        for repository in &repositories {
+            validate_repository(repository)?;
+        }
+        Ok(Self {
+            path: ini.path,
+            source: ini.source,
+            repositories,
+        })
+    }
+
+    pub fn render_preserved(&self) -> &str {
+        &self.source
+    }
+}
+
+fn validate_repository(repository: &ZypperRepository) -> Result<()> {
+    for (name, value, location) in repository
+        .options
+        .iter()
+        .filter_map(ZypperRepositoryOption::known)
+    {
+        if name == ZypperRepositoryOptionName::Path
+            && Path::new(value)
+                .components()
+                .any(|component| component == Component::ParentDir)
+        {
+            return Err(DeclarationError::new(
+                DeclarationEcosystem::ZypperRepository,
+                DeclarationErrorKind::PathEscape,
+                &location.path,
+                Some(location.line),
+                format!("repository path contains a parent component: '{value}'"),
+            ));
+        }
+        if name == ZypperRepositoryOptionName::Priority {
+            value.parse::<u32>().map_err(|_| {
+                DeclarationError::syntax(
+                    DeclarationEcosystem::ZypperRepository,
+                    &location.path,
+                    location.line,
+                    format!("invalid priority value '{value}'"),
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn repository_option_name(key: &str) -> Option<ZypperRepositoryOptionName> {
+    Some(match key {
+        "name" => ZypperRepositoryOptionName::Name,
+        "enabled" => ZypperRepositoryOptionName::Enabled,
+        "priority" => ZypperRepositoryOptionName::Priority,
+        "path" => ZypperRepositoryOptionName::Path,
+        "type" => ZypperRepositoryOptionName::Type,
+        "autorefresh" => ZypperRepositoryOptionName::Autorefresh,
+        "gpgcheck" => ZypperRepositoryOptionName::Gpgcheck,
+        "repo_gpgcheck" => ZypperRepositoryOptionName::RepoGpgcheck,
+        "pkg_gpgcheck" => ZypperRepositoryOptionName::PkgGpgcheck,
+        "keeppackages" => ZypperRepositoryOptionName::Keeppackages,
+        "service" => ZypperRepositoryOptionName::Service,
+        "proxy" => ZypperRepositoryOptionName::Proxy,
+        "baseurl" => ZypperRepositoryOptionName::Baseurl,
+        "gpgkey" => ZypperRepositoryOptionName::Gpgkey,
+        "mirrorlist" => ZypperRepositoryOptionName::Mirrorlist,
+        "metalink" => ZypperRepositoryOptionName::Metalink,
+        _ => return None,
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ZypperServiceOptionName {
+    Name,
+    Url,
+    Enabled,
+    Autorefresh,
+    Type,
+    TtlSec,
+    LrfDat,
+    ReposToEnable,
+    ReposToDisable,
+    RepositoryUrl { index: u32 },
+    RepositoryEnabled { index: u32 },
+    RepositoryAutorefresh { index: u32 },
+    RepositoryPriority { index: u32 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ZypperServiceOption {
+    pub name: ZypperServiceOptionName,
+    pub raw_value: String,
+    pub location: DeclarationLocation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ZypperService {
+    pub alias: String,
+    pub options: Vec<ZypperServiceOption>,
+    pub location: DeclarationLocation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ZypperServiceDocument {
+    pub path: PathBuf,
+    pub source: String,
+    pub services: Vec<ZypperService>,
+}
+
+impl ZypperServiceDocument {
+    pub fn parse(path: impl Into<PathBuf>, source: &str) -> Result<Self> {
+        let path = path.into();
+        let ini = IniDocument::parse(DeclarationEcosystem::ZypperService, &path, source)?;
+        let mut services: Vec<ZypperService> = Vec::new();
+        for section in ini.sections {
+            let service = if let Some(index) = services
+                .iter()
+                .position(|service| service.alias == section.name)
+            {
+                &mut services[index]
+            } else {
+                services.push(ZypperService {
+                    alias: section.name,
+                    options: Vec::new(),
+                    location: section.location,
+                });
+                services.last_mut().expect("service was pushed")
+            };
+            for entry in section.entries {
+                let name = service_option_name(&path, &entry.key, entry.location.line)?;
+                if matches!(
+                    name,
+                    ZypperServiceOptionName::TtlSec
+                        | ZypperServiceOptionName::RepositoryPriority { .. }
+                ) {
+                    entry.value.parse::<u64>().map_err(|_| {
+                        DeclarationError::syntax(
+                            DeclarationEcosystem::ZypperService,
+                            &entry.location.path,
+                            entry.location.line,
+                            format!("invalid numeric value '{}'", entry.value),
+                        )
+                    })?;
+                }
+                service.options.push(ZypperServiceOption {
+                    name,
+                    raw_value: entry.value,
+                    location: entry.location,
+                });
+            }
+        }
+        Ok(Self {
+            path: ini.path,
+            source: ini.source,
+            services,
+        })
+    }
+
+    pub fn render_preserved(&self) -> &str {
+        &self.source
+    }
+}
+
+fn service_option_name(path: &Path, key: &str, line: usize) -> Result<ZypperServiceOptionName> {
+    let fixed = match key {
+        "name" => Some(ZypperServiceOptionName::Name),
+        "url" => Some(ZypperServiceOptionName::Url),
+        "enabled" => Some(ZypperServiceOptionName::Enabled),
+        "autorefresh" => Some(ZypperServiceOptionName::Autorefresh),
+        "type" => Some(ZypperServiceOptionName::Type),
+        "ttl_sec" => Some(ZypperServiceOptionName::TtlSec),
+        "lrf_dat" => Some(ZypperServiceOptionName::LrfDat),
+        "repostoenable" => Some(ZypperServiceOptionName::ReposToEnable),
+        "repostodisable" => Some(ZypperServiceOptionName::ReposToDisable),
+        _ => None,
+    };
+    if let Some(name) = fixed {
+        return Ok(name);
+    }
+    if let Some(dynamic) = key.strip_prefix("repo_") {
+        let (index, suffix) = dynamic
+            .split_once('_')
+            .map_or((dynamic, ""), |(index, suffix)| (index, suffix));
+        if let Ok(index) = index.parse::<u32>() {
+            let name = match suffix {
+                "" => Some(ZypperServiceOptionName::RepositoryUrl { index }),
+                "enabled" => Some(ZypperServiceOptionName::RepositoryEnabled { index }),
+                "autorefresh" => Some(ZypperServiceOptionName::RepositoryAutorefresh { index }),
+                "priority" => Some(ZypperServiceOptionName::RepositoryPriority { index }),
+                _ => None,
+            };
+            if let Some(name) = name {
+                return Ok(name);
+            }
+        }
+    }
+    Err(DeclarationError::unknown(
+        DeclarationEcosystem::ZypperService,
+        path,
+        line,
+        format!("unmodeled libzypp service option '{key}'"),
+    ))
+}
+
+fn zypper_true(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "yes" | "true" | "always" | "on" | "+"
+    ) || value.trim().parse::<i64>().is_ok_and(|number| number != 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repository_preserves_repeatable_urls_and_upstream_extras() {
+        let source = "# vendor\n[vendor]\nenabled=0\nbaseurl=https://one\nbaseurl=https://two\nx-vendor=value\n";
+        let document = ZypperRepoDocument::parse("/etc/zypp/repos.d/vendor.repo", source).unwrap();
+        assert_eq!(document.render_preserved(), source);
+        assert_eq!(
+            document.repositories[0].explicit_enabled().unwrap(),
+            Some(false)
+        );
+        assert!(document.repositories[0].has_uninterpreted_authority());
+    }
+
+    #[test]
+    fn service_models_dynamic_repository_fields() {
+        let source = "[vendor]\nurl=https://service\nrepo_1=https://repo\nrepo_1_enabled=yes\n";
+        let document =
+            ZypperServiceDocument::parse("/etc/zypp/services.d/vendor.service", source).unwrap();
+        assert_eq!(document.render_preserved(), source);
+        assert!(matches!(
+            document.services[0].options[2].name,
+            ZypperServiceOptionName::RepositoryEnabled { index: 1 }
+        ));
+    }
+
+    #[test]
+    fn unknown_service_authority_fails_closed() {
+        let error = ZypperServiceDocument::parse(
+            "/etc/zypp/services.d/vendor.service",
+            "[vendor]\nfuture=value\n",
+        )
+        .unwrap_err();
+        assert_eq!(
+            error.kind,
+            super::super::DeclarationErrorKind::UnknownAuthority
+        );
+    }
+}

--- a/crates/conary-core/src/repository/mod.rs
+++ b/crates/conary-core/src/repository/mod.rs
@@ -31,6 +31,7 @@ pub mod supported_profiles;
 mod sync;
 pub mod trust;
 
+pub mod declarations;
 pub mod dependency_model;
 pub mod effective_policy;
 pub mod package_relation;

--- a/crates/conary-core/tests/fixtures/repository_declarations/apt-vendor.list
+++ b/crates/conary-core/tests/fixtures/repository_declarations/apt-vendor.list
@@ -1,0 +1,3 @@
+# APT one-line syntax: commented entries are disabled.
+# deb [arch=amd64 signed-by=/usr/share/keyrings/vendor.gpg] https://apt.example stable main
+deb-src [arch=arm64] https://apt.example stable main contrib # source packages

--- a/crates/conary-core/tests/fixtures/repository_declarations/apt-vendor.sources
+++ b/crates/conary-core/tests/fixtures/repository_declarations/apt-vendor.sources
@@ -1,0 +1,12 @@
+Types: deb deb-src
+URIs: https://apt.example
+Suites: stable updates
+Components: main contrib
+Architectures: amd64 arm64
+Architectures-Remove: i386
+Signed-By:
+ -----BEGIN PGP PUBLIC KEY BLOCK-----
+ .
+ -----END PGP PUBLIC KEY BLOCK-----
+Enabled: no
+X-Conary-Fixture: preserved annotation

--- a/crates/conary-core/tests/fixtures/repository_declarations/dnf-vendor.repo
+++ b/crates/conary-core/tests/fixtures/repository_declarations/dnf-vendor.repo
@@ -1,0 +1,12 @@
+# DNF5 preserves comments and continuation lines.
+[vendor]
+name=Vendor $releasever - $basearch
+enabled=0
+baseurl=https://one.example/$basearch
+ https://two.example/$basearch
+mirrorlist=https://mirrors.example/list
+metalink=https://mirrors.example/meta
+gpgkey=file:///etc/pki/rpm-gpg/VENDOR
+exclude=old-*
+exclude=broken-*
+priority=20

--- a/crates/conary-core/tests/fixtures/repository_declarations/pacman.conf
+++ b/crates/conary-core/tests/fixtures/repository_declarations/pacman.conf
@@ -1,0 +1,10 @@
+# ALPM repository declaration fields retain order and variables.
+[options]
+Architecture = auto
+SigLevel = Required DatabaseOptional
+Color
+
+[core]
+Server = https://mirror.example/$repo/os/$arch
+CacheServer = https://cache.example/$repo/os/$arch
+Usage = Sync Search Install Upgrade

--- a/crates/conary-core/tests/fixtures/repository_declarations/zypper-vendor.repo
+++ b/crates/conary-core/tests/fixtures/repository_declarations/zypper-vendor.repo
@@ -1,0 +1,10 @@
+# libzypp permits repeated and whitespace-separated URL declarations.
+[vendor]
+name=Vendor
+enabled=0
+autorefresh=1
+baseurl=https://one.example
+ https://two.example, https://three.example
+gpgkey=https://keys.example/vendor.asc
+priority=90
+x-vendor-preserved=opaque

--- a/crates/conary-core/tests/fixtures/repository_declarations/zypper-vendor.service
+++ b/crates/conary-core/tests/fixtures/repository_declarations/zypper-vendor.service
@@ -1,0 +1,10 @@
+[vendor]
+name=Vendor service
+url=https://service.example/index
+enabled=1
+autorefresh=1
+ttl_sec=3600
+repo_1=vendor-stable
+repo_1_enabled=1
+repo_1_autorefresh=0
+repo_1_priority=90

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -146,6 +146,7 @@ crates/conary-core/      Core library crate
     |   +-- conflict.rs  Conflict reporting and policy support
     |   +-- identity.rs  Dependency identity normalization
     +-- repository/      Remote package sources
+    |   +-- declarations/ Lossless selected-root APT, DNF5, libzypp, and ALPM declarations
     |   +-- static_repo/ Static repository format, publishing, sync, and key persistence
     |   +-- trust.rs     Tagged Debian, RPM, and Arch repository authority contracts
     |   +-- trust/openpgp.rs Trust-role dispatch over the pinned and Arch keyring owners

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -112,10 +112,12 @@ commands.
 - Declarative models, source selection, and replatforming:
   `docs/modules/feature-ownership.md` slug `model`, plus
   `docs/modules/source-selection.md`.
-- Native repository trust, authenticated metadata/package intake, typed
+- Native repository declarations, trust, authenticated metadata/package intake, typed
   package relations, provider matching, and SAT selection:
   `docs/modules/feature-ownership.md` slug `resolution`, plus
-  `docs/modules/source-selection.md`. Trust starts in
+  `docs/modules/source-selection.md`. Lossless selected-root declaration
+  discovery starts in `crates/conary-core/src/repository/declarations/` and its
+  pinned contract is `docs/specs/native-repository-declarations.md`. Trust starts in
   `crates/conary-core/src/repository/trust.rs` and
   `crates/conary-core/src/repository/trust/openpgp.rs`, with ALPM keyring and
   package-signature semantics in

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -439,6 +439,8 @@ providers through the SAT solver, and carry the selected relation graph into
 package transactions.
 
 **Start here:** `crates/conary-core/src/repository/trust.rs`;
+`crates/conary-core/src/repository/declarations/`;
+`docs/specs/native-repository-declarations.md`;
 `crates/conary-core/src/repository/trust/openpgp.rs`;
 `crates/conary-core/src/repository/trust/openpgp/arch/`;
 `crates/conary-core/src/repository/parsers/`;
@@ -471,6 +473,7 @@ selection; installed package state; model replatform planning; Remi repository
 manifests, admin routes, and hosted feed configuration.
 
 **Paths:** `crates/conary-core/src/repository/*`;
+`crates/conary-core/tests/fixtures/repository_declarations/*`;
 `crates/conary-core/tests/fixtures/rpm/*`;
 `crates/conary-core/src/resolver/*`;
 `crates/conary-core/src/transaction/package_relations.rs`;
@@ -480,6 +483,7 @@ manifests, admin routes, and hosted feed configuration.
 `crates/conary-core/src/db/models/installed_requirement_group.rs`.
 
 **Focused proof:** `cargo test -p conary-core repository::trust`;
+`cargo test -p conary-core repository::declarations`;
 `cargo test -p conary-core repository::parsers`;
 `cargo test -p conary-core repository::download`;
 `cargo test -p conary-core repository::sync`;
@@ -497,6 +501,8 @@ output changes.
 
 **Docs to update:** `docs/modules/source-selection.md`;
 `docs/llms/subsystem-map.md`; `docs/ARCHITECTURE.md`;
+`docs/specs/native-repository-declarations.md` when declaration grammar,
+selected-root discovery, or its no-enrollment boundary changes;
 `docs/specs/foreign-package-lifecycle-contracts.md` when native relation
 semantics change.
 

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-08
-revision: 31
+last_updated: 2026-08-11
+revision: 32
 summary: Document exact profile-owned source policy, multi-root model authority, Remi CCS package authority, canonical map authority, native repository authority, package identity, full-adoption root continuity, and lifecycle handoff
 ---
 
@@ -52,6 +52,7 @@ system.toml [system]
 | `DependencyMixingPolicy` | `repository/resolution_policy.rs` | Closed `strict`/`guarded`/`permissive` dependency-mixing contract |
 | `ResolutionPolicy` | `repository/resolution_policy.rs` | Exact request scope, dependency mixing, and source allowlist used by the resolver |
 | `EffectiveSourcePolicy` | `repository/effective_policy.rs` | Runtime policy assembled from DB state with one exact transaction profile |
+| `DiscoveredRepositoryDeclarations` | `repository/declarations/discovery.rs` | Lossless, source-located APT, DNF5, libzypp, and ALPM declarations confined to an explicit selected root |
 | `SystemAffinity` | `db/models/distro_pin.rs` | Informational installed-provenance measurement used for display and replatform estimates |
 | `ReplatformExecutionPlan` | `model/replatform.rs` | Executable and blocked replatform transactions derived from planned replacements |
 
@@ -214,6 +215,23 @@ disagreement rolls the whole snapshot back.
 There is no persisted per-package override table. Cross-profile movement is an
 explicit scoped request or replatform transaction, not a decorative ranking
 side channel.
+
+## Native Repository Declaration Discovery
+
+`crates/conary-core/src/repository/declarations/` owns the lossless declaration
+grammars that precede native repository enrollment. It reads APT one-line and
+deb822 sources, DNF5 repo files, libzypp repository and service files, and ALPM
+configuration with ordered includes from an explicit selected root. Documents
+retain exact source and expose typed source locations, disabled state,
+duplicates, variables, endpoint precedence, and include order. Unknown
+authority, invalid UTF-8, and root escapes fail closed; libzypp extras that
+upstream preserves are retained as uninterpreted evidence and refused by
+authoritative discovery.
+
+This layer is not trust, enrollment, persistence, or enablement authority. It
+does not invoke a native manager or read a native database. The exact upstream
+pins, grammar inventory, and consumer boundary are recorded in
+[`docs/specs/native-repository-declarations.md`](../specs/native-repository-declarations.md).
 
 ## Native Repository Authenticity
 
@@ -688,6 +706,9 @@ state requires an explicit scoped install, update, or replatform operation.
 - `crates/conary-core/src/repository/effective_policy.rs` for runtime policy loading
 - `crates/conary-core/src/repository/trust.rs` and
   `repository/trust/openpgp.rs` for native repository authority
+- `crates/conary-core/src/repository/declarations/` and
+  `docs/specs/native-repository-declarations.md` for lossless selected-root
+  declaration discovery before enrollment
 - `crates/conary-core/src/repository/parsers/` and
   `repository/download.rs` for authenticated metadata and package intake
 - `crates/conary-core/src/repository/supported_profiles/` for configured feed

--- a/docs/specs/native-repository-declarations.md
+++ b/docs/specs/native-repository-declarations.md
@@ -1,0 +1,102 @@
+---
+last_updated: 2026-08-11
+revision: 1
+summary: Pin the lossless APT, DNF5, libzypp, and ALPM native repository declaration grammars and selected-root discovery boundary
+---
+
+# Native Repository Declaration Contracts
+
+Issue #377 is the first bounded Workstream 10 conformance slice. It discovers
+the repository declarations already present in an explicitly selected root and
+decodes their source-owned syntax without invoking a native package manager or
+reading its database. This is evidence for later enrollment planning, not
+permission to import trust, enable a repository, persist it, or fetch metadata.
+
+The implementation owner is
+`crates/conary-core/src/repository/declarations/`. Each ecosystem has a distinct
+typed model. The private INI lexer is only shared mechanics; DNF5 and libzypp
+retain different comment, continuation, quoting, option, and precedence rules.
+Every UTF-8 document retains its exact source, path, ordering, comments,
+duplicates, variables, disabled state, and source locations. Rendering the
+preserved document is byte-for-byte identity.
+
+## Pinned Upstream Authority
+
+The contract was derived from these exact upstream revisions on 2026-08-11:
+
+| Ecosystem | Upstream revision | Authoritative paths |
+|---|---|---|
+| APT | [`apt-team/apt@5e6dcc8d0c8bdce61e9cc7f497abadb5349d509a`](https://salsa.debian.org/apt-team/apt/-/commit/5e6dcc8d0c8bdce61e9cc7f497abadb5349d509a) | `apt-pkg/sourcelist.cc`, `apt-pkg/deb/debmetaindex.cc`, `doc/sources.list.5.xml` |
+| DNF5 | [`rpm-software-management/dnf5@fcda6d3e34233ccfc93364f5efcc6e1d141ce41a`](https://github.com/rpm-software-management/dnf5/commit/fcda6d3e34233ccfc93364f5efcc6e1d141ce41a) | `libdnf5/utils/iniparser.cpp`, `libdnf5/conf/config_parser.cpp`, `libdnf5/repo/config_repo.cpp`, `include/libdnf5/conf/const.hpp` |
+| libzypp | [`openSUSE/libzypp@227c6725b98dbddc86652b3f6d8f761a504796f2`](https://github.com/openSUSE/libzypp/commit/227c6725b98dbddc86652b3f6d8f761a504796f2) | `zypp/parser/RepoFileReader.cc`, `zypp/parser/ServiceFileReader.cc`, `zypp/RepoInfo.cc`, `zypp/repo/RepoInfoBase.cc`, `zypp-core/parser/iniparser.cc` |
+| ALPM | [`archlinux/pacman@a6f7467d8c7c4d7e9cc846884e74c0ab7215c48d`](https://gitlab.archlinux.org/pacman/pacman/-/commit/a6f7467d8c7c4d7e9cc846884e74c0ab7215c48d) | `src/pacman/conf.c`, `doc/pacman.conf.5.asciidoc` |
+
+The former `rpm-software-management/libdnf5` location is not the current DNF5
+source repository; the pin deliberately follows the current canonical `dnf5`
+repository rather than a historical URL.
+
+## Ecosystem Models
+
+APT discovery reads `/etc/apt/sources.list` and valid ASCII
+`*.list`/`*.sources` names under `/etc/apt/sources.list.d`. The one-line and
+deb822 grammars remain distinct. Typed authority includes source kinds, URIs,
+suites, components, disabled entries, deb822 add/remove operations for
+architectures, languages, and targets, current meta-index options, `Signed-By` including an
+embedded key block, and non-authoritative deb822 annotations. Absolute suites
+ending in `/` reject components; distribution suites require them.
+
+DNF discovery reads sorted `*.repo` files from `/etc/yum.repos.d`,
+`/etc/distro.repos.d`, and `/usr/share/dnf5/repos.d`, in that order. Its typed
+options are the current `ConfigRepo`-bound fields and accepted aliases. Indented
+continuations, whole-value quoting, repeated sections and keys, variables, and
+comments remain intact. `metalink`, `mirrorlist`, and `baseurl` may coexist;
+effective endpoint precedence is exactly metalink, then mirrorlist, then the
+first base URL. Their coexistence is not a syntax error.
+
+libzypp discovery reads sorted `*.repo` and `*.service` files from
+`/etc/zypp/repos.d` and `/etc/zypp/services.d`. Repository URLs and keys retain
+repeatable and multiline forms. libzypp preserves unknown repository extras,
+so the raw model does too and marks them `Uninterpreted`; authoritative
+selected-root discovery returns a source-located `unknown-authority` error
+until an exact semantic is implemented. Services model their fixed keys and
+the numbered `repo_N` state family and reject unknown service authority.
+Parent components in a repository `path` are rejected rather than applying
+libzypp's host-oriented rewrite.
+
+ALPM discovery begins at `/etc/pacman.conf`. It models ordered `[options]` and
+repository sections, `Architecture`, global and per-repository `SigLevel`,
+`Server`, `CacheServer`, `Usage`, `$repo`/`$arch`, and `Include`. Includes are
+expanded lexically inside the selected root, sorted like the upstream glob,
+limited to ten nested files, and applied at their exact position. Included
+files inherit the current section and may change the section observed by the
+including file. Missing, cyclic, escaping, unreadable, invalid UTF-8, and
+unknown repository authority fail with typed source attribution. Unrelated
+`[options]` directives are losslessly retained but cannot become repository
+authority.
+
+## Safety And Consumer Boundary
+
+`discover_selected_root` requires a real root path and uses `safe_join` for
+every fixed path, directory entry, and include match. Symlinks and parent
+components cannot escape that root. Discovery performs filesystem reads only.
+It never executes `apt`, `dnf`, `zypper`, `pacman`, or their libraries and never
+consults their native databases.
+
+The declaration types are deliberately not `RepositoryTrustPolicy`, persisted
+repository rows, or enabled sync inputs. A later issue must combine an exact
+declaration semantic with an explicit trust-import/follow/pin decision and a
+typed plan/apply result before mutation. Distro names, file presence, URLs,
+extensions, guessed defaults, and diagnostic text cannot bridge that boundary.
+
+## Proof
+
+Source-derived fixtures live in
+`crates/conary-core/tests/fixtures/repository_declarations/`. The declaration
+contract tests prove exact rendering, disabled and duplicate preservation, all
+DNF endpoint-presence combinations, ALPM include ordering and section
+inheritance, unknown-field mutations, invalid UTF-8/path failures, and
+selected-root symlink confinement. Run:
+
+```bash
+cargo test -p conary-core repository::declarations
+```


### PR DESCRIPTION
## Problem

Workstream 10 needs source-exact native repository declaration evidence before Conary can safely plan trust import, enrollment, or additional ecosystem support. The repository previously owned authenticated metadata parsers, but it had no lossless selected-root model for the APT, DNF5, libzypp, and ALPM declarations that identify those sources.

## Solution

- add distinct typed, source-located declaration models for APT one-line/deb822, DNF5 repo files, libzypp repo/service files, and ALPM configuration/includes
- preserve exact UTF-8 source, comments, ordering, duplicates, variables, disabled state, aliases, and source locations
- confine deterministic discovery and ALPM glob expansion to an explicit selected root
- fail closed on unknown authority, invalid UTF-8, hostile paths, missing includes, cycles, and include-depth overflow
- retain libzypp repository extras as uninterpreted evidence while refusing them at the authoritative discovery boundary
- encode DNF endpoint precedence and ALPM include section inheritance from pinned upstream source
- add source-derived fixtures, combinatorial/mutation proof, and a pinned design contract
- update repository ownership and assistant routing for the new implementation boundary

This change does not import trust, enroll or enable repositories, persist repository state, fetch metadata, invoke a native package manager, or read a native package-manager database.

## Upstream pins

- APT `5e6dcc8d0c8bdce61e9cc7f497abadb5349d509a`
- DNF5 `fcda6d3e34233ccfc93364f5efcc6e1d141ce41a`
- libzypp `227c6725b98dbddc86652b3f6d8f761a504796f2`
- pacman/ALPM `a6f7467d8c7c4d7e9cc846884e74c0ab7215c48d`

## Verification

- `cargo test -p conary-core` — 3,434 passed, 3 ignored; all package integration and doc tests passed
- `cargo test -p conary-core repository::declarations --no-fail-fast` — 22 passed
- `cargo test -p conary-core repository::declarations -- --list` — all declaration tests registered
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `bash scripts/check-doc-truth.sh`
- resolution interaction gate: Conary repo, CLI, install, and conversion tests plus Remi repository-manifest and conversion tests

Closes #377
Refs #62
Refs #71
