### PR TITLE
feat(repository): own native takeover projections

### DIFF
--- a/apps/conary/src/cli/system.rs
+++ b/apps/conary/src/cli/system.rs
@@ -63,6 +63,38 @@ pub enum SystemCommands {
         yes: bool,
     },
 
+    /// Preview, apply, or roll back native repository authority takeover
+    #[command(name = "repository-takeover")]
+    RepositoryTakeover {
+        #[command(flatten)]
+        common: CommonArgs,
+
+        /// Versioned JSON enrollment manifest bound to discovered declarations
+        #[arg(long, required_unless_present = "rollback")]
+        manifest: Option<std::path::PathBuf>,
+
+        /// Digest printed by the exact dry-run preview being applied
+        #[arg(
+            long,
+            required_unless_present_any = ["dry_run", "rollback"],
+            requires = "yes",
+            conflicts_with_all = ["dry_run", "rollback"]
+        )]
+        preview_sha256: Option<String>,
+
+        /// Print the complete deterministic preview without mutation
+        #[arg(long, conflicts_with = "rollback")]
+        dry_run: bool,
+
+        /// Restore pre-takeover projection bytes and Conary authority
+        #[arg(long, conflicts_with_all = ["manifest", "preview_sha256", "dry_run"])]
+        rollback: bool,
+
+        /// Confirm applying or rolling back selected-root authority
+        #[arg(short, long, required_unless_present = "dry_run")]
+        yes: bool,
+    },
+
     /// Generate shell completions
     Completions {
         /// Shell to generate completions for

--- a/apps/conary/src/cli/tests.rs
+++ b/apps/conary/src/cli/tests.rs
@@ -560,6 +560,72 @@ fn system_init_has_no_host_distro_selector() {
 }
 
 #[test]
+fn repository_takeover_separates_preview_apply_and_rollback_intent() {
+    let preview = parse_cli([
+        "conary",
+        "system",
+        "repository-takeover",
+        "--root",
+        "/selected",
+        "--manifest",
+        "takeover.json",
+        "--dry-run",
+    ])
+    .unwrap();
+    match preview.command {
+        Some(Commands::System(SystemCommands::RepositoryTakeover {
+            common,
+            manifest,
+            dry_run,
+            rollback,
+            ..
+        })) => {
+            assert_eq!(common.root, "/selected");
+            assert_eq!(manifest.unwrap(), std::path::PathBuf::from("takeover.json"));
+            assert!(dry_run);
+            assert!(!rollback);
+        }
+        _ => panic!("expected repository takeover command"),
+    }
+
+    assert!(
+        parse_cli([
+            "conary",
+            "system",
+            "repository-takeover",
+            "--manifest",
+            "takeover.json",
+            "--yes",
+        ])
+        .is_err(),
+        "apply requires the exact preview digest"
+    );
+    assert!(
+        parse_cli([
+            "conary",
+            "system",
+            "repository-takeover",
+            "--manifest",
+            "takeover.json",
+            "--preview-sha256",
+            "00",
+        ])
+        .is_err(),
+        "apply requires explicit intent"
+    );
+    assert!(
+        parse_cli([
+            "conary",
+            "system",
+            "repository-takeover",
+            "--rollback",
+            "--yes",
+        ])
+        .is_ok()
+    );
+}
+
+#[test]
 fn install_defaults_to_always_sandbox() {
     let cli = parse_cli(["conary", "install", "bash"]).unwrap();
     match cli.command {

--- a/apps/conary/src/command_risk.rs
+++ b/apps/conary/src/command_risk.rs
@@ -16,6 +16,7 @@ pub enum CommandRisk {
     HookRefreshDbMutation,
     DbMutation,
     DestructiveDbMutation,
+    SelectedRootMutation,
     /// Internal boot continuation authorized by an exact generation artifact
     /// and kernel command-line contract rather than an interactive `--yes`.
     GenerationBootActivation,
@@ -40,6 +41,7 @@ impl CommandRiskPolicy {
         matches!(
             self.risk,
             CommandRisk::DestructiveDbMutation
+                | CommandRisk::SelectedRootMutation
                 | CommandRisk::ActiveHostMutation
                 | CommandRisk::AlwaysLive
         ) && !self.dry_run
@@ -55,6 +57,7 @@ impl CommandRiskPolicy {
             CommandRisk::DbMutation | CommandRisk::DestructiveDbMutation => {
                 Some(LiveMutationClass::LiveConaryState)
             }
+            CommandRisk::SelectedRootMutation => Some(LiveMutationClass::SelectedRootState),
             CommandRisk::ActiveHostMutation => {
                 Some(LiveMutationClass::CurrentlyLiveEvenWithRootArguments)
             }
@@ -271,6 +274,12 @@ fn classify_system(command: &cli::SystemCommands) -> Option<CommandRiskPolicy> {
             "conary system rebuild-db",
             CommandRisk::DestructiveDbMutation,
             false,
+            *yes,
+        )),
+        cli::SystemCommands::RepositoryTakeover { dry_run, yes, .. } => Some(policy_with_intent(
+            "conary system repository-takeover",
+            CommandRisk::SelectedRootMutation,
+            *dry_run,
             *yes,
         )),
         cli::SystemCommands::Completions { .. }

--- a/apps/conary/src/command_risk/tests.rs
+++ b/apps/conary/src/command_risk/tests.rs
@@ -114,6 +114,45 @@ fn classify_system_adopt_full_package_as_live_db_mutation() {
 }
 
 #[test]
+fn repository_takeover_preview_is_read_only_and_mutations_are_selected_root_scoped() {
+    let preview = policy(&[
+        "conary",
+        "system",
+        "repository-takeover",
+        "--manifest",
+        "takeover.json",
+        "--dry-run",
+    ]);
+    assert_eq!(preview.risk, CommandRisk::SelectedRootMutation);
+    assert!(preview.dry_run);
+    assert!(!preview.requires_ack());
+
+    let apply = policy(&[
+        "conary",
+        "system",
+        "repository-takeover",
+        "--manifest",
+        "takeover.json",
+        "--preview-sha256",
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        "--yes",
+    ]);
+    assert_eq!(apply.risk, CommandRisk::SelectedRootMutation);
+    assert!(!apply.dry_run);
+    assert!(apply.requires_ack());
+
+    let rollback = policy(&[
+        "conary",
+        "system",
+        "repository-takeover",
+        "--rollback",
+        "--yes",
+    ]);
+    assert_eq!(rollback.risk, CommandRisk::SelectedRootMutation);
+    assert!(rollback.requires_ack());
+}
+
+#[test]
 fn classify_installed_sync_hook_refresh_as_narrow_hook_refresh() {
     let policy = policy(&[
         "conary",

--- a/apps/conary/src/commands/mod.rs
+++ b/apps/conary/src/commands/mod.rs
@@ -52,6 +52,7 @@ mod remove;
 mod replatform_rendering;
 mod repo;
 mod repo_static;
+mod repository_takeover;
 mod restore;
 mod rollback_system_authority;
 mod self_update;
@@ -174,6 +175,7 @@ pub use repo::{
     cmd_repo_remove, cmd_repo_sync, cmd_search,
 };
 pub use repo_static::cmd_repo_reset_trust;
+pub use repository_takeover::cmd_repository_takeover;
 pub use restore::{cmd_restore, cmd_restore_all};
 pub(crate) use rollback_system_authority::RollbackSystemAuthority;
 pub use self_update::{SelfUpdateOptions, cmd_self_update};

--- a/apps/conary/src/commands/repository_takeover.rs
+++ b/apps/conary/src/commands/repository_takeover.rs
@@ -1,0 +1,85 @@
+// apps/conary/src/commands/repository_takeover.rs
+
+//! CLI boundary for native repository takeover preview, apply, and rollback.
+
+use crate::ui;
+use anyhow::{Context, Result, bail};
+use conary_core::repository::declarations::takeover::{
+    NativeRepositoryTakeoverManifest, TakeoverApplyStatus, apply_native_repository_takeover,
+    preview_native_repository_takeover, rollback_native_repository_takeover,
+};
+use std::path::Path;
+
+pub fn cmd_repository_takeover(
+    db_path: &str,
+    root: &str,
+    manifest_path: Option<&Path>,
+    expected_preview_sha256: Option<&str>,
+    dry_run: bool,
+    rollback: bool,
+) -> Result<()> {
+    let _runtime_lock = (!dry_run)
+        .then(|| super::generation::selected_root::LockedRuntimeRoot::acquire(db_path))
+        .transpose()
+        .context("acquire repository takeover mutation lock")?;
+    let conn = if dry_run {
+        conary_core::db::open_read_only(db_path)
+            .context("open current Conary database read-only for takeover preview")?
+    } else {
+        conary_core::db::open(db_path).context("open current Conary database")?
+    };
+    if rollback {
+        rollback_native_repository_takeover(&conn, root)
+            .context("roll back native repository takeover")?;
+        ui::status("Rolled back", "native repository takeover");
+        return Ok(());
+    }
+
+    let manifest_path = manifest_path
+        .ok_or_else(|| anyhow::anyhow!("--manifest is required unless --rollback is used"))?;
+    let bytes = std::fs::read(manifest_path)
+        .with_context(|| format!("read takeover manifest {}", manifest_path.display()))?;
+    let manifest: NativeRepositoryTakeoverManifest = serde_json::from_slice(&bytes)
+        .with_context(|| format!("decode takeover manifest {}", manifest_path.display()))?;
+    let preview = preview_native_repository_takeover(&conn, root, &manifest)
+        .context("preview native repository takeover")?;
+    let digest = preview.sha256()?;
+    println!("{}", serde_json::to_string_pretty(&preview)?);
+    ui::field("Preview SHA-256", &digest);
+    if dry_run {
+        if !preview.blockers.is_empty() {
+            ui::warn(&format!(
+                "takeover preview has {} blocker(s)",
+                preview.blockers.len()
+            ));
+        }
+        return Ok(());
+    }
+    let expected = expected_preview_sha256.ok_or_else(|| {
+        anyhow::anyhow!(
+            "--preview-sha256 is required for apply; run --dry-run and inspect the exact preview first"
+        )
+    })?;
+    if expected != digest {
+        bail!("provided preview SHA-256 {expected} does not match current preview {digest}");
+    }
+    let outcome = apply_native_repository_takeover(&conn, root, &manifest, expected)
+        .context("apply native repository takeover")?;
+    match outcome.status {
+        TakeoverApplyStatus::Applied => ui::status(
+            "Applied",
+            &format!(
+                "native repository takeover for {} repository row(s)",
+                outcome.repository_ids.len()
+            ),
+        ),
+        TakeoverApplyStatus::AlreadyApplied => ui::status(
+            "Verified",
+            &format!(
+                "existing native repository takeover for {} repository row(s)",
+                outcome.repository_ids.len()
+            ),
+        ),
+    }
+    Ok(())
+}

--- a/apps/conary/src/dispatch/root/try_preflight.rs
+++ b/apps/conary/src/dispatch/root/try_preflight.rs
@@ -518,7 +518,8 @@ fn selected_system_db_path(command: &cli::SystemCommands) -> &str {
         | cli::SystemCommands::Sbom { db, .. }
         | cli::SystemCommands::Takeover { db, .. } => &db.db_path,
         cli::SystemCommands::Verify { common, .. }
-        | cli::SystemCommands::Restore { common, .. } => &common.db.db_path,
+        | cli::SystemCommands::Restore { common, .. }
+        | cli::SystemCommands::RepositoryTakeover { common, .. } => &common.db.db_path,
         cli::SystemCommands::DbBackup { command } => selected_db_backup_db_path(command),
         cli::SystemCommands::State(command) => selected_state_db_path(command),
         cli::SystemCommands::Generation(command) => selected_generation_db_path(command),

--- a/apps/conary/src/dispatch/system.rs
+++ b/apps/conary/src/dispatch/system.rs
@@ -35,6 +35,30 @@ pub(super) async fn dispatch_system_command(sys_cmd: cli::SystemCommands) -> Res
             commands::cmd_rebuild_database(&db.db_path).await
         }
 
+        cli::SystemCommands::RepositoryTakeover {
+            common,
+            manifest,
+            preview_sha256,
+            dry_run,
+            rollback,
+            yes,
+        } => {
+            require_live_mutation(
+                MutationIntent::from_apply_intent(yes),
+                Cow::Borrowed("conary system repository-takeover"),
+                LiveMutationClass::SelectedRootState,
+                dry_run,
+            )?;
+            commands::cmd_repository_takeover(
+                &common.db.db_path,
+                &common.root,
+                manifest.as_deref(),
+                preview_sha256.as_deref(),
+                dry_run,
+                rollback,
+            )
+        }
+
         cli::SystemCommands::Completions { shell } => {
             let mut cmd = Cli::command();
             generate(shell, &mut cmd, "conary", &mut io::stdout());

--- a/apps/conary/src/live_host_safety.rs
+++ b/apps/conary/src/live_host_safety.rs
@@ -27,6 +27,7 @@ impl MutationIntent {
 pub enum LiveMutationClass {
     AlwaysLive,
     LiveConaryState,
+    SelectedRootState,
     CurrentlyLiveEvenWithRootArguments,
 }
 
@@ -45,6 +46,10 @@ pub fn require_mutation_intent(request: &LiveMutationRequest) -> anyhow::Result<
     let mut message = match request.class {
         LiveMutationClass::LiveConaryState => format!(
             "command '{}' may update Conary DB or CAS metadata for this machine.",
+            request.command_label
+        ),
+        LiveMutationClass::SelectedRootState => format!(
+            "command '{}' may update Conary authority and files in the explicitly selected root.",
             request.command_label
         ),
         LiveMutationClass::CurrentlyLiveEvenWithRootArguments => format!(

--- a/apps/remi/src/server/handlers/admin/repos.rs
+++ b/apps/remi/src/server/handlers/admin/repos.rs
@@ -172,6 +172,7 @@ impl TryFrom<conary_core::db::models::Repository> for RepoResponse {
             managed_by: match r.managed_by {
                 RepositoryOwnership::Operator => "operator",
                 RepositoryOwnership::RemiConfig => "remi-config",
+                RepositoryOwnership::NativeProjection => "native-projection",
             },
             native_source,
         })

--- a/crates/conary-core/src/db/current_schema/sql/repository.sql
+++ b/crates/conary-core/src/db/current_schema/sql/repository.sql
@@ -43,7 +43,7 @@ CREATE TABLE repositories (
                 CHECK(package_format IN ('arch', 'deb', 'rpm', 'json', 'unspecified')),
             parser_config_json TEXT,
             managed_by TEXT NOT NULL DEFAULT 'operator'
-                CHECK(managed_by IN ('operator', 'remi-config')),
+                CHECK(managed_by IN ('operator', 'remi-config', 'native-projection')),
             source_policy_id INTEGER REFERENCES repository_source_policies(id) ON DELETE RESTRICT,
             repository_identity TEXT,
             stream_binding_sha256 TEXT,
@@ -108,6 +108,53 @@ BEGIN
           AND policy.update_mode = 'pin'
     ) THEN RAISE(ABORT, 'repository source pin requires pin update policy') END;
 END;
+CREATE TABLE native_repository_takeovers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            selected_root TEXT NOT NULL UNIQUE,
+            preview_sha256 TEXT NOT NULL,
+            preview_json TEXT NOT NULL,
+            applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            CHECK(length(selected_root) > 0),
+            CHECK(length(preview_sha256) = 64 AND preview_sha256 NOT GLOB '*[^0-9a-f]*')
+        );
+CREATE TABLE native_repository_takeover_members (
+            takeover_id INTEGER NOT NULL REFERENCES native_repository_takeovers(id) ON DELETE CASCADE,
+            repository_id INTEGER NOT NULL UNIQUE REFERENCES repositories(id) ON DELETE RESTRICT,
+            PRIMARY KEY(takeover_id, repository_id)
+        );
+CREATE TRIGGER native_repository_takeover_members_require_owned_repository
+BEFORE INSERT ON native_repository_takeover_members
+BEGIN
+    SELECT CASE WHEN NOT EXISTS (
+        SELECT 1 FROM repositories
+        WHERE id = NEW.repository_id AND managed_by = 'native-projection'
+    ) THEN RAISE(ABORT, 'native takeover member requires native-projection ownership') END;
+END;
+CREATE TRIGGER native_repository_takeover_members_preserve_owned_repository
+BEFORE UPDATE OF managed_by ON repositories
+WHEN EXISTS (
+    SELECT 1 FROM native_repository_takeover_members
+    WHERE repository_id = OLD.id
+)
+BEGIN
+    SELECT CASE WHEN NEW.managed_by != 'native-projection'
+        THEN RAISE(ABORT, 'native takeover repository ownership is immutable') END;
+END;
+CREATE TABLE native_repository_projections (
+            takeover_id INTEGER NOT NULL REFERENCES native_repository_takeovers(id) ON DELETE CASCADE,
+            path TEXT NOT NULL,
+            content BLOB NOT NULL,
+            sha256 TEXT NOT NULL,
+            mode INTEGER NOT NULL CHECK(mode BETWEEN 0 AND 4095),
+            prior_existed INTEGER NOT NULL CHECK(prior_existed IN (0, 1)),
+            prior_content BLOB,
+            prior_mode INTEGER,
+            CHECK(length(path) > 1 AND substr(path, 1, 1) = '/'),
+            CHECK(length(sha256) = 64 AND sha256 NOT GLOB '*[^0-9a-f]*'),
+            CHECK((prior_existed = 1 AND prior_content IS NOT NULL AND prior_mode IS NOT NULL)
+                OR (prior_existed = 0 AND prior_content IS NULL AND prior_mode IS NULL)),
+            PRIMARY KEY(takeover_id, path)
+        );
 CREATE TABLE repository_packages (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             repository_id INTEGER NOT NULL,

--- a/crates/conary-core/src/db/current_schema/sql/repository.sql
+++ b/crates/conary-core/src/db/current_schema/sql/repository.sql
@@ -140,6 +140,36 @@ BEGIN
     SELECT CASE WHEN NEW.managed_by != 'native-projection'
         THEN RAISE(ABORT, 'native takeover repository ownership is immutable') END;
 END;
+CREATE TRIGGER native_repository_takeover_members_preserve_repository_authority
+BEFORE UPDATE ON repositories
+WHEN EXISTS (
+    SELECT 1 FROM native_repository_takeover_members
+    WHERE repository_id = OLD.id
+)
+BEGIN
+    SELECT CASE WHEN
+        NEW.name IS NOT OLD.name
+        OR NEW.url IS NOT OLD.url
+        OR NEW.content_url IS NOT OLD.content_url
+        OR NEW.enabled IS NOT OLD.enabled
+        OR NEW.priority IS NOT OLD.priority
+        OR NEW.trust_policy_json IS NOT OLD.trust_policy_json
+        OR NEW.metadata_expire IS NOT OLD.metadata_expire
+        OR NEW.default_strategy IS NOT OLD.default_strategy
+        OR NEW.default_strategy_endpoint IS NOT OLD.default_strategy_endpoint
+        OR NEW.source_profile IS NOT OLD.source_profile
+        OR NEW.tuf_enabled IS NOT OLD.tuf_enabled
+        OR NEW.tuf_root_version IS NOT OLD.tuf_root_version
+        OR NEW.tuf_root_url IS NOT OLD.tuf_root_url
+        OR NEW.security_advisory_support IS NOT OLD.security_advisory_support
+        OR NEW.package_format IS NOT OLD.package_format
+        OR NEW.parser_config_json IS NOT OLD.parser_config_json
+        OR NEW.managed_by IS NOT OLD.managed_by
+        OR NEW.source_policy_id IS NOT OLD.source_policy_id
+        OR NEW.repository_identity IS NOT OLD.repository_identity
+        OR NEW.stream_binding_sha256 IS NOT OLD.stream_binding_sha256
+        THEN RAISE(ABORT, 'native takeover repository authority changes require projection enrollment') END;
+END;
 CREATE TABLE native_repository_projections (
             takeover_id INTEGER NOT NULL REFERENCES native_repository_takeovers(id) ON DELETE CASCADE,
             path TEXT NOT NULL,

--- a/crates/conary-core/src/db/mod.rs
+++ b/crates/conary-core/src/db/mod.rs
@@ -16,7 +16,7 @@ pub mod rebuild;
 pub mod schema;
 
 use crate::error::{Error, Result};
-use rusqlite::Connection;
+use rusqlite::{Connection, OpenFlags};
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
@@ -33,6 +33,12 @@ const CONNECTION_PRAGMAS: &str = "\
     PRAGMA busy_timeout = 5000;\
 ";
 
+const READ_ONLY_CONNECTION_PRAGMAS: &str = "\
+    PRAGMA query_only = ON;\
+    PRAGMA foreign_keys = ON;\
+    PRAGMA busy_timeout = 5000;\
+";
+
 const SQLITE_WAL_HEADER_SIZE: u64 = 32;
 const SQLITE_WAL_MAGIC_BE: [u32; 2] = [0x377f0682, 0x377f0683];
 
@@ -42,16 +48,20 @@ fn configure(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
-fn validate_wal_file(path: &Path) -> Result<()> {
+fn database_wal_path(path: &Path) -> std::path::PathBuf {
     // Construct WAL path: "foo.db" -> "foo.db-wal", "foo" -> "foo-wal"
-    let wal_path = match path.extension().and_then(|e| e.to_str()) {
+    match path.extension().and_then(|e| e.to_str()) {
         Some(ext) => path.with_extension(format!("{ext}-wal")),
         None => {
             let mut p = path.as_os_str().to_os_string();
             p.push("-wal");
             std::path::PathBuf::from(p)
         }
-    };
+    }
+}
+
+fn validate_wal_file(path: &Path) -> Result<()> {
+    let wal_path = database_wal_path(path);
     if !wal_path.exists() {
         return Ok(());
     }
@@ -135,6 +145,40 @@ pub fn open(path: impl AsRef<Path>) -> Result<Connection> {
     Ok(conn)
 }
 
+/// Open and validate an existing current-schema database without mutation.
+pub fn open_read_only(path: impl AsRef<Path>) -> Result<Connection> {
+    let path = path.as_ref();
+    if !path.exists() {
+        return Err(Error::DatabaseNotFound(path.to_string_lossy().to_string()));
+    }
+
+    validate_wal_file(path)?;
+    let wal_path = database_wal_path(path);
+    if wal_path.metadata().is_ok_and(|metadata| metadata.len() > 0) {
+        return Err(Error::ConflictError(format!(
+            "read-only database inspection requires a checkpointed WAL; active frames remain in {}",
+            wal_path.display()
+        )));
+    }
+    let immutable_path = path.canonicalize()?;
+    let mut uri = url::Url::from_file_path(&immutable_path).map_err(|_| {
+        Error::ConfigError(format!(
+            "database path {} cannot be represented as an immutable SQLite URI",
+            immutable_path.display()
+        ))
+    })?;
+    uri.query_pairs_mut().append_pair("immutable", "1");
+    let conn = Connection::open_with_flags(
+        uri.as_str(),
+        OpenFlags::SQLITE_OPEN_READ_ONLY
+            | OpenFlags::SQLITE_OPEN_NO_MUTEX
+            | OpenFlags::SQLITE_OPEN_URI,
+    )?;
+    conn.execute_batch(READ_ONLY_CONNECTION_PRAGMAS)?;
+    schema::require_current(&conn)?;
+    Ok(conn)
+}
+
 /// Open an existing Conary database without revalidating its schema epoch.
 ///
 /// This is identical to [`open`] but skips [`schema::ensure_current`], making
@@ -214,6 +258,23 @@ mod tests {
     use super::*;
     use tempfile::NamedTempFile;
 
+    fn directory_snapshot(path: &Path) -> Vec<(String, u64, String)> {
+        let mut entries = std::fs::read_dir(path)
+            .unwrap()
+            .map(|entry| {
+                let entry = entry.unwrap();
+                let bytes = std::fs::read(entry.path()).unwrap();
+                (
+                    entry.file_name().to_string_lossy().into_owned(),
+                    bytes.len() as u64,
+                    crate::hash::sha256(&bytes),
+                )
+            })
+            .collect::<Vec<_>>();
+        entries.sort_by(|left, right| left.0.cmp(&right.0));
+        entries
+    }
+
     #[test]
     fn test_init_creates_database() {
         let temp_file = NamedTempFile::new().unwrap();
@@ -238,6 +299,31 @@ mod tests {
         // Then open
         let result = open(db_path);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn open_read_only_validates_current_schema_without_database_side_effects() {
+        let directory = tempfile::tempdir().unwrap();
+        let db_path = directory.path().join("conary.db");
+        init(&db_path).unwrap();
+        let before = directory_snapshot(directory.path());
+
+        let conn = open_read_only(&db_path).unwrap();
+        let version: i32 = conn
+            .query_row(
+                "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(version, schema::SCHEMA_VERSION);
+        assert!(
+            conn.execute("INSERT INTO schema_version (version) VALUES (999)", [])
+                .is_err()
+        );
+        assert_eq!(directory_snapshot(directory.path()), before);
+        drop(conn);
+        assert_eq!(directory_snapshot(directory.path()), before);
     }
 
     #[test]

--- a/crates/conary-core/src/db/models/repository/source.rs
+++ b/crates/conary-core/src/db/models/repository/source.rs
@@ -49,6 +49,7 @@ pub enum RepositoryOwnership {
     #[default]
     Operator,
     RemiConfig,
+    NativeProjection,
 }
 
 impl RepositoryOwnership {
@@ -56,6 +57,7 @@ impl RepositoryOwnership {
         match self {
             Self::Operator => "operator",
             Self::RemiConfig => "remi-config",
+            Self::NativeProjection => "native-projection",
         }
     }
 
@@ -63,6 +65,7 @@ impl RepositoryOwnership {
         match value {
             "operator" => Ok(Self::Operator),
             "remi-config" => Ok(Self::RemiConfig),
+            "native-projection" => Ok(Self::NativeProjection),
             other => Err(format!("unknown persisted repository ownership '{other}'")),
         }
     }

--- a/crates/conary-core/src/db/schema.rs
+++ b/crates/conary-core/src/db/schema.rs
@@ -12,13 +12,12 @@ use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 use std::path::Path;
 use tracing::info;
 
-/// Revision 31 of the current-only schema epoch.
+/// Revision 32 of the current-only schema epoch.
 ///
-/// Revision 31 replaces fixed-profile repository identity with exact native
-/// source/repository identities, shared follow-or-pin policy, immutable stream
-/// bindings, and authenticated snapshot state. Earlier pre-alpha databases must
-/// be rebuilt; no compatibility migration is provided.
-pub const SCHEMA_VERSION: i32 = 31;
+/// Revision 32 adds native repository takeover ownership and exact projection
+/// state. Earlier pre-alpha databases must be rebuilt; no compatibility
+/// migration is provided.
+pub const SCHEMA_VERSION: i32 = 32;
 /// Stable identity that distinguishes this epoch from retired schema revisions.
 pub const SCHEMA_EPOCH: &str = "conary-current-v1";
 
@@ -80,6 +79,30 @@ pub fn get_schema_version(conn: &Connection) -> Result<i32> {
     .optional()
     .map(|version| version.unwrap_or(0))
     .map_err(Into::into)
+}
+
+/// Require the current schema epoch without creating or migrating any state.
+pub fn require_current(conn: &Connection) -> Result<()> {
+    let current_version = get_schema_version(conn)?;
+    match get_schema_identity(conn)? {
+        Some((epoch, revision)) if epoch == SCHEMA_EPOCH && revision == SCHEMA_VERSION => {
+            if current_version == SCHEMA_VERSION {
+                Ok(())
+            } else {
+                Err(rebuild_required(&format!(
+                    "schema epoch {epoch} with inconsistent version {current_version}"
+                )))
+            }
+        }
+        Some((epoch, revision)) => Err(rebuild_required(&format!(
+            "schema epoch {epoch} revision {revision}"
+        ))),
+        None if database_is_fresh(conn)? => Err(rebuild_required("fresh database")),
+        None if current_version == 0 => Err(rebuild_required("unversioned non-empty")),
+        None => Err(rebuild_required(&format!(
+            "retired migration-chain schema version {current_version}"
+        ))),
+    }
 }
 
 /// Initialize a fresh database or validate that it already uses this epoch.
@@ -214,7 +237,7 @@ mod tests {
     }
 
     #[test]
-    fn revision_30_requires_rebuild_for_revision_31() {
+    fn revision_31_requires_rebuild_for_revision_32() {
         let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(
             "CREATE TABLE schema_identity (
@@ -222,19 +245,19 @@ mod tests {
                 revision INTEGER NOT NULL
             );
             INSERT INTO schema_identity (epoch, revision)
-                VALUES ('conary-current-v1', 30);
+                VALUES ('conary-current-v1', 31);
             CREATE TABLE schema_version (
                 version INTEGER PRIMARY KEY,
                 applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             );
-            INSERT INTO schema_version (version) VALUES (30);",
+            INSERT INTO schema_version (version) VALUES (31);",
         )
         .unwrap();
 
         let error = ensure_current(&conn).unwrap_err();
         assert_eq!(
             error.to_string(),
-            "Database schema rebuild required: database uses schema epoch conary-current-v1 revision 30; this pre-alpha build supports only schema epoch conary-current-v1 revision 31"
+            "Database schema rebuild required: database uses schema epoch conary-current-v1 revision 31; this pre-alpha build supports only schema epoch conary-current-v1 revision 32"
         );
     }
 

--- a/crates/conary-core/src/repository/declarations/mod.rs
+++ b/crates/conary-core/src/repository/declarations/mod.rs
@@ -15,6 +15,7 @@ pub mod apt;
 pub mod discovery;
 pub mod dnf;
 mod ini;
+pub mod takeover;
 pub mod trust_import;
 pub mod zypper;
 

--- a/crates/conary-core/src/repository/declarations/takeover.rs
+++ b/crates/conary-core/src/repository/declarations/takeover.rs
@@ -1,0 +1,680 @@
+// conary-core/src/repository/declarations/takeover.rs
+
+//! Transactional native repository takeover and owned declaration projections.
+
+use super::trust_import::{
+    NativeRepositoryReference, NativeRepositoryTrustPlan, NativeTrustImportPlan,
+    TrustEvidenceSource, TrustImportDisposition, TrustImportEvidence, plan_selected_root_trust,
+};
+use super::{DiscoveredRepositoryDeclarations, discover_selected_root};
+use crate::db::models::{
+    AuthenticatedSnapshotIdentity, NativeSourceEcosystem, NativeSourceStream, Repository,
+    RepositoryOwnership, RepositoryPolicyScope, RepositorySourcePolicy, RepositoryUpdateMode,
+};
+use crate::error::{Error, Result};
+use crate::filesystem::path::safe_join;
+use crate::repository::{
+    OpenPgpTrustRoot, RepositoryFormat, RepositoryParserConfig, RepositoryTrustPolicy,
+    RpmMetadataAuthority, TrustRole,
+};
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+mod projection;
+mod trust_policy;
+
+use projection::{
+    ProjectionContent, StagedProjection, collect_projection_content,
+    ensure_projection_inputs_unchanged, load_current_projections, load_prior_projections,
+    persist_staged, projection_drift, restore_projection_bytes, stage_projection_writes,
+};
+use trust_policy::expected_trust_policy;
+
+pub const TAKEOVER_MANIFEST_SCHEMA: u32 = 1;
+pub const TAKEOVER_PREVIEW_SCHEMA: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum TakeoverPolicyScope {
+    Repository { identity: String },
+    Group { identity: String },
+}
+
+impl TakeoverPolicyScope {
+    fn materialize(&self) -> Result<RepositoryPolicyScope> {
+        match self {
+            Self::Repository { identity } => RepositoryPolicyScope::repository(identity.clone()),
+            Self::Group { identity } => RepositoryPolicyScope::group(identity.clone()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum TakeoverSourceStream {
+    Release { identity: String },
+    Channel { identity: String },
+    Rolling { identity: String },
+}
+
+impl TakeoverSourceStream {
+    fn materialize(&self) -> Result<NativeSourceStream> {
+        match self {
+            Self::Release { identity } => NativeSourceStream::release(identity.clone()),
+            Self::Channel { identity } => NativeSourceStream::channel(identity.clone()),
+            Self::Rolling { identity } => NativeSourceStream::rolling(identity.clone()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "mode", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum TakeoverUpdatePolicy {
+    Follow,
+    Pin { snapshot_sha256: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TakeoverRepositoryInput {
+    pub declaration: NativeRepositoryReference,
+    pub name: String,
+    pub source_identity: String,
+    pub repository_identity: String,
+    pub scope: TakeoverPolicyScope,
+    pub stream: TakeoverSourceStream,
+    pub update: TakeoverUpdatePolicy,
+    pub metadata_url: String,
+    pub content_url: Option<String>,
+    pub parser: RepositoryParserConfig,
+    pub trust: RepositoryTrustPolicy,
+    pub enabled: bool,
+    pub priority: i32,
+    pub metadata_expire: i32,
+    pub source_profile: Option<String>,
+}
+
+impl TakeoverRepositoryInput {
+    fn materialize(&self) -> Result<Repository> {
+        let ecosystem = NativeSourceEcosystem::from_repository_format(self.parser.format())?;
+        let (mode, pin) = match &self.update {
+            TakeoverUpdatePolicy::Follow => (RepositoryUpdateMode::Follow, None),
+            TakeoverUpdatePolicy::Pin { snapshot_sha256 } => (
+                RepositoryUpdateMode::Pin,
+                Some(AuthenticatedSnapshotIdentity::from_sha256(
+                    snapshot_sha256.clone(),
+                )?),
+            ),
+        };
+        let policy = RepositorySourcePolicy::new(
+            self.source_identity.clone(),
+            self.scope.materialize()?,
+            ecosystem,
+            self.stream.materialize()?,
+            mode,
+        )?;
+        let mut repository = Repository::new(self.name.clone(), self.metadata_url.clone());
+        repository.content_url = self.content_url.clone();
+        repository.enabled = self.enabled;
+        repository.priority = self.priority;
+        repository.metadata_expire = self.metadata_expire;
+        repository.source_profile = self.source_profile.clone();
+        repository.managed_by = RepositoryOwnership::NativeProjection;
+        repository.set_parser_config(self.parser.clone())?;
+        repository.set_trust_policy(self.trust.clone())?;
+        repository.set_native_source_policy(policy, self.repository_identity.clone(), pin)?;
+        Ok(repository)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NativeRepositoryTakeoverManifest {
+    pub schema: u32,
+    pub repositories: Vec<TakeoverRepositoryInput>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProjectionOwnershipChange {
+    NativeToConary,
+    ConaryVerified,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NativeProjectionPreview {
+    pub path: PathBuf,
+    pub sha256: String,
+    pub mode: u32,
+    pub ownership: ProjectionOwnershipChange,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum TakeoverBlocker {
+    EnabledTrust {
+        repository: NativeRepositoryReference,
+        disposition: TrustImportDisposition,
+    },
+    MissingEnrollment {
+        repository: NativeRepositoryReference,
+    },
+    UnknownEnrollment {
+        repository: NativeRepositoryReference,
+        name: String,
+    },
+    DuplicateEnrollmentProduct {
+        repository: NativeRepositoryReference,
+        names: Vec<String>,
+    },
+    ParserFormatMismatch {
+        repository: NativeRepositoryReference,
+        name: String,
+        expected: RepositoryFormat,
+        requested: RepositoryFormat,
+    },
+    EnabledStateMismatch {
+        repository: NativeRepositoryReference,
+        name: String,
+        declared: bool,
+        requested: bool,
+    },
+    DuplicateRepositoryName {
+        name: String,
+    },
+    DuplicateRepositoryIdentity {
+        identity: String,
+    },
+    ExistingRepository {
+        name: String,
+        ownership: String,
+    },
+    TrustPolicyMismatch {
+        repository: NativeRepositoryReference,
+        name: String,
+    },
+    DynamicZypperServices {
+        paths: Vec<PathBuf>,
+    },
+    ProjectionNotRegular {
+        path: PathBuf,
+    },
+    ProjectionDrift {
+        path: PathBuf,
+        expected_sha256: String,
+        observed_sha256: Option<String>,
+    },
+    ProjectionModeDrift {
+        path: PathBuf,
+        expected_mode: u32,
+        observed_mode: Option<u32>,
+    },
+    ExistingTakeoverInputChanged,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NativeRepositoryTakeoverPreview {
+    pub schema: u32,
+    pub selected_root: PathBuf,
+    pub declarations: DiscoveredRepositoryDeclarations,
+    pub trust: NativeTrustImportPlan,
+    pub repositories: Vec<TakeoverRepositoryInput>,
+    pub projections: Vec<NativeProjectionPreview>,
+    pub blockers: Vec<TakeoverBlocker>,
+}
+
+impl NativeRepositoryTakeoverPreview {
+    pub fn sha256(&self) -> Result<String> {
+        let bytes = serde_json::to_vec(self).map_err(|error| {
+            Error::ParseError(format!(
+                "failed to serialize repository takeover preview: {error}"
+            ))
+        })?;
+        Ok(crate::hash::sha256(&bytes))
+    }
+
+    pub fn require_applicable(&self) -> Result<()> {
+        if self.blockers.is_empty() {
+            Ok(())
+        } else {
+            Err(Error::ConfigError(format!(
+                "native repository takeover has {} blocker(s)",
+                self.blockers.len()
+            )))
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TakeoverApplyStatus {
+    Applied,
+    AlreadyApplied,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TakeoverApplyOutcome {
+    pub status: TakeoverApplyStatus,
+    pub preview_sha256: String,
+    pub repository_ids: Vec<i64>,
+}
+
+/// Build a deterministic selected-root preview without mutation.
+pub fn preview_native_repository_takeover(
+    conn: &Connection,
+    selected_root: impl AsRef<Path>,
+    manifest: &NativeRepositoryTakeoverManifest,
+) -> Result<NativeRepositoryTakeoverPreview> {
+    validate_manifest(manifest)?;
+    let selected_root = selected_root.as_ref();
+    let root_identity = selected_root_identity(selected_root)?;
+    if let Some((preview_json, expected_sha256)) = conn
+        .query_row(
+            "SELECT preview_json, preview_sha256 FROM native_repository_takeovers WHERE selected_root = ?1",
+            [&root_identity],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        )
+        .optional()?
+    {
+        let mut preview: NativeRepositoryTakeoverPreview = serde_json::from_str(&preview_json)
+            .map_err(|error| Error::ParseError(format!("invalid persisted takeover preview: {error}")))?;
+        if preview.sha256()? != expected_sha256 {
+            return Err(Error::ParseError(
+                "persisted native repository takeover preview digest mismatch".to_string(),
+            ));
+        }
+        let mut requested = manifest.repositories.clone();
+        requested.sort_by(|left, right| left.name.cmp(&right.name));
+        if requested != preview.repositories {
+            preview.blockers.push(TakeoverBlocker::ExistingTakeoverInputChanged);
+        }
+        preview.blockers.extend(projection_drift(conn, selected_root, &root_identity)?);
+        return Ok(preview);
+    }
+
+    let declarations = discover_selected_root(selected_root).map_err(|error| {
+        Error::ConfigError(format!(
+            "native repository declaration discovery failed: {error}"
+        ))
+    })?;
+    let trust = plan_selected_root_trust(&declarations);
+    let (projections, projection_blockers) =
+        collect_projection_content(selected_root, &declarations, &trust)?;
+    let mut repositories = manifest.repositories.clone();
+    repositories.sort_by(|left, right| left.name.cmp(&right.name));
+    let mut blockers = validate_enrollments(conn, &declarations, &trust, &repositories)?;
+    blockers.extend(projection_blockers);
+    let projection_previews = projections
+        .iter()
+        .map(|projection| NativeProjectionPreview {
+            path: projection.path.clone(),
+            sha256: crate::hash::sha256(&projection.content),
+            mode: projection.mode,
+            ownership: ProjectionOwnershipChange::NativeToConary,
+        })
+        .collect();
+    if !declarations.zypper_services.is_empty() {
+        blockers.push(TakeoverBlocker::DynamicZypperServices {
+            paths: declarations
+                .zypper_services
+                .iter()
+                .map(|document| document.path.clone())
+                .collect(),
+        });
+    }
+    Ok(NativeRepositoryTakeoverPreview {
+        schema: TAKEOVER_PREVIEW_SCHEMA,
+        selected_root: selected_root.to_path_buf(),
+        declarations,
+        trust,
+        repositories,
+        projections: projection_previews,
+        blockers,
+    })
+}
+
+/// Apply the exact preview using one SQLite transaction and atomic file exchanges.
+pub fn apply_native_repository_takeover(
+    conn: &Connection,
+    selected_root: impl AsRef<Path>,
+    manifest: &NativeRepositoryTakeoverManifest,
+    expected_preview_sha256: &str,
+) -> Result<TakeoverApplyOutcome> {
+    apply_native_repository_takeover_with_persist(
+        conn,
+        selected_root.as_ref(),
+        manifest,
+        expected_preview_sha256,
+        persist_staged,
+    )
+}
+
+fn apply_native_repository_takeover_with_persist(
+    conn: &Connection,
+    selected_root: &Path,
+    manifest: &NativeRepositoryTakeoverManifest,
+    expected_preview_sha256: &str,
+    persist: impl FnOnce(Vec<StagedProjection>) -> Result<Vec<ProjectionContent>>,
+) -> Result<TakeoverApplyOutcome> {
+    let preview = preview_native_repository_takeover(conn, selected_root, manifest)?;
+    preview.require_applicable()?;
+    let preview_sha256 = preview.sha256()?;
+    if preview_sha256 != expected_preview_sha256 {
+        return Err(Error::ConflictError(format!(
+            "native repository takeover preview changed: expected {expected_preview_sha256}, observed {preview_sha256}"
+        )));
+    }
+    let root_identity = selected_root_identity(selected_root)?;
+    if conn
+        .query_row(
+            "SELECT 1 FROM native_repository_takeovers WHERE selected_root = ?1",
+            [&root_identity],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?
+        .is_some()
+    {
+        let repository_ids = takeover_repository_ids(conn, &root_identity)?;
+        return Ok(TakeoverApplyOutcome {
+            status: TakeoverApplyStatus::AlreadyApplied,
+            preview_sha256,
+            repository_ids,
+        });
+    }
+
+    let (projections, projection_blockers) =
+        collect_projection_content(selected_root, &preview.declarations, &preview.trust)?;
+    if !projection_blockers.is_empty() {
+        return Err(Error::ConflictError(
+            "native repository projection type changed after preview".to_string(),
+        ));
+    }
+    ensure_projection_inputs_unchanged(selected_root, &projections)?;
+    let staged = stage_projection_writes(selected_root, &projections, &projections)?;
+    let preview_json = serde_json::to_string(&preview).map_err(|error| {
+        Error::ParseError(format!(
+            "failed to serialize repository takeover preview: {error}"
+        ))
+    })?;
+    let tx = conn.unchecked_transaction()?;
+    tx.execute(
+        "INSERT INTO native_repository_takeovers (selected_root, preview_sha256, preview_json) VALUES (?1, ?2, ?3)",
+        params![root_identity, preview_sha256, preview_json],
+    )?;
+    let takeover_id = tx.last_insert_rowid();
+    let mut repository_ids = Vec::new();
+    for input in &preview.repositories {
+        let mut repository = input.materialize()?;
+        let id = repository.insert(&tx)?;
+        tx.execute(
+            "INSERT INTO native_repository_takeover_members (takeover_id, repository_id) VALUES (?1, ?2)",
+            params![takeover_id, id],
+        )?;
+        repository_ids.push(id);
+    }
+    let prior_projections = persist(staged)?;
+    let projection_result: Result<()> = (|| {
+        for (projection, prior) in projections.iter().zip(&prior_projections) {
+            tx.execute(
+                "INSERT INTO native_repository_projections
+                 (takeover_id, path, content, sha256, mode, prior_existed, prior_content, prior_mode)
+                 VALUES (?1, ?2, ?3, ?4, ?5, 1, ?6, ?7)",
+                params![
+                    takeover_id,
+                    projection.path.to_string_lossy(),
+                    projection.content,
+                    crate::hash::sha256(&projection.content),
+                    projection.mode,
+                    &prior.content,
+                    prior.mode,
+                ],
+            )?;
+        }
+        Ok(())
+    })();
+    if let Err(error) = projection_result {
+        restore_projection_bytes(selected_root, &projections, &prior_projections)?;
+        return Err(error);
+    }
+    if let Err(error) = tx.commit() {
+        restore_projection_bytes(selected_root, &projections, &prior_projections)?;
+        return Err(error.into());
+    }
+    Ok(TakeoverApplyOutcome {
+        status: TakeoverApplyStatus::Applied,
+        preview_sha256,
+        repository_ids,
+    })
+}
+
+/// Restore pre-takeover projection bytes and delete only takeover-owned rows.
+pub fn rollback_native_repository_takeover(
+    conn: &Connection,
+    selected_root: impl AsRef<Path>,
+) -> Result<()> {
+    let selected_root = selected_root.as_ref();
+    let root_identity = selected_root_identity(selected_root)?;
+    let takeover_id = conn
+        .query_row(
+            "SELECT id FROM native_repository_takeovers WHERE selected_root = ?1",
+            [&root_identity],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?
+        .ok_or_else(|| {
+            Error::NotFound(format!("no native repository takeover for {root_identity}"))
+        })?;
+    let drift = projection_drift(conn, selected_root, &root_identity)?;
+    if !drift.is_empty() {
+        return Err(Error::ConflictError(format!(
+            "native repository rollback blocked by {} projection drift finding(s)",
+            drift.len()
+        )));
+    }
+    let current = load_current_projections(conn, takeover_id)?;
+    let prior = load_prior_projections(conn, takeover_id)?;
+    let staged = stage_projection_writes(selected_root, &prior, &current)?;
+    let repository_ids = takeover_repository_ids(conn, &root_identity)?;
+    let tx = conn.unchecked_transaction()?;
+    for repository_id in &repository_ids {
+        let ownership = Repository::find_by_id(&tx, *repository_id)?
+            .ok_or_else(|| Error::NotFound(format!("takeover repository {repository_id}")))?
+            .managed_by;
+        if ownership != RepositoryOwnership::NativeProjection {
+            return Err(Error::ConflictError(format!(
+                "takeover repository {repository_id} is no longer owned by native projections"
+            )));
+        }
+        tx.execute(
+            "DELETE FROM native_repository_takeover_members WHERE takeover_id = ?1 AND repository_id = ?2",
+            params![takeover_id, repository_id],
+        )?;
+        Repository::delete(&tx, *repository_id)?;
+    }
+    tx.execute(
+        "DELETE FROM native_repository_takeovers WHERE id = ?1",
+        [takeover_id],
+    )?;
+    let observed_current = persist_staged(staged)?;
+    if let Err(error) = tx.commit() {
+        restore_projection_bytes(selected_root, &prior, &observed_current)?;
+        return Err(error.into());
+    }
+    Ok(())
+}
+
+fn validate_manifest(manifest: &NativeRepositoryTakeoverManifest) -> Result<()> {
+    if manifest.schema != TAKEOVER_MANIFEST_SCHEMA {
+        return Err(Error::ConfigError(format!(
+            "native repository takeover manifest schema {} is unsupported; expected {}",
+            manifest.schema, TAKEOVER_MANIFEST_SCHEMA
+        )));
+    }
+    for repository in &manifest.repositories {
+        repository.materialize()?;
+    }
+    Ok(())
+}
+
+fn validate_enrollments(
+    conn: &Connection,
+    declarations: &DiscoveredRepositoryDeclarations,
+    trust: &NativeTrustImportPlan,
+    repositories: &[TakeoverRepositoryInput],
+) -> Result<Vec<TakeoverBlocker>> {
+    let mut blockers = Vec::new();
+    let mut names = BTreeSet::new();
+    let mut identities = BTreeSet::new();
+    let mut products: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for input in repositories {
+        if !names.insert(input.name.clone()) {
+            blockers.push(TakeoverBlocker::DuplicateRepositoryName {
+                name: input.name.clone(),
+            });
+        }
+        let identity_key = (
+            input.source_identity.clone(),
+            match &input.scope {
+                TakeoverPolicyScope::Repository { identity } => {
+                    format!("repository:{identity}")
+                }
+                TakeoverPolicyScope::Group { identity } => format!("group:{identity}"),
+            },
+            input.repository_identity.clone(),
+        );
+        if !identities.insert(identity_key) {
+            blockers.push(TakeoverBlocker::DuplicateRepositoryIdentity {
+                identity: input.repository_identity.clone(),
+            });
+        }
+        let Some(plan) = trust
+            .repositories
+            .iter()
+            .find(|plan| plan.repository == input.declaration)
+        else {
+            blockers.push(TakeoverBlocker::UnknownEnrollment {
+                repository: input.declaration.clone(),
+                name: input.name.clone(),
+            });
+            continue;
+        };
+        let expected_format = match &input.declaration {
+            NativeRepositoryReference::Apt { .. } => RepositoryFormat::Debian,
+            NativeRepositoryReference::Dnf { .. } | NativeRepositoryReference::Zypper { .. } => {
+                RepositoryFormat::Fedora
+            }
+            NativeRepositoryReference::Alpm { .. } => RepositoryFormat::Arch,
+        };
+        let requested_format = input.parser.format();
+        if requested_format != expected_format {
+            blockers.push(TakeoverBlocker::ParserFormatMismatch {
+                repository: input.declaration.clone(),
+                name: input.name.clone(),
+                expected: expected_format,
+                requested: requested_format,
+            });
+        }
+        let product_key = serde_json::to_string(&(
+            &input.declaration,
+            &input.metadata_url,
+            &input.content_url,
+            &input.parser,
+        ))
+        .map_err(|error| {
+            Error::ParseError(format!(
+                "failed to serialize native enrollment product: {error}"
+            ))
+        })?;
+        products
+            .entry(product_key)
+            .or_default()
+            .push(input.name.clone());
+        if requested_format == expected_format
+            && matches!(plan.disposition, TrustImportDisposition::Importable)
+            && expected_trust_policy(
+                &declarations.root,
+                declarations,
+                plan,
+                input.parser.format(),
+            )?
+            .as_ref()
+                != Some(&input.trust)
+        {
+            blockers.push(TakeoverBlocker::TrustPolicyMismatch {
+                repository: input.declaration.clone(),
+                name: input.name.clone(),
+            });
+        }
+        let declared = plan.enabled.unwrap_or(true);
+        if declared != input.enabled {
+            blockers.push(TakeoverBlocker::EnabledStateMismatch {
+                repository: input.declaration.clone(),
+                name: input.name.clone(),
+                declared,
+                requested: input.enabled,
+            });
+        }
+        if let Some(existing) = Repository::find_by_name(conn, &input.name)? {
+            blockers.push(TakeoverBlocker::ExistingRepository {
+                name: input.name.clone(),
+                ownership: existing.managed_by.as_str().to_string(),
+            });
+        }
+    }
+    for names in products.values().filter(|names| names.len() > 1) {
+        let first = repositories
+            .iter()
+            .find(|input| input.name == names[0])
+            .expect("product names came from repository inputs");
+        blockers.push(TakeoverBlocker::DuplicateEnrollmentProduct {
+            repository: first.declaration.clone(),
+            names: names.clone(),
+        });
+    }
+    for plan in &trust.repositories {
+        let enabled = plan.enabled.unwrap_or(true);
+        let matching = repositories
+            .iter()
+            .any(|input| input.declaration == plan.repository);
+        if !matching {
+            blockers.push(TakeoverBlocker::MissingEnrollment {
+                repository: plan.repository.clone(),
+            });
+        }
+        if enabled && !matches!(plan.disposition, TrustImportDisposition::Importable) {
+            blockers.push(TakeoverBlocker::EnabledTrust {
+                repository: plan.repository.clone(),
+                disposition: plan.disposition.clone(),
+            });
+        }
+    }
+    Ok(blockers)
+}
+
+fn takeover_repository_ids(conn: &Connection, root_identity: &str) -> Result<Vec<i64>> {
+    let mut statement = conn.prepare(
+        "SELECT member.repository_id
+         FROM native_repository_takeover_members member
+         JOIN native_repository_takeovers takeover ON takeover.id = member.takeover_id
+         WHERE takeover.selected_root = ?1 ORDER BY member.repository_id",
+    )?;
+    statement
+        .query_map([root_identity], |row| row.get(0))?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(Into::into)
+}
+
+fn selected_root_identity(selected_root: &Path) -> Result<String> {
+    selected_root
+        .canonicalize()?
+        .to_str()
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| Error::ConfigError("selected root path is not valid UTF-8".to_string()))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/conary-core/src/repository/declarations/takeover.rs
+++ b/crates/conary-core/src/repository/declarations/takeover.rs
@@ -19,13 +19,14 @@ use crate::repository::{
 };
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+mod enrollment;
 mod projection;
 mod trust_policy;
 
+use enrollment::validate_enrollments;
 use projection::{
     ProjectionContent, StagedProjection, collect_projection_content,
     ensure_projection_inputs_unchanged, load_current_projections, load_prior_projections,
@@ -155,6 +156,17 @@ pub struct NativeProjectionPreview {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum NativeEnrollmentProduct {
+    Repository,
+    Apt {
+        uri: String,
+        suite: String,
+        component: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
 pub enum TakeoverBlocker {
     EnabledTrust {
         repository: NativeRepositoryReference,
@@ -162,13 +174,20 @@ pub enum TakeoverBlocker {
     },
     MissingEnrollment {
         repository: NativeRepositoryReference,
+        products: Vec<NativeEnrollmentProduct>,
     },
     UnknownEnrollment {
         repository: NativeRepositoryReference,
         name: String,
     },
+    UnknownEnrollmentProduct {
+        repository: NativeRepositoryReference,
+        name: String,
+        product: NativeEnrollmentProduct,
+    },
     DuplicateEnrollmentProduct {
         repository: NativeRepositoryReference,
+        product: NativeEnrollmentProduct,
         names: Vec<String>,
     },
     ParserFormatMismatch {
@@ -518,141 +537,6 @@ fn validate_manifest(manifest: &NativeRepositoryTakeoverManifest) -> Result<()> 
         repository.materialize()?;
     }
     Ok(())
-}
-
-fn validate_enrollments(
-    conn: &Connection,
-    declarations: &DiscoveredRepositoryDeclarations,
-    trust: &NativeTrustImportPlan,
-    repositories: &[TakeoverRepositoryInput],
-) -> Result<Vec<TakeoverBlocker>> {
-    let mut blockers = Vec::new();
-    let mut names = BTreeSet::new();
-    let mut identities = BTreeSet::new();
-    let mut products: BTreeMap<String, Vec<String>> = BTreeMap::new();
-    for input in repositories {
-        if !names.insert(input.name.clone()) {
-            blockers.push(TakeoverBlocker::DuplicateRepositoryName {
-                name: input.name.clone(),
-            });
-        }
-        let identity_key = (
-            input.source_identity.clone(),
-            match &input.scope {
-                TakeoverPolicyScope::Repository { identity } => {
-                    format!("repository:{identity}")
-                }
-                TakeoverPolicyScope::Group { identity } => format!("group:{identity}"),
-            },
-            input.repository_identity.clone(),
-        );
-        if !identities.insert(identity_key) {
-            blockers.push(TakeoverBlocker::DuplicateRepositoryIdentity {
-                identity: input.repository_identity.clone(),
-            });
-        }
-        let Some(plan) = trust
-            .repositories
-            .iter()
-            .find(|plan| plan.repository == input.declaration)
-        else {
-            blockers.push(TakeoverBlocker::UnknownEnrollment {
-                repository: input.declaration.clone(),
-                name: input.name.clone(),
-            });
-            continue;
-        };
-        let expected_format = match &input.declaration {
-            NativeRepositoryReference::Apt { .. } => RepositoryFormat::Debian,
-            NativeRepositoryReference::Dnf { .. } | NativeRepositoryReference::Zypper { .. } => {
-                RepositoryFormat::Fedora
-            }
-            NativeRepositoryReference::Alpm { .. } => RepositoryFormat::Arch,
-        };
-        let requested_format = input.parser.format();
-        if requested_format != expected_format {
-            blockers.push(TakeoverBlocker::ParserFormatMismatch {
-                repository: input.declaration.clone(),
-                name: input.name.clone(),
-                expected: expected_format,
-                requested: requested_format,
-            });
-        }
-        let product_key = serde_json::to_string(&(
-            &input.declaration,
-            &input.metadata_url,
-            &input.content_url,
-            &input.parser,
-        ))
-        .map_err(|error| {
-            Error::ParseError(format!(
-                "failed to serialize native enrollment product: {error}"
-            ))
-        })?;
-        products
-            .entry(product_key)
-            .or_default()
-            .push(input.name.clone());
-        if requested_format == expected_format
-            && matches!(plan.disposition, TrustImportDisposition::Importable)
-            && expected_trust_policy(
-                &declarations.root,
-                declarations,
-                plan,
-                input.parser.format(),
-            )?
-            .as_ref()
-                != Some(&input.trust)
-        {
-            blockers.push(TakeoverBlocker::TrustPolicyMismatch {
-                repository: input.declaration.clone(),
-                name: input.name.clone(),
-            });
-        }
-        let declared = plan.enabled.unwrap_or(true);
-        if declared != input.enabled {
-            blockers.push(TakeoverBlocker::EnabledStateMismatch {
-                repository: input.declaration.clone(),
-                name: input.name.clone(),
-                declared,
-                requested: input.enabled,
-            });
-        }
-        if let Some(existing) = Repository::find_by_name(conn, &input.name)? {
-            blockers.push(TakeoverBlocker::ExistingRepository {
-                name: input.name.clone(),
-                ownership: existing.managed_by.as_str().to_string(),
-            });
-        }
-    }
-    for names in products.values().filter(|names| names.len() > 1) {
-        let first = repositories
-            .iter()
-            .find(|input| input.name == names[0])
-            .expect("product names came from repository inputs");
-        blockers.push(TakeoverBlocker::DuplicateEnrollmentProduct {
-            repository: first.declaration.clone(),
-            names: names.clone(),
-        });
-    }
-    for plan in &trust.repositories {
-        let enabled = plan.enabled.unwrap_or(true);
-        let matching = repositories
-            .iter()
-            .any(|input| input.declaration == plan.repository);
-        if !matching {
-            blockers.push(TakeoverBlocker::MissingEnrollment {
-                repository: plan.repository.clone(),
-            });
-        }
-        if enabled && !matches!(plan.disposition, TrustImportDisposition::Importable) {
-            blockers.push(TakeoverBlocker::EnabledTrust {
-                repository: plan.repository.clone(),
-                disposition: plan.disposition.clone(),
-            });
-        }
-    }
-    Ok(blockers)
 }
 
 fn takeover_repository_ids(conn: &Connection, root_identity: &str) -> Result<Vec<i64>> {

--- a/crates/conary-core/src/repository/declarations/takeover/enrollment.rs
+++ b/crates/conary-core/src/repository/declarations/takeover/enrollment.rs
@@ -1,0 +1,282 @@
+// conary-core/src/repository/declarations/takeover/enrollment.rs
+
+//! Complete native-product enrollment validation.
+
+use super::*;
+use crate::repository::declarations::apt::AptSourceKind;
+use std::collections::BTreeSet;
+
+pub(super) fn validate_enrollments(
+    conn: &Connection,
+    declarations: &DiscoveredRepositoryDeclarations,
+    trust: &NativeTrustImportPlan,
+    repositories: &[TakeoverRepositoryInput],
+) -> Result<Vec<TakeoverBlocker>> {
+    let mut blockers = Vec::new();
+    let mut names = BTreeSet::new();
+    let mut identities = BTreeSet::new();
+
+    for input in repositories {
+        validate_unique_identity(input, &mut names, &mut identities, &mut blockers);
+        let Some(plan) = trust
+            .repositories
+            .iter()
+            .find(|plan| plan.repository == input.declaration)
+        else {
+            blockers.push(TakeoverBlocker::UnknownEnrollment {
+                repository: input.declaration.clone(),
+                name: input.name.clone(),
+            });
+            continue;
+        };
+        validate_input_contract(conn, declarations, plan, input, &mut blockers)?;
+    }
+
+    for plan in &trust.repositories {
+        validate_product_coverage(declarations, plan, repositories, &mut blockers)?;
+        if plan.enabled.unwrap_or(true)
+            && !matches!(plan.disposition, TrustImportDisposition::Importable)
+        {
+            blockers.push(TakeoverBlocker::EnabledTrust {
+                repository: plan.repository.clone(),
+                disposition: plan.disposition.clone(),
+            });
+        }
+    }
+    Ok(blockers)
+}
+
+fn validate_unique_identity(
+    input: &TakeoverRepositoryInput,
+    names: &mut BTreeSet<String>,
+    identities: &mut BTreeSet<(String, String, String)>,
+    blockers: &mut Vec<TakeoverBlocker>,
+) {
+    if !names.insert(input.name.clone()) {
+        blockers.push(TakeoverBlocker::DuplicateRepositoryName {
+            name: input.name.clone(),
+        });
+    }
+    let scope = match &input.scope {
+        TakeoverPolicyScope::Repository { identity } => format!("repository:{identity}"),
+        TakeoverPolicyScope::Group { identity } => format!("group:{identity}"),
+    };
+    if !identities.insert((
+        input.source_identity.clone(),
+        scope,
+        input.repository_identity.clone(),
+    )) {
+        blockers.push(TakeoverBlocker::DuplicateRepositoryIdentity {
+            identity: input.repository_identity.clone(),
+        });
+    }
+}
+
+fn validate_input_contract(
+    conn: &Connection,
+    declarations: &DiscoveredRepositoryDeclarations,
+    plan: &NativeRepositoryTrustPlan,
+    input: &TakeoverRepositoryInput,
+    blockers: &mut Vec<TakeoverBlocker>,
+) -> Result<()> {
+    let expected_format = reference_format(&input.declaration);
+    let requested_format = input.parser.format();
+    if requested_format != expected_format {
+        blockers.push(TakeoverBlocker::ParserFormatMismatch {
+            repository: input.declaration.clone(),
+            name: input.name.clone(),
+            expected: expected_format,
+            requested: requested_format,
+        });
+    }
+    if requested_format == expected_format
+        && matches!(plan.disposition, TrustImportDisposition::Importable)
+        && expected_trust_policy(
+            &declarations.root,
+            declarations,
+            plan,
+            input.parser.format(),
+        )?
+        .as_ref()
+            != Some(&input.trust)
+    {
+        blockers.push(TakeoverBlocker::TrustPolicyMismatch {
+            repository: input.declaration.clone(),
+            name: input.name.clone(),
+        });
+    }
+    let declared = plan.enabled.unwrap_or(true);
+    if declared != input.enabled {
+        blockers.push(TakeoverBlocker::EnabledStateMismatch {
+            repository: input.declaration.clone(),
+            name: input.name.clone(),
+            declared,
+            requested: input.enabled,
+        });
+    }
+    if let Some(existing) = Repository::find_by_name(conn, &input.name)? {
+        blockers.push(TakeoverBlocker::ExistingRepository {
+            name: input.name.clone(),
+            ownership: existing.managed_by.as_str().to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_product_coverage(
+    declarations: &DiscoveredRepositoryDeclarations,
+    plan: &NativeRepositoryTrustPlan,
+    repositories: &[TakeoverRepositoryInput],
+    blockers: &mut Vec<TakeoverBlocker>,
+) -> Result<()> {
+    let expected = expected_products(declarations, &plan.repository)?;
+    let matching = repositories
+        .iter()
+        .filter(|input| input.declaration == plan.repository)
+        .collect::<Vec<_>>();
+    let mut covered = vec![Vec::<String>::new(); expected.len()];
+
+    for input in matching {
+        let product = input_product(input);
+        if let Some(index) = expected
+            .iter()
+            .position(|expected| product_matches(expected, &product))
+        {
+            covered[index].push(input.name.clone());
+        } else {
+            blockers.push(TakeoverBlocker::UnknownEnrollmentProduct {
+                repository: plan.repository.clone(),
+                name: input.name.clone(),
+                product,
+            });
+        }
+    }
+
+    let missing = expected
+        .iter()
+        .zip(&covered)
+        .filter(|(_, names)| names.is_empty())
+        .map(|(product, _)| product.clone())
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        blockers.push(TakeoverBlocker::MissingEnrollment {
+            repository: plan.repository.clone(),
+            products: missing,
+        });
+    }
+    for (product, names) in expected.into_iter().zip(covered) {
+        if names.len() > 1 {
+            blockers.push(TakeoverBlocker::DuplicateEnrollmentProduct {
+                repository: plan.repository.clone(),
+                product,
+                names,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn expected_products(
+    declarations: &DiscoveredRepositoryDeclarations,
+    reference: &NativeRepositoryReference,
+) -> Result<Vec<NativeEnrollmentProduct>> {
+    let NativeRepositoryReference::Apt {
+        document,
+        entry_index,
+        ..
+    } = reference
+    else {
+        return Ok(vec![NativeEnrollmentProduct::Repository]);
+    };
+    let entry = declarations
+        .apt
+        .iter()
+        .find(|candidate| &candidate.path == document)
+        .and_then(|candidate| candidate.entries.get(*entry_index))
+        .ok_or_else(|| {
+            Error::ConfigError(format!(
+                "APT enrollment declaration {} entry {} is absent",
+                document.display(),
+                entry_index
+            ))
+        })?;
+    if !entry.kinds.contains(&AptSourceKind::Deb) {
+        return Ok(Vec::new());
+    }
+    let components: Vec<Option<&str>> = if entry.components.is_empty() {
+        vec![None]
+    } else {
+        entry
+            .components
+            .iter()
+            .map(|value| Some(value.as_str()))
+            .collect()
+    };
+    let mut products = Vec::new();
+    for uri in &entry.uris {
+        for suite in &entry.suites {
+            for component in &components {
+                let product = NativeEnrollmentProduct::Apt {
+                    uri: uri.clone(),
+                    suite: suite.clone(),
+                    component: component.map(str::to_string),
+                };
+                if !products
+                    .iter()
+                    .any(|existing| product_matches(existing, &product))
+                {
+                    products.push(product);
+                }
+            }
+        }
+    }
+    Ok(products)
+}
+
+fn input_product(input: &TakeoverRepositoryInput) -> NativeEnrollmentProduct {
+    match &input.parser {
+        RepositoryParserConfig::Deb {
+            distribution,
+            component,
+            ..
+        } => NativeEnrollmentProduct::Apt {
+            uri: input.metadata_url.clone(),
+            suite: distribution.clone(),
+            component: Some(component.clone()),
+        },
+        _ => NativeEnrollmentProduct::Repository,
+    }
+}
+
+fn product_matches(expected: &NativeEnrollmentProduct, observed: &NativeEnrollmentProduct) -> bool {
+    match (expected, observed) {
+        (NativeEnrollmentProduct::Repository, NativeEnrollmentProduct::Repository) => true,
+        (
+            NativeEnrollmentProduct::Apt {
+                uri: expected_uri,
+                suite: expected_suite,
+                component: expected_component,
+            },
+            NativeEnrollmentProduct::Apt {
+                uri: observed_uri,
+                suite: observed_suite,
+                component: observed_component,
+            },
+        ) => {
+            expected_uri.trim_end_matches('/') == observed_uri.trim_end_matches('/')
+                && expected_suite == observed_suite
+                && expected_component == observed_component
+        }
+        _ => false,
+    }
+}
+
+fn reference_format(reference: &NativeRepositoryReference) -> RepositoryFormat {
+    match reference {
+        NativeRepositoryReference::Apt { .. } => RepositoryFormat::Debian,
+        NativeRepositoryReference::Dnf { .. } | NativeRepositoryReference::Zypper { .. } => {
+            RepositoryFormat::Fedora
+        }
+        NativeRepositoryReference::Alpm { .. } => RepositoryFormat::Arch,
+    }
+}

--- a/crates/conary-core/src/repository/declarations/takeover/projection.rs
+++ b/crates/conary-core/src/repository/declarations/takeover/projection.rs
@@ -1,0 +1,391 @@
+// conary-core/src/repository/declarations/takeover/projection.rs
+
+//! Projection discovery, drift inspection, staging, and byte restoration.
+
+use super::*;
+use crate::filesystem::durable::sync_parent_directory;
+use nix::fcntl::{RenameFlags, renameat2};
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ProjectionContent {
+    pub(super) path: PathBuf,
+    pub(super) content: Vec<u8>,
+    pub(super) mode: u32,
+}
+
+pub(super) fn ensure_projection_inputs_unchanged(
+    selected_root: &Path,
+    projections: &[ProjectionContent],
+) -> Result<()> {
+    for projection in projections {
+        let path = safe_join(selected_root, &projection.path)?;
+        let observed = fs::read(&path)?;
+        let expected_sha256 = crate::hash::sha256(&projection.content);
+        let observed_sha256 = crate::hash::sha256(&observed);
+        if observed_sha256 != expected_sha256 {
+            return Err(Error::ConflictError(format!(
+                "native repository projection {} changed after preview: expected {}, observed {}",
+                projection.path.display(),
+                expected_sha256,
+                observed_sha256
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn collect_projection_content(
+    selected_root: &Path,
+    declarations: &DiscoveredRepositoryDeclarations,
+    trust: &NativeTrustImportPlan,
+) -> Result<(Vec<ProjectionContent>, Vec<TakeoverBlocker>)> {
+    let mut sources: Vec<(PathBuf, Vec<u8>)> = Vec::new();
+    sources.extend(
+        declarations
+            .apt
+            .iter()
+            .map(|document| (document.path.clone(), document.source.as_bytes().to_vec())),
+    );
+    sources.extend(
+        declarations
+            .dnf
+            .iter()
+            .map(|document| (document.path.clone(), document.source.as_bytes().to_vec())),
+    );
+    sources.extend(
+        declarations
+            .zypper_repositories
+            .iter()
+            .map(|document| (document.path.clone(), document.source.as_bytes().to_vec())),
+    );
+    sources.extend(
+        declarations
+            .zypper_services
+            .iter()
+            .map(|document| (document.path.clone(), document.source.as_bytes().to_vec())),
+    );
+    if let Some(alpm) = &declarations.alpm {
+        sources.extend(
+            alpm.files
+                .iter()
+                .map(|document| (document.path.clone(), document.source.as_bytes().to_vec())),
+        );
+    }
+    for plan in &trust.repositories {
+        for evidence in &plan.evidence {
+            if let TrustEvidenceSource::SelectedRootFile { path } = &evidence.source {
+                sources.push((path.clone(), fs::read(safe_join(selected_root, path)?)?));
+            }
+        }
+    }
+    sources.sort_by(|left, right| left.0.cmp(&right.0));
+    sources.dedup_by(|left, right| left.0 == right.0 && left.1 == right.1);
+    let mut projections = Vec::new();
+    let mut blockers = Vec::new();
+    for (path, source) in sources {
+        let host_path = safe_join(selected_root, &path)?;
+        let metadata = fs::symlink_metadata(&host_path)?;
+        if !metadata.file_type().is_file() {
+            blockers.push(TakeoverBlocker::ProjectionNotRegular { path });
+            continue;
+        }
+        projections.push(ProjectionContent {
+            path,
+            content: source,
+            mode: metadata.permissions().mode() & 0o7777,
+        });
+    }
+    Ok((projections, blockers))
+}
+
+pub(super) fn projection_drift(
+    conn: &Connection,
+    selected_root: &Path,
+    root_identity: &str,
+) -> Result<Vec<TakeoverBlocker>> {
+    let mut statement = conn.prepare(
+        "SELECT projection.path, projection.sha256, projection.mode
+         FROM native_repository_projections projection
+         JOIN native_repository_takeovers takeover ON takeover.id = projection.takeover_id
+         WHERE takeover.selected_root = ?1 ORDER BY projection.path",
+    )?;
+    let rows = statement
+        .query_map([root_identity], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, u32>(2)?,
+            ))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let mut blockers = Vec::new();
+    for (path, expected_sha256, expected_mode) in rows {
+        let path = PathBuf::from(path);
+        let host_path = safe_join(selected_root, &path)?;
+        let observed = match fs::read(&host_path) {
+            Ok(content) => Some((
+                crate::hash::sha256(&content),
+                fs::metadata(&host_path)?.permissions().mode() & 0o7777,
+            )),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error.into()),
+        };
+        let observed_sha256 = observed.as_ref().map(|(sha256, _)| sha256.clone());
+        if observed_sha256.as_deref() != Some(expected_sha256.as_str()) {
+            blockers.push(TakeoverBlocker::ProjectionDrift {
+                path,
+                expected_sha256,
+                observed_sha256,
+            });
+        } else if observed
+            .as_ref()
+            .is_some_and(|(_, mode)| *mode != expected_mode)
+        {
+            blockers.push(TakeoverBlocker::ProjectionModeDrift {
+                path,
+                expected_mode,
+                observed_mode: observed.map(|(_, mode)| mode),
+            });
+        }
+    }
+    Ok(blockers)
+}
+
+pub(super) fn load_prior_projections(
+    conn: &Connection,
+    takeover_id: i64,
+) -> Result<Vec<ProjectionContent>> {
+    load_projections(conn, takeover_id, "prior_content", "prior_mode")
+}
+
+pub(super) fn load_current_projections(
+    conn: &Connection,
+    takeover_id: i64,
+) -> Result<Vec<ProjectionContent>> {
+    load_projections(conn, takeover_id, "content", "mode")
+}
+
+fn load_projections(
+    conn: &Connection,
+    takeover_id: i64,
+    content_column: &str,
+    mode_column: &str,
+) -> Result<Vec<ProjectionContent>> {
+    let sql = format!(
+        "SELECT path, {content_column}, {mode_column}
+         FROM native_repository_projections WHERE takeover_id = ?1 ORDER BY path"
+    );
+    let mut statement = conn.prepare(&sql)?;
+    statement
+        .query_map([takeover_id], |row| {
+            Ok(ProjectionContent {
+                path: PathBuf::from(row.get::<_, String>(0)?),
+                content: row.get(1)?,
+                mode: row.get(2)?,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(Into::into)
+}
+
+pub(super) struct StagedProjection {
+    projection_path: PathBuf,
+    path: PathBuf,
+    temporary: tempfile::NamedTempFile,
+    expected_sha256: String,
+    expected_mode: u32,
+}
+
+pub(super) fn stage_projection_writes(
+    selected_root: &Path,
+    desired: &[ProjectionContent],
+    expected: &[ProjectionContent],
+) -> Result<Vec<StagedProjection>> {
+    if desired.len() != expected.len()
+        || desired
+            .iter()
+            .zip(expected)
+            .any(|(desired, expected)| desired.path != expected.path)
+    {
+        return Err(Error::ConfigError(
+            "native repository projection desired and expected path sets differ".to_string(),
+        ));
+    }
+    let mut staged = Vec::new();
+    for (desired, expected) in desired.iter().zip(expected) {
+        let path = safe_join(selected_root, &desired.path)?;
+        let parent = path.parent().ok_or_else(|| {
+            Error::ConfigError(format!(
+                "projection {} has no parent",
+                desired.path.display()
+            ))
+        })?;
+        fs::create_dir_all(parent)?;
+        let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
+        temporary.as_file_mut().write_all(&desired.content)?;
+        temporary
+            .as_file_mut()
+            .set_permissions(fs::Permissions::from_mode(desired.mode))?;
+        temporary.as_file_mut().sync_all()?;
+        staged.push(StagedProjection {
+            projection_path: desired.path.clone(),
+            path,
+            temporary,
+            expected_sha256: crate::hash::sha256(&expected.content),
+            expected_mode: expected.mode,
+        });
+    }
+    Ok(staged)
+}
+
+pub(super) fn persist_staged(staged: Vec<StagedProjection>) -> Result<Vec<ProjectionContent>> {
+    persist_staged_with_failure(staged, None)
+}
+
+fn persist_staged_with_failure(
+    staged: Vec<StagedProjection>,
+    fail_after: Option<usize>,
+) -> Result<Vec<ProjectionContent>> {
+    let mut exchanged = Vec::new();
+    for (index, staged) in staged.into_iter().enumerate() {
+        if fail_after == Some(index) {
+            rollback_exchanged(&mut exchanged)?;
+            return Err(Error::IoError(
+                "forced projection persist failure".to_string(),
+            ));
+        }
+        match exchange_and_verify(staged) {
+            Ok(exchanged_projection) => exchanged.push(exchanged_projection),
+            Err(error) => {
+                rollback_exchanged(&mut exchanged)?;
+                return Err(error);
+            }
+        }
+    }
+    let priors = exchanged.iter().map(|(_, prior)| prior.clone()).collect();
+    drop(exchanged);
+    Ok(priors)
+}
+
+pub(super) fn restore_projection_bytes(
+    selected_root: &Path,
+    expected: &[ProjectionContent],
+    desired: &[ProjectionContent],
+) -> Result<()> {
+    let staged = stage_projection_writes(selected_root, desired, expected)?;
+    persist_staged(staged).map(|_| ())
+}
+
+fn exchange_and_verify(staged: StagedProjection) -> Result<(StagedProjection, ProjectionContent)> {
+    exchange_paths(&staged)?;
+    let (content, mode) = match read_displaced_projection(&staged) {
+        Ok(observed) => observed,
+        Err(error) => {
+            exchange_paths(&staged)?;
+            return Err(error);
+        }
+    };
+    let observed_sha256 = crate::hash::sha256(&content);
+    if observed_sha256 != staged.expected_sha256 || mode != staged.expected_mode {
+        exchange_paths(&staged)?;
+        return Err(Error::ConflictError(format!(
+            "native repository projection {} changed before atomic exchange: expected {} mode {:o}, observed {} mode {:o}",
+            staged.projection_path.display(),
+            staged.expected_sha256,
+            staged.expected_mode,
+            observed_sha256,
+            mode,
+        )));
+    }
+    let path = staged.projection_path.clone();
+    Ok((
+        staged,
+        ProjectionContent {
+            path,
+            content,
+            mode,
+        },
+    ))
+}
+
+fn read_displaced_projection(staged: &StagedProjection) -> Result<(Vec<u8>, u32)> {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(staged.temporary.path())?;
+    let metadata = file.metadata()?;
+    if !metadata.file_type().is_file() {
+        return Err(Error::ConflictError(format!(
+            "native repository projection {} became a non-regular file before atomic exchange",
+            staged.projection_path.display()
+        )));
+    }
+    let mut content = Vec::new();
+    file.read_to_end(&mut content)?;
+    Ok((content, metadata.permissions().mode() & 0o7777))
+}
+
+fn exchange_paths(staged: &StagedProjection) -> Result<()> {
+    let parent = staged.path.parent().ok_or_else(|| {
+        Error::ConfigError(format!(
+            "projection {} has no parent",
+            staged.projection_path.display()
+        ))
+    })?;
+    let directory = File::open(parent)?;
+    let temporary_name = staged.temporary.path().file_name().ok_or_else(|| {
+        Error::ConfigError("staged projection has no temporary basename".to_string())
+    })?;
+    let target_name = staged.path.file_name().ok_or_else(|| {
+        Error::ConfigError(format!(
+            "projection {} has no basename",
+            staged.projection_path.display()
+        ))
+    })?;
+    let exchange = || {
+        renameat2(
+            &directory,
+            Path::new(temporary_name),
+            &directory,
+            Path::new(target_name),
+            RenameFlags::RENAME_EXCHANGE,
+        )
+    };
+    exchange().map_err(|error| {
+        Error::IoError(format!(
+            "failed to atomically exchange native repository projection {}: {error}",
+            staged.projection_path.display()
+        ))
+    })?;
+    if let Err(sync_error) = sync_parent_directory(&staged.path) {
+        if let Err(rollback_error) = exchange() {
+            return Err(Error::IoError(format!(
+                "failed to sync atomic exchange for native repository projection {}: {sync_error}; exchange rollback also failed: {rollback_error}",
+                staged.projection_path.display()
+            )));
+        }
+        let _ = sync_parent_directory(&staged.path);
+        return Err(Error::IoError(format!(
+            "failed to sync atomic exchange for native repository projection {}: {sync_error}",
+            staged.projection_path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn rollback_exchanged(exchanged: &mut Vec<(StagedProjection, ProjectionContent)>) -> Result<()> {
+    while let Some((staged, _)) = exchanged.pop() {
+        exchange_paths(&staged)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+pub(super) fn persist_staged_after_one_for_test(
+    staged: Vec<StagedProjection>,
+) -> Result<Vec<ProjectionContent>> {
+    persist_staged_with_failure(staged, Some(1))
+}

--- a/crates/conary-core/src/repository/declarations/takeover/projection.rs
+++ b/crates/conary-core/src/repository/declarations/takeover/projection.rs
@@ -4,9 +4,11 @@
 
 use super::*;
 use crate::filesystem::durable::sync_parent_directory;
-use nix::fcntl::{RenameFlags, renameat2};
+use std::ffi::{CString, OsStr};
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
+use std::os::fd::AsRawFd;
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -345,15 +347,7 @@ fn exchange_paths(staged: &StagedProjection) -> Result<()> {
             staged.projection_path.display()
         ))
     })?;
-    let exchange = || {
-        renameat2(
-            &directory,
-            Path::new(temporary_name),
-            &directory,
-            Path::new(target_name),
-            RenameFlags::RENAME_EXCHANGE,
-        )
-    };
+    let exchange = || rename_exchange_at(&directory, temporary_name, target_name);
     exchange().map_err(|error| {
         Error::IoError(format!(
             "failed to atomically exchange native repository projection {}: {error}",
@@ -374,6 +368,35 @@ fn exchange_paths(staged: &StagedProjection) -> Result<()> {
         )));
     }
     Ok(())
+}
+
+fn rename_exchange_at(
+    directory: &File,
+    source: &OsStr,
+    destination: &OsStr,
+) -> std::io::Result<()> {
+    let source = CString::new(source.as_bytes())
+        .map_err(|_| std::io::Error::from_raw_os_error(libc::EINVAL))?;
+    let destination = CString::new(destination.as_bytes())
+        .map_err(|_| std::io::Error::from_raw_os_error(libc::EINVAL))?;
+    // SAFETY: both path arguments are owned NUL-terminated byte strings, the
+    // directory descriptor remains open for the call, and renameat2 does not
+    // retain any pointer or descriptor after returning.
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_renameat2,
+            directory.as_raw_fd(),
+            source.as_ptr(),
+            directory.as_raw_fd(),
+            destination.as_ptr(),
+            libc::RENAME_EXCHANGE,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
 }
 
 fn rollback_exchanged(exchanged: &mut Vec<(StagedProjection, ProjectionContent)>) -> Result<()> {

--- a/crates/conary-core/src/repository/declarations/takeover/tests.rs
+++ b/crates/conary-core/src/repository/declarations/takeover/tests.rs
@@ -1,0 +1,479 @@
+// conary-core/src/repository/declarations/takeover/tests.rs
+
+use super::*;
+use crate::repository::{OpenPgpTrustRoot, RpmMetadataAuthority};
+use openpgp::cert::prelude::CertBuilder;
+use openpgp::serialize::Serialize;
+use sequoia_openpgp as openpgp;
+use std::os::unix::fs::PermissionsExt;
+
+fn certificate() -> (Vec<u8>, String) {
+    let (certificate, _) = CertBuilder::new()
+        .add_userid("Native takeover fixture")
+        .generate()
+        .unwrap();
+    let fingerprint = certificate.fingerprint().to_hex();
+    let mut bytes = Vec::new();
+    certificate.serialize(&mut bytes).unwrap();
+    (bytes, fingerprint)
+}
+
+fn armored_certificate() -> (String, String) {
+    let (certificate, _) = CertBuilder::new()
+        .add_userid("Embedded takeover fixture")
+        .generate()
+        .unwrap();
+    let fingerprint = certificate.fingerprint().to_hex();
+    let mut bytes = Vec::new();
+    certificate.armored().serialize(&mut bytes).unwrap();
+    (String::from_utf8(bytes).unwrap(), fingerprint)
+}
+
+fn fixture() -> (
+    tempfile::TempDir,
+    Connection,
+    NativeRepositoryTakeoverManifest,
+) {
+    let root = tempfile::tempdir().unwrap();
+    fs::create_dir_all(root.path().join("etc/yum.repos.d")).unwrap();
+    fs::create_dir_all(root.path().join("etc/pki/rpm-gpg")).unwrap();
+    let (certificate, fingerprint) = certificate();
+    let key_path = root.path().join("etc/pki/rpm-gpg/VENDOR");
+    fs::write(&key_path, certificate).unwrap();
+    let declaration_path = root.path().join("etc/yum.repos.d/vendor.repo");
+    fs::write(
+        &declaration_path,
+        "[vendor]\nenabled=1\npriority=40\nmetalink=https://mirrors.example/metalink\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=file:///etc/pki/rpm-gpg/VENDOR\n",
+    )
+    .unwrap();
+    fs::set_permissions(&declaration_path, fs::Permissions::from_mode(0o644)).unwrap();
+    let db_path = root.path().join("conary.db");
+    crate::db::init(&db_path).unwrap();
+    let conn = crate::db::open(&db_path).unwrap();
+    let declarations = discover_selected_root(root.path()).unwrap();
+    let reference = plan_selected_root_trust(&declarations).repositories[0]
+        .repository
+        .clone();
+    let manifest = NativeRepositoryTakeoverManifest {
+        schema: TAKEOVER_MANIFEST_SCHEMA,
+        repositories: vec![TakeoverRepositoryInput {
+            declaration: reference,
+            name: "vendor".to_string(),
+            source_identity: "vendor-rpm".to_string(),
+            repository_identity: "vendor".to_string(),
+            scope: TakeoverPolicyScope::Repository {
+                identity: "vendor".to_string(),
+            },
+            stream: TakeoverSourceStream::Release {
+                identity: "stable".to_string(),
+            },
+            update: TakeoverUpdatePolicy::Follow,
+            metadata_url: "https://packages.example/repo".to_string(),
+            content_url: Some("https://packages.example/content".to_string()),
+            parser: RepositoryParserConfig::Rpm {
+                architecture: "x86_64".to_string(),
+            },
+            trust: RepositoryTrustPolicy::Rpm {
+                metadata: RpmMetadataAuthority::Metalink {
+                    url: "https://mirrors.example/metalink".to_string(),
+                },
+                package_keys: vec![OpenPgpTrustRoot {
+                    url: url::Url::from_file_path(key_path).unwrap().to_string(),
+                    fingerprint,
+                }],
+            },
+            enabled: true,
+            priority: 40,
+            metadata_expire: 3600,
+            source_profile: None,
+        }],
+    };
+    (root, conn, manifest)
+}
+
+#[test]
+fn preview_is_deterministic_serializable_and_rejects_unknown_input() {
+    let (root, conn, manifest) = fixture();
+    let first = preview_native_repository_takeover(&conn, root.path(), &manifest).unwrap();
+    let second = preview_native_repository_takeover(&conn, root.path(), &manifest).unwrap();
+    assert_eq!(first, second);
+    assert!(first.blockers.is_empty());
+    assert_eq!(first.sha256().unwrap(), second.sha256().unwrap());
+    let encoded = serde_json::to_string(&manifest).unwrap();
+    let malformed = encoded.replacen("{", "{\"future\":true,", 1);
+    assert!(serde_json::from_str::<NativeRepositoryTakeoverManifest>(&malformed).is_err());
+}
+
+#[test]
+fn ambiguous_enabled_trust_blocks_without_database_or_filesystem_changes() {
+    let (root, conn, mut manifest) = fixture();
+    let declaration_path = root.path().join("etc/yum.repos.d/vendor.repo");
+    fs::write(
+        &declaration_path,
+        "[vendor]\nenabled=1\nbaseurl=https://packages.example/repo\n",
+    )
+    .unwrap();
+    let declarations = discover_selected_root(root.path()).unwrap();
+    manifest.repositories[0].declaration = plan_selected_root_trust(&declarations).repositories[0]
+        .repository
+        .clone();
+    let before = fs::read(&declaration_path).unwrap();
+    let preview = preview_native_repository_takeover(&conn, root.path(), &manifest).unwrap();
+    assert!(
+        preview
+            .blockers
+            .iter()
+            .any(|blocker| matches!(blocker, TakeoverBlocker::EnabledTrust { .. }))
+    );
+    assert!(
+        apply_native_repository_takeover(&conn, root.path(), &manifest, &preview.sha256().unwrap())
+            .is_err()
+    );
+    assert_eq!(fs::read(&declaration_path).unwrap(), before);
+    assert!(Repository::find_by_name(&conn, "vendor").unwrap().is_none());
+}
+
+#[test]
+fn enrollment_cannot_substitute_unrelated_trust_for_imported_evidence() {
+    let (root, conn, mut manifest) = fixture();
+    let (_, unrelated_fingerprint) = certificate();
+    let RepositoryTrustPolicy::Rpm { package_keys, .. } = &mut manifest.repositories[0].trust
+    else {
+        unreachable!("fixture is RPM")
+    };
+    package_keys[0].fingerprint = unrelated_fingerprint;
+
+    let preview = preview_native_repository_takeover(&conn, root.path(), &manifest).unwrap();
+    assert!(preview.blockers.iter().any(|blocker| matches!(
+        blocker,
+        TakeoverBlocker::TrustPolicyMismatch { name, .. } if name == "vendor"
+    )));
+    assert!(apply_native_repository_takeover(
+        &conn,
+        root.path(),
+        &manifest,
+        &preview.sha256().unwrap(),
+    )
+    .is_err());
+    assert!(Repository::find_by_name(&conn, "vendor").unwrap().is_none());
+}
+
+#[test]
+fn complete_enrollment_includes_disabled_repositories_and_exact_products() {
+    let (root, conn, mut manifest) = fixture();
+    let declaration_path = root.path().join("etc/yum.repos.d/vendor.repo");
+    fs::write(
+        &declaration_path,
+        "[vendor]\nenabled=0\npriority=40\nmetalink=https://mirrors.example/metalink\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=file:///etc/pki/rpm-gpg/VENDOR\n",
+    )
+    .unwrap();
+    let declarations = discover_selected_root(root.path()).unwrap();
+    manifest.repositories[0].declaration = plan_selected_root_trust(&declarations).repositories[0]
+        .repository
+        .clone();
+    manifest.repositories[0].enabled = false;
+
+    let mut missing = manifest.clone();
+    missing.repositories.clear();
+    let preview = preview_native_repository_takeover(&conn, root.path(), &missing).unwrap();
+    assert!(
+        preview
+            .blockers
+            .iter()
+            .any(|blocker| matches!(blocker, TakeoverBlocker::MissingEnrollment { .. }))
+    );
+
+    let mut duplicate = manifest;
+    let mut second = duplicate.repositories[0].clone();
+    second.name = "vendor-copy".to_string();
+    second.source_identity = "vendor-rpm-copy".to_string();
+    second.repository_identity = "vendor-copy".to_string();
+    second.scope = TakeoverPolicyScope::Repository {
+        identity: "vendor-copy".to_string(),
+    };
+    duplicate.repositories.push(second);
+    let preview = preview_native_repository_takeover(&conn, root.path(), &duplicate).unwrap();
+    assert!(preview.blockers.iter().any(|blocker| matches!(
+        blocker,
+        TakeoverBlocker::DuplicateEnrollmentProduct { names, .. }
+            if names == &["vendor".to_string(), "vendor-copy".to_string()]
+    )));
+}
+
+#[test]
+fn parser_and_existing_ownership_conflicts_leave_authority_unchanged() {
+    let (root, conn, mut manifest) = fixture();
+    let release_keys = match &manifest.repositories[0].trust {
+        RepositoryTrustPolicy::Rpm { package_keys, .. } => package_keys.clone(),
+        _ => unreachable!("fixture is RPM"),
+    };
+    manifest.repositories[0].parser = RepositoryParserConfig::Deb {
+        distribution: "stable".to_string(),
+        component: "main".to_string(),
+        architecture: "amd64".to_string(),
+    };
+    manifest.repositories[0].trust = RepositoryTrustPolicy::Debian { release_keys };
+    let preview = preview_native_repository_takeover(&conn, root.path(), &manifest).unwrap();
+    assert!(preview.blockers.iter().any(|blocker| matches!(
+        blocker,
+        TakeoverBlocker::ParserFormatMismatch {
+            expected: RepositoryFormat::Fedora,
+            requested: RepositoryFormat::Debian,
+            ..
+        }
+    )));
+
+    manifest.repositories[0].parser = RepositoryParserConfig::Rpm {
+        architecture: "x86_64".to_string(),
+    };
+    let declarations = discover_selected_root(root.path()).unwrap();
+    let trust = plan_selected_root_trust(&declarations);
+    let expected = expected_trust_policy(
+        root.path(),
+        &declarations,
+        &trust.repositories[0],
+        RepositoryFormat::Fedora,
+    )
+    .unwrap()
+    .unwrap();
+    manifest.repositories[0].trust = expected;
+    let mut existing = Repository::new(
+        "vendor".to_string(),
+        "https://operator.example/repo".to_string(),
+    );
+    let existing_id = existing.insert(&conn).unwrap();
+    let declaration_path = root.path().join("etc/yum.repos.d/vendor.repo");
+    let before = fs::read(&declaration_path).unwrap();
+    let preview = preview_native_repository_takeover(&conn, root.path(), &manifest).unwrap();
+    assert!(preview.blockers.iter().any(|blocker| matches!(
+        blocker,
+        TakeoverBlocker::ExistingRepository { name, ownership }
+            if name == "vendor" && ownership == "operator"
+    )));
+    assert!(apply_native_repository_takeover(
+        &conn,
+        root.path(),
+        &manifest,
+        &preview.sha256().unwrap(),
+    )
+    .is_err());
+    assert_eq!(fs::read(declaration_path).unwrap(), before);
+    let loaded = Repository::find_by_id(&conn, existing_id)
+        .unwrap()
+        .expect("operator repository remains");
+    assert_eq!(loaded.name, existing.name);
+    assert_eq!(loaded.url, existing.url);
+    assert_eq!(loaded.managed_by, RepositoryOwnership::Operator);
+    let takeover_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM native_repository_takeovers",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(takeover_count, 0);
+}
+
+#[test]
+fn embedded_apt_key_material_becomes_exact_inline_trust_authority() {
+    let root = tempfile::tempdir().unwrap();
+    fs::create_dir_all(root.path().join("etc/apt/sources.list.d")).unwrap();
+    let (armor, fingerprint) = armored_certificate();
+    let continuation = armor
+        .lines()
+        .map(|line| {
+            if line.is_empty() {
+                " .".to_string()
+            } else {
+                format!(" {line}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(
+        root.path().join("etc/apt/sources.list.d/vendor.sources"),
+        format!(
+            "Types: deb\nURIs: https://apt.example\nSuites: stable\nComponents: main\nSigned-By:\n{continuation}\n"
+        ),
+    )
+    .unwrap();
+    let declarations = discover_selected_root(root.path()).unwrap();
+    let trust = plan_selected_root_trust(&declarations);
+    let policy = expected_trust_policy(
+        root.path(),
+        &declarations,
+        &trust.repositories[0],
+        RepositoryFormat::Debian,
+    )
+    .unwrap()
+    .unwrap();
+    let RepositoryTrustPolicy::Debian { release_keys } = policy else {
+        unreachable!("APT evidence produces Debian trust")
+    };
+    assert_eq!(release_keys[0].fingerprint, fingerprint);
+    assert!(
+        release_keys[0]
+            .url
+            .starts_with("data:application/pgp-keys;base64,")
+    );
+    release_keys[0].validate().unwrap();
+}
+
+#[test]
+fn apply_repeat_drift_and_rollback_preserve_exact_authority() {
+    let (root, conn, manifest) = fixture();
+    let declaration_path = root.path().join("etc/yum.repos.d/vendor.repo");
+    let original = fs::read(&declaration_path).unwrap();
+    let preview = preview_native_repository_takeover(&conn, root.path(), &manifest).unwrap();
+    let digest = preview.sha256().unwrap();
+    let applied = apply_native_repository_takeover(&conn, root.path(), &manifest, &digest).unwrap();
+    assert_eq!(applied.status, TakeoverApplyStatus::Applied);
+    assert_eq!(
+        Repository::find_by_name(&conn, "vendor")
+            .unwrap()
+            .unwrap()
+            .managed_by,
+        RepositoryOwnership::NativeProjection
+    );
+
+    let repeated =
+        apply_native_repository_takeover(&conn, root.path(), &manifest, &digest).unwrap();
+    assert_eq!(repeated.status, TakeoverApplyStatus::AlreadyApplied);
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM repositories", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(count, 1);
+
+    fs::write(&declaration_path, b"drift\n").unwrap();
+    let drifted = preview_native_repository_takeover(&conn, root.path(), &manifest).unwrap();
+    assert!(drifted.blockers.iter().any(|blocker| matches!(
+        blocker,
+        TakeoverBlocker::ProjectionDrift {
+            path,
+            expected_sha256,
+            observed_sha256: Some(_),
+        } if path == Path::new("/etc/yum.repos.d/vendor.repo")
+            && expected_sha256 == &crate::hash::sha256(&original)
+    )));
+    assert!(rollback_native_repository_takeover(&conn, root.path()).is_err());
+    assert!(Repository::find_by_name(&conn, "vendor").unwrap().is_some());
+
+    fs::write(&declaration_path, &original).unwrap();
+    fs::set_permissions(&declaration_path, fs::Permissions::from_mode(0o600)).unwrap();
+    let mode_drifted = preview_native_repository_takeover(&conn, root.path(), &manifest).unwrap();
+    assert!(mode_drifted.blockers.iter().any(|blocker| matches!(
+        blocker,
+        TakeoverBlocker::ProjectionModeDrift {
+            path,
+            expected_mode: 0o644,
+            observed_mode: Some(0o600),
+        } if path == Path::new("/etc/yum.repos.d/vendor.repo")
+    )));
+    fs::set_permissions(&declaration_path, fs::Permissions::from_mode(0o644)).unwrap();
+    rollback_native_repository_takeover(&conn, root.path()).unwrap();
+    assert_eq!(fs::read(&declaration_path).unwrap(), original);
+    assert!(Repository::find_by_name(&conn, "vendor").unwrap().is_none());
+    let takeover_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM native_repository_takeovers",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(takeover_count, 0);
+}
+
+#[test]
+fn staged_projection_failure_restores_files_and_rolls_back_database() {
+    let (root, conn, manifest) = fixture();
+    let declaration_path = root.path().join("etc/yum.repos.d/vendor.repo");
+    let original = fs::read(&declaration_path).unwrap();
+    let preview = preview_native_repository_takeover(&conn, root.path(), &manifest).unwrap();
+    let error = apply_native_repository_takeover_with_persist(
+        &conn,
+        root.path(),
+        &manifest,
+        &preview.sha256().unwrap(),
+        projection::persist_staged_after_one_for_test,
+    )
+    .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("forced projection persist failure")
+    );
+    assert_eq!(fs::read(declaration_path).unwrap(), original);
+    assert!(Repository::find_by_name(&conn, "vendor").unwrap().is_none());
+    let takeover_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM native_repository_takeovers",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(takeover_count, 0);
+}
+
+#[test]
+fn database_failure_after_exchange_restores_guest_projection_identity_and_bytes() {
+    let (root, conn, manifest) = fixture();
+    let declaration_path = root.path().join("etc/yum.repos.d/vendor.repo");
+    let original = fs::read(&declaration_path).unwrap();
+    conn.execute_batch(
+        "CREATE TRIGGER force_projection_insert_failure
+         BEFORE INSERT ON native_repository_projections
+         BEGIN
+             SELECT RAISE(ABORT, 'forced projection database failure');
+         END;",
+    )
+    .unwrap();
+    let preview = preview_native_repository_takeover(&conn, root.path(), &manifest).unwrap();
+    let error =
+        apply_native_repository_takeover(&conn, root.path(), &manifest, &preview.sha256().unwrap())
+            .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("forced projection database failure")
+    );
+    assert_eq!(fs::read(declaration_path).unwrap(), original);
+    assert!(Repository::find_by_name(&conn, "vendor").unwrap().is_none());
+    let takeover_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM native_repository_takeovers",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(takeover_count, 0);
+}
+
+#[test]
+fn atomic_exchange_preserves_concurrent_native_drift_and_rolls_back_database() {
+    let (root, conn, manifest) = fixture();
+    let declaration_path = root.path().join("etc/yum.repos.d/vendor.repo");
+    let preview = preview_native_repository_takeover(&conn, root.path(), &manifest).unwrap();
+    let concurrent = b"[vendor]\nenabled=0\n";
+    let error = apply_native_repository_takeover_with_persist(
+        &conn,
+        root.path(),
+        &manifest,
+        &preview.sha256().unwrap(),
+        |staged| {
+            fs::write(&declaration_path, concurrent)?;
+            persist_staged(staged)
+        },
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("changed before atomic exchange"));
+    assert_eq!(fs::read(&declaration_path).unwrap(), concurrent);
+    assert!(Repository::find_by_name(&conn, "vendor").unwrap().is_none());
+    let takeover_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM native_repository_takeovers",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(takeover_count, 0);
+}

--- a/crates/conary-core/src/repository/declarations/takeover/tests.rs
+++ b/crates/conary-core/src/repository/declarations/takeover/tests.rs
@@ -320,6 +320,96 @@ fn embedded_apt_key_material_becomes_exact_inline_trust_authority() {
 }
 
 #[test]
+fn apt_enrollment_covers_every_uri_suite_component_product_exactly_once() {
+    let root = tempfile::tempdir().unwrap();
+    fs::create_dir_all(root.path().join("etc/apt/sources.list.d")).unwrap();
+    let (armor, _) = armored_certificate();
+    let continuation = armor
+        .lines()
+        .map(|line| {
+            if line.is_empty() {
+                " .".to_string()
+            } else {
+                format!(" {line}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(
+        root.path().join("etc/apt/sources.list.d/vendor.sources"),
+        format!(
+            "Types: deb\nURIs: https://apt.example\nSuites: stable\nComponents: main updates\nSigned-By:\n{continuation}\n"
+        ),
+    )
+    .unwrap();
+    let db_path = root.path().join("conary.db");
+    crate::db::init(&db_path).unwrap();
+    let conn = crate::db::open(&db_path).unwrap();
+    let declarations = discover_selected_root(root.path()).unwrap();
+    let trust = plan_selected_root_trust(&declarations);
+    let reference = trust.repositories[0].repository.clone();
+    let policy = expected_trust_policy(
+        root.path(),
+        &declarations,
+        &trust.repositories[0],
+        RepositoryFormat::Debian,
+    )
+    .unwrap()
+    .unwrap();
+    let input = |name: &str, component: &str| TakeoverRepositoryInput {
+        declaration: reference.clone(),
+        name: name.to_string(),
+        source_identity: "apt-vendor".to_string(),
+        repository_identity: name.to_string(),
+        scope: TakeoverPolicyScope::Group {
+            identity: "apt-vendor".to_string(),
+        },
+        stream: TakeoverSourceStream::Release {
+            identity: "stable".to_string(),
+        },
+        update: TakeoverUpdatePolicy::Follow,
+        metadata_url: "https://apt.example/".to_string(),
+        content_url: None,
+        parser: RepositoryParserConfig::Deb {
+            distribution: "stable".to_string(),
+            component: component.to_string(),
+            architecture: "amd64".to_string(),
+        },
+        trust: policy.clone(),
+        enabled: true,
+        priority: 40,
+        metadata_expire: 3600,
+        source_profile: None,
+    };
+    let mut manifest = NativeRepositoryTakeoverManifest {
+        schema: TAKEOVER_MANIFEST_SCHEMA,
+        repositories: vec![input("apt-main", "main")],
+    };
+    let incomplete = preview_native_repository_takeover(&conn, root.path(), &manifest).unwrap();
+    assert!(incomplete.blockers.iter().any(|blocker| matches!(
+        blocker,
+        TakeoverBlocker::MissingEnrollment { products, .. }
+            if products == &vec![NativeEnrollmentProduct::Apt {
+                uri: "https://apt.example".to_string(),
+                suite: "stable".to_string(),
+                component: Some("updates".to_string()),
+            }]
+    )));
+
+    manifest.repositories.push(input("apt-updates", "updates"));
+    let complete = preview_native_repository_takeover(&conn, root.path(), &manifest).unwrap();
+    assert!(complete.blockers.is_empty(), "{:?}", complete.blockers);
+    let outcome = apply_native_repository_takeover(
+        &conn,
+        root.path(),
+        &manifest,
+        &complete.sha256().unwrap(),
+    )
+    .unwrap();
+    assert_eq!(outcome.repository_ids.len(), 2);
+}
+
+#[test]
 fn apply_repeat_drift_and_rollback_preserve_exact_authority() {
     let (root, conn, manifest) = fixture();
     let declaration_path = root.path().join("etc/yum.repos.d/vendor.repo");
@@ -335,6 +425,14 @@ fn apply_repeat_drift_and_rollback_preserve_exact_authority() {
             .managed_by,
         RepositoryOwnership::NativeProjection
     );
+    assert!(
+        crate::repository::set_repository_enabled(&conn, "vendor", false).is_err(),
+        "native projection authority cannot drift through generic repository mutation"
+    );
+    let mut sync_update = Repository::find_by_name(&conn, "vendor").unwrap().unwrap();
+    assert!(sync_update.enabled);
+    sync_update.last_sync = Some("2026-08-11T00:00:00Z".to_string());
+    sync_update.update(&conn).unwrap();
 
     let repeated =
         apply_native_repository_takeover(&conn, root.path(), &manifest, &digest).unwrap();

--- a/crates/conary-core/src/repository/declarations/takeover/trust_policy.rs
+++ b/crates/conary-core/src/repository/declarations/takeover/trust_policy.rs
@@ -1,0 +1,193 @@
+// conary-core/src/repository/declarations/takeover/trust_policy.rs
+
+//! Exact projection from discovered trust evidence into persisted policy.
+
+use super::*;
+use base64::Engine;
+
+pub(super) fn expected_trust_policy(
+    selected_root: &Path,
+    declarations: &DiscoveredRepositoryDeclarations,
+    plan: &NativeRepositoryTrustPlan,
+    format: RepositoryFormat,
+) -> Result<Option<RepositoryTrustPolicy>> {
+    match format {
+        RepositoryFormat::Debian => Ok(Some(RepositoryTrustPolicy::Debian {
+            release_keys: roots_for_role(
+                selected_root,
+                declarations,
+                plan,
+                TrustRole::DebianRelease,
+            )?,
+        })),
+        RepositoryFormat::Fedora => {
+            let metadata_urls: Vec<_> = plan
+                .evidence
+                .iter()
+                .filter_map(|evidence| match (&evidence.role, &evidence.source) {
+                    (TrustRole::RpmMetadata, TrustEvidenceSource::RpmMetalink { url }) => {
+                        Some(url.clone())
+                    }
+                    _ => None,
+                })
+                .collect();
+            let metadata = if metadata_urls.len() == 1 {
+                RpmMetadataAuthority::Metalink {
+                    url: metadata_urls[0].clone(),
+                }
+            } else {
+                RpmMetadataAuthority::OpenPgp {
+                    keys: roots_for_role(
+                        selected_root,
+                        declarations,
+                        plan,
+                        TrustRole::RpmMetadata,
+                    )?,
+                }
+            };
+            Ok(Some(RepositoryTrustPolicy::Rpm {
+                metadata,
+                package_keys: roots_for_role(
+                    selected_root,
+                    declarations,
+                    plan,
+                    TrustRole::RpmPackage,
+                )?,
+            }))
+        }
+        RepositoryFormat::Arch => Ok(None),
+        RepositoryFormat::Json | RepositoryFormat::Unspecified => Err(Error::ConfigError(
+            "native repository takeover requires an Arch, Debian, or RPM parser".to_string(),
+        )),
+    }
+}
+
+fn roots_for_role(
+    selected_root: &Path,
+    declarations: &DiscoveredRepositoryDeclarations,
+    plan: &NativeRepositoryTrustPlan,
+    role: TrustRole,
+) -> Result<Vec<OpenPgpTrustRoot>> {
+    let mut roots = Vec::new();
+    for evidence in plan
+        .evidence
+        .iter()
+        .filter(|evidence| evidence.role == role)
+    {
+        let Some(url) = evidence_openpgp_url(selected_root, declarations, plan, evidence)? else {
+            continue;
+        };
+        for certificate in &evidence.certificates {
+            roots.push(OpenPgpTrustRoot {
+                url: url.clone(),
+                fingerprint: certificate.certificate_fingerprint.clone(),
+            });
+        }
+    }
+    roots.sort_by(|left, right| {
+        (&left.fingerprint, &left.url).cmp(&(&right.fingerprint, &right.url))
+    });
+    roots.dedup_by(|left, right| left.fingerprint == right.fingerprint);
+    Ok(roots)
+}
+
+fn evidence_openpgp_url(
+    selected_root: &Path,
+    declarations: &DiscoveredRepositoryDeclarations,
+    plan: &NativeRepositoryTrustPlan,
+    evidence: &TrustImportEvidence,
+) -> Result<Option<String>> {
+    match &evidence.source {
+        TrustEvidenceSource::SelectedRootFile { path } => {
+            let host_path = safe_join(selected_root, path)?;
+            let url = url::Url::from_file_path(&host_path).map_err(|_| {
+                Error::ConfigError(format!(
+                    "selected-root trust path {} cannot be represented as a file URL",
+                    host_path.display()
+                ))
+            })?;
+            Ok(Some(url.to_string()))
+        }
+        TrustEvidenceSource::EmbeddedOpenPgp => {
+            let bytes = embedded_openpgp_bytes(declarations, plan)?;
+            Ok(Some(format!(
+                "data:application/pgp-keys;base64,{}",
+                base64::engine::general_purpose::STANDARD.encode(bytes)
+            )))
+        }
+        TrustEvidenceSource::RpmMetalink { .. } | TrustEvidenceSource::AlpmSigLevel { .. } => {
+            Ok(None)
+        }
+    }
+}
+
+fn embedded_openpgp_bytes(
+    declarations: &DiscoveredRepositoryDeclarations,
+    plan: &NativeRepositoryTrustPlan,
+) -> Result<Vec<u8>> {
+    let NativeRepositoryReference::Apt {
+        document,
+        entry_index,
+        ..
+    } = &plan.repository
+    else {
+        return Err(Error::ConfigError(
+            "embedded OpenPGP evidence is only valid for an APT declaration".to_string(),
+        ));
+    };
+    let entry = declarations
+        .apt
+        .iter()
+        .find(|candidate| &candidate.path == document)
+        .and_then(|candidate| candidate.entries.get(*entry_index))
+        .ok_or_else(|| {
+            Error::ConfigError(format!(
+                "embedded OpenPGP declaration {} entry {} is absent",
+                document.display(),
+                entry_index
+            ))
+        })?;
+    let values: Vec<_> = entry
+        .options
+        .iter()
+        .filter(|option| option.name == super::super::apt::AptOptionName::SignedBy)
+        .flat_map(|option| option.values.iter())
+        .filter(|value| {
+            value
+                .trim_start()
+                .starts_with("-----BEGIN PGP PUBLIC KEY BLOCK-----")
+        })
+        .collect();
+    if values.len() != 1 {
+        return Err(Error::ConfigError(format!(
+            "embedded OpenPGP evidence at {}:{} has {} exact source values",
+            entry.location.path.display(),
+            entry.location.line,
+            values.len()
+        )));
+    }
+    Ok(normalize_deb822_embedded(values[0].trim_start().as_bytes()))
+}
+
+fn normalize_deb822_embedded(bytes: &[u8]) -> Vec<u8> {
+    let Ok(value) = std::str::from_utf8(bytes) else {
+        return bytes.to_vec();
+    };
+    let mut normalized = String::new();
+    for (index, line) in value.lines().enumerate() {
+        if index > 0 {
+            normalized.push('\n');
+        }
+        if line == "." {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("..") {
+            normalized.push('.');
+            normalized.push_str(rest);
+        } else {
+            normalized.push_str(line);
+        }
+    }
+    normalized.push('\n');
+    normalized.into_bytes()
+}

--- a/crates/conary-core/src/repository/trust.rs
+++ b/crates/conary-core/src/repository/trust.rs
@@ -14,6 +14,34 @@ use url::Url;
 
 pub mod openpgp;
 
+const MAX_EMBEDDED_OPENPGP_BYTES: usize = 4 * 1024 * 1024;
+const MAX_EMBEDDED_OPENPGP_BASE64: usize = MAX_EMBEDDED_OPENPGP_BYTES.div_ceil(3) * 4;
+
+pub(crate) fn decode_embedded_openpgp_source(source: &str) -> Option<Result<Vec<u8>>> {
+    let encoded = source.strip_prefix("data:application/pgp-keys;base64,")?;
+    Some((|| {
+        if encoded.is_empty() || encoded.len() > MAX_EMBEDDED_OPENPGP_BASE64 {
+            return Err(Error::ConfigError(format!(
+                "embedded OpenPGP trust root must encode 1 to {MAX_EMBEDDED_OPENPGP_BYTES} bytes"
+            )));
+        }
+        use base64::Engine;
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .map_err(|error| {
+                Error::ConfigError(format!(
+                    "embedded OpenPGP trust root is invalid base64: {error}"
+                ))
+            })?;
+        if bytes.is_empty() || bytes.len() > MAX_EMBEDDED_OPENPGP_BYTES {
+            return Err(Error::ConfigError(format!(
+                "embedded OpenPGP trust root must contain 1 to {MAX_EMBEDDED_OPENPGP_BYTES} bytes"
+            )));
+        }
+        Ok(bytes)
+    })())
+}
+
 /// One explicitly pinned OpenPGP certificate source.
 ///
 /// The downloaded object may be an OpenPGP keyring, but only the certificate
@@ -34,6 +62,17 @@ impl OpenPgpTrustRoot {
     }
 
     pub fn validate(&self) -> Result<()> {
+        if let Some(bytes) = decode_embedded_openpgp_source(&self.url) {
+            bytes?;
+            let fingerprint = self.normalized_fingerprint()?;
+            if fingerprint != self.fingerprint {
+                return Err(Error::ConfigError(format!(
+                    "OpenPGP fingerprint '{}' must be uppercase hexadecimal without separators",
+                    self.fingerprint
+                )));
+            }
+            return Ok(());
+        }
         let parsed = Url::parse(&self.url).map_err(|error| {
             Error::ConfigError(format!(
                 "OpenPGP trust-root URL '{}' is invalid: {error}",
@@ -42,7 +81,7 @@ impl OpenPgpTrustRoot {
         })?;
         if !matches!(parsed.scheme(), "https" | "file") {
             return Err(Error::ConfigError(format!(
-                "OpenPGP trust-root URL '{}' must use https:// or file://",
+                "OpenPGP trust-root URL '{}' must use https://, file://, or an exact embedded application/pgp-keys data URL",
                 self.url
             )));
         }
@@ -392,6 +431,34 @@ mod tests {
             url: "https://keys.example.test/archive.asc".to_string(),
             fingerprint: "A".repeat(40),
         }
+    }
+
+    #[test]
+    fn bounded_embedded_openpgp_data_authority_is_exact() {
+        use base64::Engine;
+        let embedded = OpenPgpTrustRoot {
+            url: format!(
+                "data:application/pgp-keys;base64,{}",
+                base64::engine::general_purpose::STANDARD.encode(b"certificate bytes")
+            ),
+            fingerprint: "A".repeat(40),
+        };
+        embedded.validate().unwrap();
+
+        let malformed = OpenPgpTrustRoot {
+            url: "data:application/pgp-keys;base64,%%%".to_string(),
+            fingerprint: "A".repeat(40),
+        };
+        assert!(malformed.validate().is_err());
+
+        let oversized = OpenPgpTrustRoot {
+            url: format!(
+                "data:application/pgp-keys;base64,{}",
+                "A".repeat(MAX_EMBEDDED_OPENPGP_BASE64 + 1)
+            ),
+            fingerprint: "A".repeat(40),
+        };
+        assert!(oversized.validate().is_err());
     }
 
     #[test]

--- a/crates/conary-core/src/repository/trust/openpgp/store.rs
+++ b/crates/conary-core/src/repository/trust/openpgp/store.rs
@@ -22,9 +22,12 @@ use super::super::{OpenPgpTrustRoot, TrustRole};
 
 /// Downloads a configured trust source.
 ///
-/// Only `https://` and `file://` are representable; anything else is a typed
-/// configuration error rather than an opportunistic fallback.
+/// Only `https://`, `file://`, and the bounded exact embedded-key data form are
+/// representable; anything else is a typed configuration error.
 pub(super) async fn fetch_key_source(source: &str) -> Result<Vec<u8>> {
+    if let Some(bytes) = super::super::decode_embedded_openpgp_source(source) {
+        return bytes;
+    }
     let url = Url::parse(source)
         .map_err(|error| Error::ConfigError(format!("invalid trust-root URL: {error}")))?;
     match url.scheme() {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -586,7 +586,7 @@ The schema itself is split by ownership under
 `crates/conary-core/src/db/current_schema/sql/`: local package-manager state,
 repository/service state, and Remi conversion/administration state.
 
-Schema revision 31 retains the fail-closed persisted-state constraints and
+Schema revision 32 retains the fail-closed persisted-state constraints and
 adds normalized native source policies, exact repository identities,
 revision-bound stream commitments, per-member pins, and admitted authenticated
 snapshot identity. Native repositories no longer use the fixed public-profile

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -122,7 +122,11 @@ commands.
   follow-or-pin persistence, stream binding, and authenticated-snapshot
   admission start in `crates/conary-core/src/db/models/repository/source.rs`,
   `crates/conary-core/src/db/models/repository/source/policy.rs`, and
-  `docs/specs/native-source-identity-policy.md`. Trust verification starts in
+  `docs/specs/native-source-identity-policy.md`. Native repository takeover,
+  selected-root projection ownership, drift, and rollback start in
+  `crates/conary-core/src/repository/declarations/takeover.rs`,
+  `apps/conary/src/commands/repository_takeover.rs`, and
+  `docs/specs/native-repository-takeover.md`. Trust verification starts in
   `crates/conary-core/src/repository/trust.rs` and
   `crates/conary-core/src/repository/trust/openpgp.rs`, with ALPM keyring and
   package-signature semantics in

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -436,13 +436,17 @@ gates.
 **Capability:** authenticate and parse native repository metadata into
 source-scheme-aware relations, persist exact requirement groups, resolve
 providers through the SAT solver, and carry the selected relation graph into
-package transactions.
+package transactions. Discover, preview, and transactionally take ownership of
+native repository declarations as drift-detected selected-root projections.
 
 **Start here:** `crates/conary-core/src/repository/trust.rs`;
 `crates/conary-core/src/repository/declarations/`;
 `docs/specs/native-repository-declarations.md`;
 `docs/specs/native-repository-trust-import.md`;
 `docs/specs/native-source-identity-policy.md`;
+`docs/specs/native-repository-takeover.md`;
+`crates/conary-core/src/repository/declarations/takeover.rs`;
+`apps/conary/src/commands/repository_takeover.rs`;
 `crates/conary-core/src/repository/trust/openpgp.rs`;
 `crates/conary-core/src/repository/trust/openpgp/arch/`;
 `crates/conary-core/src/repository/parsers/`;
@@ -486,10 +490,12 @@ manifests, admin routes, and hosted feed configuration.
 `crates/conary-core/src/db/models/repository/source/*`;
 `crates/conary-core/src/db/models/repository/*`;
 `crates/conary-core/src/db/models/installed_requirement_atom.rs`;
-`crates/conary-core/src/db/models/installed_requirement_group.rs`.
+`crates/conary-core/src/db/models/installed_requirement_group.rs`;
+`apps/conary/src/commands/repository_takeover.rs`.
 
 **Focused proof:** `cargo test -p conary-core repository::trust`;
 `cargo test -p conary-core repository::declarations`;
+`cargo test -p conary-core repository::declarations::takeover`;
 `cargo test -p conary-core repository::parsers`;
 `cargo test -p conary-core repository::download`;
 `cargo test -p conary-core repository::sync`;
@@ -511,6 +517,8 @@ output changes.
 selected-root discovery, or its no-enrollment boundary changes;
 `docs/specs/native-repository-trust-import.md` when trust-import disposition,
 evidence, or selected-root key planning changes;
+`docs/specs/native-repository-takeover.md` when enrollment preview, projection
+ownership, drift, or rollback changes;
 `docs/specs/foreign-package-lifecycle-contracts.md` when native relation
 semantics change.
 

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -285,7 +285,7 @@ the authenticated source artifact. Public, OCI, index, search, chunk, and
 garbage-collection paths validate that typed artifact instead of filling
 missing fields with guesses or empty values. Architecture and the repository
 provide digest are required constructor and API-view fields, and the current
-schema rejects missing, empty, or malformed values. Schema revision 31 retains
+schema rejects missing, empty, or malformed values. Schema revision 32 retains
 fail-closed source-authority state and adds exact native source/repository
 identities, normalized follow-or-pin policy, stream bindings, and authenticated
 snapshot state. It is a pre-alpha hard cut: prior databases are rebuilt and

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -589,6 +589,17 @@ order is never transaction authority.
 
 ### Native Package Adoption
 
+Native repository takeover is a separate authority transition from package
+adoption. `conary system repository-takeover --dry-run --root <selected-root>
+--manifest <enrollment.json>` serializes the complete declaration, trust,
+identity, policy, and projection plan without mutation. Apply requires that
+exact preview SHA-256 and `--yes`; rollback restores the persisted prior
+projection bytes and removes only takeover-owned repository rows. Native
+declaration paths remain byte-identical compatibility projections, and any
+missing or changed path is reported as drift rather than becoming new
+authority. The exact contract is
+[`native-repository-takeover.md`](../specs/native-repository-takeover.md).
+
 `conary system adopt <pkg> --dry-run` builds the same package-specific plan
 that apply consumes. The preview opens an existing current-schema database
 read-only and never migrates it. Native discovery resolves the exact installed

--- a/docs/roadmaps/development-roadmap.md
+++ b/docs/roadmaps/development-roadmap.md
@@ -492,8 +492,7 @@ accepted here.
 - **Outcome:** Conary enrolls native repositories transactionally and supports
   package ecosystems without a distro-name routing matrix.
 - **Execution status:** final conformance remains gated on W9. #62 is tracked as
-  bounded child slices: #377 and #379 are merged; #380 owns the active
-  policy/schema hard cut; #381 through #384 own takeover/projection,
+  bounded child slices: #377, #379, and #380 are merged; #381 through #384 own takeover/projection,
   lifecycle-enrollment, capability-compatibility, and distro-conformance work.
   #68 follows.
 - **Issues:** #62 as epic; #377 and #379-#384 as tracked children; #68 follows.

--- a/docs/roadmaps/development-roadmap.md
+++ b/docs/roadmaps/development-roadmap.md
@@ -515,12 +515,13 @@ accepted here.
     derivative, openSUSE Tumbleweed as an independent RPM ecosystem, and Artix
     as a non-systemd target-capability test. Named distributions are conformance
     proof, not runtime selectors.
-- **Schema prerequisite:** #380 replaces fixed `source_profile` membership with
+- **Schema prerequisite:** #380 replaced fixed `source_profile` membership with
   normalized source policy, distinct repository identity, typed ecosystem and
   version ordering, immutable stream binding, and authenticated follow-or-pin
-  snapshot state in current schema revision 31. It removes the inline
-  three-profile checks from repository and repository-package identity without
-  growing a catalog. Target capability compatibility remains owned by #383.
+  snapshot state in binding revision 31. #381 advances the current database
+  schema to revision 32 for takeover and projection ownership. #380 removed the
+  inline three-profile checks from repository and repository-package identity
+  without growing a catalog. Target capability compatibility remains owned by #383.
   Pre-alpha rebuild and authoritative-input re-enrollment are explicit; no
   compatibility migration is retained.
 

--- a/docs/specs/native-repository-takeover.md
+++ b/docs/specs/native-repository-takeover.md
@@ -45,23 +45,33 @@ suite and component combinations.
 Preview reads the current-schema database and selected root only. It does not
 write SQLite, stage files, invoke a native package manager, fetch metadata or
 keys, or inspect the live host when another selected root was requested.
+The CLI opens SQLite through an immutable read-only connection. If the database
+has uncheckpointed WAL frames, preview fails closed instead of creating SQLite
+sidecars or ignoring newer authority in the WAL.
 
 ## Apply And Projection Ownership
 
 Apply consumes the exact preview digest. Before mutation it repeats discovery
 and planning and refuses if the serialized preview changed. Projection content
 on first takeover is the exact UTF-8 declaration content already admitted by
-the lossless grammar. It is persisted beside its SHA-256 and prior path state;
+the lossless grammar. Selected-root key files referenced by importable trust
+evidence become owned projections too. APT embedded OpenPGP blocks remain in
+their exact declaration projection and are persisted as bounded exact
+`application/pgp-keys` data authority for Conary's pinned certificate loader.
+Projection content is persisted beside its SHA-256 and prior path state;
 subsequent operations render from that persisted Conary authority rather than
 scraping the filesystem into a second owner.
 
 Projection writes are staged in the destination directory, flushed, and
-atomically renamed. The database transaction persists repository authority,
-projection content and digests, and takeover membership. A failure restores
-every already-replaced path before the database transaction is abandoned.
-Existing projection state is checked before staging: a missing path or digest
-mismatch is reported with its exact guest path and expected and observed
-SHA-256 values. Drift is never accepted as a new declaration.
+atomically exchanged with the destination. Conary verifies the digest and mode
+of the displaced inode after the exchange; a mismatch is exchanged back before
+returning an error. If a later exchange or database operation fails, every
+earlier exchange is rolled back from its exact displaced bytes and mode before
+the database transaction is abandoned. The transaction persists repository
+authority, projection content and digests, and takeover membership. Existing
+projection state is checked before staging: a missing path, digest mismatch, or
+mode mismatch is reported with its exact guest path and expected and observed
+state. Drift is never accepted as a new declaration.
 
 Takeover-created repository rows use the closed `native-projection` ownership
 value. Apply refuses to overwrite an operator- or Remi-owned row. A repeated

--- a/docs/specs/native-repository-takeover.md
+++ b/docs/specs/native-repository-takeover.md
@@ -40,7 +40,11 @@ unresolved trust does not enable mutation authority, but their enrollment may
 not be silently enabled. Every enabled declaration must have exactly one
 enrollment binding, and one declaration may expand into multiple exact Conary
 repository rows when the native grammar declares a typed product such as APT
-suite and component combinations.
+URI, suite, and component combinations. Coverage validation derives that
+product set from the parsed declaration, binds each manifest row through its
+exact Debian parser inputs and semantically identical base URI, and blocks both
+missing and duplicate products. A manifest cannot establish completeness merely
+by naming a declaration once.
 
 Preview reads the current-schema database and selected root only. It does not
 write SQLite, stage files, invoke a native package manager, fetch metadata or
@@ -74,8 +78,12 @@ mode mismatch is reported with its exact guest path and expected and observed
 state. Drift is never accepted as a new declaration.
 
 Takeover-created repository rows use the closed `native-projection` ownership
-value. Apply refuses to overwrite an operator- or Remi-owned row. A repeated
-apply with the same preview is an idempotent verification; it creates no new
+value. Apply refuses to overwrite an operator- or Remi-owned row. While a row
+belongs to a takeover, schema authority rejects generic repository-definition
+updates (including enablement, priority, parser, trust, endpoints, and source
+policy); authenticated snapshot and last-sync observations may still advance.
+Definition changes require a projection-enrollment transaction. A repeated apply
+with the same preview is an idempotent verification; it creates no new
 repository, policy, membership, or projection rows.
 
 ## Rollback

--- a/docs/specs/native-repository-takeover.md
+++ b/docs/specs/native-repository-takeover.md
@@ -1,0 +1,109 @@
+---
+last_updated: 2026-08-11
+revision: 1
+summary: Define deterministic native repository takeover, owned projections, drift detection, and rollback
+---
+
+# Native Repository Takeover And Projections
+
+## Status And Boundary
+
+Issue #381 is the fourth bounded W10 slice. It consumes lossless selected-root
+declarations, their trust-import dispositions, and an explicit versioned
+enrollment manifest. It produces a complete preview before mutation and can
+then make Conary the sole repository authority while preserving the native
+manager's repository files as deterministic compatibility projections.
+
+Discovery evidence is not enrollment authority. Source identity, repository
+identity, stream policy, parser selectors, authenticated pins, and target
+architecture cannot be inferred from distribution names, paths, URLs, or
+repository aliases. The enrollment manifest supplies those exact values and
+binds each one to a lossless `NativeRepositoryReference` emitted by discovery.
+
+## Preview Contract
+
+The takeover preview is versioned, serializable, and deterministic. It records:
+
+- the selected root and exact declaration provenance;
+- every native repository's enabled state, trust disposition, source
+  locations, priority, filters, and ownership transition;
+- the exact Conary repository rows, source policies, parser inputs, trust
+  roots, follow-or-pin policy, and authenticated snapshot input to persist;
+- every projected path with its exact SHA-256 and ownership transition; and
+- closed blockers, including ambiguous or unsupported enabled trust,
+  dynamically generated libzypp service repositories, missing or duplicate
+  enrollment bindings, conflicting existing Conary authority, and projection
+  drift.
+
+Disabled repositories remain in the preview and projection universe. Their
+unresolved trust does not enable mutation authority, but their enrollment may
+not be silently enabled. Every enabled declaration must have exactly one
+enrollment binding, and one declaration may expand into multiple exact Conary
+repository rows when the native grammar declares a typed product such as APT
+suite and component combinations.
+
+Preview reads the current-schema database and selected root only. It does not
+write SQLite, stage files, invoke a native package manager, fetch metadata or
+keys, or inspect the live host when another selected root was requested.
+
+## Apply And Projection Ownership
+
+Apply consumes the exact preview digest. Before mutation it repeats discovery
+and planning and refuses if the serialized preview changed. Projection content
+on first takeover is the exact UTF-8 declaration content already admitted by
+the lossless grammar. It is persisted beside its SHA-256 and prior path state;
+subsequent operations render from that persisted Conary authority rather than
+scraping the filesystem into a second owner.
+
+Projection writes are staged in the destination directory, flushed, and
+atomically renamed. The database transaction persists repository authority,
+projection content and digests, and takeover membership. A failure restores
+every already-replaced path before the database transaction is abandoned.
+Existing projection state is checked before staging: a missing path or digest
+mismatch is reported with its exact guest path and expected and observed
+SHA-256 values. Drift is never accepted as a new declaration.
+
+Takeover-created repository rows use the closed `native-projection` ownership
+value. Apply refuses to overwrite an operator- or Remi-owned row. A repeated
+apply with the same preview is an idempotent verification; it creates no new
+repository, policy, membership, or projection rows.
+
+## Rollback
+
+Rollback is scoped to one persisted takeover. It first verifies that every
+owned projection still matches Conary's expected digest. It then stages the
+recorded pre-takeover bytes (or a removal for paths that were absent), removes
+only the takeover's `native-projection` repository rows and policy membership
+inside one SQLite transaction, atomically restores the prior path state, and
+deletes the takeover record. Conflicting ownership or projection drift blocks
+rollback without changing SQLite or the selected root.
+
+This slice never deletes or mutates a native package-manager database. The
+native manager retains its normal enabled repository universe and update
+behavior because it continues reading the same declaration paths and bytes;
+only their mutation authority changes.
+
+## Schema Hard Cut
+
+Schema revision 32 adds `native-projection` repository ownership plus normalized
+takeover, membership, and projection-state tables. Projection paths are unique
+within the current Conary database, content and prior bytes are stored as BLOBs,
+and SHA-256 values are lowercase exact-length values. Revision 31 databases are
+retired pre-alpha state. Recovery is:
+
+```bash
+conary system rebuild-db --discard-state --yes
+```
+
+followed by a new preview and apply from authoritative declarations, trust, and
+enrollment input. There is no compatibility migration or legacy reader.
+
+## Proof
+
+Focused proof must cover deterministic JSON and unknown-field rejection,
+complete enabled-declaration enrollment, ambiguous and unsupported trust
+blocking, selected-root confinement, staged write failure, database conflict,
+repeat apply, exact drift reporting, and rollback restoration of both database
+authority and prior projection bytes. The adoption interaction gate, workspace
+Clippy, formatting, current-schema rejection/rebuild proof, and documentation
+truth checks remain required.

--- a/docs/specs/native-source-identity-policy.md
+++ b/docs/specs/native-source-identity-policy.md
@@ -159,10 +159,12 @@ to a pin.
 
 ## Hard Cut And Recovery
 
-This change increments the current schema revision from 30 to 31 and replaces
+This change introduced schema revision 31 and replaced
 disposable pre-alpha state. There is no migration, compatibility reader,
 implicit default, or adapter for repositories that lack an exact source
-policy.
+policy. Native repository takeover subsequently advances the current database
+schema to revision 32 while retaining revision 31 as the stream-binding
+encoding identity.
 
 Recovery is `conary system rebuild-db --discard-state --yes`, followed by
 re-enrollment from authoritative native declarations, imported trust roots,
@@ -179,7 +181,8 @@ Focused proof covers:
 - first-party and uncatalogued third-party enrollment;
 - transactional follow advancement and pin mismatch rollback;
 - parser snapshot identity for ALPM, Debian, and RPM trust chains.
-- rejection of revision 30 plus documented rebuild recovery into revision 31;
+- rejection of retired revisions plus documented rebuild recovery into the
+  current schema;
 - CLI flag exclusivity, native replacement, and group reuse behavior;
 - stable revision-31 binding encoding and fail-closed encoding drift;
 - pin refusal leaving package rows, canonical links, converted-package


### PR DESCRIPTION
## Problem

Native repository declarations and trust could be discovered and planned, but Conary could not take authority without leaving native files as a second mutable owner.

## What changed

- add a deterministic versioned `conary system repository-takeover` preview/apply/rollback contract
- require exact enrollment, parser, enabled state, source policy, trust evidence, and preview digest before mutation
- derive complete APT enrollment coverage from every URI × suite × component product and reject missing, duplicate, or invented products
- acquire the selected-root mutation lock before writable database authority reads
- make dry-run SQLite inspection immutable and side-effect-free, failing closed on uncheckpointed WAL authority
- persist `native-projection` ownership, takeover membership, exact declaration/key bytes, modes, and drift digests in schema revision 32
- reject generic definition mutation for takeover-owned repositories while allowing authenticated sync observations to advance
- stage projection writes beside their destinations and atomically exchange them, verifying the displaced inode before accepting the write
- use the Linux `renameat2(RENAME_EXCHANGE)` syscall through libc so the atomic projection contract compiles for both glibc and musl
- roll back earlier exchanges and SQLite authority on native races, filesystem failures, projection-row failures, or commit failures
- restore exact prior bytes and modes on explicit rollback
- keep Remi/operator ownership closed against takeover

## Verification

- `bash scripts/agent-context.sh --feature resolution --run focused` — all 9 commands passed on `77c61df6`
- `bash scripts/agent-context.sh --feature resolution --run gate` — all 6 commands passed on `77c61df6`
- `cargo test -p conary-core repository::declarations::takeover -- --nocapture` — 11 passed on `47841d0b`
- `cargo check -p conary-core --target x86_64-unknown-linux-musl` — passed on `47841d0b`
- `cargo clippy -p conary-core --all-targets -- -D warnings` — passed on `47841d0b`
- `cargo fmt --all -- --check` — passed on `47841d0b`
- `cargo test -p conary-core db::` — 360 passed
- `cargo test -p conary --lib command_risk` — 28 passed
- `cargo test -p conary --lib live_host_safety` — 6 passed
- `cargo test -p remi server::handlers::admin::repos` — 9 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `bash scripts/check-doc-truth.sh` — passed

Refs #62
Closes #381
