### PR TITLE
feat(repository): plan native trust import

### DIFF
--- a/crates/conary-core/src/repository/declarations/mod.rs
+++ b/crates/conary-core/src/repository/declarations/mod.rs
@@ -15,6 +15,7 @@ pub mod apt;
 pub mod discovery;
 pub mod dnf;
 mod ini;
+pub mod trust_import;
 pub mod zypper;
 
 #[cfg(test)]

--- a/crates/conary-core/src/repository/declarations/trust_import/apt.rs
+++ b/crates/conary-core/src/repository/declarations/trust_import/apt.rs
@@ -1,0 +1,100 @@
+// conary-core/src/repository/declarations/trust_import/apt.rs
+
+use super::openpgp::collect_declared_roots;
+use super::{
+    NativeRepositoryTrustPlan, PlanFindings, TrustImportFindingKind, apt_reference, finding,
+};
+use crate::repository::TrustRole;
+use crate::repository::declarations::apt::{AptOption, AptOptionName, AptSourceEntry};
+use std::path::Path;
+
+pub(super) fn plan(
+    selected_root: &Path,
+    document: &Path,
+    entry_index: usize,
+    entry: &AptSourceEntry,
+) -> NativeRepositoryTrustPlan {
+    let mut findings = PlanFindings::default();
+    reject_bypasses(entry, &mut findings);
+    let signed_by: Vec<String> = entry
+        .options
+        .iter()
+        .filter(|option| option.name == AptOptionName::SignedBy)
+        .flat_map(|option| option.values.iter().cloned())
+        .collect();
+    let evidence = if signed_by.is_empty() {
+        findings.ambiguous(finding(
+            TrustImportFindingKind::ImplicitGlobalAuthority,
+            Some(TrustRole::DebianRelease),
+            &entry.location,
+            "APT source has no Signed-By binding and therefore inherits global native trust",
+        ));
+        Vec::new()
+    } else {
+        collect_declared_roots(
+            selected_root,
+            TrustRole::DebianRelease,
+            &signed_by,
+            &entry.location,
+            &mut findings,
+        )
+        .evidence
+    };
+    if evidence.is_empty() && findings.is_empty() {
+        findings.ambiguous(finding(
+            TrustImportFindingKind::MissingRequiredAuthority,
+            Some(TrustRole::DebianRelease),
+            &entry.location,
+            "APT source has no importable Release-signing certificate authority",
+        ));
+    }
+    NativeRepositoryTrustPlan {
+        repository: apt_reference(document, entry_index, entry),
+        enabled: Some(entry.enabled),
+        evidence,
+        disposition: findings.finish(),
+    }
+}
+
+fn reject_bypasses(entry: &AptSourceEntry, findings: &mut PlanFindings) {
+    for option in &entry.options {
+        let is_verification_option = matches!(
+            option.name,
+            AptOptionName::Trusted
+                | AptOptionName::AllowInsecure
+                | AptOptionName::AllowWeak
+                | AptOptionName::AllowDowngradeToInsecure
+        );
+        if is_verification_option {
+            match native_bool(option) {
+                Some(true) => findings.unsupported(finding(
+                    TrustImportFindingKind::VerificationDisabled,
+                    Some(TrustRole::DebianRelease),
+                    &option.location,
+                    format!(
+                        "APT option '{:?}' weakens authenticated Release authority",
+                        option.name
+                    ),
+                )),
+                Some(false) => {}
+                None => findings.unsupported(finding(
+                    TrustImportFindingKind::UnsupportedTrustValue,
+                    Some(TrustRole::DebianRelease),
+                    &option.location,
+                    format!(
+                        "APT option '{:?}' uses unsupported trust value '{}'",
+                        option.name, option.raw_value
+                    ),
+                )),
+            }
+        }
+    }
+}
+
+fn native_bool(option: &AptOption) -> Option<bool> {
+    match option.raw_value.trim().to_ascii_lowercase().as_str() {
+        "1" | "yes" | "true" | "on" => Some(true),
+        "0" | "no" | "false" | "off" => Some(false),
+        _ => None,
+    }
+}

--- a/crates/conary-core/src/repository/declarations/trust_import/mod.rs
+++ b/crates/conary-core/src/repository/declarations/trust_import/mod.rs
@@ -1,0 +1,365 @@
+// conary-core/src/repository/declarations/trust_import/mod.rs
+
+//! Fail-closed trust-import planning for native repository declarations.
+//!
+//! Planning reads only explicitly declared material below the selected root.
+//! It does not fetch keys, persist trust, enable repositories, or infer roles
+//! from names and URLs.
+
+use super::alpm::{AlpmDirective, AlpmRepositoryOptionName};
+use super::apt::AptSourceEntry;
+use super::dnf::DnfRepository;
+use super::zypper::ZypperRepository;
+use super::{DeclarationLocation, DiscoveredRepositoryDeclarations};
+use crate::repository::TrustRole;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+mod apt;
+mod openpgp;
+mod rpm;
+
+/// Exact native declaration identity. APT has no repository name, so its
+/// document path and entry index remain the identity until enrollment assigns
+/// a durable source ID.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "ecosystem", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum NativeRepositoryReference {
+    Apt {
+        document: PathBuf,
+        entry_index: usize,
+        uris: Vec<String>,
+        suites: Vec<String>,
+        location: DeclarationLocation,
+    },
+    Dnf {
+        id: String,
+        location: DeclarationLocation,
+    },
+    Zypper {
+        alias: String,
+        location: DeclarationLocation,
+    },
+    Alpm {
+        name: String,
+        location: DeclarationLocation,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum TrustEvidenceSource {
+    SelectedRootFile { path: PathBuf },
+    EmbeddedOpenPgp,
+    RpmMetalink { url: String },
+    AlpmSigLevel { values: Vec<String> },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OpenPgpCertificateEvidence {
+    pub certificate_fingerprint: String,
+    pub key_fingerprints: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OpenPgpFingerprintSelector {
+    pub fingerprint: String,
+    /// APT's trailing `!` restricts authority to the exact selected key rather
+    /// than admitting its signing subkeys.
+    pub primary_only: bool,
+}
+
+/// Exact evidence that can be carried into a later apply transaction.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TrustImportEvidence {
+    pub role: TrustRole,
+    pub source: TrustEvidenceSource,
+    pub certificates: Vec<OpenPgpCertificateEvidence>,
+    pub fingerprint_selectors: Vec<OpenPgpFingerprintSelector>,
+    pub location: DeclarationLocation,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TrustImportFindingKind {
+    ImplicitGlobalAuthority,
+    MissingRequiredAuthority,
+    UnpinnedRemoteAuthority,
+    MissingDeclaredTrustSource,
+    SelectedRootEscape,
+    MalformedOpenPgp,
+    FingerprintSelectorWithoutSource,
+    FingerprintSelectorMismatch,
+    VerificationDisabled,
+    OptionalPackageSignature,
+    TrustAll,
+    AlpmKeyringBindingMissing,
+    UnsupportedTrustValue,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TrustImportFinding {
+    pub kind: TrustImportFindingKind,
+    pub role: Option<TrustRole>,
+    pub location: DeclarationLocation,
+    pub message: String,
+}
+
+/// A plan is importable only when all required roles have exact evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum TrustImportDisposition {
+    Importable,
+    Ambiguous { findings: Vec<TrustImportFinding> },
+    Unsupported { findings: Vec<TrustImportFinding> },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NativeRepositoryTrustPlan {
+    pub repository: NativeRepositoryReference,
+    pub enabled: Option<bool>,
+    pub evidence: Vec<TrustImportEvidence>,
+    pub disposition: TrustImportDisposition,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NativeTrustImportPlan {
+    pub selected_root: PathBuf,
+    pub repositories: Vec<NativeRepositoryTrustPlan>,
+}
+
+#[derive(Default)]
+struct PlanFindings {
+    ambiguous: Vec<TrustImportFinding>,
+    unsupported: Vec<TrustImportFinding>,
+}
+
+type AlpmRepositoryState<'a> = (
+    String,
+    DeclarationLocation,
+    Option<(&'a [String], &'a DeclarationLocation)>,
+);
+
+impl PlanFindings {
+    fn ambiguous(&mut self, finding: TrustImportFinding) {
+        self.ambiguous.push(finding);
+    }
+
+    fn unsupported(&mut self, finding: TrustImportFinding) {
+        self.unsupported.push(finding);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.ambiguous.is_empty() && self.unsupported.is_empty()
+    }
+
+    fn has_role(&self, role: TrustRole) -> bool {
+        self.ambiguous
+            .iter()
+            .chain(&self.unsupported)
+            .any(|finding| finding.role == Some(role))
+    }
+
+    fn finish(mut self) -> TrustImportDisposition {
+        if !self.unsupported.is_empty() {
+            self.unsupported.append(&mut self.ambiguous);
+            TrustImportDisposition::Unsupported {
+                findings: self.unsupported,
+            }
+        } else if !self.ambiguous.is_empty() {
+            TrustImportDisposition::Ambiguous {
+                findings: self.ambiguous,
+            }
+        } else {
+            TrustImportDisposition::Importable
+        }
+    }
+}
+
+/// Produce deterministic preview data without mutating or fetching anything.
+pub fn plan_selected_root_trust(
+    declarations: &DiscoveredRepositoryDeclarations,
+) -> NativeTrustImportPlan {
+    let mut repositories = Vec::new();
+    for document in &declarations.apt {
+        for (entry_index, entry) in document.entries.iter().enumerate() {
+            repositories.push(apt::plan(
+                &declarations.root,
+                &document.path,
+                entry_index,
+                entry,
+            ));
+        }
+    }
+    for document in &declarations.dnf {
+        for repository in &document.repositories {
+            repositories.push(rpm::plan_dnf(&declarations.root, repository));
+        }
+    }
+    for document in &declarations.zypper_repositories {
+        for repository in &document.repositories {
+            repositories.push(rpm::plan_zypper(&declarations.root, repository));
+        }
+    }
+    if let Some(config) = &declarations.alpm {
+        repositories.extend(plan_alpm(config));
+    }
+    NativeTrustImportPlan {
+        selected_root: declarations.root.clone(),
+        repositories,
+    }
+}
+
+fn plan_alpm(config: &super::alpm::AlpmConfigSet) -> Vec<NativeRepositoryTrustPlan> {
+    let global_sig_level = config
+        .directives
+        .iter()
+        .rev()
+        .find_map(|directive| match directive {
+            AlpmDirective::GlobalSigLevel { values, location } => Some((values, location)),
+            _ => None,
+        });
+    let mut repositories: Vec<AlpmRepositoryState<'_>> = Vec::new();
+    for directive in &config.directives {
+        let AlpmDirective::RepositoryOption {
+            repository,
+            name,
+            values,
+            location,
+            ..
+        } = directive
+        else {
+            continue;
+        };
+        let entry = if let Some(index) = repositories
+            .iter()
+            .position(|(name, _, _)| name == repository)
+        {
+            &mut repositories[index]
+        } else {
+            repositories.push((repository.clone(), location.clone(), None));
+            repositories.last_mut().expect("repository was pushed")
+        };
+        if *name == AlpmRepositoryOptionName::SigLevel {
+            entry.2 = Some((values, location));
+        }
+    }
+    repositories
+        .into_iter()
+        .map(|(name, location, repository_sig_level)| {
+            let (values, sig_location) = repository_sig_level
+                .or_else(|| global_sig_level.map(|(values, location)| (values.as_slice(), location)))
+                .unwrap_or((&[], &location));
+            let mut evidence = Vec::new();
+            for role in [TrustRole::ArchDatabase, TrustRole::ArchPackage] {
+                evidence.push(TrustImportEvidence {
+                    role,
+                    source: TrustEvidenceSource::AlpmSigLevel {
+                        values: values.to_vec(),
+                    },
+                    certificates: Vec::new(),
+                    fingerprint_selectors: Vec::new(),
+                    location: sig_location.clone(),
+                });
+            }
+            let mut findings = PlanFindings::default();
+            classify_alpm_sig_level(values, sig_location, &mut findings);
+            if findings.unsupported.is_empty() {
+                findings.ambiguous(finding(
+                    TrustImportFindingKind::AlpmKeyringBindingMissing,
+                    Some(TrustRole::ArchPackage),
+                    sig_location,
+                    "pacman SigLevel does not bind repositories to an exact authenticated keyring snapshot and master-fingerprint threshold",
+                ));
+            }
+            NativeRepositoryTrustPlan {
+                repository: NativeRepositoryReference::Alpm { name, location },
+                enabled: Some(true),
+                evidence,
+                disposition: findings.finish(),
+            }
+        })
+        .collect()
+}
+
+fn classify_alpm_sig_level(
+    values: &[String],
+    location: &DeclarationLocation,
+    findings: &mut PlanFindings,
+) {
+    for value in values {
+        if value.ends_with("TrustAll") || value == "TrustAll" {
+            findings.unsupported(finding(
+                TrustImportFindingKind::TrustAll,
+                None,
+                location,
+                format!("ALPM SigLevel token '{value}' admits untrusted signing keys"),
+            ));
+        } else if value.ends_with("Never") || value == "Never" {
+            findings.unsupported(finding(
+                TrustImportFindingKind::VerificationDisabled,
+                None,
+                location,
+                format!("ALPM SigLevel token '{value}' disables signature verification"),
+            ));
+        } else if value == "Optional" || value == "PackageOptional" {
+            findings.unsupported(finding(
+                TrustImportFindingKind::OptionalPackageSignature,
+                Some(TrustRole::ArchPackage),
+                location,
+                format!("ALPM SigLevel token '{value}' permits unsigned packages"),
+            ));
+        }
+    }
+}
+
+fn finding(
+    kind: TrustImportFindingKind,
+    role: Option<TrustRole>,
+    location: &DeclarationLocation,
+    message: impl Into<String>,
+) -> TrustImportFinding {
+    TrustImportFinding {
+        kind,
+        role,
+        location: location.clone(),
+        message: message.into(),
+    }
+}
+
+fn apt_reference(
+    document: &std::path::Path,
+    entry_index: usize,
+    entry: &AptSourceEntry,
+) -> NativeRepositoryReference {
+    NativeRepositoryReference::Apt {
+        document: document.to_path_buf(),
+        entry_index,
+        uris: entry.uris.clone(),
+        suites: entry.suites.clone(),
+        location: entry.location.clone(),
+    }
+}
+
+fn dnf_reference(repository: &DnfRepository) -> NativeRepositoryReference {
+    NativeRepositoryReference::Dnf {
+        id: repository.id.clone(),
+        location: repository.location.clone(),
+    }
+}
+
+fn zypper_reference(repository: &ZypperRepository) -> NativeRepositoryReference {
+    NativeRepositoryReference::Zypper {
+        alias: repository.alias.clone(),
+        location: repository.location.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/conary-core/src/repository/declarations/trust_import/openpgp.rs
+++ b/crates/conary-core/src/repository/declarations/trust_import/openpgp.rs
@@ -1,0 +1,329 @@
+// conary-core/src/repository/declarations/trust_import/openpgp.rs
+
+use super::{
+    OpenPgpCertificateEvidence, OpenPgpFingerprintSelector, PlanFindings, TrustEvidenceSource,
+    TrustImportEvidence, TrustImportFindingKind, finding,
+};
+use crate::filesystem::path::safe_join;
+use crate::repository::TrustRole;
+use crate::repository::declarations::DeclarationLocation;
+use openpgp::cert::CertParser;
+use openpgp::parse::Parse;
+use sequoia_openpgp as openpgp;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use url::Url;
+
+pub(super) struct CollectedRoots {
+    pub evidence: Vec<TrustImportEvidence>,
+}
+
+pub(super) fn collect_declared_roots(
+    selected_root: &Path,
+    role: TrustRole,
+    values: &[String],
+    location: &DeclarationLocation,
+    findings: &mut PlanFindings,
+) -> CollectedRoots {
+    let mut evidence = Vec::new();
+    let mut selectors: Vec<OpenPgpFingerprintSelector> = Vec::new();
+    for raw_value in values {
+        if raw_value
+            .trim_start()
+            .starts_with("-----BEGIN PGP PUBLIC KEY BLOCK-----")
+        {
+            collect_embedded(
+                role,
+                raw_value.trim_start().as_bytes(),
+                location,
+                &mut evidence,
+                findings,
+            );
+            continue;
+        }
+        for value in raw_value.split_whitespace() {
+            let value = value.trim_matches(',');
+            if value.is_empty() {
+                continue;
+            }
+            if let Some(selector) = fingerprint_selector(value) {
+                selectors.push(selector);
+                continue;
+            }
+            match declared_path(value) {
+                DeclaredSource::SelectedRoot(path) => collect_file(
+                    selected_root,
+                    role,
+                    &path,
+                    location,
+                    &mut evidence,
+                    findings,
+                ),
+                DeclaredSource::Remote(url) => findings.ambiguous(finding(
+                    TrustImportFindingKind::UnpinnedRemoteAuthority,
+                    Some(role),
+                    location,
+                    format!(
+                        "declared trust source '{url}' is remote and carries no exact certificate fingerprint pin"
+                    ),
+                )),
+                DeclaredSource::Unsupported(value) => findings.unsupported(finding(
+                    TrustImportFindingKind::UnsupportedTrustValue,
+                    Some(role),
+                    location,
+                    format!("unsupported declared trust source '{value}'"),
+                )),
+            }
+        }
+    }
+    selectors.sort_by(|left, right| {
+        (&left.fingerprint, left.primary_only).cmp(&(&right.fingerprint, right.primary_only))
+    });
+    selectors.dedup();
+    if !selectors.is_empty() && evidence.is_empty() {
+        findings.ambiguous(finding(
+            TrustImportFindingKind::FingerprintSelectorWithoutSource,
+            Some(role),
+            location,
+            "fingerprint selectors refer to implicit global native trust rather than an exact declared key source",
+        ));
+    }
+    if !selectors.is_empty() && !evidence.is_empty() {
+        let available: BTreeSet<_> = evidence
+            .iter()
+            .flat_map(|item| {
+                item.certificates
+                    .iter()
+                    .flat_map(|certificate| certificate.key_fingerprints.iter().cloned())
+            })
+            .collect();
+        let missing: Vec<_> = selectors
+            .iter()
+            .filter(|selector| {
+                if selector.primary_only {
+                    !evidence.iter().any(|item| {
+                        item.certificates.iter().any(|certificate| {
+                            certificate.certificate_fingerprint == selector.fingerprint
+                        })
+                    })
+                } else {
+                    !available.contains(selector.fingerprint.as_str())
+                }
+            })
+            .map(|selector| selector.fingerprint.clone())
+            .collect();
+        if !missing.is_empty() {
+            findings.unsupported(finding(
+                TrustImportFindingKind::FingerprintSelectorMismatch,
+                Some(role),
+                location,
+                format!(
+                    "declared fingerprint selectors are absent from the declared key material: {}",
+                    missing.join(", ")
+                ),
+            ));
+        } else {
+            for item in &mut evidence {
+                item.certificates.retain(|certificate| {
+                    selectors
+                        .iter()
+                        .any(|selector| selector_matches_certificate(selector, certificate))
+                });
+                item.fingerprint_selectors = selectors
+                    .iter()
+                    .filter(|selector| {
+                        item.certificates
+                            .iter()
+                            .any(|certificate| selector_matches_certificate(selector, certificate))
+                    })
+                    .cloned()
+                    .collect();
+            }
+            evidence.retain(|item| !item.certificates.is_empty());
+        }
+    }
+    CollectedRoots { evidence }
+}
+
+fn selector_matches_certificate(
+    selector: &OpenPgpFingerprintSelector,
+    certificate: &OpenPgpCertificateEvidence,
+) -> bool {
+    if selector.primary_only {
+        certificate.certificate_fingerprint == selector.fingerprint
+    } else {
+        certificate.key_fingerprints.contains(&selector.fingerprint)
+    }
+}
+
+pub(super) fn collect_embedded(
+    role: TrustRole,
+    bytes: &[u8],
+    location: &DeclarationLocation,
+    evidence: &mut Vec<TrustImportEvidence>,
+    findings: &mut PlanFindings,
+) {
+    let normalized = normalize_deb822_embedded(bytes);
+    match fingerprints(&normalized) {
+        Ok(certificates) => evidence.push(TrustImportEvidence {
+            role,
+            source: TrustEvidenceSource::EmbeddedOpenPgp,
+            certificates,
+            fingerprint_selectors: Vec::new(),
+            location: location.clone(),
+        }),
+        Err(message) => findings.unsupported(finding(
+            TrustImportFindingKind::MalformedOpenPgp,
+            Some(role),
+            location,
+            message,
+        )),
+    }
+}
+
+fn normalize_deb822_embedded(bytes: &[u8]) -> Vec<u8> {
+    let Ok(value) = std::str::from_utf8(bytes) else {
+        return bytes.to_vec();
+    };
+    let mut normalized = String::new();
+    for (index, line) in value.lines().enumerate() {
+        if index > 0 {
+            normalized.push('\n');
+        }
+        if line == "." {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("..") {
+            normalized.push('.');
+            normalized.push_str(rest);
+        } else {
+            normalized.push_str(line);
+        }
+    }
+    normalized.push('\n');
+    normalized.into_bytes()
+}
+
+fn collect_file(
+    selected_root: &Path,
+    role: TrustRole,
+    guest_path: &Path,
+    location: &DeclarationLocation,
+    evidence: &mut Vec<TrustImportEvidence>,
+    findings: &mut PlanFindings,
+) {
+    let host_path = match safe_join(selected_root, guest_path) {
+        Ok(path) => path,
+        Err(error) => {
+            findings.unsupported(finding(
+                TrustImportFindingKind::SelectedRootEscape,
+                Some(role),
+                location,
+                format!(
+                    "declared trust path '{}' escapes the selected root: {error}",
+                    guest_path.display()
+                ),
+            ));
+            return;
+        }
+    };
+    let bytes = match fs::read(&host_path) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            findings.unsupported(finding(
+                TrustImportFindingKind::MissingDeclaredTrustSource,
+                Some(role),
+                location,
+                format!(
+                    "declared trust source '{}' is not readable below the selected root: {error}",
+                    guest_path.display()
+                ),
+            ));
+            return;
+        }
+    };
+    match fingerprints(&bytes) {
+        Ok(certificates) => evidence.push(TrustImportEvidence {
+            role,
+            source: TrustEvidenceSource::SelectedRootFile {
+                path: guest_path.to_path_buf(),
+            },
+            certificates,
+            fingerprint_selectors: Vec::new(),
+            location: location.clone(),
+        }),
+        Err(message) => findings.unsupported(finding(
+            TrustImportFindingKind::MalformedOpenPgp,
+            Some(role),
+            location,
+            format!(
+                "declared trust source '{}' is not exact OpenPGP certificate material: {message}",
+                guest_path.display()
+            ),
+        )),
+    }
+}
+
+fn fingerprints(bytes: &[u8]) -> Result<Vec<OpenPgpCertificateEvidence>, String> {
+    let parser = CertParser::from_bytes(bytes)
+        .map_err(|error| format!("failed to parse OpenPGP certificate stream: {error}"))?;
+    let mut certificates = Vec::new();
+    for certificate in parser {
+        let certificate =
+            certificate.map_err(|error| format!("malformed OpenPGP certificate: {error}"))?;
+        let mut key_fingerprints: Vec<_> = certificate
+            .keys()
+            .map(|key| key.key().fingerprint().to_hex())
+            .collect();
+        key_fingerprints.sort();
+        key_fingerprints.dedup();
+        certificates.push(OpenPgpCertificateEvidence {
+            certificate_fingerprint: certificate.fingerprint().to_hex(),
+            key_fingerprints,
+        });
+    }
+    if certificates.is_empty() {
+        return Err("OpenPGP source contains no certificates".to_string());
+    }
+    certificates.sort_by(|left, right| {
+        left.certificate_fingerprint
+            .cmp(&right.certificate_fingerprint)
+    });
+    certificates
+        .dedup_by(|left, right| left.certificate_fingerprint == right.certificate_fingerprint);
+    Ok(certificates)
+}
+
+enum DeclaredSource {
+    SelectedRoot(PathBuf),
+    Remote(String),
+    Unsupported(String),
+}
+
+fn declared_path(value: &str) -> DeclaredSource {
+    if value.starts_with('/') {
+        return DeclaredSource::SelectedRoot(PathBuf::from(value));
+    }
+    let Ok(url) = Url::parse(value) else {
+        return DeclaredSource::Unsupported(value.to_string());
+    };
+    match url.scheme() {
+        "file" => url
+            .to_file_path()
+            .map(DeclaredSource::SelectedRoot)
+            .unwrap_or_else(|_| DeclaredSource::Unsupported(value.to_string())),
+        "https" => DeclaredSource::Remote(value.to_string()),
+        _ => DeclaredSource::Unsupported(value.to_string()),
+    }
+}
+
+fn fingerprint_selector(value: &str) -> Option<OpenPgpFingerprintSelector> {
+    let primary_only = value.ends_with('!');
+    let stripped = value.strip_suffix('!').unwrap_or(value);
+    (matches!(stripped.len(), 40 | 64) && stripped.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        .then(|| OpenPgpFingerprintSelector {
+            fingerprint: stripped.to_ascii_uppercase(),
+            primary_only,
+        })
+}

--- a/crates/conary-core/src/repository/declarations/trust_import/rpm.rs
+++ b/crates/conary-core/src/repository/declarations/trust_import/rpm.rs
@@ -1,0 +1,343 @@
+// conary-core/src/repository/declarations/trust_import/rpm.rs
+
+use super::openpgp::collect_declared_roots;
+use super::{
+    NativeRepositoryTrustPlan, PlanFindings, TrustEvidenceSource, TrustImportEvidence,
+    TrustImportFindingKind, dnf_reference, finding, zypper_reference,
+};
+use crate::repository::TrustRole;
+use crate::repository::declarations::DeclarationLocation;
+use crate::repository::declarations::dnf::{DnfEndpointKind, DnfOptionName, DnfRepository};
+use crate::repository::declarations::zypper::{
+    ZypperRepository, ZypperRepositoryOption, ZypperRepositoryOptionName,
+};
+use std::path::Path;
+
+pub(super) fn plan_dnf(
+    selected_root: &Path,
+    repository: &DnfRepository,
+) -> NativeRepositoryTrustPlan {
+    let mut findings = PlanFindings::default();
+    let mut evidence = Vec::new();
+    let package_check = dnf_last_bool(
+        repository,
+        &[DnfOptionName::Gpgcheck, DnfOptionName::PkgGpgcheck],
+    );
+    require_verification(
+        &package_check,
+        TrustRole::RpmPackage,
+        &repository.location,
+        "DNF package",
+        &mut findings,
+    );
+    if package_check.is_true() {
+        evidence.extend(dnf_keys(
+            selected_root,
+            repository,
+            TrustRole::RpmPackage,
+            &mut findings,
+        ));
+    }
+
+    let metadata_check = dnf_last_bool(repository, &[DnfOptionName::RepoGpgcheck]);
+    if metadata_check.is_true() {
+        evidence.extend(dnf_keys(
+            selected_root,
+            repository,
+            TrustRole::RpmMetadata,
+            &mut findings,
+        ));
+    } else if let Some((DnfEndpointKind::Metalink, url)) = repository.effective_endpoint() {
+        let location = repository
+            .options
+            .iter()
+            .rev()
+            .find(|option| option.name == DnfOptionName::Metalink)
+            .map_or(&repository.location, |option| &option.location);
+        evidence.push(TrustImportEvidence {
+            role: TrustRole::RpmMetadata,
+            source: TrustEvidenceSource::RpmMetalink {
+                url: url.to_string(),
+            },
+            certificates: Vec::new(),
+            fingerprint_selectors: Vec::new(),
+            location: location.clone(),
+        });
+    } else {
+        require_verification(
+            &metadata_check,
+            TrustRole::RpmMetadata,
+            &repository.location,
+            "DNF repository metadata",
+            &mut findings,
+        );
+    }
+    ensure_roles(&evidence, &repository.location, &mut findings);
+    let enabled = match repository.explicit_enabled() {
+        Ok(Some(value)) => Some(value),
+        Ok(None) => Some(true),
+        Err(error) => {
+            findings.unsupported(finding(
+                TrustImportFindingKind::UnsupportedTrustValue,
+                None,
+                &repository.location,
+                format!("DNF enabled state is invalid: {error}"),
+            ));
+            None
+        }
+    };
+    NativeRepositoryTrustPlan {
+        repository: dnf_reference(repository),
+        enabled,
+        evidence,
+        disposition: findings.finish(),
+    }
+}
+
+pub(super) fn plan_zypper(
+    selected_root: &Path,
+    repository: &ZypperRepository,
+) -> NativeRepositoryTrustPlan {
+    let mut findings = PlanFindings::default();
+    let mut evidence = Vec::new();
+    let general = zypper_last_bool(repository, ZypperRepositoryOptionName::Gpgcheck);
+    let package_check =
+        zypper_last_bool(repository, ZypperRepositoryOptionName::PkgGpgcheck).or(general.clone());
+    let metadata_check =
+        zypper_last_bool(repository, ZypperRepositoryOptionName::RepoGpgcheck).or(general);
+    require_verification(
+        &package_check,
+        TrustRole::RpmPackage,
+        &repository.location,
+        "Zypper package",
+        &mut findings,
+    );
+    if package_check.is_true() {
+        evidence.extend(zypper_keys(
+            selected_root,
+            repository,
+            TrustRole::RpmPackage,
+            &mut findings,
+        ));
+    }
+    if metadata_check.is_true() {
+        evidence.extend(zypper_keys(
+            selected_root,
+            repository,
+            TrustRole::RpmMetadata,
+            &mut findings,
+        ));
+    } else if let Some((url, location)) =
+        zypper_last_value(repository, ZypperRepositoryOptionName::Metalink)
+    {
+        evidence.push(TrustImportEvidence {
+            role: TrustRole::RpmMetadata,
+            source: TrustEvidenceSource::RpmMetalink {
+                url: url.trim().to_string(),
+            },
+            certificates: Vec::new(),
+            fingerprint_selectors: Vec::new(),
+            location: location.clone(),
+        });
+    } else {
+        require_verification(
+            &metadata_check,
+            TrustRole::RpmMetadata,
+            &repository.location,
+            "Zypper repository metadata",
+            &mut findings,
+        );
+    }
+    ensure_roles(&evidence, &repository.location, &mut findings);
+    let enabled = match repository.explicit_enabled() {
+        Ok(Some(value)) => Some(value),
+        Ok(None) => Some(true),
+        Err(error) => {
+            findings.unsupported(finding(
+                TrustImportFindingKind::UnsupportedTrustValue,
+                None,
+                &repository.location,
+                format!("Zypper enabled state is invalid: {error}"),
+            ));
+            None
+        }
+    };
+    NativeRepositoryTrustPlan {
+        repository: zypper_reference(repository),
+        enabled,
+        evidence,
+        disposition: findings.finish(),
+    }
+}
+
+fn dnf_keys(
+    selected_root: &Path,
+    repository: &DnfRepository,
+    role: TrustRole,
+    findings: &mut PlanFindings,
+) -> Vec<TrustImportEvidence> {
+    let Some(option) = repository
+        .options
+        .iter()
+        .rev()
+        .find(|option| option.name == DnfOptionName::Gpgkey)
+    else {
+        findings.ambiguous(finding(
+            TrustImportFindingKind::MissingRequiredAuthority,
+            Some(role),
+            &repository.location,
+            format!("DNF repository '{}' has no declared gpgkey", repository.id),
+        ));
+        return Vec::new();
+    };
+    collect_declared_roots(
+        selected_root,
+        role,
+        std::slice::from_ref(&option.raw_value),
+        &option.location,
+        findings,
+    )
+    .evidence
+}
+
+fn zypper_keys(
+    selected_root: &Path,
+    repository: &ZypperRepository,
+    role: TrustRole,
+    findings: &mut PlanFindings,
+) -> Vec<TrustImportEvidence> {
+    let Some((value, location)) = zypper_last_value(repository, ZypperRepositoryOptionName::Gpgkey)
+    else {
+        findings.ambiguous(finding(
+            TrustImportFindingKind::MissingRequiredAuthority,
+            Some(role),
+            &repository.location,
+            format!(
+                "Zypper repository '{}' has no declared gpgkey",
+                repository.alias
+            ),
+        ));
+        return Vec::new();
+    };
+    let value = value.to_string();
+    collect_declared_roots(
+        selected_root,
+        role,
+        std::slice::from_ref(&value),
+        location,
+        findings,
+    )
+    .evidence
+}
+
+fn ensure_roles(
+    evidence: &[TrustImportEvidence],
+    location: &DeclarationLocation,
+    findings: &mut PlanFindings,
+) {
+    for role in [TrustRole::RpmMetadata, TrustRole::RpmPackage] {
+        if !evidence.iter().any(|item| item.role == role) && !findings.has_role(role) {
+            findings.ambiguous(finding(
+                TrustImportFindingKind::MissingRequiredAuthority,
+                Some(role),
+                location,
+                format!("no exact {} authority was discovered", role.as_str()),
+            ));
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum NativeBool {
+    Missing,
+    True,
+    False(DeclarationLocation),
+    Unsupported(String, DeclarationLocation),
+}
+
+impl NativeBool {
+    fn is_true(&self) -> bool {
+        matches!(self, Self::True)
+    }
+
+    fn or(self, fallback: Self) -> Self {
+        if matches!(self, Self::Missing) {
+            fallback
+        } else {
+            self
+        }
+    }
+}
+
+fn require_verification(
+    value: &NativeBool,
+    role: TrustRole,
+    default_location: &DeclarationLocation,
+    label: &str,
+    findings: &mut PlanFindings,
+) {
+    match value {
+        NativeBool::True => {}
+        NativeBool::Missing => findings.ambiguous(finding(
+            TrustImportFindingKind::MissingRequiredAuthority,
+            Some(role),
+            default_location,
+            format!("{label} verification is inherited from unmodeled global native configuration"),
+        )),
+        NativeBool::False(location) => findings.unsupported(finding(
+            TrustImportFindingKind::VerificationDisabled,
+            Some(role),
+            location,
+            format!("{label} verification is disabled"),
+        )),
+        NativeBool::Unsupported(value, location) => findings.unsupported(finding(
+            TrustImportFindingKind::UnsupportedTrustValue,
+            Some(role),
+            location,
+            format!("{label} uses unsupported trust value '{value}'"),
+        )),
+    }
+}
+
+fn dnf_last_bool(repository: &DnfRepository, names: &[DnfOptionName]) -> NativeBool {
+    repository
+        .options
+        .iter()
+        .rev()
+        .find(|option| names.contains(&option.name))
+        .map_or(NativeBool::Missing, |option| {
+            parse_native_bool(&option.raw_value, &option.location)
+        })
+}
+
+fn zypper_last_bool(repository: &ZypperRepository, name: ZypperRepositoryOptionName) -> NativeBool {
+    zypper_last_value(repository, name).map_or(NativeBool::Missing, |(value, location)| {
+        parse_native_bool(value, location)
+    })
+}
+
+fn zypper_last_value(
+    repository: &ZypperRepository,
+    name: ZypperRepositoryOptionName,
+) -> Option<(&str, &DeclarationLocation)> {
+    repository
+        .options
+        .iter()
+        .rev()
+        .find_map(|option| match option {
+            ZypperRepositoryOption::Known {
+                name: candidate,
+                raw_value,
+                location,
+            } if *candidate == name => Some((raw_value.as_str(), location)),
+            _ => None,
+        })
+}
+
+fn parse_native_bool(value: &str, location: &DeclarationLocation) -> NativeBool {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "yes" | "true" | "on" => NativeBool::True,
+        "0" | "no" | "false" | "off" => NativeBool::False(location.clone()),
+        _ => NativeBool::Unsupported(value.to_string(), location.clone()),
+    }
+}

--- a/crates/conary-core/src/repository/declarations/trust_import/rpm.rs
+++ b/crates/conary-core/src/repository/declarations/trust_import/rpm.rs
@@ -5,6 +5,7 @@ use super::{
     NativeRepositoryTrustPlan, PlanFindings, TrustEvidenceSource, TrustImportEvidence,
     TrustImportFindingKind, dnf_reference, finding, zypper_reference,
 };
+use crate::filesystem::path::safe_join;
 use crate::repository::TrustRole;
 use crate::repository::declarations::DeclarationLocation;
 use crate::repository::declarations::dnf::{DnfEndpointKind, DnfOptionName, DnfRepository};
@@ -12,6 +13,7 @@ use crate::repository::declarations::zypper::{
     ZypperRepository, ZypperRepositoryOption, ZypperRepositoryOptionName,
 };
 use std::path::Path;
+use url::Url;
 
 pub(super) fn plan_dnf(
     selected_root: &Path,
@@ -54,15 +56,9 @@ pub(super) fn plan_dnf(
             .rev()
             .find(|option| option.name == DnfOptionName::Metalink)
             .map_or(&repository.location, |option| &option.location);
-        evidence.push(TrustImportEvidence {
-            role: TrustRole::RpmMetadata,
-            source: TrustEvidenceSource::RpmMetalink {
-                url: url.to_string(),
-            },
-            certificates: Vec::new(),
-            fingerprint_selectors: Vec::new(),
-            location: location.clone(),
-        });
+        if let Some(item) = metalink_evidence(selected_root, url, location, &mut findings) {
+            evidence.push(item);
+        }
     } else {
         require_verification(
             &metadata_check,
@@ -130,15 +126,9 @@ pub(super) fn plan_zypper(
     } else if let Some((url, location)) =
         zypper_last_value(repository, ZypperRepositoryOptionName::Metalink)
     {
-        evidence.push(TrustImportEvidence {
-            role: TrustRole::RpmMetadata,
-            source: TrustEvidenceSource::RpmMetalink {
-                url: url.trim().to_string(),
-            },
-            certificates: Vec::new(),
-            fingerprint_selectors: Vec::new(),
-            location: location.clone(),
-        });
+        if let Some(item) = metalink_evidence(selected_root, url.trim(), location, &mut findings) {
+            evidence.push(item);
+        }
     } else {
         require_verification(
             &metadata_check,
@@ -176,12 +166,12 @@ fn dnf_keys(
     role: TrustRole,
     findings: &mut PlanFindings,
 ) -> Vec<TrustImportEvidence> {
-    let Some(option) = repository
+    let options: Vec<_> = repository
         .options
         .iter()
-        .rev()
-        .find(|option| option.name == DnfOptionName::Gpgkey)
-    else {
+        .filter(|option| option.name == DnfOptionName::Gpgkey)
+        .collect();
+    if options.is_empty() {
         findings.ambiguous(finding(
             TrustImportFindingKind::MissingRequiredAuthority,
             Some(role),
@@ -189,15 +179,72 @@ fn dnf_keys(
             format!("DNF repository '{}' has no declared gpgkey", repository.id),
         ));
         return Vec::new();
-    };
-    collect_declared_roots(
-        selected_root,
-        role,
-        std::slice::from_ref(&option.raw_value),
-        &option.location,
-        findings,
-    )
-    .evidence
+    }
+    let mut evidence = Vec::new();
+    for option in options {
+        evidence.extend(
+            collect_declared_roots(
+                selected_root,
+                role,
+                std::slice::from_ref(&option.raw_value),
+                &option.location,
+                findings,
+            )
+            .evidence,
+        );
+    }
+    evidence
+}
+
+fn metalink_evidence(
+    selected_root: &Path,
+    value: &str,
+    location: &DeclarationLocation,
+    findings: &mut PlanFindings,
+) -> Option<TrustImportEvidence> {
+    if let Err(error) = crate::repository::trust::validate_https_or_file_url(value, "RPM metalink")
+    {
+        findings.unsupported(finding(
+            TrustImportFindingKind::UnsupportedTrustValue,
+            Some(TrustRole::RpmMetadata),
+            location,
+            error.to_string(),
+        ));
+        return None;
+    }
+    let url = Url::parse(value).expect("validated RPM metalink URL");
+    if url.scheme() == "file" {
+        let Ok(path) = url.to_file_path() else {
+            findings.unsupported(finding(
+                TrustImportFindingKind::UnsupportedTrustValue,
+                Some(TrustRole::RpmMetadata),
+                location,
+                format!("RPM metalink '{value}' is not a local file URL"),
+            ));
+            return None;
+        };
+        if let Err(error) = safe_join(selected_root, &path) {
+            findings.unsupported(finding(
+                TrustImportFindingKind::SelectedRootEscape,
+                Some(TrustRole::RpmMetadata),
+                location,
+                format!(
+                    "RPM metalink path '{}' escapes the selected root: {error}",
+                    path.display()
+                ),
+            ));
+            return None;
+        }
+    }
+    Some(TrustImportEvidence {
+        role: TrustRole::RpmMetadata,
+        source: TrustEvidenceSource::RpmMetalink {
+            url: value.to_string(),
+        },
+        certificates: Vec::new(),
+        fingerprint_selectors: Vec::new(),
+        location: location.clone(),
+    })
 }
 
 fn zypper_keys(

--- a/crates/conary-core/src/repository/declarations/trust_import/tests.rs
+++ b/crates/conary-core/src/repository/declarations/trust_import/tests.rs
@@ -1,0 +1,281 @@
+// conary-core/src/repository/declarations/trust_import/tests.rs
+
+use super::*;
+use crate::repository::declarations::discover_selected_root;
+use openpgp::cert::prelude::CertBuilder;
+use openpgp::serialize::Serialize;
+use sequoia_openpgp as openpgp;
+use std::fs;
+use std::path::Path;
+
+fn certificate() -> (Vec<u8>, String) {
+    let (certificate, _) = CertBuilder::new()
+        .add_userid("Native repository fixture")
+        .generate()
+        .unwrap();
+    let fingerprint = certificate.fingerprint().to_hex();
+    let mut bytes = Vec::new();
+    certificate.serialize(&mut bytes).unwrap();
+    (bytes, fingerprint)
+}
+
+fn armored_certificate() -> (String, String) {
+    let (certificate, _) = CertBuilder::new()
+        .add_userid("Embedded native repository fixture")
+        .generate()
+        .unwrap();
+    let fingerprint = certificate.fingerprint().to_hex();
+    let mut bytes = Vec::new();
+    certificate.armored().serialize(&mut bytes).unwrap();
+    (String::from_utf8(bytes).unwrap(), fingerprint)
+}
+
+fn prepare(root: &Path) {
+    for directory in [
+        "etc/apt/sources.list.d",
+        "etc/apt/keyrings",
+        "etc/yum.repos.d",
+        "etc/pki/rpm-gpg",
+        "etc/zypp/repos.d",
+    ] {
+        fs::create_dir_all(root.join(directory)).unwrap();
+    }
+}
+
+#[test]
+fn apt_local_signed_by_is_importable_with_exact_fingerprint() {
+    let root = tempfile::tempdir().unwrap();
+    prepare(root.path());
+    let (certificate, fingerprint) = certificate();
+    fs::write(root.path().join("etc/apt/keyrings/vendor.gpg"), certificate).unwrap();
+    fs::write(
+        root.path().join("etc/apt/sources.list.d/vendor.list"),
+        format!(
+            "deb [signed-by=/etc/apt/keyrings/vendor.gpg,{fingerprint}!] https://apt.example stable main\n"
+        ),
+    )
+    .unwrap();
+
+    let declarations = discover_selected_root(root.path()).unwrap();
+    let plan = plan_selected_root_trust(&declarations);
+    assert_eq!(plan.repositories.len(), 1);
+    assert_eq!(
+        plan.repositories[0].disposition,
+        TrustImportDisposition::Importable
+    );
+    assert_eq!(
+        plan.repositories[0].evidence[0].certificates[0].certificate_fingerprint,
+        fingerprint
+    );
+    assert_eq!(
+        plan.repositories[0].evidence[0].fingerprint_selectors,
+        [OpenPgpFingerprintSelector {
+            fingerprint: fingerprint.clone(),
+            primary_only: true,
+        }]
+    );
+    assert_eq!(
+        plan.repositories[0].evidence[0].role,
+        TrustRole::DebianRelease
+    );
+}
+
+#[test]
+fn apt_global_and_remote_authority_are_ambiguous_not_imported() {
+    let root = tempfile::tempdir().unwrap();
+    prepare(root.path());
+    fs::write(
+        root.path().join("etc/apt/sources.list.d/vendor.list"),
+        "deb https://apt.example stable main\n\
+         deb [signed-by=https://keys.example/vendor.asc] https://other.example stable main\n",
+    )
+    .unwrap();
+
+    let plan = plan_selected_root_trust(&discover_selected_root(root.path()).unwrap());
+    assert!(plan.repositories.iter().all(|repository| matches!(
+        repository.disposition,
+        TrustImportDisposition::Ambiguous { .. }
+    )));
+}
+
+#[test]
+fn apt_deb822_embedded_key_unescapes_blank_lines() {
+    let root = tempfile::tempdir().unwrap();
+    prepare(root.path());
+    let (armor, fingerprint) = armored_certificate();
+    let continuation = armor
+        .lines()
+        .map(|line| {
+            if line.is_empty() {
+                " .".to_string()
+            } else {
+                format!(" {line}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(
+        root.path().join("etc/apt/sources.list.d/vendor.sources"),
+        format!(
+            "Types: deb\nURIs: https://apt.example\nSuites: stable\nComponents: main\nSigned-By:\n{continuation}\n"
+        ),
+    )
+    .unwrap();
+
+    let plan = plan_selected_root_trust(&discover_selected_root(root.path()).unwrap());
+    assert_eq!(
+        plan.repositories[0].disposition,
+        TrustImportDisposition::Importable
+    );
+    assert_eq!(
+        plan.repositories[0].evidence[0].certificates[0].certificate_fingerprint,
+        fingerprint
+    );
+    assert!(matches!(
+        plan.repositories[0].evidence[0].source,
+        TrustEvidenceSource::EmbeddedOpenPgp
+    ));
+}
+
+#[test]
+fn dnf_metalink_and_local_package_key_keep_roles_separate() {
+    let root = tempfile::tempdir().unwrap();
+    prepare(root.path());
+    let (certificate, fingerprint) = certificate();
+    fs::write(root.path().join("etc/pki/rpm-gpg/VENDOR"), certificate).unwrap();
+    fs::write(
+        root.path().join("etc/yum.repos.d/vendor.repo"),
+        "[vendor]\nenabled=1\nmetalink=https://mirrors.example/metalink\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=file:///etc/pki/rpm-gpg/VENDOR\n",
+    )
+    .unwrap();
+
+    let plan = plan_selected_root_trust(&discover_selected_root(root.path()).unwrap());
+    let repository = &plan.repositories[0];
+    assert_eq!(repository.disposition, TrustImportDisposition::Importable);
+    assert!(repository.evidence.iter().any(|item| {
+        item.role == TrustRole::RpmMetadata
+            && matches!(item.source, TrustEvidenceSource::RpmMetalink { .. })
+    }));
+    assert!(repository.evidence.iter().any(|item| {
+        item.role == TrustRole::RpmPackage
+            && item.certificates[0].certificate_fingerprint == fingerprint
+    }));
+}
+
+#[test]
+fn zypper_openpgp_metadata_and_package_roles_are_explicit() {
+    let root = tempfile::tempdir().unwrap();
+    prepare(root.path());
+    let (certificate, fingerprint) = certificate();
+    fs::write(root.path().join("etc/pki/rpm-gpg/VENDOR"), certificate).unwrap();
+    fs::write(
+        root.path().join("etc/zypp/repos.d/vendor.repo"),
+        "[vendor]\nenabled=0\nbaseurl=https://rpm.example\nrepo_gpgcheck=1\npkg_gpgcheck=1\ngpgkey=file:///etc/pki/rpm-gpg/VENDOR\n",
+    )
+    .unwrap();
+
+    let plan = plan_selected_root_trust(&discover_selected_root(root.path()).unwrap());
+    let repository = &plan.repositories[0];
+    assert_eq!(repository.enabled, Some(false));
+    assert_eq!(repository.disposition, TrustImportDisposition::Importable);
+    for role in [TrustRole::RpmMetadata, TrustRole::RpmPackage] {
+        assert!(repository.evidence.iter().any(|item| {
+            item.role == role && item.certificates[0].certificate_fingerprint == fingerprint
+        }));
+    }
+}
+
+#[test]
+fn alpm_safe_siglevel_is_ambiguous_until_keyring_is_bound() {
+    let root = tempfile::tempdir().unwrap();
+    prepare(root.path());
+    fs::write(
+        root.path().join("etc/pacman.conf"),
+        "[options]\nSigLevel=Required DatabaseOptional\n[core]\nServer=https://mirror.example/$repo/$arch\n",
+    )
+    .unwrap();
+
+    let plan = plan_selected_root_trust(&discover_selected_root(root.path()).unwrap());
+    assert!(matches!(
+        plan.repositories[0].disposition,
+        TrustImportDisposition::Ambiguous { ref findings }
+            if findings.iter().any(|finding| finding.kind == TrustImportFindingKind::AlpmKeyringBindingMissing)
+    ));
+}
+
+#[test]
+fn unsafe_native_verification_modes_are_unsupported() {
+    let root = tempfile::tempdir().unwrap();
+    prepare(root.path());
+    fs::write(
+        root.path().join("etc/pacman.conf"),
+        "[options]\nSigLevel=Required TrustAll\n[core]\nServer=https://mirror.example/$repo/$arch\n",
+    )
+    .unwrap();
+
+    let plan = plan_selected_root_trust(&discover_selected_root(root.path()).unwrap());
+    assert!(matches!(
+        plan.repositories[0].disposition,
+        TrustImportDisposition::Unsupported { ref findings }
+            if findings.iter().any(|finding| finding.kind == TrustImportFindingKind::TrustAll)
+    ));
+}
+
+#[test]
+fn malformed_apt_trust_bypass_value_is_unsupported() {
+    let root = tempfile::tempdir().unwrap();
+    prepare(root.path());
+    let (certificate, _) = certificate();
+    fs::write(root.path().join("etc/apt/keyrings/vendor.gpg"), certificate).unwrap();
+    fs::write(
+        root.path().join("etc/apt/sources.list.d/vendor.list"),
+        "deb [trusted=maybe signed-by=/etc/apt/keyrings/vendor.gpg] https://apt.example stable main\n",
+    )
+    .unwrap();
+
+    let plan = plan_selected_root_trust(&discover_selected_root(root.path()).unwrap());
+    assert!(matches!(
+        plan.repositories[0].disposition,
+        TrustImportDisposition::Unsupported { ref findings }
+            if findings.iter().any(|finding| finding.kind == TrustImportFindingKind::UnsupportedTrustValue)
+    ));
+}
+
+#[cfg(unix)]
+#[test]
+fn declared_key_symlink_cannot_escape_selected_root() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    prepare(root.path());
+    let (certificate, _) = certificate();
+    fs::write(outside.path().join("vendor.gpg"), certificate).unwrap();
+    fs::remove_dir(root.path().join("etc/apt/keyrings")).unwrap();
+    symlink(outside.path(), root.path().join("etc/apt/keyrings")).unwrap();
+    fs::write(
+        root.path().join("etc/apt/sources.list.d/vendor.list"),
+        "deb [signed-by=/etc/apt/keyrings/vendor.gpg] https://apt.example stable main\n",
+    )
+    .unwrap();
+
+    let plan = plan_selected_root_trust(&discover_selected_root(root.path()).unwrap());
+    assert!(matches!(
+        plan.repositories[0].disposition,
+        TrustImportDisposition::Unsupported { ref findings }
+            if findings.iter().any(|finding| finding.kind == TrustImportFindingKind::SelectedRootEscape)
+    ));
+}
+
+#[test]
+fn preview_json_rejects_unknown_fields() {
+    let root = tempfile::tempdir().unwrap();
+    prepare(root.path());
+    let plan = plan_selected_root_trust(&discover_selected_root(root.path()).unwrap());
+    let mut value = serde_json::to_value(plan).unwrap();
+    value
+        .as_object_mut()
+        .unwrap()
+        .insert("future".to_string(), serde_json::Value::Bool(true));
+    assert!(serde_json::from_value::<NativeTrustImportPlan>(value).is_err());
+}

--- a/crates/conary-core/src/repository/declarations/trust_import/tests.rs
+++ b/crates/conary-core/src/repository/declarations/trust_import/tests.rs
@@ -163,6 +163,95 @@ fn dnf_metalink_and_local_package_key_keep_roles_separate() {
 }
 
 #[test]
+fn dnf_repeated_gpgkey_lines_append_exact_sources_for_each_role() {
+    let root = tempfile::tempdir().unwrap();
+    prepare(root.path());
+    let (first, first_fingerprint) = certificate();
+    let (second, second_fingerprint) = certificate();
+    fs::write(root.path().join("etc/pki/rpm-gpg/FIRST"), first).unwrap();
+    fs::write(root.path().join("etc/pki/rpm-gpg/SECOND"), second).unwrap();
+    fs::write(
+        root.path().join("etc/yum.repos.d/vendor.repo"),
+        "[vendor]\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=file:///etc/pki/rpm-gpg/FIRST\ngpgkey=file:///etc/pki/rpm-gpg/SECOND\n",
+    )
+    .unwrap();
+
+    let plan = plan_selected_root_trust(&discover_selected_root(root.path()).unwrap());
+    let repository = &plan.repositories[0];
+    assert_eq!(repository.disposition, TrustImportDisposition::Importable);
+    for role in [TrustRole::RpmMetadata, TrustRole::RpmPackage] {
+        let role_evidence: Vec<_> = repository
+            .evidence
+            .iter()
+            .filter(|item| item.role == role)
+            .collect();
+        assert_eq!(role_evidence.len(), 2);
+        assert_eq!(
+            role_evidence
+                .iter()
+                .map(|item| item.certificates[0].certificate_fingerprint.as_str())
+                .collect::<Vec<_>>(),
+            [first_fingerprint.as_str(), second_fingerprint.as_str()]
+        );
+        assert_eq!(
+            role_evidence
+                .iter()
+                .map(|item| item.location.line)
+                .collect::<Vec<_>>(),
+            [4, 5]
+        );
+    }
+}
+
+#[test]
+fn rpm_metalink_outside_persisted_transport_contract_is_unsupported() {
+    let root = tempfile::tempdir().unwrap();
+    prepare(root.path());
+    let (certificate, _) = certificate();
+    fs::write(root.path().join("etc/pki/rpm-gpg/VENDOR"), certificate).unwrap();
+    fs::write(
+        root.path().join("etc/yum.repos.d/vendor.repo"),
+        "[vendor]\nmetalink=http://mirrors.example/metalink\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=file:///etc/pki/rpm-gpg/VENDOR\n",
+    )
+    .unwrap();
+
+    let plan = plan_selected_root_trust(&discover_selected_root(root.path()).unwrap());
+    assert!(matches!(
+        plan.repositories[0].disposition,
+        TrustImportDisposition::Unsupported { ref findings }
+            if findings.iter().any(|finding| finding.kind == TrustImportFindingKind::UnsupportedTrustValue
+                && finding.role == Some(TrustRole::RpmMetadata))
+    ));
+}
+
+#[cfg(unix)]
+#[test]
+fn file_metalink_cannot_escape_selected_root() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    prepare(root.path());
+    let (certificate, _) = certificate();
+    fs::write(root.path().join("etc/pki/rpm-gpg/VENDOR"), certificate).unwrap();
+    fs::write(outside.path().join("metalink.xml"), "outside").unwrap();
+    symlink(outside.path(), root.path().join("etc/metalink")).unwrap();
+    fs::write(
+        root.path().join("etc/yum.repos.d/vendor.repo"),
+        "[vendor]\nmetalink=file:///etc/metalink/metalink.xml\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=file:///etc/pki/rpm-gpg/VENDOR\n",
+    )
+    .unwrap();
+
+    let plan = plan_selected_root_trust(&discover_selected_root(root.path()).unwrap());
+    assert!(matches!(
+        plan.repositories[0].disposition,
+        TrustImportDisposition::Unsupported { ref findings }
+            if findings.iter().any(|finding| finding.kind == TrustImportFindingKind::SelectedRootEscape
+                && finding.role == Some(TrustRole::RpmMetadata))
+    ));
+}
+
+#[test]
 fn zypper_openpgp_metadata_and_package_roles_are_explicit() {
     let root = tempfile::tempdir().unwrap();
     prepare(root.path());
@@ -278,4 +367,22 @@ fn preview_json_rejects_unknown_fields() {
         .unwrap()
         .insert("future".to_string(), serde_json::Value::Bool(true));
     assert!(serde_json::from_value::<NativeTrustImportPlan>(value).is_err());
+}
+
+#[test]
+fn repeated_planning_serializes_identically() {
+    let root = tempfile::tempdir().unwrap();
+    prepare(root.path());
+    let (certificate, _) = certificate();
+    fs::write(root.path().join("etc/apt/keyrings/vendor.gpg"), certificate).unwrap();
+    fs::write(
+        root.path().join("etc/apt/sources.list.d/vendor.list"),
+        "deb [signed-by=/etc/apt/keyrings/vendor.gpg] https://apt.example stable main\n",
+    )
+    .unwrap();
+
+    let declarations = discover_selected_root(root.path()).unwrap();
+    let first = serde_json::to_vec(&plan_selected_root_trust(&declarations)).unwrap();
+    let second = serde_json::to_vec(&plan_selected_root_trust(&declarations)).unwrap();
+    assert_eq!(first, second);
 }

--- a/crates/conary-core/src/repository/trust.rs
+++ b/crates/conary-core/src/repository/trust.rs
@@ -361,7 +361,7 @@ fn validate_fingerprint(fingerprint: &str, label: &str) -> Result<()> {
     Ok(())
 }
 
-fn validate_https_or_file_url(value: &str, label: &str) -> Result<()> {
+pub(crate) fn validate_https_or_file_url(value: &str, label: &str) -> Result<()> {
     let parsed = Url::parse(value).map_err(|error| {
         Error::ConfigError(format!("{label} URL '{value}' is invalid: {error}"))
     })?;

--- a/crates/conary-core/src/repository/trust.rs
+++ b/crates/conary-core/src/repository/trust.rs
@@ -307,7 +307,8 @@ impl RepositoryTrustPolicy {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum TrustRole {
     DebianRelease,
     RpmMetadata,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-08-08
-revision: 42
-summary: Describe workspace architecture, source-authority projections, repository trust, package transactions, lifecycle execution, typed carrier security, generation GC, and service boundaries
+last_updated: 2026-08-11
+revision: 43
+summary: Describe workspace architecture, source-authority projections, native trust-import planning, repository verification, package transactions, lifecycle execution, typed carrier security, generation GC, and service boundaries
 ---
 
 # Conary Architecture
@@ -146,7 +146,7 @@ crates/conary-core/      Core library crate
     |   +-- conflict.rs  Conflict reporting and policy support
     |   +-- identity.rs  Dependency identity normalization
     +-- repository/      Remote package sources
-    |   +-- declarations/ Lossless selected-root APT, DNF5, libzypp, and ALPM declarations
+    |   +-- declarations/ Lossless selected-root declarations and fail-closed native trust-import preview
     |   +-- static_repo/ Static repository format, publishing, sync, and key persistence
     |   +-- trust.rs     Tagged Debian, RPM, and Arch repository authority contracts
     |   +-- trust/openpgp.rs Trust-role dispatch over the pinned and Arch keyring owners

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-08-09
-revision: 64
-summary: Route typed database rebuilds, lossless source authority, exact Remi signing, selected-root mutation, rollback lineage, canonical-map authority, carrier security, generation GC, release authority, and subsystem proof through current feature owners.
+last_updated: 2026-08-11
+revision: 65
+summary: Route typed database rebuilds, lossless source authority and trust-import planning, exact Remi signing, selected-root mutation, rollback lineage, canonical-map authority, carrier security, generation GC, release authority, and subsystem proof through current feature owners.
 ---
 
 # Assistant Subsystem Map
@@ -117,7 +117,8 @@ commands.
   `docs/modules/feature-ownership.md` slug `resolution`, plus
   `docs/modules/source-selection.md`. Lossless selected-root declaration
   discovery starts in `crates/conary-core/src/repository/declarations/` and its
-  pinned contract is `docs/specs/native-repository-declarations.md`. Trust starts in
+  pinned contracts are `docs/specs/native-repository-declarations.md` and
+  `docs/specs/native-repository-trust-import.md`. Trust verification starts in
   `crates/conary-core/src/repository/trust.rs` and
   `crates/conary-core/src/repository/trust/openpgp.rs`, with ALPM keyring and
   package-signature semantics in

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-08-08
-revision: 66
-summary: Route feature ownership through typed database rebuilds, exact Remi signing, streaming package payloads, serialized selected-root mutation, typed rollback lineage, exact lifecycle, canonical-map authority, carrier security, generation GC, exact release authority, and current canonical docs
+last_updated: 2026-08-11
+revision: 67
+summary: Route feature ownership through typed database rebuilds, native declaration and trust-import planning, exact Remi signing, streaming package payloads, serialized selected-root mutation, typed rollback lineage, exact lifecycle, canonical-map authority, carrier security, generation GC, exact release authority, and current canonical docs
 ---
 
 # Feature Ownership And Interaction Gates
@@ -441,6 +441,7 @@ package transactions.
 **Start here:** `crates/conary-core/src/repository/trust.rs`;
 `crates/conary-core/src/repository/declarations/`;
 `docs/specs/native-repository-declarations.md`;
+`docs/specs/native-repository-trust-import.md`;
 `crates/conary-core/src/repository/trust/openpgp.rs`;
 `crates/conary-core/src/repository/trust/openpgp/arch/`;
 `crates/conary-core/src/repository/parsers/`;
@@ -503,6 +504,8 @@ output changes.
 `docs/llms/subsystem-map.md`; `docs/ARCHITECTURE.md`;
 `docs/specs/native-repository-declarations.md` when declaration grammar,
 selected-root discovery, or its no-enrollment boundary changes;
+`docs/specs/native-repository-trust-import.md` when trust-import disposition,
+evidence, or selected-root key planning changes;
 `docs/specs/foreign-package-lifecycle-contracts.md` when native relation
 semantics change.
 

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-11
-revision: 32
-summary: Document exact profile-owned source policy, multi-root model authority, Remi CCS package authority, canonical map authority, native repository authority, package identity, full-adoption root continuity, and lifecycle handoff
+revision: 33
+summary: Document exact profile-owned source policy, multi-root model authority, Remi CCS package authority, canonical map authority, native declaration and trust-import planning, package identity, full-adoption root continuity, and lifecycle handoff
 ---
 
 # Source Selection Module (conary-core/src/repository/ + conary-core/src/model/)
@@ -53,6 +53,7 @@ system.toml [system]
 | `ResolutionPolicy` | `repository/resolution_policy.rs` | Exact request scope, dependency mixing, and source allowlist used by the resolver |
 | `EffectiveSourcePolicy` | `repository/effective_policy.rs` | Runtime policy assembled from DB state with one exact transaction profile |
 | `DiscoveredRepositoryDeclarations` | `repository/declarations/discovery.rs` | Lossless, source-located APT, DNF5, libzypp, and ALPM declarations confined to an explicit selected root |
+| `NativeTrustImportPlan` | `repository/declarations/trust_import/` | Deterministic importable, ambiguous, or unsupported role-separated trust preview for discovered native repositories |
 | `SystemAffinity` | `db/models/distro_pin.rs` | Informational installed-provenance measurement used for display and replatform estimates |
 | `ReplatformExecutionPlan` | `model/replatform.rs` | Executable and blocked replatform transactions derived from planned replacements |
 
@@ -232,6 +233,25 @@ This layer is not trust, enrollment, persistence, or enablement authority. It
 does not invoke a native manager or read a native database. The exact upstream
 pins, grammar inventory, and consumer boundary are recorded in
 [`docs/specs/native-repository-declarations.md`](../specs/native-repository-declarations.md).
+
+## Native Trust-Import Planning
+
+`repository/declarations/trust_import/` consumes discovered declarations and
+reads only their explicit local key material below the same selected root. Its
+strict JSON preview retains native declaration identity, enabled state, source
+locations, exact certificate fingerprints, and separate Debian Release, RPM
+metadata, RPM package, ALPM database, and ALPM package roles. An exact RPM
+metalink can authenticate metadata but never substitutes for package-signing
+authority.
+
+The only dispositions are `importable`, `ambiguous`, and `unsupported`.
+Implicit global trust, unpinned remote key sources, and an unbound ALPM keyring
+are ambiguous. Disabled verification, permissive trust, optional package
+signatures, missing or malformed key material, selector mismatches, and
+selected-root escapes are unsupported. Neither status can silently become an
+enabled persisted repository. This slice does not fetch, persist, enable, or
+mutate; the pinned semantics and consumer boundary live in
+[`docs/specs/native-repository-trust-import.md`](../specs/native-repository-trust-import.md).
 
 ## Native Repository Authenticity
 
@@ -708,7 +728,9 @@ state requires an explicit scoped install, update, or replatform operation.
   `repository/trust/openpgp.rs` for native repository authority
 - `crates/conary-core/src/repository/declarations/` and
   `docs/specs/native-repository-declarations.md` for lossless selected-root
-  declaration discovery before enrollment
+  declaration discovery, then
+  `docs/specs/native-repository-trust-import.md` for fail-closed trust planning
+  before enrollment
 - `crates/conary-core/src/repository/parsers/` and
   `repository/download.rs` for authenticated metadata and package intake
 - `crates/conary-core/src/repository/supported_profiles/` for configured feed

--- a/docs/roadmaps/development-roadmap.md
+++ b/docs/roadmaps/development-roadmap.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-08-06
-revision: 14
-summary: Track Conary's cross-distro package milestone, ordered workstreams, evidence, blockers, and post-milestone horizons
+last_updated: 2026-08-11
+revision: 15
+summary: Track Conary's cross-distro package milestone, ordered workstreams, evidence, blockers, and the issue-decomposed W10 takeover horizon
 proof_baseline: "immutable v0.14.0 at fe23a604b64ea6f7cc87fce8298911e2245e027f and production remi-v0.9.5 at 101dba655257f1ff3d1bee689d9c5ac8b2b68cbd; exact asset, deployment, and released-package proof complete"
 current_milestone: first external tester loop
 active_workstream: W6 Authority Audit Closure
@@ -491,9 +491,11 @@ accepted here.
 
 - **Outcome:** Conary enrolls native repositories transactionally and supports
   package ecosystems without a distro-name routing matrix.
-- **Execution status:** gated on W9. #62 remains an epic and is not implemented
-  as one slice.
-- **Issues:** #62 as epic, decomposed into the slices below; #68 follows.
+- **Execution status:** final conformance remains gated on W9. #62 is tracked as
+  bounded child slices: #377 is merged, and #379 through #384 own the remaining
+  trust, policy/schema, takeover/projection, lifecycle-enrollment,
+  capability-compatibility, and distro-conformance work. #68 follows.
+- **Issues:** #62 as epic; #377 and #379-#384 as tracked children; #68 follows.
 - **Decomposition:**
   - Lossless native repository declarations, with separate parsers and models
     for APT, RPM/DNF, Zypper, and ALPM. No generic repository-config model until

--- a/docs/specs/native-repository-declarations.md
+++ b/docs/specs/native-repository-declarations.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-11
-revision: 1
-summary: Pin the lossless APT, DNF5, libzypp, and ALPM native repository declaration grammars and selected-root discovery boundary
+revision: 2
+summary: Pin the lossless APT, DNF5, libzypp, and ALPM native repository declaration grammars, selected-root discovery boundary, and trust-planning handoff
 ---
 
 # Native Repository Declaration Contracts
@@ -83,10 +83,13 @@ It never executes `apt`, `dnf`, `zypper`, `pacman`, or their libraries and never
 consults their native databases.
 
 The declaration types are deliberately not `RepositoryTrustPolicy`, persisted
-repository rows, or enabled sync inputs. A later issue must combine an exact
-declaration semantic with an explicit trust-import/follow/pin decision and a
-typed plan/apply result before mutation. Distro names, file presence, URLs,
-extensions, guessed defaults, and diagnostic text cannot bridge that boundary.
+repository rows, or enabled sync inputs. Issue #379 adds the next read-only
+handoff: exact declarations plus selected-root key material produce an
+importable, ambiguous, or unsupported trust preview under
+[`native-repository-trust-import.md`](native-repository-trust-import.md).
+Follow/pin policy, persistence, and apply remain later explicit boundaries.
+Distro names, file presence, URLs, extensions, guessed defaults, and diagnostic
+text cannot bridge them.
 
 ## Proof
 

--- a/docs/specs/native-repository-trust-import.md
+++ b/docs/specs/native-repository-trust-import.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-11
-revision: 1
+revision: 2
 summary: Define deterministic fail-closed trust-import planning for selected-root APT, DNF5, libzypp, and ALPM repository declarations
 ---
 
@@ -51,19 +51,36 @@ or implicit authority.
 ## Ecosystem Rules
 
 APT `Signed-By` paths are resolved only below the selected root. Full
-fingerprint selectors filter the certificates and their key fingerprints in those
-exact sources; the trailing `!` exact-key restriction remains typed preview
+fingerprint selectors filter the combined certificate set from every exact
+source named by that entry, matching APT's role-global selector behavior; the
+trailing `!` exact-key restriction remains typed preview
 evidence, and a missing selector is an unsupported mismatch. Deb822 embedded
 key blocks are decoded with their dot-escaped blank lines and parsed directly.
 A fingerprint without a declared source still refers to global native trust and is ambiguous.
 `Trusted=yes` and insecure, weak, or downgrade allowances are unsupported.
 
-DNF and Zypper keep RPM metadata and package roles separate. Explicit strict
+DNF and Zypper keep RPM metadata and package roles separate. Repeated DNF
+`gpgkey` declarations append in declaration order and retain their individual
+locations. Explicit strict
 GPG checks plus selected-root `file:` key material can be imported for either
-role. An exact metalink may instead authenticate RPM metadata, but never package
-bytes. HTTPS key URLs are preserved as ambiguous evidence because their content
-does not pin its own certificate fingerprint. Missing inherited check policy is
-also ambiguous; an explicit false or permissive value is unsupported.
+role. An exact `https:` or `file:` metalink without credentials or a fragment
+may instead authenticate RPM metadata, but never package bytes; local metalink
+paths are confined below the selected root. A declared
+metalink satisfies that role even when inherited `gpgcheck_policy` could add a
+second native metadata check; an explicit `repo_gpgcheck=true` instead selects
+the declared OpenPGP keys. HTTPS key URLs are preserved as ambiguous evidence
+because their content does not pin its own certificate fingerprint. Missing
+inherited check policy is otherwise ambiguous; an explicit false or permissive
+value is unsupported.
+
+Enabled state retains each manager's native boolean grammar. In particular,
+libzypp treats its true tokens and nonzero integers as true and other values as
+false; the planner does not replace that upstream rule with a new grammar.
+
+Libzypp service declarations and repositories generated dynamically by those
+services are not trust-enrollment inputs in this slice. The later enrollment
+slice must surface them explicitly rather than treating an empty repository
+plan as complete.
 
 ALPM `Never`, `TrustAll`, and optional package signatures are unsupported.
 Strict `SigLevel` remains ambiguous until a later input binds the selected
@@ -87,9 +104,10 @@ and rejected by older consumers.
 ## Proof
 
 Focused tests generate real OpenPGP certificates and cover APT local and
-embedded keys, global and remote ambiguity, DNF metalink/package separation,
-Zypper metadata/package separation, ALPM strict and unsafe modes, unknown JSON,
-and selected-root symlink escape:
+embedded keys, global and remote ambiguity, repeated DNF key declarations,
+metalink/package separation and transport rejection, Zypper metadata/package
+separation, ALPM strict and unsafe modes, deterministic serialization, unknown
+JSON, and selected-root key and metalink symlink escape:
 
 ```bash
 cargo test -p conary-core repository::declarations::trust_import

--- a/docs/specs/native-repository-trust-import.md
+++ b/docs/specs/native-repository-trust-import.md
@@ -1,0 +1,96 @@
+---
+last_updated: 2026-08-11
+revision: 1
+summary: Define deterministic fail-closed trust-import planning for selected-root APT, DNF5, libzypp, and ALPM repository declarations
+---
+
+# Native Repository Trust-Import Planning
+
+Issue #379 is the second bounded Workstream 10 slice. It consumes the lossless
+declarations from
+[`native-repository-declarations.md`](native-repository-declarations.md) and
+produces strict, serializable preview data. Planning does not fetch keys,
+persist trust, enable repositories, invoke a native manager, or mutate the
+selected root.
+
+The implementation owner is
+`crates/conary-core/src/repository/declarations/trust_import/`. Every planned
+repository retains its native declaration identity, enabled state, exact source
+locations, role-separated evidence, and one closed disposition:
+
+- `importable`: every required role has an exact local or embedded OpenPGP
+  certificate fingerprint, or RPM metadata is authenticated by the exact
+  declared metalink root;
+- `ambiguous`: native configuration inherits global trust, refers to an unpinned
+  remote key, or otherwise lacks an exact binding that Conary can import
+  without guessing;
+- `unsupported`: verification is disabled or weakened, a declared source is
+  missing or malformed, a selector does not match its key material, or a path
+  escapes the selected root.
+
+An ambiguous or unsupported disposition is preview evidence, never an enabled
+`RepositoryTrustPolicy`. The later takeover/apply slice must resolve every
+enabled repository to exact authority before mutation.
+
+## Pinned Source Semantics
+
+Trust planning uses the same upstream revisions pinned by the declaration
+contract:
+
+| Ecosystem | Revision | Trust-bearing source contracts |
+|---|---|---|
+| APT | `apt-team/apt@5e6dcc8d0c8bdce61e9cc7f497abadb5349d509a` | `Signed-By`, embedded deb822 keys, `Trusted`, insecure/weak allowances, and Release verification in `apt-pkg/deb/debmetaindex.cc`, `methods/gpgv.cc`, and `doc/sources.list.5.xml` |
+| DNF5 | `rpm-software-management/dnf5@fcda6d3e34233ccfc93364f5efcc6e1d141ce41a` | `gpgkey`, `gpgcheck`/`pkg_gpgcheck`, `repo_gpgcheck`, and metalink precedence in `libdnf5/repo/` and `libdnf5/repo/config/` |
+| libzypp | `openSUSE/libzypp@227c6725b98dbddc86652b3f6d8f761a504796f2` | `gpgkey`, general/repository/package GPG policy, and metalink repository authority in `zypp/RepoInfo.cc`, `zypp/repo/RepoInfoBase.cc`, and repository workflow code |
+| ALPM | `archlinux/pacman@a6f7467d8c7c4d7e9cc846884e74c0ab7215c48d` | ordered global/per-repository `SigLevel` plus pacman-key populated trust in `src/pacman/conf.c`, `lib/libalpm/signing.c`, and `doc/pacman.conf.5.asciidoc` |
+
+The source package manager can accept broader native trust state than Conary.
+Import preserves that fact as a disposition; it does not reproduce permissive
+or implicit authority.
+
+## Ecosystem Rules
+
+APT `Signed-By` paths are resolved only below the selected root. Full
+fingerprint selectors filter the certificates and their key fingerprints in those
+exact sources; the trailing `!` exact-key restriction remains typed preview
+evidence, and a missing selector is an unsupported mismatch. Deb822 embedded
+key blocks are decoded with their dot-escaped blank lines and parsed directly.
+A fingerprint without a declared source still refers to global native trust and is ambiguous.
+`Trusted=yes` and insecure, weak, or downgrade allowances are unsupported.
+
+DNF and Zypper keep RPM metadata and package roles separate. Explicit strict
+GPG checks plus selected-root `file:` key material can be imported for either
+role. An exact metalink may instead authenticate RPM metadata, but never package
+bytes. HTTPS key URLs are preserved as ambiguous evidence because their content
+does not pin its own certificate fingerprint. Missing inherited check policy is
+also ambiguous; an explicit false or permissive value is unsupported.
+
+ALPM `Never`, `TrustAll`, and optional package signatures are unsupported.
+Strict `SigLevel` remains ambiguous until a later input binds the selected
+root's populated keyring snapshot to exact master fingerprints and a
+certification threshold. Repository names and keyring filenames cannot create
+that binding.
+
+## Selected-Root And Serialization Contract
+
+Every local key path passes through `safe_join`. Existing symlinks are resolved
+against the canonical selected root, and escapes become typed unsupported
+findings without reading the external file. OpenPGP streams must contain at
+least one complete certificate; fingerprints are uppercase, deduplicated, and
+sorted. Repository and evidence ordering follows declaration order so repeated
+planning produces identical JSON.
+
+All preview types deny unknown fields. This is a versioned implementation input,
+not an extensible diagnostic bag: future authority must be added deliberately
+and rejected by older consumers.
+
+## Proof
+
+Focused tests generate real OpenPGP certificates and cover APT local and
+embedded keys, global and remote ambiguity, DNF metalink/package separation,
+Zypper metadata/package separation, ALPM strict and unsafe modes, unknown JSON,
+and selected-root symlink escape:
+
+```bash
+cargo test -p conary-core repository::declarations::trust_import
+```


### PR DESCRIPTION
Closes #379
Refs #62

## Problem

W10 needs exact, role-separated trust authority before any native repository can be enrolled. The declaration readers preserve native trust configuration, but Conary did not yet have a typed, fail-closed preview that distinguishes importable local authority from implicit, remote, malformed, or verification-bypassing state.

## Changes

- add deterministic trust-import planning for APT, DNF, Zypper, and ALPM declarations
- preserve exact repository identity, selected-root locations, enabled state, OpenPGP certificate/key fingerprints, APT fingerprint selectors, and role-separated evidence
- preserve repeated DNF `gpgkey` append semantics and each declaration's exact location
- classify implicit global trust and unpinned remote material as ambiguous, and verification bypasses, malformed material, selector mismatches, unsafe metalinks, and selected-root escapes as unsupported
- keep ALPM enrollment ambiguous until an exact keyring snapshot and master-fingerprint threshold are bound
- publish the durable W10 trust-import contract and update owning architecture/routing/roadmap truth

This slice is serial and preview-only: it does not fetch keys, mutate trust state, enable repositories, or enroll sources.

## Review

- DeepSeek V4 Flash adversarial implementation review identified the repeated-DNF-key evidence loss and planner/persisted-policy metalink mismatch; both findings are fixed with regression coverage
- libzypp's native true-token/nonzero-integer boolean grammar remains authoritative rather than being replaced by a stricter incompatible grammar

## Verification

- `cargo test -p conary-core repository::declarations::trust_import --no-fail-fast` with an isolated target directory — 14 passed
- `cargo test -p conary-core --no-fail-fast` with an isolated target directory — 3,449 library tests passed, 3 ignored; all integration and doc-test targets passed
- `cargo clippy --workspace --all-targets -- -D warnings` with an isolated target directory — passed
- `bash scripts/check-doc-truth.sh` — passed
- `cargo fmt --check` — passed
- `git diff --check` — passed
