### PR TITLE
feat(adopt): restore exact artifact CCS conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
+ "bytes",
  "crypto-common 0.1.7",
  "generic-array 0.14.7",
 ]
@@ -45,6 +46,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes-kw"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
+dependencies = [
+ "aes",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,7 +64,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.8.50",
 ]
 
 [[package]]
@@ -208,6 +218,7 @@ dependencies = [
  "blake2",
  "cpufeatures 0.2.17",
  "password-hash 0.5.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -473,6 +484,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
+name = "bitfields"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6e59298da389bc0649c7463856b34c6e17fe542f88939426ede4436c6b1195"
+dependencies = [
+ "bitfields-impl",
+]
+
+[[package]]
+name = "bitfields-impl"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c044f98f86f15414668d6c8187c7e4fadab1ad2b31680f648703e0fe07c555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,7 +555,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "hybrid-array",
+ "hybrid-array 0.4.12",
 ]
 
 [[package]]
@@ -630,6 +662,15 @@ checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
  "serde_core",
+]
+
+[[package]]
+name = "buffer-redux"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431a9cc8d7efa49bc326729264537f5e60affce816c66edf434350778c9f4f54"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -967,7 +1008,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "xxhash-rust",
- "zerocopy",
+ "zerocopy 0.8.50",
  "zstd",
 ]
 
@@ -1306,6 +1347,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,6 +1408,12 @@ dependencies = [
  "digest 0.10.7",
  "spin 0.10.1",
 ]
+
+[[package]]
+name = "crc24"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd121741cf3eb82c08dd3023eb55bf2665e5f60ec20f89760cf836ae4562e6a0"
 
 [[package]]
 name = "crc32fast"
@@ -1470,7 +1526,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "hybrid-array",
+ "hybrid-array 0.4.12",
 ]
 
 [[package]]
@@ -1541,7 +1597,9 @@ checksum = "b4c0cf476284b03eb6c10e78787b21c7abb7d7d43cb2f02532ba6b831ed892fa"
 dependencies = [
  "crypto-bigint",
  "elliptic-curve",
+ "pkcs8",
  "rand_core 0.6.4",
+ "serdect 0.3.0",
  "sha3",
  "signature 2.2.0",
  "subtle",
@@ -1757,6 +1815,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-xid",
+]
+
+[[package]]
 name = "des"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1959,7 +2040,7 @@ dependencies = [
  "rand_core 0.6.4",
  "sec1",
  "serde_json",
- "serdect",
+ "serdect 0.2.0",
  "subtle",
  "tap",
  "zeroize",
@@ -2170,6 +2251,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2607,7 +2689,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
- "zerocopy",
+ "zerocopy 0.8.50",
 ]
 
 [[package]]
@@ -2779,6 +2861,25 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d15931895091dea5c47afa5b3c9a01ba634b311919fd4d41388fa0e3d76af"
+dependencies = [
+ "typenum",
+ "zeroize",
+]
 
 [[package]]
 name = "hybrid-array"
@@ -3130,7 +3231,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "hybrid-array",
+ "hybrid-array 0.4.12",
 ]
 
 [[package]]
@@ -3294,12 +3395,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8645470337db67b01a7f966decf7d0bafedbae74147d33e641c67a91df239f"
+dependencies = [
+ "rand_core 0.6.4",
+ "zeroize",
 ]
 
 [[package]]
@@ -3697,6 +3822,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ml-dsa"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac4a46643af2001eafebcc37031fc459eb72d45057aac5d7a15b00046a2ad6db"
+dependencies = [
+ "const-oid 0.9.6",
+ "hybrid-array 0.3.1",
+ "num-traits",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha3",
+ "signature 2.2.0",
+ "zeroize",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de49b3df74c35498c0232031bb7e85f9389f913e2796169c8ab47a53993a18f"
+dependencies = [
+ "hybrid-array 0.2.3",
+ "kem",
+ "rand_core 0.6.4",
+ "sha3",
+ "zeroize",
+]
+
+[[package]]
 name = "mlua"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3841,6 +3995,7 @@ dependencies = [
  "num-iter",
  "num-traits",
  "rand 0.8.6",
+ "serde",
  "smallvec",
  "zeroize",
 ]
@@ -3910,6 +4065,28 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4303,6 +4480,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "pgp"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaffe1ec22db286599c30ae6be75b37493b558735d86c8e59ec5c38794415fe4"
+dependencies = [
+ "aead",
+ "aes",
+ "aes-gcm",
+ "aes-kw",
+ "argon2",
+ "base64 0.21.7",
+ "bitfields",
+ "block-padding",
+ "blowfish",
+ "buffer-redux",
+ "byteorder",
+ "bytes",
+ "bzip2",
+ "camellia",
+ "cast5",
+ "cfb-mode",
+ "cipher 0.4.4",
+ "const-oid 0.9.6",
+ "crc24",
+ "curve25519-dalek",
+ "cx448",
+ "derive_builder",
+ "derive_more",
+ "des",
+ "digest 0.10.7",
+ "dsa",
+ "eax",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "flate2",
+ "generic-array 0.14.7",
+ "hex",
+ "hkdf",
+ "idea",
+ "k256",
+ "log",
+ "md-5 0.10.6",
+ "ml-dsa",
+ "ml-kem",
+ "nom 8.0.0",
+ "num-bigint-dig",
+ "num-traits",
+ "num_enum",
+ "ocb3",
+ "p256",
+ "p384",
+ "p521",
+ "rand 0.8.6",
+ "regex",
+ "replace_with",
+ "ripemd",
+ "rsa",
+ "sha1",
+ "sha1-checked",
+ "sha2 0.10.9",
+ "sha3",
+ "signature 2.2.0",
+ "slh-dsa",
+ "smallvec",
+ "snafu",
+ "twofish",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
 name = "phc"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4455,7 +4704,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.50",
 ]
 
 [[package]]
@@ -4481,6 +4730,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -4942,6 +5200,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "replace_with"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5146,9 +5410,11 @@ checksum = "3a5c5d43b95d73d6f0a1b8fbeab72a7ebebf618cdc99f2b9a28f269ee343766e"
 dependencies = [
  "base64 0.22.1",
  "bitflags",
+ "chrono",
  "digest 0.10.7",
  "enum-display-derive",
  "enum-primitive-derive",
+ "getrandom 0.4.2",
  "hex",
  "itertools 0.14.0",
  "log",
@@ -5157,6 +5423,7 @@ dependencies = [
  "num",
  "num-derive",
  "num-traits",
+ "pgp",
  "rpm-version",
  "sha1",
  "sha2 0.10.9",
@@ -5535,7 +5802,7 @@ dependencies = [
  "der",
  "generic-array 0.14.7",
  "pkcs8",
- "serdect",
+ "serdect 0.2.0",
  "subtle",
  "zeroize",
 ]
@@ -5829,6 +6096,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5837,6 +6114,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest 0.10.7",
+ "sha1",
+ "zeroize",
 ]
 
 [[package]]
@@ -6045,10 +6333,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slh-dsa"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2f20f4049197e03db1104a6452f4d9e96665d79f880198dce4a7026ba5f267"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "hmac 0.12.1",
+ "hybrid-array 0.3.1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+ "sha3",
+ "signature 2.2.0",
+ "typenum",
+ "zerocopy 0.7.35",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "socket-pktinfo"
@@ -7873,6 +8201,7 @@ checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.6.4",
+ "serde",
  "zeroize",
 ]
 
@@ -7931,11 +8260,32 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.8.50",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8023,6 +8373,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,6 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "bytes",
  "crypto-common 0.1.7",
  "generic-array 0.14.7",
 ]
@@ -46,15 +45,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aes-kw"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
-dependencies = [
- "aes",
-]
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,7 +54,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
- "zerocopy 0.8.50",
+ "zerocopy",
 ]
 
 [[package]]
@@ -218,7 +208,6 @@ dependencies = [
  "blake2",
  "cpufeatures 0.2.17",
  "password-hash 0.5.0",
- "zeroize",
 ]
 
 [[package]]
@@ -484,27 +473,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
-name = "bitfields"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6e59298da389bc0649c7463856b34c6e17fe542f88939426ede4436c6b1195"
-dependencies = [
- "bitfields-impl",
-]
-
-[[package]]
-name = "bitfields-impl"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c044f98f86f15414668d6c8187c7e4fadab1ad2b31680f648703e0fe07c555"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,7 +523,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "hybrid-array 0.4.12",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -662,15 +630,6 @@ checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
  "serde_core",
-]
-
-[[package]]
-name = "buffer-redux"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431a9cc8d7efa49bc326729264537f5e60affce816c66edf434350778c9f4f54"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1008,7 +967,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "xxhash-rust",
- "zerocopy 0.8.50",
+ "zerocopy",
  "zstd",
 ]
 
@@ -1347,15 +1306,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,12 +1358,6 @@ dependencies = [
  "digest 0.10.7",
  "spin 0.10.1",
 ]
-
-[[package]]
-name = "crc24"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd121741cf3eb82c08dd3023eb55bf2665e5f60ec20f89760cf836ae4562e6a0"
 
 [[package]]
 name = "crc32fast"
@@ -1526,7 +1470,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "hybrid-array 0.4.12",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1597,9 +1541,7 @@ checksum = "b4c0cf476284b03eb6c10e78787b21c7abb7d7d43cb2f02532ba6b831ed892fa"
 dependencies = [
  "crypto-bigint",
  "elliptic-curve",
- "pkcs8",
  "rand_core 0.6.4",
- "serdect 0.3.0",
  "sha3",
  "signature 2.2.0",
  "subtle",
@@ -1815,29 +1757,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 2.0.117",
- "unicode-xid",
-]
-
-[[package]]
 name = "des"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2040,7 +1959,7 @@ dependencies = [
  "rand_core 0.6.4",
  "sec1",
  "serde_json",
- "serdect 0.2.0",
+ "serdect",
  "subtle",
  "tap",
  "zeroize",
@@ -2251,7 +2170,6 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
- "zlib-rs",
 ]
 
 [[package]]
@@ -2689,7 +2607,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
- "zerocopy 0.8.50",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2861,25 +2779,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "hybrid-array"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "hybrid-array"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d15931895091dea5c47afa5b3c9a01ba634b311919fd4d41388fa0e3d76af"
-dependencies = [
- "typenum",
- "zeroize",
-]
 
 [[package]]
 name = "hybrid-array"
@@ -3231,7 +3130,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "hybrid-array 0.4.12",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -3297,6 +3196,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -3395,36 +3303,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "k256"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
-dependencies = [
- "cfg-if",
- "ecdsa",
- "elliptic-curve",
- "once_cell",
- "sha2 0.10.9",
- "signature 2.2.0",
-]
-
-[[package]]
 name = "keccak"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "kem"
-version = "0.3.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8645470337db67b01a7f966decf7d0bafedbae74147d33e641c67a91df239f"
-dependencies = [
- "rand_core 0.6.4",
- "zeroize",
 ]
 
 [[package]]
@@ -3822,35 +3706,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ml-dsa"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac4a46643af2001eafebcc37031fc459eb72d45057aac5d7a15b00046a2ad6db"
-dependencies = [
- "const-oid 0.9.6",
- "hybrid-array 0.3.1",
- "num-traits",
- "pkcs8",
- "rand_core 0.6.4",
- "sha3",
- "signature 2.2.0",
- "zeroize",
-]
-
-[[package]]
-name = "ml-kem"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de49b3df74c35498c0232031bb7e85f9389f913e2796169c8ab47a53993a18f"
-dependencies = [
- "hybrid-array 0.2.3",
- "kem",
- "rand_core 0.6.4",
- "sha3",
- "zeroize",
-]
-
-[[package]]
 name = "mlua"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3995,7 +3850,6 @@ dependencies = [
  "num-iter",
  "num-traits",
  "rand 0.8.6",
- "serde",
  "smallvec",
  "zeroize",
 ]
@@ -4017,13 +3871,13 @@ checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+checksum = "e4e98dc3b890f6c23a0f9d3d491a2823d0dea0fa656302a13dd225fa924112a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4068,34 +3922,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
-dependencies = [
- "num_enum_derive",
- "rustversion",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "oauth2"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http",
@@ -4480,78 +4312,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pgp"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaffe1ec22db286599c30ae6be75b37493b558735d86c8e59ec5c38794415fe4"
-dependencies = [
- "aead",
- "aes",
- "aes-gcm",
- "aes-kw",
- "argon2",
- "base64 0.21.7",
- "bitfields",
- "block-padding",
- "blowfish",
- "buffer-redux",
- "byteorder",
- "bytes",
- "bzip2",
- "camellia",
- "cast5",
- "cfb-mode",
- "cipher 0.4.4",
- "const-oid 0.9.6",
- "crc24",
- "curve25519-dalek",
- "cx448",
- "derive_builder",
- "derive_more",
- "des",
- "digest 0.10.7",
- "dsa",
- "eax",
- "ecdsa",
- "ed25519-dalek",
- "elliptic-curve",
- "flate2",
- "generic-array 0.14.7",
- "hex",
- "hkdf",
- "idea",
- "k256",
- "log",
- "md-5 0.10.6",
- "ml-dsa",
- "ml-kem",
- "nom 8.0.0",
- "num-bigint-dig",
- "num-traits",
- "num_enum",
- "ocb3",
- "p256",
- "p384",
- "p521",
- "rand 0.8.6",
- "regex",
- "replace_with",
- "ripemd",
- "rsa",
- "sha1",
- "sha1-checked",
- "sha2 0.10.9",
- "sha3",
- "signature 2.2.0",
- "slh-dsa",
- "smallvec",
- "snafu",
- "twofish",
- "x25519-dalek",
- "zeroize",
-]
-
-[[package]]
 name = "phc"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4704,7 +4464,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.50",
+ "zerocopy",
 ]
 
 [[package]]
@@ -4730,15 +4490,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit",
 ]
 
 [[package]]
@@ -4795,7 +4546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -4814,7 +4565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5200,12 +4951,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "replace_with"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
-
-[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5404,27 +5149,24 @@ checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
 name = "rpm"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a5c5d43b95d73d6f0a1b8fbeab72a7ebebf618cdc99f2b9a28f269ee343766e"
+version = "0.27.1"
+source = "git+https://github.com/rpm-rs/rpm-rs?rev=283563a92383dd63cf92fe1d261d42ecdf71ff12#283563a92383dd63cf92fe1d261d42ecdf71ff12"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bitflags",
- "chrono",
  "digest 0.10.7",
  "enum-display-derive",
  "enum-primitive-derive",
- "getrandom 0.4.2",
  "hex",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "memchr",
  "nom 8.0.0",
  "num",
  "num-derive",
  "num-traits",
- "pgp",
  "rpm-version",
+ "sequoia-openpgp",
  "sha1",
  "sha2 0.10.9",
  "sha3",
@@ -5802,7 +5544,7 @@ dependencies = [
  "der",
  "generic-array 0.14.7",
  "pkcs8",
- "serdect 0.2.0",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -5861,7 +5603,7 @@ dependencies = [
  "aes-gcm",
  "anyhow",
  "argon2",
- "base64 0.22.1",
+ "base64 0.21.7",
  "block-padding",
  "blowfish",
  "buffered-reader",
@@ -5905,7 +5647,7 @@ dependencies = [
  "sha1collisiondetection",
  "sha2 0.10.9",
  "sha3",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "twofish",
  "typenum",
  "x25519-dalek",
@@ -6096,16 +5838,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serdect"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
-dependencies = [
- "base16ct",
- "serde",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6114,17 +5846,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha1-checked"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
-dependencies = [
- "digest 0.10.7",
- "sha1",
- "zeroize",
 ]
 
 [[package]]
@@ -6333,50 +6054,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "slh-dsa"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd2f20f4049197e03db1104a6452f4d9e96665d79f880198dce4a7026ba5f267"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "hmac 0.12.1",
- "hybrid-array 0.3.1",
- "pkcs8",
- "rand_core 0.6.4",
- "sha2 0.10.9",
- "sha3",
- "signature 2.2.0",
- "typenum",
- "zerocopy 0.7.35",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "snafu"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
-dependencies = [
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "socket-pktinfo"
@@ -8201,7 +7882,6 @@ checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.6.4",
- "serde",
  "zeroize",
 ]
 
@@ -8260,32 +7940,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
- "zerocopy-derive 0.8.50",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -8373,12 +8032,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "zlib-rs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,8 @@ x509-cert = { version = "0.2", features = ["pem", "std"] }
 # Archives
 tar = "0.4"
 flate2 = "1.0"
-rpm = { version = "0.25", default-features = false, features = ["payload"] }
+# Pin the upstream Sequoia signature backend until it reaches a crates.io release.
+rpm = { git = "https://github.com/rpm-rs/rpm-rs", rev = "283563a92383dd63cf92fe1d261d42ecdf71ff12", version = "0.27.1", default-features = false, features = ["payload"] }
 rpm-version = "0.5.0"
 debversion = "0.5.4"
 alpm-types = "0.11.2"

--- a/apps/conary/Cargo.toml
+++ b/apps/conary/Cargo.toml
@@ -82,6 +82,6 @@ conary-core = { path = "../../crates/conary-core" }
 axum.workspace = true
 ed25519-dalek.workspace = true
 remi = { path = "../remi" }
-rpm.workspace = true
+rpm = { workspace = true, features = ["signature-pgp"] }
 sequoia-openpgp.workspace = true
 tower.workspace = true

--- a/apps/conary/Cargo.toml
+++ b/apps/conary/Cargo.toml
@@ -82,6 +82,6 @@ conary-core = { path = "../../crates/conary-core" }
 axum.workspace = true
 ed25519-dalek.workspace = true
 remi = { path = "../remi" }
-rpm = { workspace = true, features = ["signature-pgp"] }
+rpm = { workspace = true, features = ["signature-sequoia"] }
 sequoia-openpgp.workspace = true
 tower.workspace = true

--- a/apps/conary/src/cli/system.rs
+++ b/apps/conary/src/cli/system.rs
@@ -157,24 +157,24 @@ pub enum SystemCommands {
         db: DbArgs,
 
         /// Select native authority when more than one package database is populated
-        #[arg(long, value_enum)]
+        #[arg(long, value_enum, conflicts_with = "convert")]
         package_manager: Option<NativePackageManager>,
 
         /// Copy files to CAS for full management (enables rollback)
         /// Used by: default (package adopt), --system
-        #[arg(long, conflicts_with_all = ["status", "sync_hook", "from_sync_hook"])]
+        #[arg(long, conflicts_with_all = ["status", "convert", "sync_hook", "from_sync_hook"])]
         full: bool,
 
         /// Adopt all installed system packages
-        #[arg(long, conflicts_with_all = ["status", "refresh", "sync_hook"])]
+        #[arg(long, conflicts_with_all = ["status", "refresh", "convert", "sync_hook"])]
         system: bool,
 
         /// Show adoption status
-        #[arg(long, conflicts_with_all = ["system", "refresh", "sync_hook"])]
+        #[arg(long, conflicts_with_all = ["system", "refresh", "convert", "sync_hook"])]
         status: bool,
 
         /// Show what would be adopted without making changes
-        /// Used by: package names, --system, and --refresh. Package
+        /// Used by: package names, --system, --refresh, and --convert. Package
         /// preview shares discovery and policy with apply without writing
         /// SQLite, CAS, native package-manager, generation, hook, or live-root state.
         #[arg(long, conflicts_with_all = ["status", "sync_hook"])]
@@ -182,25 +182,37 @@ pub enum SystemCommands {
 
         /// Only adopt packages matching this glob pattern (e.g., "lib*")
         /// Used by: --system only
-        #[arg(long, requires = "system", conflicts_with_all = ["status", "refresh", "sync_hook"])]
+        #[arg(long, requires = "system", conflicts_with_all = ["status", "refresh", "convert", "sync_hook"])]
         pattern: Option<String>,
 
         /// Skip packages matching this glob pattern (e.g., "kernel*")
         /// Used by: --system only
-        #[arg(long, requires = "system", conflicts_with_all = ["status", "refresh", "sync_hook"])]
+        #[arg(long, requires = "system", conflicts_with_all = ["status", "refresh", "convert", "sync_hook"])]
         exclude: Option<String>,
 
         /// Only adopt explicitly installed packages (skip auto-installed deps)
         /// Used by: --system only
-        #[arg(long, requires = "system", conflicts_with_all = ["status", "refresh", "sync_hook"])]
+        #[arg(long, requires = "system", conflicts_with_all = ["status", "refresh", "convert", "sync_hook"])]
         explicit_only: bool,
 
         /// Check adopted packages for version drift and update changed ones
-        #[arg(long, conflicts_with_all = ["system", "status", "sync_hook"])]
+        #[arg(long, conflicts_with_all = ["system", "status", "convert", "sync_hook"])]
         refresh: bool,
 
+        /// Convert exact adopted native artifacts to signed CCS packages
+        #[arg(long, conflicts_with_all = ["system", "status", "refresh", "sync_hook", "full"])]
+        convert: bool,
+
+        /// Exact package version to convert when installed variants share a name
+        #[arg(long, requires = "convert")]
+        version: Option<String>,
+
+        /// Exact package architecture to convert when installed variants share a name
+        #[arg(long, requires = "convert")]
+        arch: Option<String>,
+
         /// Install/remove system PM sync hooks
-        #[arg(long, conflicts_with_all = ["system", "status", "refresh"])]
+        #[arg(long, conflicts_with_all = ["system", "status", "refresh", "convert"])]
         sync_hook: bool,
 
         /// Remove sync hooks instead of installing (requires --sync-hook)
@@ -209,14 +221,14 @@ pub enum SystemCommands {
 
         /// Suppress output (for use by PM hooks and --refresh)
         /// Used by: --refresh only
-        #[arg(long, requires = "refresh", conflicts_with_all = ["system", "status", "sync_hook"])]
+        #[arg(long, requires = "refresh", conflicts_with_all = ["system", "status", "convert", "sync_hook"])]
         quiet: bool,
 
         /// Internal path used by installed native package-manager sync hooks.
         ///
         /// Requires --refresh --quiet and cannot be combined with --full; hook
         /// install/remove remains the explicit consent point.
-        #[arg(long, hide = true, requires_all = ["refresh", "quiet"], conflicts_with_all = ["system", "status", "sync_hook", "full"])]
+        #[arg(long, hide = true, requires_all = ["refresh", "quiet"], conflicts_with_all = ["system", "status", "convert", "sync_hook", "full"])]
         from_sync_hook: bool,
     },
 

--- a/apps/conary/src/cli/system.rs
+++ b/apps/conary/src/cli/system.rs
@@ -199,7 +199,7 @@ pub enum SystemCommands {
         #[arg(long, conflicts_with_all = ["system", "status", "convert", "sync_hook"])]
         refresh: bool,
 
-        /// Convert exact adopted native artifacts to signed CCS packages
+        /// Convert full-adoption packages from exact native artifacts to signed CCS
         #[arg(long, conflicts_with_all = ["system", "status", "refresh", "sync_hook", "full"])]
         convert: bool,
 

--- a/apps/conary/src/cli/tests/installed.rs
+++ b/apps/conary/src/cli/tests/installed.rs
@@ -320,12 +320,47 @@ fn rejects_system_adopt_from_sync_hook_with_full() {
 }
 
 #[test]
-fn rejects_removed_unsafe_adopt_convert_surface() {
+fn parses_exact_adopt_convert_scope() {
+    let cli = parse_cli([
+        "conary",
+        "system",
+        "adopt",
+        "curl",
+        "--convert",
+        "--version",
+        "8.12.1-3",
+        "--arch",
+        "x86_64",
+        "--dry-run",
+    ])
+    .expect("exact adopted-artifact conversion should parse");
+
+    match cli.command {
+        Some(Commands::System(SystemCommands::Adopt {
+            packages,
+            convert,
+            version,
+            arch,
+            dry_run,
+            ..
+        })) => {
+            assert_eq!(packages, vec!["curl".to_string()]);
+            assert!(convert);
+            assert_eq!(version.as_deref(), Some("8.12.1-3"));
+            assert_eq!(arch.as_deref(), Some("x86_64"));
+            assert!(dry_run);
+        }
+        _ => panic!("expected system adopt command"),
+    }
+
     let error = match parse_cli(["conary", "system", "adopt", "--convert"]) {
-        Ok(_) => panic!("adopt conversion requires exact artifact re-resolution"),
+        Ok(_) => panic!("adopt conversion must name an adopted package"),
         Err(error) => error,
     };
-    assert_eq!(error.kind(), clap::error::ErrorKind::UnknownArgument);
+    assert_eq!(
+        error.kind(),
+        clap::error::ErrorKind::MissingRequiredArgument
+    );
 }
 
 #[test]

--- a/apps/conary/src/cli/tests/installed.rs
+++ b/apps/conary/src/cli/tests/installed.rs
@@ -361,6 +361,12 @@ fn parses_exact_adopt_convert_scope() {
         error.kind(),
         clap::error::ErrorKind::MissingRequiredArgument
     );
+
+    let error = match parse_cli(["conary", "system", "adopt", "curl", "--convert", "--full"]) {
+        Ok(_) => panic!("conversion must not recapture payload authority in the same command"),
+        Err(error) => error,
+    };
+    assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
 }
 
 #[test]

--- a/apps/conary/src/commands/adopt/cas_capture.rs
+++ b/apps/conary/src/commands/adopt/cas_capture.rs
@@ -149,6 +149,11 @@ fn bind_package_hardlinks(captured: &mut [CapturedFile]) -> Result<()> {
         captured[indices[0]].file.node.source.kind = PayloadNodeKind::Regular {
             hardlink_identity: Some(identity.clone()),
         };
+        let primary = &captured[indices[0]].file;
+        primary
+            .node
+            .source
+            .validate_content(primary.content.as_ref())?;
         for index in indices.iter().skip(1) {
             let file = &mut captured[*index].file;
             file.node.source.kind = PayloadNodeKind::Hardlink {

--- a/apps/conary/src/commands/adopt/cas_capture.rs
+++ b/apps/conary/src/commands/adopt/cas_capture.rs
@@ -1,5 +1,6 @@
 // apps/conary/src/commands/adopt/cas_capture.rs
 
+use std::collections::BTreeMap;
 use std::fs::OpenOptions;
 use std::io::Read;
 use std::path::Path;
@@ -23,6 +24,17 @@ pub(crate) struct CapturedAdoptionFile {
     pub(crate) content: Option<PayloadContentAuthority>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct HardlinkKey {
+    device: u64,
+    inode: u64,
+}
+
+struct CapturedFile {
+    file: CapturedAdoptionFile,
+    hardlink_key: Option<HardlinkKey>,
+}
+
 impl CapturedAdoptionFile {
     pub(crate) fn file_entry(&self, trove_id: i64) -> FileEntry {
         FileEntry::new(
@@ -39,7 +51,7 @@ pub(crate) fn capture_package_files(
     files: &[FileInfoTuple],
     cas: Option<&CasStore>,
 ) -> Result<Vec<CapturedAdoptionFile>> {
-    let captured = files
+    let mut captured = files
         .iter()
         .map(|file| {
             capture_file(file, cas).map_err(|error| {
@@ -49,8 +61,12 @@ pub(crate) fn capture_package_files(
                 )
             })
         })
-        .collect::<Result<Vec<_>>>()?;
-    Ok(captured.into_iter().flatten().collect())
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    bind_package_hardlinks(&mut captured)?;
+    Ok(captured.into_iter().map(|captured| captured.file).collect())
 }
 
 pub(crate) fn validate_package_files(package_name: &str, files: &[FileInfoTuple]) -> Result<()> {
@@ -65,10 +81,7 @@ pub(crate) fn validate_package_files(package_name: &str, files: &[FileInfoTuple]
     Ok(())
 }
 
-fn capture_file(
-    file: &FileInfoTuple,
-    cas: Option<&CasStore>,
-) -> Result<Option<CapturedAdoptionFile>> {
+fn capture_file(file: &FileInfoTuple, cas: Option<&CasStore>) -> Result<Option<CapturedFile>> {
     let path = Path::new(&file.0);
     if is_selected_root_anchor(path) {
         return Ok(None);
@@ -79,27 +92,74 @@ fn capture_file(
     let node = conary_core::generation::root_manifest::capture_existing_payload_node(path)
         .map_err(anyhow::Error::from)
         .with_context(|| format!("failed to capture exact node {}", file.0))?;
-    let content = if matches!(node.source.kind, PayloadNodeKind::Regular { .. }) {
-        let bytes = read_regular_without_following(path)?;
+    let (content, hardlink_key) = if matches!(node.source.kind, PayloadNodeKind::Regular { .. }) {
+        let (bytes, hardlink_key) = read_regular_without_following(path)?;
         let sha256 = if let Some(cas) = cas {
             cas.store_private_copy(&bytes)
                 .with_context(|| format!("failed to store {} in private CAS", file.0))?
         } else {
             conary_core::hash::sha256(&bytes)
         };
-        Some(PayloadContentAuthority {
-            sha256,
-            size: bytes.len() as u64,
-        })
+        (
+            Some(PayloadContentAuthority {
+                sha256,
+                size: bytes.len() as u64,
+            }),
+            hardlink_key,
+        )
     } else {
-        None
+        (None, None)
     };
     node.source.validate_content(content.as_ref())?;
-    Ok(Some(CapturedAdoptionFile {
-        source: file.clone(),
-        node,
-        content,
+    Ok(Some(CapturedFile {
+        file: CapturedAdoptionFile {
+            source: file.clone(),
+            node,
+            content,
+        },
+        hardlink_key,
     }))
+}
+
+fn bind_package_hardlinks(captured: &mut [CapturedFile]) -> Result<()> {
+    let mut groups = BTreeMap::<HardlinkKey, Vec<usize>>::new();
+    for (index, captured) in captured.iter().enumerate() {
+        if let Some(key) = captured.hardlink_key {
+            groups.entry(key).or_default().push(index);
+        }
+    }
+    for indices in groups.values_mut().filter(|indices| indices.len() > 1) {
+        indices.sort_by(|left, right| {
+            captured[*left]
+                .file
+                .source
+                .0
+                .cmp(&captured[*right].file.source.0)
+        });
+        let target = captured[indices[0]].file.source.0.clone();
+        let identity_input = indices
+            .iter()
+            .map(|index| captured[*index].file.source.0.as_str())
+            .collect::<Vec<_>>()
+            .join("\0");
+        let identity = format!(
+            "adopted-hardlink:sha256:{}",
+            conary_core::hash::sha256(identity_input.as_bytes())
+        );
+        captured[indices[0]].file.node.source.kind = PayloadNodeKind::Regular {
+            hardlink_identity: Some(identity.clone()),
+        };
+        for index in indices.iter().skip(1) {
+            let file = &mut captured[*index].file;
+            file.node.source.kind = PayloadNodeKind::Hardlink {
+                target: target.clone(),
+                identity: identity.clone(),
+            };
+            file.content = None;
+            file.node.source.validate_content(None)?;
+        }
+    }
+    Ok(())
 }
 
 fn validate_file(file: &FileInfoTuple) -> Result<()> {
@@ -139,7 +199,7 @@ fn permitted_native_absence(file: &FileInfoTuple, path: &Path) -> bool {
     )
 }
 
-fn read_regular_without_following(path: &Path) -> Result<Vec<u8>> {
+fn read_regular_without_following(path: &Path) -> Result<(Vec<u8>, Option<HardlinkKey>)> {
     let mut options = OpenOptions::new();
     options.read(true);
     #[cfg(unix)]
@@ -162,7 +222,17 @@ fn read_regular_without_following(path: &Path) -> Result<Vec<u8>> {
     let mut bytes = Vec::new();
     file.read_to_end(&mut bytes)
         .with_context(|| format!("failed to read regular file {}", path.display()))?;
-    Ok(bytes)
+    #[cfg(unix)]
+    let hardlink_key = {
+        use std::os::unix::fs::MetadataExt;
+        (metadata.nlink() > 1).then_some(HardlinkKey {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        })
+    };
+    #[cfg(not(unix))]
+    let hardlink_key = None;
+    Ok((bytes, hardlink_key))
 }
 
 #[cfg(test)]
@@ -305,6 +375,51 @@ mod tests {
             std::fs::metadata(&cas_path).unwrap().ino(),
             "live full adoption must not share an inode with mutable source files"
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn full_adoption_captures_package_hardlink_topology() {
+        let tmp = tempdir_in_target();
+        let primary = tmp.path().join("hardlink-a");
+        let secondary = tmp.path().join("hardlink-b");
+        std::fs::write(&primary, b"shared inode bytes").unwrap();
+        std::fs::hard_link(&primary, &secondary).unwrap();
+        let cwd = std::env::current_dir().unwrap();
+        let primary_arg = primary.strip_prefix(&cwd).unwrap().to_str().unwrap();
+        let secondary_arg = secondary.strip_prefix(&cwd).unwrap().to_str().unwrap();
+
+        let captured = capture_package_files(
+            "fixture",
+            &[
+                file_tuple(secondary_arg, 18, 0o100644, None, None),
+                file_tuple(primary_arg, 18, 0o100644, None, None),
+            ],
+            None,
+        )
+        .unwrap();
+
+        let primary = captured
+            .iter()
+            .find(|file| file.source.0 == primary_arg)
+            .unwrap();
+        let secondary = captured
+            .iter()
+            .find(|file| file.source.0 == secondary_arg)
+            .unwrap();
+        let PayloadNodeKind::Regular {
+            hardlink_identity: Some(primary_identity),
+        } = &primary.node.source.kind
+        else {
+            panic!("lexicographically first package hardlink is not the primary");
+        };
+        let PayloadNodeKind::Hardlink { target, identity } = &secondary.node.source.kind else {
+            panic!("second package hardlink is not typed as a hardlink");
+        };
+        assert_eq!(target, primary_arg);
+        assert_eq!(identity, primary_identity);
+        assert!(primary.content.is_some());
+        assert!(secondary.content.is_none());
     }
 
     #[test]

--- a/apps/conary/src/commands/adopt/convert.rs
+++ b/apps/conary/src/commands/adopt/convert.rs
@@ -1,0 +1,615 @@
+// apps/conary/src/commands/adopt/convert.rs
+
+//! Exact native-artifact conversion for already-adopted packages.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use conary_core::ccs::TrustPolicy;
+use conary_core::db::models::{
+    Changeset, ChangesetStatus, ConvertedPackage, PackagePayloadEntry, PackagePayloadOwnership,
+    Repository, RepositoryPackage,
+};
+use conary_core::packages::{InstalledPackageIdentity, PackageFormat, PackageFormatType};
+use conary_core::payload::{PayloadContentAuthority, PayloadNode, PayloadNodeKind};
+use conary_core::repository::selector::PackageWithRepo;
+use conary_core::repository::{
+    DownloadOptions, PackageSelector, RepositoryFormat, download_package_verified,
+    verify_cached_package_verified,
+};
+use tempfile::{NamedTempFile, TempDir};
+
+use super::super::generation::selected_root::LockedRuntimeRoot;
+use super::super::install::{convert_native_package_to_ccs, resolve_native_payload_nodes};
+use super::super::{InstalledPackageSelector, detect_package_format, open_db};
+
+#[derive(Debug, thiserror::Error)]
+enum AdoptedConversionError {
+    #[error("adopted package '{package}' has no exact native package identity")]
+    MissingNativeIdentity { package: String },
+    #[error("no enrolled native repository contains exact artifact {identity}")]
+    ArtifactUnavailable { identity: String },
+    #[error("exact artifact {identity} is ambiguous across repositories: {repositories}")]
+    AmbiguousArtifact {
+        identity: String,
+        repositories: String,
+    },
+    #[error(
+        "resolved artifact identity mismatch for {field}: expected {expected:?}, got {actual:?}"
+    )]
+    IdentityMismatch {
+        field: &'static str,
+        expected: String,
+        actual: String,
+    },
+    #[error("resolved artifact is missing adopted payload path {path}")]
+    MissingPayloadPath { path: String },
+    #[error("resolved artifact has unexpected payload path {path}")]
+    UnexpectedPayloadPath { path: String },
+    #[error("resolved artifact payload mismatch at {path}: {detail}")]
+    PayloadMismatch { path: String, detail: String },
+}
+
+struct AdoptedConversionPlan {
+    trove_id: i64,
+    identity: InstalledPackageIdentity,
+    payload: PackagePayloadOwnership,
+    source: PackageWithRepo,
+}
+
+struct AcquiredArtifact {
+    path: PathBuf,
+    _download: Option<TempDir>,
+}
+
+pub async fn cmd_adopt_convert(
+    packages: &[String],
+    version: Option<&str>,
+    architecture: Option<&str>,
+    db_path: &str,
+    dry_run: bool,
+) -> Result<()> {
+    if packages.is_empty() {
+        bail!("Specify at least one adopted package to convert");
+    }
+    if packages.len() > 1 && (version.is_some() || architecture.is_some()) {
+        bail!("--version and --arch may be used only with one adopted package");
+    }
+
+    if dry_run {
+        let conn = open_db(db_path)?;
+        for package in packages {
+            let plan = plan_conversion(&conn, package, version, architecture)?;
+            render_plan(&plan);
+        }
+        crate::ui::note("Dry run: no artifacts were acquired, converted, or published");
+        return Ok(());
+    }
+
+    let _locked_root = LockedRuntimeRoot::acquire(db_path)
+        .context("failed to acquire the runtime mutation lock for adopted conversion")?;
+    let mut conn = open_db(db_path)?;
+    for package in packages {
+        let plan = plan_conversion(&conn, package, version, architecture)?;
+        if current_conversion_is_usable(&conn, &plan)? {
+            crate::ui::note(&format!(
+                "{} already has a verified current CCS artifact",
+                plan.identity.selector()
+            ));
+            continue;
+        }
+        let acquired = acquire_exact_artifact(db_path, &plan.source).await?;
+        let format = detect_package_format(
+            acquired
+                .path
+                .to_str()
+                .context("native artifact cache path is not UTF-8")?,
+        )?;
+        let parsed = conary_core::packages::parse_package(&acquired.path)?;
+        validate_native_identity(parsed.as_ref(), format, &plan.identity)?;
+        validate_payload_equivalence(parsed.as_ref(), format, &plan.payload)?;
+
+        let source_profile = plan.source.package.source_profile.as_deref().or(plan
+            .source
+            .repository
+            .source_profile
+            .as_deref());
+        let converted =
+            convert_native_package_to_ccs(parsed.as_ref(), &acquired.path, format, source_profile)?;
+        publish_conversion(&mut conn, db_path, &plan, converted)?;
+        crate::ui::status(
+            "Converted",
+            &format!("{} to verified CCS", plan.identity.selector()),
+        );
+    }
+    Ok(())
+}
+
+fn plan_conversion(
+    conn: &rusqlite::Connection,
+    package: &str,
+    version: Option<&str>,
+    architecture: Option<&str>,
+) -> Result<AdoptedConversionPlan> {
+    let installed = super::super::resolve_installed_package(
+        conn,
+        &InstalledPackageSelector::new(
+            package.to_string(),
+            version.map(str::to_string),
+            architecture.map(str::to_string),
+        ),
+    )?;
+    if !installed.trove.install_source.is_adopted() {
+        bail!(
+            "Package '{}' is not under adopted native authority",
+            package
+        );
+    }
+    let identity = installed
+        .trove
+        .native_package_identity
+        .clone()
+        .ok_or_else(|| AdoptedConversionError::MissingNativeIdentity {
+            package: package.to_string(),
+        })?;
+    identity.validate()?;
+    let payload = PackagePayloadOwnership::load(conn, installed.trove_id)?;
+    let source = resolve_exact_repository_artifact(conn, &identity)?;
+    Ok(AdoptedConversionPlan {
+        trove_id: installed.trove_id,
+        identity,
+        payload,
+        source,
+    })
+}
+
+fn resolve_exact_repository_artifact(
+    conn: &rusqlite::Connection,
+    identity: &InstalledPackageIdentity,
+) -> Result<PackageWithRepo> {
+    let expected_format = repository_format(identity);
+    let mut candidates = Vec::new();
+    for package in RepositoryPackage::find_by_name(conn, identity.name())? {
+        if package.version != identity.version()
+            || package.architecture.as_deref() != Some(identity.architecture())
+            || package.version_scheme != identity.version_scheme()
+        {
+            continue;
+        }
+        let repository = Repository::find_by_id(conn, package.repository_id)?
+            .context("exact repository package references a missing repository")?;
+        if !repository.enabled || repository.package_format != expected_format {
+            continue;
+        }
+        repository.require_source_policy()?;
+        repository.require_trust_policy()?;
+        candidates.push(PackageWithRepo {
+            package,
+            repository,
+        });
+    }
+    if candidates.is_empty() {
+        return Err(AdoptedConversionError::ArtifactUnavailable {
+            identity: identity.selector().to_string(),
+        }
+        .into());
+    }
+    PackageSelector::select_best(candidates).map_err(|error| {
+        if matches!(error, conary_core::Error::AmbiguousPackageSelection { .. }) {
+            AdoptedConversionError::AmbiguousArtifact {
+                identity: identity.selector().to_string(),
+                repositories: error.to_string(),
+            }
+            .into()
+        } else {
+            anyhow::Error::from(error)
+        }
+    })
+}
+
+fn repository_format(identity: &InstalledPackageIdentity) -> RepositoryFormat {
+    match identity {
+        InstalledPackageIdentity::Rpm { .. } => RepositoryFormat::Fedora,
+        InstalledPackageIdentity::Dpkg { .. } => RepositoryFormat::Debian,
+        InstalledPackageIdentity::Pacman { .. } => RepositoryFormat::Arch,
+    }
+}
+
+fn package_format(identity: &InstalledPackageIdentity) -> PackageFormatType {
+    match identity {
+        InstalledPackageIdentity::Rpm { .. } => PackageFormatType::Rpm,
+        InstalledPackageIdentity::Dpkg { .. } => PackageFormatType::Deb,
+        InstalledPackageIdentity::Pacman { .. } => PackageFormatType::Arch,
+    }
+}
+
+fn render_plan(plan: &AdoptedConversionPlan) {
+    crate::ui::row(
+        crate::ui::Status::Pending,
+        &[
+            plan.identity.selector(),
+            &format!("repository={}", plan.source.repository.name),
+            &format!("checksum={}", plan.source.package.checksum),
+            &format!("payload_nodes={}", plan.payload.entries().len()),
+        ],
+    );
+}
+
+async fn acquire_exact_artifact(
+    db_path: &str,
+    source: &PackageWithRepo,
+) -> Result<AcquiredArtifact> {
+    let digest = exact_sha256(&source.package.checksum)?;
+    let cache_dir = conary_core::db::paths::db_dir(db_path)
+        .join("native-artifacts")
+        .join("sha256");
+    fs::create_dir_all(&cache_dir).with_context(|| {
+        format!(
+            "failed to create native artifact cache {}",
+            cache_dir.display()
+        )
+    })?;
+    let cache_path = cache_dir.join(digest);
+    let trust = DownloadOptions::for_repository(
+        &source.repository,
+        &conary_core::db::paths::keyring_dir(db_path),
+    )?;
+
+    if cache_path.exists() {
+        match verify_cached_package_verified(&source.package, &cache_path, &trust).await {
+            Ok(()) => {
+                return Ok(AcquiredArtifact {
+                    path: cache_path,
+                    _download: None,
+                });
+            }
+            Err(error) => {
+                fs::remove_file(&cache_path).with_context(|| {
+                    format!(
+                        "cached native artifact {} failed authority verification ({error}) and could not be removed",
+                        cache_path.display()
+                    )
+                })?;
+            }
+        }
+    }
+
+    let download_dir = conary_core::db::paths::temp_dir(db_path);
+    fs::create_dir_all(&download_dir).with_context(|| {
+        format!(
+            "failed to create native artifact download directory {}",
+            download_dir.display()
+        )
+    })?;
+    let download = tempfile::tempdir_in(download_dir)
+        .context("failed to create native artifact download staging")?;
+    let downloaded = download_package_verified(&source.package, download.path(), &trust).await?;
+    let mut staged = NamedTempFile::new_in(&cache_dir)
+        .context("failed to create native artifact cache staging")?;
+    let mut input = File::open(&downloaded)?;
+    std::io::copy(&mut input, staged.as_file_mut())?;
+    staged.as_file_mut().flush()?;
+    staged.as_file().sync_all()?;
+    match staged.persist_noclobber(&cache_path) {
+        Ok(_) => {}
+        Err(error) if cache_path.exists() => {
+            drop(error.file);
+        }
+        Err(error) => return Err(error.error.into()),
+    }
+    verify_cached_package_verified(&source.package, &cache_path, &trust).await?;
+    Ok(AcquiredArtifact {
+        path: cache_path,
+        _download: Some(download),
+    })
+}
+
+fn exact_sha256(checksum: &str) -> Result<String> {
+    let value = checksum.strip_prefix("sha256:").unwrap_or(checksum);
+    let hash = conary_core::hash::Hash::new(conary_core::hash::HashAlgorithm::Sha256, value)?;
+    Ok(hash.value)
+}
+
+fn validate_native_identity(
+    package: &dyn PackageFormat,
+    format: PackageFormatType,
+    identity: &InstalledPackageIdentity,
+) -> Result<()> {
+    for (field, expected, actual) in [
+        (
+            "name",
+            identity.name().to_string(),
+            package.name().to_string(),
+        ),
+        ("version", identity.version(), package.version().to_string()),
+        (
+            "architecture",
+            identity.architecture().to_string(),
+            package.architecture().unwrap_or("").to_string(),
+        ),
+        (
+            "version scheme",
+            identity.version_scheme().as_str().to_string(),
+            package.version_scheme().as_str().to_string(),
+        ),
+        (
+            "package format",
+            format!("{:?}", package_format(identity)),
+            format!("{format:?}"),
+        ),
+    ] {
+        if expected != actual {
+            return Err(AdoptedConversionError::IdentityMismatch {
+                field,
+                expected,
+                actual,
+            }
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn validate_payload_equivalence(
+    package: &dyn PackageFormat,
+    format: PackageFormatType,
+    adopted: &PackagePayloadOwnership,
+) -> Result<()> {
+    let payload = package.package_payload()?;
+    let resolved_nodes = resolve_native_payload_nodes(
+        Path::new("/"),
+        payload.files().iter().map(|file| file.node.clone()),
+        format,
+    )?;
+    let mut artifact = BTreeMap::new();
+    for (file, node) in payload.files().iter().zip(resolved_nodes) {
+        let path = canonical_payload_path(&file.path)?;
+        if artifact
+            .insert(path.clone(), (node, file.content_authority.clone()))
+            .is_some()
+        {
+            return Err(AdoptedConversionError::PayloadMismatch {
+                path,
+                detail: "source artifact declares the path more than once".to_string(),
+            }
+            .into());
+        }
+    }
+    let installed = adopted
+        .entries()
+        .iter()
+        .map(|entry| (entry.path.clone(), entry))
+        .collect::<BTreeMap<_, _>>();
+
+    for path in installed.keys().collect::<BTreeSet<_>>() {
+        if !artifact.contains_key(path) {
+            return Err(AdoptedConversionError::MissingPayloadPath {
+                path: (*path).clone(),
+            }
+            .into());
+        }
+    }
+    for path in artifact.keys().collect::<BTreeSet<_>>() {
+        if !installed.contains_key(path) {
+            return Err(AdoptedConversionError::UnexpectedPayloadPath {
+                path: (*path).clone(),
+            }
+            .into());
+        }
+    }
+    for (path, (node, content)) in artifact {
+        compare_payload_entry(&path, node, content, installed[&path])?;
+    }
+    Ok(())
+}
+
+fn canonical_payload_path(value: &str) -> Result<String> {
+    if value.is_empty() || value.contains('\0') {
+        bail!("native artifact contains an empty or NUL-bearing payload path");
+    }
+    let relative = value.strip_prefix('/').unwrap_or(value);
+    if relative.is_empty()
+        || relative
+            .split('/')
+            .any(|component| component.is_empty() || matches!(component, "." | ".."))
+    {
+        bail!("native artifact payload path {value:?} is not canonical");
+    }
+    let absolute = if value.starts_with('/') {
+        PathBuf::from(value)
+    } else {
+        Path::new("/").join(value)
+    };
+    if absolute.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::CurDir | Component::Prefix(_)
+        )
+    }) {
+        bail!("native artifact payload path {value:?} is not canonical");
+    }
+    Ok(absolute.to_string_lossy().into_owned())
+}
+
+fn compare_payload_entry(
+    path: &str,
+    artifact_node: conary_core::payload::ResolvedPayloadNode,
+    artifact_content: Option<PayloadContentAuthority>,
+    installed: &PackagePayloadEntry,
+) -> Result<()> {
+    let comparable = |node: &PayloadNode| {
+        (
+            comparable_kind(&node.kind),
+            node.mode,
+            node.mtime,
+            node.xattrs.clone(),
+        )
+    };
+    if comparable(&artifact_node.source) != comparable(&installed.node.source) {
+        return Err(AdoptedConversionError::PayloadMismatch {
+            path: path.to_string(),
+            detail: "node kind, mode, timestamp, or xattrs differ".to_string(),
+        }
+        .into());
+    }
+    if artifact_node.uid != installed.node.uid || artifact_node.gid != installed.node.gid {
+        return Err(AdoptedConversionError::PayloadMismatch {
+            path: path.to_string(),
+            detail: format!(
+                "resolved ownership differs (artifact {}:{}, adopted {}:{})",
+                artifact_node.uid, artifact_node.gid, installed.node.uid, installed.node.gid
+            ),
+        }
+        .into());
+    }
+    if artifact_content != installed.content {
+        return Err(AdoptedConversionError::PayloadMismatch {
+            path: path.to_string(),
+            detail: "content size or SHA-256 differs".to_string(),
+        }
+        .into());
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum ComparableNodeKind {
+    Regular(bool),
+    Directory,
+    Symlink(String),
+    Hardlink(String),
+    BlockDevice(u64, u64),
+    CharacterDevice(u64, u64),
+    Fifo,
+    Socket,
+}
+
+fn comparable_kind(kind: &PayloadNodeKind) -> ComparableNodeKind {
+    match kind {
+        PayloadNodeKind::Regular { hardlink_identity } => {
+            ComparableNodeKind::Regular(hardlink_identity.is_some())
+        }
+        PayloadNodeKind::Directory => ComparableNodeKind::Directory,
+        PayloadNodeKind::Symlink { target } => ComparableNodeKind::Symlink(target.clone()),
+        PayloadNodeKind::Hardlink { target, .. } => ComparableNodeKind::Hardlink(target.clone()),
+        PayloadNodeKind::BlockDevice { major, minor } => {
+            ComparableNodeKind::BlockDevice(*major, *minor)
+        }
+        PayloadNodeKind::CharacterDevice { major, minor } => {
+            ComparableNodeKind::CharacterDevice(*major, *minor)
+        }
+        PayloadNodeKind::Fifo => ComparableNodeKind::Fifo,
+        PayloadNodeKind::Socket => ComparableNodeKind::Socket,
+    }
+}
+
+fn current_conversion_is_usable(
+    conn: &rusqlite::Connection,
+    plan: &AdoptedConversionPlan,
+) -> Result<bool> {
+    let Some(existing) = ConvertedPackage::find_by_trove(conn, plan.trove_id)? else {
+        return Ok(false);
+    };
+    if existing.needs_reconversion() {
+        return Ok(false);
+    }
+    let Some(path) = existing.ccs_path.as_deref() else {
+        return Ok(false);
+    };
+    let key = super::super::ccs::load_or_create_local_dev_key()?;
+    Ok(conary_core::ccs::verify::verify_package(
+        Path::new(path),
+        &TrustPolicy::strict(vec![key.public_key_base64()]),
+    )
+    .is_ok())
+}
+
+fn publish_conversion(
+    conn: &mut rusqlite::Connection,
+    db_path: &str,
+    plan: &AdoptedConversionPlan,
+    converted: super::super::install::NativeCcsConversion,
+) -> Result<()> {
+    let output_dir = conary_core::db::paths::db_dir(db_path)
+        .join("packages")
+        .join("adopted");
+    fs::create_dir_all(&output_dir)?;
+    let checksum = exact_sha256(&plan.source.package.checksum)?;
+    let file_name = conary_core::filesystem::path::sanitize_filename(&format!(
+        "{}-{}-{}-v{}-{}.ccs",
+        plan.identity.name(),
+        plan.identity.version(),
+        plan.identity.architecture(),
+        conary_core::db::models::CONVERSION_VERSION,
+        &checksum[..16]
+    ))?;
+    let final_path = output_dir.join(file_name);
+    let mut staged = NamedTempFile::new_in(&output_dir)?;
+    let mut input = File::open(&converted.ccs_path)?;
+    std::io::copy(&mut input, staged.as_file_mut())?;
+    staged.as_file_mut().flush()?;
+    staged.as_file().sync_all()?;
+    let policy = TrustPolicy::strict(vec![converted.signing_public_key.clone()]);
+    conary_core::ccs::verify::verify_package(staged.path(), &policy)
+        .context("same-directory adopted CCS staging failed verification")?;
+
+    let published_new = if final_path.exists() {
+        if file_sha256(staged.path())? != file_sha256(&final_path)? {
+            bail!(
+                "refusing to replace different adopted CCS artifact at {}",
+                final_path.display()
+            );
+        }
+        conary_core::ccs::verify::verify_package(&final_path, &policy)
+            .context("existing adopted CCS output failed verification")?;
+        false
+    } else {
+        staged
+            .persist_noclobber(&final_path)
+            .map_err(|error| error.error)?;
+        sync_directory(&output_dir)?;
+        true
+    };
+
+    let db_result = (|| -> Result<()> {
+        let tx = conn.unchecked_transaction()?;
+        ConvertedPackage::delete_installed_by_trove(&tx, plan.trove_id)?;
+        let mut record = converted.pending_record.into_record(plan.trove_id)?;
+        record.set_installed_ccs_path(final_path.to_string_lossy().into_owned())?;
+        record.insert(&tx)?;
+        let mut changeset = Changeset::new(format!(
+            "Convert adopted package {} to exact CCS",
+            plan.identity.selector()
+        ));
+        changeset.tx_uuid = Some(uuid::Uuid::new_v4().to_string());
+        changeset.insert(&tx)?;
+        changeset.update_status(&tx, ChangesetStatus::Applied)?;
+        tx.commit()?;
+        Ok(())
+    })();
+    if let Err(error) = db_result {
+        if published_new {
+            let _ = fs::remove_file(&final_path);
+            let _ = sync_directory(&output_dir);
+        }
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn file_sha256(path: &Path) -> Result<String> {
+    let mut file = File::open(path)?;
+    Ok(conary_core::hash::hash_reader(conary_core::hash::HashAlgorithm::Sha256, &mut file)?.value)
+}
+
+fn sync_directory(path: &Path) -> Result<()> {
+    File::open(path)?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "convert/tests.rs"]
+mod tests;

--- a/apps/conary/src/commands/adopt/convert.rs
+++ b/apps/conary/src/commands/adopt/convert.rs
@@ -10,14 +10,14 @@ use std::path::{Component, Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use conary_core::ccs::TrustPolicy;
 use conary_core::db::models::{
-    Changeset, ChangesetStatus, ConvertedPackage, PackagePayloadEntry, PackagePayloadOwnership,
-    Repository, RepositoryPackage,
+    Changeset, ChangesetStatus, ConvertedPackage, InstallSource, PackagePayloadEntry,
+    PackagePayloadOwnership, Repository, RepositoryPackage,
 };
 use conary_core::packages::{InstalledPackageIdentity, PackageFormat, PackageFormatType};
 use conary_core::payload::{PayloadContentAuthority, PayloadNode, PayloadNodeKind};
 use conary_core::repository::selector::PackageWithRepo;
 use conary_core::repository::{
-    DownloadOptions, PackageSelector, RepositoryFormat, download_package_verified,
+    DownloadOptions, PackageSelector, RepositoryFormat, download_package_with_authority_verified,
     verify_cached_package_verified,
 };
 use tempfile::{NamedTempFile, TempDir};
@@ -30,6 +30,10 @@ use super::super::{InstalledPackageSelector, detect_package_format, open_db};
 enum AdoptedConversionError {
     #[error("adopted package '{package}' has no exact native package identity")]
     MissingNativeIdentity { package: String },
+    #[error(
+        "adopted package '{package}' has no complete payload authority; run 'conary system adopt {package} --full' before conversion"
+    )]
+    PayloadAuthorityRequired { package: String },
     #[error("no enrolled native repository contains exact artifact {identity}")]
     ArtifactUnavailable { identity: String },
     #[error("exact artifact {identity} is ambiguous across repositories: {repositories}")]
@@ -51,6 +55,10 @@ enum AdoptedConversionError {
     UnexpectedPayloadPath { path: String },
     #[error("resolved artifact payload mismatch at {path}: {detail}")]
     PayloadMismatch { path: String, detail: String },
+    #[error(
+        "converted source checksum mismatch: repository selected {expected}, converter consumed {actual}"
+    )]
+    SourceChecksumMismatch { expected: String, actual: String },
 }
 
 struct AdoptedConversionPlan {
@@ -119,6 +127,10 @@ pub async fn cmd_adopt_convert(
             .as_deref());
         let converted =
             convert_native_package_to_ccs(parsed.as_ref(), &acquired.path, format, source_profile)?;
+        validate_converted_source_checksum(
+            converted.pending_record.original_checksum(),
+            &plan.source.package.checksum,
+        )?;
         publish_conversion(&mut conn, db_path, &plan, converted)?;
         crate::ui::status(
             "Converted",
@@ -148,6 +160,7 @@ fn plan_conversion(
             package
         );
     }
+    require_conversion_payload_authority(package, &installed.trove.install_source)?;
     let identity = installed
         .trove
         .native_package_identity
@@ -164,6 +177,16 @@ fn plan_conversion(
         payload,
         source,
     })
+}
+
+fn require_conversion_payload_authority(package: &str, source: &InstallSource) -> Result<()> {
+    if source != &InstallSource::AdoptedFull {
+        return Err(AdoptedConversionError::PayloadAuthorityRequired {
+            package: package.to_string(),
+        }
+        .into());
+    }
+    Ok(())
 }
 
 fn resolve_exact_repository_artifact(
@@ -184,6 +207,7 @@ fn resolve_exact_repository_artifact(
         if !repository.enabled || repository.package_format != expected_format {
             continue;
         }
+        repository.validate_stream_binding()?;
         repository.require_source_policy()?;
         repository.require_trust_policy()?;
         candidates.push(PackageWithRepo {
@@ -253,13 +277,29 @@ async fn acquire_exact_artifact(
         )
     })?;
     let cache_path = cache_dir.join(digest);
+    let signature_path = cache_path.with_extension("sig");
+    if !cache_path.exists() && signature_path.exists() {
+        fs::remove_file(&signature_path).with_context(|| {
+            format!(
+                "failed to remove orphaned native cache authority {}",
+                signature_path.display()
+            )
+        })?;
+    }
     let trust = DownloadOptions::for_repository(
         &source.repository,
         &conary_core::db::paths::keyring_dir(db_path),
     )?;
 
     if cache_path.exists() {
-        match verify_cached_package_verified(&source.package, &cache_path, &trust).await {
+        match verify_cached_package_verified(
+            &source.package,
+            &cache_path,
+            &trust,
+            signature_path.exists().then_some(signature_path.as_path()),
+        )
+        .await
+        {
             Ok(()) => {
                 return Ok(AcquiredArtifact {
                     path: cache_path,
@@ -267,7 +307,7 @@ async fn acquire_exact_artifact(
                 });
             }
             Err(error) => {
-                fs::remove_file(&cache_path).with_context(|| {
+                remove_cached_artifact(&cache_path, &signature_path).with_context(|| {
                     format!(
                         "cached native artifact {} failed authority verification ({error}) and could not be removed",
                         cache_path.display()
@@ -286,10 +326,14 @@ async fn acquire_exact_artifact(
     })?;
     let download = tempfile::tempdir_in(download_dir)
         .context("failed to create native artifact download staging")?;
-    let downloaded = download_package_verified(&source.package, download.path(), &trust).await?;
+    let downloaded =
+        download_package_with_authority_verified(&source.package, download.path(), &trust).await?;
+    if let Some(signature) = downloaded.detached_authority {
+        persist_cache_bytes(&signature_path, &signature)?;
+    }
     let mut staged = NamedTempFile::new_in(&cache_dir)
         .context("failed to create native artifact cache staging")?;
-    let mut input = File::open(&downloaded)?;
+    let mut input = File::open(&downloaded.path)?;
     std::io::copy(&mut input, staged.as_file_mut())?;
     staged.as_file_mut().flush()?;
     staged.as_file().sync_all()?;
@@ -300,17 +344,72 @@ async fn acquire_exact_artifact(
         }
         Err(error) => return Err(error.error.into()),
     }
-    verify_cached_package_verified(&source.package, &cache_path, &trust).await?;
+    if let Err(error) = verify_cached_package_verified(
+        &source.package,
+        &cache_path,
+        &trust,
+        signature_path.exists().then_some(signature_path.as_path()),
+    )
+    .await
+    {
+        remove_cached_artifact(&cache_path, &signature_path).with_context(|| {
+            format!(
+                "new native artifact cache entry {} failed authority verification ({error}) and could not be removed",
+                cache_path.display()
+            )
+        })?;
+        return Err(error.into());
+    }
     Ok(AcquiredArtifact {
         path: cache_path,
         _download: Some(download),
     })
 }
 
+fn remove_cached_artifact(cache_path: &Path, signature_path: &Path) -> Result<()> {
+    if cache_path.exists() {
+        fs::remove_file(cache_path)?;
+    }
+    if signature_path.exists() {
+        fs::remove_file(signature_path)?;
+    }
+    Ok(())
+}
+
+fn persist_cache_bytes(path: &Path, bytes: &[u8]) -> Result<()> {
+    let parent = path
+        .parent()
+        .context("native cache companion path has no parent")?;
+    let mut staged = NamedTempFile::new_in(parent)?;
+    staged.as_file_mut().write_all(bytes)?;
+    staged.as_file_mut().flush()?;
+    staged.as_file().sync_all()?;
+    match staged.persist_noclobber(path) {
+        Ok(_) => sync_directory(parent),
+        Err(error) if path.exists() => {
+            drop(error.file);
+            Ok(())
+        }
+        Err(error) => Err(error.error.into()),
+    }
+}
+
 fn exact_sha256(checksum: &str) -> Result<String> {
     let value = checksum.strip_prefix("sha256:").unwrap_or(checksum);
     let hash = conary_core::hash::Hash::new(conary_core::hash::HashAlgorithm::Sha256, value)?;
     Ok(hash.value)
+}
+
+fn validate_converted_source_checksum(actual: &str, expected: &str) -> Result<()> {
+    let expected = format!("sha256:{}", exact_sha256(expected)?);
+    if actual != expected {
+        return Err(AdoptedConversionError::SourceChecksumMismatch {
+            expected,
+            actual: actual.to_string(),
+        }
+        .into());
+    }
+    Ok(())
 }
 
 fn validate_native_identity(
@@ -358,6 +457,14 @@ fn validate_payload_equivalence(
     format: PackageFormatType,
     adopted: &PackagePayloadOwnership,
 ) -> Result<()> {
+    validate_payload_entries(package, format, adopted.entries())
+}
+
+fn validate_payload_entries(
+    package: &dyn PackageFormat,
+    format: PackageFormatType,
+    installed_entries: &[PackagePayloadEntry],
+) -> Result<()> {
     let payload = package.package_payload()?;
     let resolved_nodes = resolve_native_payload_nodes(
         Path::new("/"),
@@ -378,8 +485,7 @@ fn validate_payload_equivalence(
             .into());
         }
     }
-    let installed = adopted
-        .entries()
+    let installed = installed_entries
         .iter()
         .map(|entry| (entry.path.clone(), entry))
         .collect::<BTreeMap<_, _>>();
@@ -400,10 +506,102 @@ fn validate_payload_equivalence(
             .into());
         }
     }
-    for (path, (node, content)) in artifact {
-        compare_payload_entry(&path, node, content, installed[&path])?;
+    let artifact_topology = hardlink_topology(
+        artifact
+            .iter()
+            .map(|(path, (node, _))| (path.as_str(), &node.source)),
+    );
+    let installed_topology = hardlink_topology(
+        installed
+            .iter()
+            .map(|(path, entry)| (path.as_str(), &entry.node.source)),
+    );
+    for (path, (node, content)) in &artifact {
+        let installed_entry = installed[path];
+        let artifact_group = artifact_topology.get(path);
+        let installed_group = installed_topology.get(path);
+        if artifact_group != installed_group {
+            return Err(AdoptedConversionError::PayloadMismatch {
+                path: path.clone(),
+                detail: "hardlink group membership differs".to_string(),
+            }
+            .into());
+        }
+        let artifact_content = effective_hardlink_content(
+            path,
+            artifact_group,
+            artifact
+                .iter()
+                .map(|(member, (_, content))| (member.as_str(), content.as_ref())),
+        )?;
+        let installed_content = effective_hardlink_content(
+            path,
+            installed_group,
+            installed
+                .iter()
+                .map(|(member, entry)| (member.as_str(), entry.content.as_ref())),
+        )?;
+        compare_payload_entry(
+            path,
+            node,
+            artifact_content.or_else(|| content.clone()),
+            installed_content.or_else(|| installed_entry.content.clone()),
+            artifact_group.is_some(),
+            installed_entry,
+        )?;
     }
     Ok(())
+}
+
+fn hardlink_topology<'a>(
+    entries: impl Iterator<Item = (&'a str, &'a PayloadNode)>,
+) -> BTreeMap<String, BTreeSet<String>> {
+    let mut groups = BTreeMap::<String, BTreeSet<String>>::new();
+    for (path, node) in entries {
+        let identity = match &node.kind {
+            PayloadNodeKind::Regular {
+                hardlink_identity: Some(identity),
+            }
+            | PayloadNodeKind::Hardlink { identity, .. } => identity,
+            _ => continue,
+        };
+        groups
+            .entry(identity.clone())
+            .or_default()
+            .insert(path.to_string());
+    }
+    let mut by_path = BTreeMap::new();
+    for members in groups.into_values().filter(|members| members.len() > 1) {
+        for path in &members {
+            by_path.insert(path.clone(), members.clone());
+        }
+    }
+    by_path
+}
+
+fn effective_hardlink_content<'a>(
+    path: &str,
+    group: Option<&BTreeSet<String>>,
+    entries: impl Iterator<Item = (&'a str, Option<&'a PayloadContentAuthority>)>,
+) -> Result<Option<PayloadContentAuthority>> {
+    let Some(group) = group else {
+        return Ok(None);
+    };
+    let mut authority = None;
+    for (_, content) in entries.filter(|(member, _)| group.contains(*member)) {
+        let Some(content) = content else {
+            continue;
+        };
+        if authority.as_ref().is_some_and(|current| current != content) {
+            return Err(AdoptedConversionError::PayloadMismatch {
+                path: path.to_string(),
+                detail: "hardlink group carries contradictory content authority".to_string(),
+            }
+            .into());
+        }
+        authority = Some(content.clone());
+    }
+    Ok(authority)
 }
 
 fn canonical_payload_path(value: &str) -> Result<String> {
@@ -436,13 +634,15 @@ fn canonical_payload_path(value: &str) -> Result<String> {
 
 fn compare_payload_entry(
     path: &str,
-    artifact_node: conary_core::payload::ResolvedPayloadNode,
+    artifact_node: &conary_core::payload::ResolvedPayloadNode,
     artifact_content: Option<PayloadContentAuthority>,
+    installed_content: Option<PayloadContentAuthority>,
+    hardlink_member: bool,
     installed: &PackagePayloadEntry,
 ) -> Result<()> {
     let comparable = |node: &PayloadNode| {
         (
-            comparable_kind(&node.kind),
+            comparable_kind(&node.kind, hardlink_member),
             node.mode,
             node.mtime,
             node.xattrs.clone(),
@@ -465,7 +665,7 @@ fn compare_payload_entry(
         }
         .into());
     }
-    if artifact_content != installed.content {
+    if artifact_content != installed_content {
         return Err(AdoptedConversionError::PayloadMismatch {
             path: path.to_string(),
             detail: "content size or SHA-256 differs".to_string(),
@@ -477,24 +677,32 @@ fn compare_payload_entry(
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 enum ComparableNodeKind {
-    Regular(bool),
+    Regular,
+    HardlinkMember,
     Directory,
     Symlink(String),
-    Hardlink(String),
     BlockDevice(u64, u64),
     CharacterDevice(u64, u64),
     Fifo,
     Socket,
 }
 
-fn comparable_kind(kind: &PayloadNodeKind) -> ComparableNodeKind {
+fn comparable_kind(kind: &PayloadNodeKind, hardlink_member: bool) -> ComparableNodeKind {
+    if hardlink_member
+        && matches!(
+            kind,
+            PayloadNodeKind::Regular {
+                hardlink_identity: Some(_)
+            } | PayloadNodeKind::Hardlink { .. }
+        )
+    {
+        return ComparableNodeKind::HardlinkMember;
+    }
     match kind {
-        PayloadNodeKind::Regular { hardlink_identity } => {
-            ComparableNodeKind::Regular(hardlink_identity.is_some())
-        }
+        PayloadNodeKind::Regular { .. } => ComparableNodeKind::Regular,
         PayloadNodeKind::Directory => ComparableNodeKind::Directory,
         PayloadNodeKind::Symlink { target } => ComparableNodeKind::Symlink(target.clone()),
-        PayloadNodeKind::Hardlink { target, .. } => ComparableNodeKind::Hardlink(target.clone()),
+        PayloadNodeKind::Hardlink { .. } => ComparableNodeKind::HardlinkMember,
         PayloadNodeKind::BlockDevice { major, minor } => {
             ComparableNodeKind::BlockDevice(*major, *minor)
         }
@@ -516,15 +724,45 @@ fn current_conversion_is_usable(
     if existing.needs_reconversion() {
         return Ok(false);
     }
+    let expected_checksum = exact_sha256(&plan.source.package.checksum)?;
+    let existing_checksum = exact_sha256(&existing.original_checksum)?;
+    let expected_format = match package_format(&plan.identity) {
+        PackageFormatType::Rpm => "rpm",
+        PackageFormatType::Deb => "deb",
+        PackageFormatType::Arch => "arch",
+    };
+    if existing_checksum != expected_checksum || existing.original_format != expected_format {
+        return Ok(false);
+    }
     let Some(path) = existing.ccs_path.as_deref() else {
         return Ok(false);
     };
     let key = super::super::ccs::load_or_create_local_dev_key()?;
-    Ok(conary_core::ccs::verify::verify_package(
+    let Ok(verified) = conary_core::ccs::verify::verify_package(
         Path::new(path),
         &TrustPolicy::strict(vec![key.public_key_base64()]),
-    )
-    .is_ok())
+    ) else {
+        return Ok(false);
+    };
+    let Ok(package) = conary_core::ccs::CcsPackage::from_verified_archive(path, &verified) else {
+        return Ok(false);
+    };
+    let manifest = package.manifest();
+    let expected_source_checksum = format!("sha256:{expected_checksum}");
+    Ok(manifest.package.name == plan.identity.name()
+        && manifest.package.version == plan.identity.version()
+        && manifest.package.version_scheme == plan.identity.version_scheme()
+        && manifest
+            .package
+            .platform
+            .as_ref()
+            .and_then(|platform| platform.arch.as_deref())
+            == Some(plan.identity.architecture())
+        && manifest
+            .native_lifecycle
+            .as_ref()
+            .and_then(|lifecycle| lifecycle.source_checksum.as_deref())
+            == Some(expected_source_checksum.as_str()))
 }
 
 fn publish_conversion(
@@ -592,8 +830,17 @@ fn publish_conversion(
     })();
     if let Err(error) = db_result {
         if published_new {
-            let _ = fs::remove_file(&final_path);
-            let _ = sync_directory(&output_dir);
+            fs::remove_file(&final_path).with_context(|| {
+                format!(
+                    "conversion persistence failed ({error}); newly published CCS {} could not be removed",
+                    final_path.display()
+                )
+            })?;
+            sync_directory(&output_dir).with_context(|| {
+                format!(
+                    "conversion persistence failed ({error}); CCS cleanup was not durably synchronized"
+                )
+            })?;
         }
         return Err(error);
     }

--- a/apps/conary/src/commands/adopt/convert/tests.rs
+++ b/apps/conary/src/commands/adopt/convert/tests.rs
@@ -1,6 +1,325 @@
 // apps/conary/src/commands/adopt/convert/tests.rs
 
 use super::*;
+use conary_core::db::models::{
+    NativeSourceEcosystem, NativeSourceStream, PackagePayloadEntry, RepositoryPolicyScope,
+    RepositorySourcePolicy, RepositoryUpdateMode, Trove, TroveType,
+};
+use conary_core::packages::traits::{ExtractedFile, PackageFile};
+use conary_core::payload::{
+    PayloadContentAuthority, PayloadIdentity, PayloadNode, PayloadTimestamp,
+};
+use conary_core::repository::dependency_model::RepositoryRequirementGroup;
+use conary_core::repository::versioning::VersionScheme;
+use conary_core::repository::{
+    ArchKeyringFormat, ArchKeyringTrust, ArchSigLevel, OpenPgpTrustRoot, RepositoryParserConfig,
+    RepositoryTrustPolicy, RpmMetadataAuthority,
+};
+use std::collections::BTreeMap;
+
+#[path = "tests/acquisition.rs"]
+mod acquisition;
+#[path = "tests/lifecycle.rs"]
+mod lifecycle;
+
+#[derive(Clone)]
+struct ExactPackage {
+    name: String,
+    version: String,
+    architecture: String,
+    scheme: VersionScheme,
+    files: Vec<PackageFile>,
+    extracted: Vec<ExtractedFile>,
+}
+
+impl PackageFormat for ExactPackage {
+    fn parse(_path: &str) -> conary_core::Result<Self> {
+        unreachable!("the exact package test double is constructed directly")
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn version(&self) -> &str {
+        &self.version
+    }
+
+    fn version_scheme(&self) -> VersionScheme {
+        self.scheme
+    }
+
+    fn architecture(&self) -> Option<&str> {
+        Some(&self.architecture)
+    }
+
+    fn description(&self) -> Option<&str> {
+        None
+    }
+
+    fn files(&self) -> &[PackageFile] {
+        &self.files
+    }
+
+    fn requirements(&self) -> &[RepositoryRequirementGroup] {
+        &[]
+    }
+
+    fn package_payload(&self) -> conary_core::Result<conary_core::packages::PackagePayload> {
+        conary_core::packages::PackagePayload::from_extracted_in_memory(self.extracted.clone())
+    }
+
+    fn to_trove(&self) -> Trove {
+        Trove::new(
+            self.name.clone(),
+            self.version.clone(),
+            TroveType::Package,
+            self.scheme,
+        )
+    }
+}
+
+fn node(kind: PayloadNodeKind, permissions: u32) -> PayloadNode {
+    let node_type = match kind {
+        PayloadNodeKind::Directory => libc::S_IFDIR,
+        PayloadNodeKind::Symlink { .. } => libc::S_IFLNK,
+        _ => libc::S_IFREG,
+    };
+    PayloadNode {
+        kind,
+        mode: node_type | permissions,
+        user: PayloadIdentity::Numeric { id: 0 },
+        group: PayloadIdentity::Numeric { id: 0 },
+        mtime: PayloadTimestamp::UNIX_EPOCH,
+        xattrs: BTreeMap::new(),
+    }
+}
+
+fn package_for(scheme: VersionScheme) -> ExactPackage {
+    let content = b"exact payload".to_vec();
+    let authority = PayloadContentAuthority {
+        sha256: conary_core::hash::sha256(&content),
+        size: content.len() as u64,
+    };
+    let nodes = vec![
+        (
+            "/usr/lib/exact".to_string(),
+            node(PayloadNodeKind::Directory, 0o755),
+            None,
+            Vec::new(),
+        ),
+        (
+            "/usr/lib/exact/tool".to_string(),
+            node(
+                PayloadNodeKind::Regular {
+                    hardlink_identity: Some("source-group".to_string()),
+                },
+                0o755,
+            ),
+            Some(authority.clone()),
+            content,
+        ),
+        (
+            "/usr/lib/exact/tool-link".to_string(),
+            node(
+                PayloadNodeKind::Hardlink {
+                    target: "/usr/lib/exact/tool".to_string(),
+                    identity: "source-group".to_string(),
+                },
+                0o755,
+            ),
+            None,
+            Vec::new(),
+        ),
+        (
+            "/usr/bin/exact".to_string(),
+            node(
+                PayloadNodeKind::Symlink {
+                    target: "../lib/exact/tool".to_string(),
+                },
+                0o777,
+            ),
+            None,
+            Vec::new(),
+        ),
+    ];
+    ExactPackage {
+        name: "exact".to_string(),
+        version: "1.2.3-4".to_string(),
+        architecture: "x86_64".to_string(),
+        scheme,
+        files: nodes
+            .iter()
+            .map(|(path, node, authority, _)| PackageFile {
+                path: path.clone(),
+                node: node.clone(),
+                content: authority.clone(),
+            })
+            .collect(),
+        extracted: nodes
+            .into_iter()
+            .map(|(path, node, authority, content)| ExtractedFile {
+                path,
+                node,
+                content,
+                content_authority: authority,
+            })
+            .collect(),
+    }
+}
+
+fn installed_entries(
+    package: &ExactPackage,
+    format: PackageFormatType,
+) -> Vec<PackagePayloadEntry> {
+    let payload = package.package_payload().unwrap();
+    let resolved = resolve_native_payload_nodes(
+        Path::new("/"),
+        payload.files().iter().map(|file| file.node.clone()),
+        format,
+    )
+    .unwrap();
+    payload
+        .files()
+        .iter()
+        .zip(resolved)
+        .map(|(file, node)| PackagePayloadEntry {
+            path: file.path.clone(),
+            node,
+            content: file.content_authority.clone(),
+            trove_id: 7,
+            installed_at: None,
+            component_id: None,
+            materialized_file_id: None,
+        })
+        .collect()
+}
+
+fn identity_for(scheme: VersionScheme) -> InstalledPackageIdentity {
+    match scheme {
+        VersionScheme::Rpm => InstalledPackageIdentity::rpm(
+            "exact-1.2.3-4.x86_64",
+            "exact",
+            None,
+            "1.2.3",
+            "4",
+            "x86_64",
+        )
+        .unwrap(),
+        VersionScheme::Debian => {
+            InstalledPackageIdentity::dpkg("exact:x86_64", "exact", "1.2.3-4", "x86_64").unwrap()
+        }
+        VersionScheme::Arch => {
+            InstalledPackageIdentity::pacman("exact", "exact", "1.2.3-4", "x86_64").unwrap()
+        }
+        other => panic!("unsupported native test scheme {other:?}"),
+    }
+}
+
+fn format_for(scheme: VersionScheme) -> PackageFormatType {
+    match scheme {
+        VersionScheme::Rpm => PackageFormatType::Rpm,
+        VersionScheme::Debian => PackageFormatType::Deb,
+        VersionScheme::Arch => PackageFormatType::Arch,
+        other => panic!("unsupported native test scheme {other:?}"),
+    }
+}
+
+fn insert_repository_package(
+    conn: &rusqlite::Connection,
+    scheme: VersionScheme,
+    name: &str,
+    priority: i32,
+) {
+    let ecosystem = match scheme {
+        VersionScheme::Rpm => NativeSourceEcosystem::Rpm,
+        VersionScheme::Debian => NativeSourceEcosystem::Deb,
+        VersionScheme::Arch => NativeSourceEcosystem::Alpm,
+        other => panic!("unsupported native test scheme {other:?}"),
+    };
+    let root = OpenPgpTrustRoot {
+        url: format!("https://keys.example.test/{name}.gpg"),
+        fingerprint: "A".repeat(40),
+    };
+    let mut repository = Repository::new(
+        name.to_string(),
+        format!("https://packages.example.test/{name}"),
+    );
+    repository.priority = priority;
+    match ecosystem {
+        NativeSourceEcosystem::Rpm => {
+            repository
+                .set_parser_config(RepositoryParserConfig::Rpm {
+                    architecture: "x86_64".to_string(),
+                })
+                .unwrap();
+            repository
+                .set_trust_policy(RepositoryTrustPolicy::Rpm {
+                    metadata: RpmMetadataAuthority::OpenPgp {
+                        keys: vec![root.clone()],
+                    },
+                    package_keys: vec![root],
+                })
+                .unwrap();
+        }
+        NativeSourceEcosystem::Deb => {
+            repository
+                .set_parser_config(RepositoryParserConfig::Deb {
+                    distribution: "stable".to_string(),
+                    component: "main".to_string(),
+                    architecture: "x86_64".to_string(),
+                })
+                .unwrap();
+            repository
+                .set_trust_policy(RepositoryTrustPolicy::Debian {
+                    release_keys: vec![root],
+                })
+                .unwrap();
+        }
+        NativeSourceEcosystem::Alpm => {
+            repository
+                .set_parser_config(RepositoryParserConfig::Arch {
+                    database: "core".to_string(),
+                })
+                .unwrap();
+            repository
+                .set_trust_policy(RepositoryTrustPolicy::Arch {
+                    keyring: ArchKeyringTrust {
+                        url: "https://keys.example.test/archlinux-keyring.pkg.tar.zst".to_string(),
+                        format: ArchKeyringFormat::AlpmPackageZstd,
+                        master_fingerprints: vec!["A".repeat(40)],
+                        packager_key_threshold: 1,
+                    },
+                    sig_level: ArchSigLevel::distribution_default(),
+                })
+                .unwrap();
+        }
+    }
+    let repository_identity = format!("test:{name}");
+    let policy = RepositorySourcePolicy::new(
+        "test-source",
+        RepositoryPolicyScope::repository(repository_identity.clone()).unwrap(),
+        ecosystem,
+        NativeSourceStream::channel("stable").unwrap(),
+        RepositoryUpdateMode::Follow,
+    )
+    .unwrap();
+    repository
+        .set_native_source_policy(policy, repository_identity, None)
+        .unwrap();
+    let repository_id = repository.insert(conn).unwrap();
+    let mut package = RepositoryPackage::new(
+        repository_id,
+        "exact".to_string(),
+        "1.2.3-4".to_string(),
+        scheme,
+        "a".repeat(64),
+        1,
+        format!("https://packages.example.test/{name}/exact.pkg"),
+    );
+    package.architecture = Some("x86_64".to_string());
+    package.insert(conn).unwrap();
+}
 
 #[test]
 fn payload_paths_are_normalized_without_accepting_dot_segments() {
@@ -26,6 +345,24 @@ fn artifact_cache_identity_requires_an_exact_sha256() {
 }
 
 #[test]
+fn conversion_requires_complete_adopted_payload_authority() {
+    let error =
+        require_conversion_payload_authority("exact", &InstallSource::AdoptedTrack).unwrap_err();
+    assert!(error.to_string().contains("adopt exact --full"), "{error}");
+    require_conversion_payload_authority("exact", &InstallSource::AdoptedFull).unwrap();
+}
+
+#[test]
+fn conversion_rejects_bytes_other_than_the_selected_repository_artifact() {
+    let expected = format!("sha256:{}", "a".repeat(64));
+    let actual = format!("sha256:{}", "b".repeat(64));
+    let error = validate_converted_source_checksum(&actual, &expected).unwrap_err();
+    assert!(error.to_string().contains(&expected), "{error}");
+    assert!(error.to_string().contains(&actual), "{error}");
+    validate_converted_source_checksum(&expected, &expected).unwrap();
+}
+
+#[test]
 fn hardlink_comparison_uses_topology_not_capture_specific_identity() {
     let left = PayloadNodeKind::Hardlink {
         target: "/usr/lib/tool".to_string(),
@@ -35,5 +372,130 @@ fn hardlink_comparison_uses_topology_not_capture_specific_identity() {
         target: "/usr/lib/tool".to_string(),
         identity: "adopted-group-9".to_string(),
     };
-    assert_eq!(comparable_kind(&left), comparable_kind(&right));
+    assert_eq!(comparable_kind(&left, true), comparable_kind(&right, true));
+}
+
+#[test]
+fn hardlink_equivalence_does_not_depend_on_the_selected_primary_path() {
+    let package = package_for(VersionScheme::Rpm);
+    let format = PackageFormatType::Rpm;
+    let mut installed = installed_entries(&package, format);
+    let primary = installed
+        .iter_mut()
+        .find(|entry| entry.path == "/usr/lib/exact/tool")
+        .unwrap();
+    let content = primary.content.take();
+    primary.node.source.kind = PayloadNodeKind::Hardlink {
+        target: "/usr/lib/exact/tool-link".to_string(),
+        identity: "adopted-group".to_string(),
+    };
+    let alternate = installed
+        .iter_mut()
+        .find(|entry| entry.path == "/usr/lib/exact/tool-link")
+        .unwrap();
+    alternate.node.source.kind = PayloadNodeKind::Regular {
+        hardlink_identity: Some("adopted-group".to_string()),
+    };
+    alternate.content = content;
+
+    validate_payload_entries(&package, format, &installed).unwrap();
+}
+
+#[test]
+fn exact_identity_and_payload_equivalence_cover_all_native_formats() {
+    for scheme in [
+        VersionScheme::Rpm,
+        VersionScheme::Debian,
+        VersionScheme::Arch,
+    ] {
+        let package = package_for(scheme);
+        let format = format_for(scheme);
+        validate_native_identity(&package, format, &identity_for(scheme)).unwrap();
+        validate_payload_entries(&package, format, &installed_entries(&package, format)).unwrap();
+    }
+}
+
+#[test]
+fn identity_mismatch_is_typed_for_all_native_formats() {
+    for scheme in [
+        VersionScheme::Rpm,
+        VersionScheme::Debian,
+        VersionScheme::Arch,
+    ] {
+        let mut package = package_for(scheme);
+        package.architecture = "aarch64".to_string();
+        let error = validate_native_identity(&package, format_for(scheme), &identity_for(scheme))
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("resolved artifact identity mismatch for architecture"),
+            "unexpected {scheme:?} identity error: {error}"
+        );
+    }
+}
+
+#[test]
+fn payload_drift_is_path_specific_for_all_native_formats() {
+    for scheme in [
+        VersionScheme::Rpm,
+        VersionScheme::Debian,
+        VersionScheme::Arch,
+    ] {
+        let package = package_for(scheme);
+        let format = format_for(scheme);
+        let mut installed = installed_entries(&package, format);
+        let drifted = installed
+            .iter_mut()
+            .find(|entry| entry.path == "/usr/lib/exact/tool")
+            .unwrap();
+        drifted.content.as_mut().unwrap().sha256 = "f".repeat(64);
+
+        let error = validate_payload_entries(&package, format, &installed).unwrap_err();
+        let text = error.to_string();
+        assert!(text.contains("/usr/lib/exact/tool"), "{text}");
+        assert!(text.contains("content size or SHA-256 differs"), "{text}");
+    }
+}
+
+#[test]
+fn exact_repository_resolution_covers_all_native_formats() {
+    for scheme in [
+        VersionScheme::Rpm,
+        VersionScheme::Debian,
+        VersionScheme::Arch,
+    ] {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conary_core::db::schema::ensure_current(&conn).unwrap();
+        insert_repository_package(&conn, scheme, "exact-source", 10);
+
+        let selected = resolve_exact_repository_artifact(&conn, &identity_for(scheme)).unwrap();
+        assert_eq!(selected.repository.name, "exact-source");
+        assert_eq!(selected.package.version, "1.2.3-4");
+        assert_eq!(selected.package.architecture.as_deref(), Some("x86_64"));
+    }
+}
+
+#[test]
+fn repository_resolution_reports_unavailable_and_ambiguous_artifacts() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conary_core::db::schema::ensure_current(&conn).unwrap();
+    let identity = identity_for(VersionScheme::Debian);
+    let unavailable = resolve_exact_repository_artifact(&conn, &identity).unwrap_err();
+    assert!(
+        unavailable
+            .to_string()
+            .contains("no enrolled native repository contains exact artifact"),
+        "{unavailable}"
+    );
+
+    insert_repository_package(&conn, VersionScheme::Debian, "source-a", 10);
+    insert_repository_package(&conn, VersionScheme::Debian, "source-b", 10);
+    let ambiguous = resolve_exact_repository_artifact(&conn, &identity).unwrap_err();
+    assert!(
+        ambiguous
+            .to_string()
+            .contains("is ambiguous across repositories"),
+        "{ambiguous}"
+    );
 }

--- a/apps/conary/src/commands/adopt/convert/tests.rs
+++ b/apps/conary/src/commands/adopt/convert/tests.rs
@@ -1,0 +1,39 @@
+// apps/conary/src/commands/adopt/convert/tests.rs
+
+use super::*;
+
+#[test]
+fn payload_paths_are_normalized_without_accepting_dot_segments() {
+    assert_eq!(
+        canonical_payload_path("usr/bin/tool").unwrap(),
+        "/usr/bin/tool"
+    );
+    assert_eq!(
+        canonical_payload_path("/etc/tool.conf").unwrap(),
+        "/etc/tool.conf"
+    );
+    assert!(canonical_payload_path("usr/../bin/tool").is_err());
+    assert!(canonical_payload_path("./usr/bin/tool").is_err());
+    assert!(canonical_payload_path("").is_err());
+}
+
+#[test]
+fn artifact_cache_identity_requires_an_exact_sha256() {
+    let digest = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    assert_eq!(exact_sha256(digest).unwrap(), digest);
+    assert_eq!(exact_sha256(&format!("sha256:{digest}")).unwrap(), digest);
+    assert!(exact_sha256("sha256:abcd").is_err());
+}
+
+#[test]
+fn hardlink_comparison_uses_topology_not_capture_specific_identity() {
+    let left = PayloadNodeKind::Hardlink {
+        target: "/usr/lib/tool".to_string(),
+        identity: "artifact-group-1".to_string(),
+    };
+    let right = PayloadNodeKind::Hardlink {
+        target: "/usr/lib/tool".to_string(),
+        identity: "adopted-group-9".to_string(),
+    };
+    assert_eq!(comparable_kind(&left), comparable_kind(&right));
+}

--- a/apps/conary/src/commands/adopt/convert/tests/acquisition.rs
+++ b/apps/conary/src/commands/adopt/convert/tests/acquisition.rs
@@ -1,0 +1,317 @@
+// apps/conary/src/commands/adopt/convert/tests/acquisition.rs
+
+use super::super::*;
+use conary_core::db::models::{
+    NativeSourceEcosystem, NativeSourceStream, RepositoryPolicyScope, RepositorySourcePolicy,
+    RepositoryUpdateMode,
+};
+use conary_core::repository::trust::openpgp::PreparedOpenPgpTrust;
+use conary_core::repository::versioning::VersionScheme;
+use conary_core::repository::{
+    ArchKeyringFormat, ArchKeyringTrust, ArchSigLevel, OpenPgpTrustRoot, RepositoryParserConfig,
+    RepositoryTrustPolicy, RpmMetadataAuthority,
+};
+use sequoia_openpgp as openpgp;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+struct PgpAuthority {
+    certificate: openpgp::Cert,
+    root: OpenPgpTrustRoot,
+}
+
+fn pgp_authority(directory: &Path) -> PgpAuthority {
+    use openpgp::cert::prelude::CertBuilder;
+    use openpgp::serialize::Serialize;
+
+    let (certificate, _) = CertBuilder::new()
+        .add_userid("Exact Artifact Test Signer")
+        .add_signing_subkey()
+        .generate()
+        .unwrap();
+    let public = certificate.clone().strip_secret_key_material();
+    let mut bytes = Vec::new();
+    public.serialize(&mut bytes).unwrap();
+    let path = directory.join("repository-signing-key.pgp");
+    std::fs::write(&path, bytes).unwrap();
+    PgpAuthority {
+        root: OpenPgpTrustRoot {
+            url: format!("file://{}", path.display()),
+            fingerprint: certificate.fingerprint().to_hex(),
+        },
+        certificate,
+    }
+}
+
+fn detached_signature(certificate: &openpgp::Cert, data: &[u8]) -> Vec<u8> {
+    use openpgp::policy::StandardPolicy;
+    use openpgp::serialize::stream::{Message, Signer};
+
+    let policy = StandardPolicy::new();
+    let keypair = certificate
+        .keys()
+        .unencrypted_secret()
+        .with_policy(&policy, None)
+        .supported()
+        .alive()
+        .revoked(false)
+        .for_signing()
+        .next()
+        .unwrap()
+        .key()
+        .clone()
+        .into_keypair()
+        .unwrap();
+    let mut signature = Vec::new();
+    let message = Message::new(&mut signature);
+    let mut signer = Signer::new(message, keypair)
+        .unwrap()
+        .detached()
+        .build()
+        .unwrap();
+    signer.write_all(data).unwrap();
+    signer.finalize().unwrap();
+    signature
+}
+
+fn signed_rpm_bytes(authority: &PgpAuthority) -> Vec<u8> {
+    let mut builder = rpm::PackageBuilder::new(
+        "exact",
+        "1.2.3",
+        "MIT",
+        "x86_64",
+        "exact acquisition fixture",
+    );
+    builder.release("4");
+    builder
+        .with_file_contents(
+            b"exact rpm payload".to_vec(),
+            rpm::FileOptions::new("/usr/bin/exact").permissions(0o755),
+        )
+        .unwrap();
+    let mut package = builder.build().unwrap();
+    let signature = detached_signature(&authority.certificate, &package.header_bytes().unwrap());
+    package.apply_signature(signature).unwrap();
+    let mut bytes = Vec::new();
+    package.write(&mut bytes).unwrap();
+    bytes
+}
+
+async fn serve_artifact(
+    package: Vec<u8>,
+    signature: Option<Vec<u8>>,
+) -> (String, Arc<AtomicUsize>, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let requests = Arc::new(AtomicUsize::new(0));
+    let observed = Arc::clone(&requests);
+    let task = tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            let package = package.clone();
+            let signature = signature.clone();
+            let observed = Arc::clone(&observed);
+            tokio::spawn(async move {
+                let mut request = Vec::new();
+                let mut buffer = [0_u8; 1024];
+                loop {
+                    let count = stream.read(&mut buffer).await.unwrap();
+                    if count == 0 {
+                        return;
+                    }
+                    request.extend_from_slice(&buffer[..count]);
+                    if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+                observed.fetch_add(1, Ordering::SeqCst);
+                let request = String::from_utf8_lossy(&request);
+                let wants_signature = request
+                    .lines()
+                    .next()
+                    .is_some_and(|line| line.contains("/exact.pkg.sig"));
+                let body = if wants_signature {
+                    signature.as_deref()
+                } else {
+                    Some(package.as_slice())
+                };
+                let (status, body) = body
+                    .map(|body| ("200 OK", body))
+                    .unwrap_or(("404 Not Found", &[]));
+                let headers = format!(
+                    "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                stream.write_all(headers.as_bytes()).await.unwrap();
+                stream.write_all(body).await.unwrap();
+            });
+        }
+    });
+    (format!("http://{address}/exact.pkg"), requests, task)
+}
+
+fn arch_keyring() -> ArchKeyringTrust {
+    let keyring = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../crates/conary-core/tests/fixtures/arch/archlinux-keyring-corpus.pkg.tar.zst")
+        .canonicalize()
+        .unwrap();
+    ArchKeyringTrust {
+        url: format!("file://{}", keyring.display()),
+        format: ArchKeyringFormat::AlpmPackageZstd,
+        master_fingerprints: vec![
+            "2AC0A42EFB0B5CBC7A0402ED4DC95B6D7BE9892E".to_string(),
+            "3572FA2A1B067F22C58AF155F8B821B42A6FDCD7".to_string(),
+            "69E6471E3AE065297529832E6BA0F5A2037F4F41".to_string(),
+            "99B6618472A3B3B814185BAED7D3D823B88BDB9B".to_string(),
+            "D8AFDDA07A5B6EDFA7D8CCDAD6D055F927843F1C".to_string(),
+        ],
+        packager_key_threshold: 3,
+    }
+}
+
+fn configured_source(
+    scheme: VersionScheme,
+    url: String,
+    package: &[u8],
+    pgp: Option<&PgpAuthority>,
+) -> PackageWithRepo {
+    let ecosystem = match scheme {
+        VersionScheme::Rpm => NativeSourceEcosystem::Rpm,
+        VersionScheme::Debian => NativeSourceEcosystem::Deb,
+        VersionScheme::Arch => NativeSourceEcosystem::Alpm,
+        other => panic!("unsupported native test scheme {other:?}"),
+    };
+    let mut repository = Repository::new(
+        format!("exact-{}", scheme.as_str()),
+        "https://metadata.example.test/repository".to_string(),
+    );
+    match ecosystem {
+        NativeSourceEcosystem::Rpm => {
+            let root = pgp.unwrap().root.clone();
+            repository
+                .set_parser_config(RepositoryParserConfig::Rpm {
+                    architecture: "x86_64".to_string(),
+                })
+                .unwrap();
+            repository
+                .set_trust_policy(RepositoryTrustPolicy::Rpm {
+                    metadata: RpmMetadataAuthority::OpenPgp {
+                        keys: vec![root.clone()],
+                    },
+                    package_keys: vec![root],
+                })
+                .unwrap();
+        }
+        NativeSourceEcosystem::Deb => {
+            repository
+                .set_parser_config(RepositoryParserConfig::Deb {
+                    distribution: "stable".to_string(),
+                    component: "main".to_string(),
+                    architecture: "x86_64".to_string(),
+                })
+                .unwrap();
+            repository
+                .set_trust_policy(RepositoryTrustPolicy::Debian {
+                    release_keys: vec![pgp.unwrap().root.clone()],
+                })
+                .unwrap();
+        }
+        NativeSourceEcosystem::Alpm => {
+            repository
+                .set_parser_config(RepositoryParserConfig::Arch {
+                    database: "core".to_string(),
+                })
+                .unwrap();
+            repository
+                .set_trust_policy(RepositoryTrustPolicy::Arch {
+                    keyring: arch_keyring(),
+                    sig_level: ArchSigLevel::distribution_default(),
+                })
+                .unwrap();
+        }
+    }
+    let identity = format!("test:{}", repository.name);
+    let policy = RepositorySourcePolicy::new(
+        "test-source",
+        RepositoryPolicyScope::repository(identity.clone()).unwrap(),
+        ecosystem,
+        NativeSourceStream::channel("stable").unwrap(),
+        RepositoryUpdateMode::Follow,
+    )
+    .unwrap();
+    repository
+        .set_native_source_policy(policy, identity, None)
+        .unwrap();
+    let mut package_row = RepositoryPackage::new(
+        1,
+        "exact".to_string(),
+        "1.2.3-4".to_string(),
+        scheme,
+        conary_core::hash::sha256(package),
+        i64::try_from(package.len()).unwrap(),
+        url,
+    );
+    package_row.architecture = Some("x86_64".to_string());
+    PackageWithRepo {
+        repository,
+        package: package_row,
+    }
+}
+
+#[tokio::test]
+async fn repository_fetch_then_offline_cache_hit_cover_all_native_formats() {
+    for scheme in [
+        VersionScheme::Rpm,
+        VersionScheme::Debian,
+        VersionScheme::Arch,
+    ] {
+        let temp = tempfile::tempdir().unwrap();
+        let pgp = pgp_authority(temp.path());
+        let (package, signature) = match scheme {
+            VersionScheme::Rpm => (signed_rpm_bytes(&pgp), None),
+            VersionScheme::Debian => (b"authenticated Debian package bytes".to_vec(), None),
+            VersionScheme::Arch => {
+                let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join(
+                    "../../crates/conary-core/tests/fixtures/arch/packages/base-3-3-any.pkg.tar.zst",
+                );
+                (
+                    std::fs::read(&fixture).unwrap(),
+                    Some(std::fs::read(fixture.with_extension("zst.sig")).unwrap()),
+                )
+            }
+            other => panic!("unsupported native test scheme {other:?}"),
+        };
+        let (url, requests, server) = serve_artifact(package.clone(), signature).await;
+        let source = configured_source(scheme, url, &package, Some(&pgp));
+        let db_path = temp.path().join("runtime/conary.db");
+        std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+        PreparedOpenPgpTrust::prepare(
+            &source.repository.name,
+            &conary_core::db::paths::keyring_dir(db_path.to_str().unwrap()),
+            source.repository.require_trust_policy().unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let first = acquire_exact_artifact(db_path.to_str().unwrap(), &source)
+            .await
+            .unwrap();
+        assert_eq!(std::fs::read(&first.path).unwrap(), package);
+        let requests_after_fetch = requests.load(Ordering::SeqCst);
+        assert!(requests_after_fetch >= 1);
+
+        let second = acquire_exact_artifact(db_path.to_str().unwrap(), &source)
+            .await
+            .unwrap();
+        assert_eq!(second.path, first.path);
+        assert_eq!(
+            requests.load(Ordering::SeqCst),
+            requests_after_fetch,
+            "{scheme:?} cache hit unexpectedly required repository network authority"
+        );
+        server.abort();
+    }
+}

--- a/apps/conary/src/commands/adopt/convert/tests/lifecycle.rs
+++ b/apps/conary/src/commands/adopt/convert/tests/lifecycle.rs
@@ -1,0 +1,591 @@
+// apps/conary/src/commands/adopt/convert/tests/lifecycle.rs
+
+use super::super::*;
+use conary_core::ccs::builder::BuildResult;
+use conary_core::ccs::manifest::{Authors, CcsManifest, Platform, ScriptHook};
+use conary_core::db::models::{
+    InstallSource, PackagePayloadOwnership, Repository, RepositoryPackage, Trove, TroveType,
+};
+use conary_core::repository::selector::PackageWithRepo;
+use conary_core::repository::versioning::VersionScheme;
+use std::collections::HashMap;
+
+fn lifecycle_build_result(version: &str) -> BuildResult {
+    let mut manifest = CcsManifest::new_minimal("exact-lifecycle", version);
+    manifest.package.license = Some("MIT".to_string());
+    manifest.package.homepage = Some("https://example.invalid/exact-lifecycle".to_string());
+    manifest.package.authors = Some(Authors {
+        maintainers: vec!["Exact Test <exact@example.invalid>".to_string()],
+        upstream: None,
+    });
+    manifest.package.platform = Some(Platform {
+        arch: Some("x86_64".to_string()),
+        ..Default::default()
+    });
+    manifest.hooks.post_install = Some(ScriptHook {
+        script: ":".to_string(),
+        reversible: None,
+    });
+    manifest.hooks.pre_remove = Some(ScriptHook {
+        script: ":".to_string(),
+        reversible: None,
+    });
+    BuildResult {
+        manifest,
+        components: HashMap::new(),
+        files: Vec::new(),
+        payloads: Vec::new(),
+        total_size: 0,
+        chunked: false,
+        chunk_stats: None,
+    }
+}
+
+fn lifecycle_identity(
+    scheme: VersionScheme,
+    version: &str,
+    architecture: &str,
+) -> InstalledPackageIdentity {
+    match scheme {
+        VersionScheme::Rpm => {
+            let (version, release) = version.rsplit_once('-').unwrap();
+            InstalledPackageIdentity::rpm(
+                format!("exact-lifecycle-{version}-{release}.{architecture}"),
+                "exact-lifecycle",
+                None,
+                version,
+                release,
+                architecture,
+            )
+            .unwrap()
+        }
+        VersionScheme::Debian => InstalledPackageIdentity::dpkg(
+            format!("exact-lifecycle:{architecture}"),
+            "exact-lifecycle",
+            version,
+            architecture,
+        )
+        .unwrap(),
+        VersionScheme::Arch => InstalledPackageIdentity::pacman(
+            "exact-lifecycle",
+            "exact-lifecycle",
+            version,
+            architecture,
+        )
+        .unwrap(),
+        other => panic!("unsupported native test scheme {other:?}"),
+    }
+}
+
+#[test]
+fn canonical_conversion_preserves_lifecycle_for_all_native_formats() {
+    let temp = tempfile::tempdir().unwrap();
+    for (format, extension) in [
+        (PackageFormatType::Rpm, "rpm"),
+        (PackageFormatType::Deb, "deb"),
+        (PackageFormatType::Arch, "pkg.tar.zst"),
+    ] {
+        let package_path = temp.path().join(format!("exact-lifecycle.{extension}"));
+        let result = lifecycle_build_result("1.2.3");
+        match format {
+            PackageFormatType::Rpm => {
+                conary_core::ccs::native_export::rpm::generate(&result, &package_path).unwrap();
+            }
+            PackageFormatType::Deb => {
+                conary_core::ccs::native_export::deb::generate(&result, &package_path).unwrap();
+            }
+            PackageFormatType::Arch => {
+                conary_core::ccs::native_export::arch::generate(&result, &package_path).unwrap();
+            }
+        }
+        let parsed = conary_core::packages::parse_package(&package_path).unwrap();
+        assert!(
+            parsed.native_scriptlet_abi().len() >= 2,
+            "{format:?} fixture lost its lifecycle ABI before conversion"
+        );
+
+        let source_profile = match format {
+            PackageFormatType::Rpm => "fedora-44",
+            PackageFormatType::Deb => "ubuntu-26.04",
+            PackageFormatType::Arch => "arch",
+        };
+        let converted = convert_native_package_to_ccs(
+            parsed.as_ref(),
+            &package_path,
+            format,
+            Some(source_profile),
+        )
+        .unwrap();
+        assert!(converted.ccs_path.exists());
+        let record = converted.pending_record.into_record(42).unwrap();
+        let summary = record.scriptlet_summary().unwrap();
+        assert_ne!(summary.scriptlet_fidelity, "native-free");
+        assert!(summary.evidence_digest.is_some());
+    }
+}
+
+#[test]
+fn persistence_failure_rolls_back_record_changeset_and_artifact_for_all_formats() {
+    let temp = tempfile::tempdir().unwrap();
+    for (format, scheme, extension) in [
+        (PackageFormatType::Rpm, VersionScheme::Rpm, "rpm"),
+        (PackageFormatType::Deb, VersionScheme::Debian, "deb"),
+        (PackageFormatType::Arch, VersionScheme::Arch, "pkg.tar.zst"),
+    ] {
+        let case_dir = temp.path().join(format!("failure-{}", scheme.as_str()));
+        std::fs::create_dir_all(&case_dir).unwrap();
+        let package_path = case_dir.join(format!("exact-lifecycle.{extension}"));
+        let result = lifecycle_build_result("1.2.3");
+        match format {
+            PackageFormatType::Rpm => {
+                conary_core::ccs::native_export::rpm::generate(&result, &package_path).unwrap();
+            }
+            PackageFormatType::Deb => {
+                conary_core::ccs::native_export::deb::generate(&result, &package_path).unwrap();
+            }
+            PackageFormatType::Arch => {
+                conary_core::ccs::native_export::arch::generate(&result, &package_path).unwrap();
+            }
+        }
+        let parsed = conary_core::packages::parse_package(&package_path).unwrap();
+        let source_profile = match format {
+            PackageFormatType::Rpm => "fedora-44",
+            PackageFormatType::Deb => "ubuntu-26.04",
+            PackageFormatType::Arch => "arch",
+        };
+        let converted = convert_native_package_to_ccs(
+            parsed.as_ref(),
+            &package_path,
+            format,
+            Some(source_profile),
+        )
+        .unwrap();
+
+        let db_path = case_dir.join("runtime/conary.db");
+        conary_core::db::init(&db_path).unwrap();
+        let mut conn = conary_core::db::open(&db_path).unwrap();
+        let mut trove = Trove::new_with_source(
+            "exact-lifecycle".to_string(),
+            parsed.version().to_string(),
+            TroveType::Package,
+            InstallSource::AdoptedFull,
+            scheme,
+        );
+        let architecture = parsed.architecture().unwrap();
+        trove.architecture = Some(architecture.to_string());
+        if scheme == VersionScheme::Debian {
+            trove.debian_multi_arch =
+                Some(conary_core::repository::dependency_model::DebianMultiArch::No);
+        }
+        let identity = lifecycle_identity(scheme, parsed.version(), architecture);
+        trove.native_package_identity = Some(identity.clone());
+        let trove_id = trove.insert(&conn).unwrap();
+        conn.execute_batch(
+            "CREATE TRIGGER fail_adopted_conversion_apply
+             BEFORE UPDATE OF status ON changesets
+             WHEN NEW.status = 'applied'
+             BEGIN
+                 SELECT RAISE(ABORT, 'forced conversion persistence failure');
+             END;",
+        )
+        .unwrap();
+        let mut package_file = std::fs::File::open(&package_path).unwrap();
+        let checksum = conary_core::hash::hash_reader(
+            conary_core::hash::HashAlgorithm::Sha256,
+            &mut package_file,
+        )
+        .unwrap()
+        .value;
+        let mut package = RepositoryPackage::new(
+            1,
+            "exact-lifecycle".to_string(),
+            parsed.version().to_string(),
+            scheme,
+            checksum,
+            i64::try_from(std::fs::metadata(&package_path).unwrap().len()).unwrap(),
+            "https://packages.example.invalid/exact".to_string(),
+        );
+        package.architecture = Some(architecture.to_string());
+        let plan = AdoptedConversionPlan {
+            trove_id,
+            identity,
+            payload: PackagePayloadOwnership::load(&conn, trove_id).unwrap(),
+            source: PackageWithRepo {
+                package,
+                repository: Repository::new(
+                    "exact-source".to_string(),
+                    "https://metadata.example.invalid/exact".to_string(),
+                ),
+            },
+        };
+
+        let error =
+            publish_conversion(&mut conn, db_path.to_str().unwrap(), &plan, converted).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("forced conversion persistence failure")
+        );
+        assert!(
+            conary_core::db::models::ConvertedPackage::find_by_trove(&conn, trove_id)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            conary_core::db::models::Changeset::list_all(&conn)
+                .unwrap()
+                .is_empty()
+        );
+        let output_dir =
+            conary_core::db::paths::db_dir(db_path.to_str().unwrap()).join("packages/adopted");
+        assert!(
+            !output_dir.exists() || std::fs::read_dir(output_dir).unwrap().next().is_none(),
+            "{format:?} persistence failure retained a published CCS artifact"
+        );
+
+        conn.execute_batch("DROP TRIGGER fail_adopted_conversion_apply;")
+            .unwrap();
+        let converted = convert_native_package_to_ccs(
+            parsed.as_ref(),
+            &package_path,
+            format,
+            Some(source_profile),
+        )
+        .unwrap();
+        publish_conversion(&mut conn, db_path.to_str().unwrap(), &plan, converted).unwrap();
+        let record = conary_core::db::models::ConvertedPackage::find_by_trove(&conn, trove_id)
+            .unwrap()
+            .unwrap();
+        let usable = current_conversion_is_usable(&conn, &plan).unwrap();
+        if !usable {
+            let key = crate::commands::ccs::load_or_create_local_dev_key().unwrap();
+            let path = record.ccs_path.as_deref().unwrap();
+            let verified = conary_core::ccs::verify::verify_package(
+                Path::new(path),
+                &TrustPolicy::strict(vec![key.public_key_base64()]),
+            )
+            .unwrap();
+            let package =
+                conary_core::ccs::CcsPackage::from_verified_archive(path, &verified).unwrap();
+            let manifest = package.manifest();
+            panic!(
+                "{format:?} current conversion mismatch: manifest={:?}/{:?}/{:?}/{:?} lifecycle_checksum={:?}, expected={:?}/{:?}/{:?}, record={:?}/{:?}",
+                manifest.package.name,
+                manifest.package.version,
+                manifest.package.release,
+                manifest.package.version_scheme,
+                manifest
+                    .native_lifecycle
+                    .as_ref()
+                    .and_then(|lifecycle| lifecycle.source_checksum.as_deref()),
+                plan.identity.name(),
+                plan.identity.version(),
+                plan.identity.version_scheme(),
+                record.original_format,
+                record.original_checksum,
+            );
+        }
+        assert!(Path::new(record.ccs_path.as_deref().unwrap()).exists());
+        let changesets = conary_core::db::models::Changeset::list_all(&conn).unwrap();
+        assert_eq!(changesets.len(), 1);
+        assert_eq!(
+            changesets[0].status,
+            conary_core::db::models::ChangesetStatus::Applied
+        );
+    }
+}
+
+fn publish_lifecycle_conversion(
+    case_dir: &Path,
+    format: PackageFormatType,
+    scheme: VersionScheme,
+    extension: &str,
+    version: &str,
+) -> (PathBuf, String, String) {
+    std::fs::create_dir_all(case_dir).unwrap();
+    let package_path = case_dir.join(format!("exact-lifecycle-{version}.{extension}"));
+    let result = lifecycle_build_result(version);
+    match format {
+        PackageFormatType::Rpm => {
+            conary_core::ccs::native_export::rpm::generate(&result, &package_path).unwrap();
+        }
+        PackageFormatType::Deb => {
+            conary_core::ccs::native_export::deb::generate(&result, &package_path).unwrap();
+        }
+        PackageFormatType::Arch => {
+            conary_core::ccs::native_export::arch::generate(&result, &package_path).unwrap();
+        }
+    }
+    let parsed = conary_core::packages::parse_package(&package_path).unwrap();
+    let source_profile = match format {
+        PackageFormatType::Rpm => "fedora-44",
+        PackageFormatType::Deb => "ubuntu-26.04",
+        PackageFormatType::Arch => "arch",
+    };
+    let converted =
+        convert_native_package_to_ccs(parsed.as_ref(), &package_path, format, Some(source_profile))
+            .unwrap();
+    let signing_public_key = converted.signing_public_key.clone();
+
+    let db_path = case_dir.join("source/conary.db");
+    conary_core::db::init(&db_path).unwrap();
+    let mut conn = conary_core::db::open(&db_path).unwrap();
+    let architecture = parsed.architecture().unwrap();
+    let mut trove = Trove::new_with_source(
+        "exact-lifecycle".to_string(),
+        parsed.version().to_string(),
+        TroveType::Package,
+        InstallSource::AdoptedFull,
+        scheme,
+    );
+    trove.architecture = Some(architecture.to_string());
+    if scheme == VersionScheme::Debian {
+        trove.debian_multi_arch =
+            Some(conary_core::repository::dependency_model::DebianMultiArch::No);
+    }
+    let identity = lifecycle_identity(scheme, parsed.version(), architecture);
+    trove.native_package_identity = Some(identity.clone());
+    let trove_id = trove.insert(&conn).unwrap();
+    let mut package_file = std::fs::File::open(&package_path).unwrap();
+    let checksum =
+        conary_core::hash::hash_reader(conary_core::hash::HashAlgorithm::Sha256, &mut package_file)
+            .unwrap()
+            .value;
+    let mut package = RepositoryPackage::new(
+        1,
+        "exact-lifecycle".to_string(),
+        parsed.version().to_string(),
+        scheme,
+        checksum,
+        i64::try_from(std::fs::metadata(&package_path).unwrap().len()).unwrap(),
+        "https://packages.example.invalid/exact".to_string(),
+    );
+    package.architecture = Some(architecture.to_string());
+    let plan = AdoptedConversionPlan {
+        trove_id,
+        identity,
+        payload: PackagePayloadOwnership::load(&conn, trove_id).unwrap(),
+        source: PackageWithRepo {
+            package,
+            repository: Repository::new(
+                "exact-source".to_string(),
+                "https://metadata.example.invalid/exact".to_string(),
+            ),
+        },
+    };
+    publish_conversion(&mut conn, db_path.to_str().unwrap(), &plan, converted).unwrap();
+    let record = conary_core::db::models::ConvertedPackage::find_by_trove(&conn, trove_id)
+        .unwrap()
+        .unwrap();
+    (
+        PathBuf::from(record.ccs_path.unwrap()),
+        signing_public_key,
+        parsed.version().to_string(),
+    )
+}
+
+fn seed_target_shell_runtime(db_path: &Path) {
+    let trove_id = crate::commands::test_helpers::seed_test_bootable_runtime(db_path);
+    let mut paths = std::collections::BTreeSet::new();
+    for executable in ["/bin/sh", "/bin/bash", "/usr/bin/bash"] {
+        if !Path::new(executable).exists() {
+            continue;
+        }
+        let output = std::process::Command::new("ldd")
+            .arg(executable)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        paths.extend(
+            String::from_utf8(output.stdout)
+                .unwrap()
+                .split_whitespace()
+                .filter(|field| field.starts_with('/'))
+                .map(|field| field.trim_end_matches(':').to_string()),
+        );
+        paths.insert(executable.to_string());
+    }
+    paths.insert("/lib64/ld-linux-x86-64.so.2".to_string());
+
+    let conn = conary_core::db::open(db_path).unwrap();
+    for destination in paths {
+        if conary_core::db::models::FileEntry::find_by_path(&conn, &destination)
+            .unwrap()
+            .is_some()
+        {
+            continue;
+        }
+        let source = std::fs::canonicalize(&destination).unwrap();
+        let bytes = std::fs::read(&source).unwrap();
+        let mode = std::os::unix::fs::MetadataExt::mode(&std::fs::metadata(&source).unwrap());
+        crate::commands::test_helpers::insert_test_regular_file_with_parents(
+            &conn,
+            db_path,
+            &destination,
+            &bytes,
+            mode,
+            trove_id,
+            None,
+        );
+    }
+}
+
+fn run_target_root_lifecycle_test(test_name: &str) -> bool {
+    const CHILD_MARKER: &str = "CONARY_ADOPTED_CCS_LIFECYCLE_TEST_MARKER";
+    if nix::unistd::geteuid().is_root() {
+        if let Some(marker) = std::env::var_os(CHILD_MARKER) {
+            std::fs::write(marker, test_name).unwrap();
+        }
+        return true;
+    }
+    assert!(
+        std::env::var_os(CHILD_MARKER).is_none(),
+        "adopted CCS lifecycle child did not gain root in its user namespace"
+    );
+    let namespace_args = [
+        "--user",
+        "--map-root-user",
+        "--mount",
+        "--propagation",
+        "private",
+    ];
+    let probe = std::process::Command::new("unshare")
+        .args(namespace_args)
+        .arg("/bin/true")
+        .status();
+    assert!(
+        probe.is_ok_and(|status| status.success()),
+        "full adopted CCS lifecycle proof requires a root or unprivileged user namespace"
+    );
+    let marker = tempfile::NamedTempFile::new().unwrap();
+    let status = std::process::Command::new("unshare")
+        .args(namespace_args)
+        .arg(std::env::current_exe().unwrap())
+        .arg(test_name)
+        .args(["--exact", "--nocapture"])
+        .env(CHILD_MARKER, marker.path())
+        .status()
+        .unwrap();
+    assert!(status.success(), "adopted CCS lifecycle child failed");
+    assert_eq!(std::fs::read_to_string(marker.path()).unwrap(), test_name);
+    false
+}
+
+#[tokio::test]
+async fn published_adopted_ccs_drives_full_lifecycle_without_native_manager_runtime() {
+    const TEST_NAME: &str = "commands::adopt::convert::tests::lifecycle::published_adopted_ccs_drives_full_lifecycle_without_native_manager_runtime";
+    if !run_target_root_lifecycle_test(TEST_NAME) {
+        return;
+    }
+    let _mount_guard = crate::commands::composefs_ops::test_mount_skip_guard();
+    let temp = tempfile::tempdir().unwrap();
+    for (format, scheme, extension) in [
+        (PackageFormatType::Rpm, VersionScheme::Rpm, "rpm"),
+        (PackageFormatType::Deb, VersionScheme::Debian, "deb"),
+        (PackageFormatType::Arch, VersionScheme::Arch, "pkg.tar.zst"),
+    ] {
+        let format_dir = temp.path().join(scheme.as_str());
+        let (v1_ccs, public_key, v1_version) = publish_lifecycle_conversion(
+            &format_dir.join("v1"),
+            format,
+            scheme,
+            extension,
+            "1.2.3",
+        );
+        let (v2_ccs, v2_public_key, v2_version) = publish_lifecycle_conversion(
+            &format_dir.join("v2"),
+            format,
+            scheme,
+            extension,
+            "1.2.4",
+        );
+        assert_eq!(public_key, v2_public_key);
+
+        let target = format_dir.join("target");
+        let root = target.join("root");
+        let db_path = target.join("conary.db");
+        std::fs::create_dir_all(&root).unwrap();
+        conary_core::db::init(&db_path).unwrap();
+        seed_target_shell_runtime(&db_path);
+        let policy = target.join("trust-policy.toml");
+        std::fs::write(
+            &policy,
+            format!("trusted_keys = [\"{public_key}\"]\nrequire_timestamp = false\n"),
+        )
+        .unwrap();
+        let db_path = db_path.to_string_lossy().into_owned();
+        let root = root.to_string_lossy().into_owned();
+        let policy = policy.to_string_lossy().into_owned();
+
+        crate::commands::ccs::cmd_ccs_install(
+            v1_ccs.to_str().unwrap(),
+            &db_path,
+            &root,
+            false,
+            Some(policy.clone()),
+            None,
+            crate::commands::SandboxMode::Always,
+            true,
+            false,
+        )
+        .await
+        .unwrap();
+        let conn = conary_core::db::open(&db_path).unwrap();
+        let installed = Trove::find_by_name(&conn, "exact-lifecycle").unwrap();
+        assert_eq!(installed.len(), 1);
+        assert_eq!(installed[0].version, v1_version);
+        drop(conn);
+
+        crate::commands::ccs::cmd_ccs_install(
+            v2_ccs.to_str().unwrap(),
+            &db_path,
+            &root,
+            false,
+            Some(policy.clone()),
+            None,
+            crate::commands::SandboxMode::Always,
+            true,
+            false,
+        )
+        .await
+        .unwrap();
+        let conn = conary_core::db::open(&db_path).unwrap();
+        let installed = Trove::find_by_name(&conn, "exact-lifecycle").unwrap();
+        assert_eq!(installed.len(), 1);
+        assert_eq!(installed[0].version, v2_version);
+        let update_changeset = installed[0].installed_by_changeset_id.unwrap();
+        drop(conn);
+
+        crate::commands::cmd_rollback(update_changeset, &db_path)
+            .await
+            .unwrap();
+        let conn = conary_core::db::open(&db_path).unwrap();
+        let installed = Trove::find_by_name(&conn, "exact-lifecycle").unwrap();
+        assert_eq!(installed.len(), 1);
+        assert_eq!(installed[0].version, v1_version);
+        let trove_id = installed[0].id.unwrap();
+        assert!(
+            conary_core::db::models::InstalledNativeLifecycleBundle::find_by_trove(&conn, trove_id)
+                .unwrap()
+                .is_some()
+        );
+        drop(conn);
+
+        crate::commands::cmd_remove(
+            "exact-lifecycle",
+            &db_path,
+            None,
+            None,
+            crate::commands::SandboxMode::Always,
+            false,
+        )
+        .await
+        .unwrap();
+        let conn = conary_core::db::open(&db_path).unwrap();
+        assert!(
+            Trove::find_by_name(&conn, "exact-lifecycle")
+                .unwrap()
+                .is_empty()
+        );
+    }
+}

--- a/apps/conary/src/commands/adopt/mod.rs
+++ b/apps/conary/src/commands/adopt/mod.rs
@@ -8,6 +8,7 @@
 pub(crate) mod cas_capture;
 mod checkpoint;
 mod conflicts;
+mod convert;
 mod hooks;
 mod native_handoff;
 mod outcome;
@@ -21,6 +22,7 @@ mod unadopt;
 
 // Re-export all public commands
 pub use conflicts::cmd_conflicts;
+pub use convert::cmd_adopt_convert;
 pub use hooks::cmd_sync_hook_install;
 pub use native_handoff::{
     NativeHandoffOptions, NativeHandoffOutcome, NativeHandoffSummary, cmd_native_handoff,

--- a/apps/conary/src/commands/install/conversion.rs
+++ b/apps/conary/src/commands/install/conversion.rs
@@ -264,8 +264,10 @@ pub struct PendingInstalledConversion {
 }
 
 impl PendingInstalledConversion {
-    pub fn persist(self, db_path: &str, trove_id: i64) -> Result<()> {
-        let conn = open_db(db_path)?;
+    pub(crate) fn into_record(
+        self,
+        trove_id: i64,
+    ) -> Result<conary_core::db::models::ConvertedPackage> {
         let mut converted = conary_core::db::models::ConvertedPackage::new_installed(
             trove_id,
             self.original_format,
@@ -273,9 +275,27 @@ impl PendingInstalledConversion {
         );
         converted.set_scriptlet_metadata(&self.scriptlet_summary)?;
         converted.extracted_provenance_json = self.extracted_provenance_json;
+        Ok(converted)
+    }
+
+    pub fn persist(self, db_path: &str, trove_id: i64) -> Result<()> {
+        let conn = open_db(db_path)?;
+        let mut converted = self.into_record(trove_id)?;
         converted.insert(&conn)?;
         Ok(())
     }
+}
+
+/// Fully verified output of the canonical native-package conversion pipeline.
+///
+/// The temporary directory owns `ccs_path`. Callers must either consume the
+/// artifact while this value is alive or copy it into same-directory staging
+/// before publishing it durably.
+pub(crate) struct NativeCcsConversion {
+    pub(crate) ccs_path: std::path::PathBuf,
+    pub(crate) temp_dir: TempDir,
+    pub(crate) pending_record: PendingInstalledConversion,
+    pub(crate) signing_public_key: String,
 }
 
 pub struct CcsArtifactInstallOptions<'a> {
@@ -326,13 +346,6 @@ pub async fn try_convert_to_ccs(
             })?;
     let original_checksum_text = original_checksum.to_prefixed_string();
 
-    // Determine format string
-    let format_str = match format {
-        PackageFormatType::Rpm => "rpm",
-        PackageFormatType::Deb => "deb",
-        PackageFormatType::Arch => "arch",
-    };
-
     // Open database early to check for existing conversion
     let conn = open_db(db_path)?;
 
@@ -361,6 +374,69 @@ pub async fn try_convert_to_ccs(
         }
     }
 
+    let converted = convert_native_package_to_ccs_with_checksum(
+        pkg,
+        package_path,
+        format,
+        source_profile,
+        &original_checksum,
+    )?;
+    let ccs_path = converted.ccs_path.to_string_lossy().to_string();
+    Ok(ConversionResult::Converted {
+        ccs_path,
+        temp_dir: converted.temp_dir,
+        pending_record: converted.pending_record,
+        signing_public_key: converted.signing_public_key,
+    })
+}
+
+/// Convert one exact native artifact through the same parser/lifecycle/CCS
+/// pipeline used by direct installation.
+///
+/// This function performs no database mutation and returns only after the
+/// signed CCS archive has passed strict verification and capability-policy
+/// validation.
+pub(crate) fn convert_native_package_to_ccs(
+    pkg: &dyn PackageFormat,
+    package_path: &Path,
+    format: PackageFormatType,
+    source_profile: Option<&str>,
+) -> Result<NativeCcsConversion> {
+    let mut package_file = std::fs::File::open(package_path).with_context(|| {
+        format!(
+            "Failed to open package file for checksum: {}",
+            package_path.display()
+        )
+    })?;
+    let original_checksum =
+        conary_core::hash::hash_reader(conary_core::hash::HashAlgorithm::Sha256, &mut package_file)
+            .with_context(|| {
+                format!(
+                    "Failed to stream package checksum: {}",
+                    package_path.display()
+                )
+            })?;
+    convert_native_package_to_ccs_with_checksum(
+        pkg,
+        package_path,
+        format,
+        source_profile,
+        &original_checksum,
+    )
+}
+
+fn convert_native_package_to_ccs_with_checksum(
+    pkg: &dyn PackageFormat,
+    package_path: &Path,
+    format: PackageFormatType,
+    source_profile: Option<&str>,
+    original_checksum: &conary_core::hash::Hash,
+) -> Result<NativeCcsConversion> {
+    let format_str = match format {
+        PackageFormatType::Rpm => "rpm",
+        PackageFormatType::Deb => "deb",
+        PackageFormatType::Arch => "arch",
+    };
     // Extract files for conversion
     let extracted = pkg
         .package_payload()
@@ -382,7 +458,7 @@ pub async fn try_convert_to_ccs(
         converter = converter.with_source_profile(profile);
     }
     let conversion_result = converter
-        .convert_payload(&metadata, &extracted, format_str, &original_checksum)
+        .convert_payload(&metadata, &extracted, format_str, original_checksum)
         .with_context(|| format!("Failed to convert {} to CCS format", pkg.name()))?;
 
     // Get the package path
@@ -430,9 +506,8 @@ pub async fn try_convert_to_ccs(
         scriptlet_summary: conversion_result.scriptlet_metadata.clone(),
     };
 
-    let ccs_path = ccs_package_path.to_string_lossy().to_string();
-    Ok(ConversionResult::Converted {
-        ccs_path,
+    Ok(NativeCcsConversion {
+        ccs_path: ccs_package_path.to_path_buf(),
         temp_dir: ccs_temp,
         pending_record,
         signing_public_key: conversion_result.signing_public_key.clone(),

--- a/apps/conary/src/commands/install/conversion.rs
+++ b/apps/conary/src/commands/install/conversion.rs
@@ -264,6 +264,10 @@ pub struct PendingInstalledConversion {
 }
 
 impl PendingInstalledConversion {
+    pub(crate) fn original_checksum(&self) -> &str {
+        &self.original_checksum
+    }
+
     pub(crate) fn into_record(
         self,
         trove_id: i64,

--- a/apps/conary/src/commands/install/mod.rs
+++ b/apps/conary/src/commands/install/mod.rs
@@ -35,8 +35,10 @@ mod validation;
 pub use batch::{BatchInstaller, prepare_package_for_batch};
 pub use command::cmd_install;
 pub(crate) use command::cmd_install_replatform;
+pub(crate) use conversion::{NativeCcsConversion, convert_native_package_to_ccs};
 pub use ownership_mode::OwnershipMode;
 pub(crate) use package_set::{PackageSetRequest, install_package_set, validate_package_set};
+pub(crate) use payload_identity::resolve_native_payload_nodes;
 
 #[allow(unused_imports)]
 pub(crate) use ccs_transaction::{

--- a/apps/conary/src/commands/install/payload_identity.rs
+++ b/apps/conary/src/commands/install/payload_identity.rs
@@ -17,6 +17,14 @@ use std::path::{Path, PathBuf};
 
 const MAX_IDENTITY_DATABASE_SIZE: u64 = 16 * 1024 * 1024;
 
+pub(crate) fn resolve_native_payload_nodes(
+    root: &Path,
+    nodes: impl IntoIterator<Item = PayloadNode>,
+    format: PackageFormatType,
+) -> Result<Vec<ResolvedPayloadNode>> {
+    resolve_payload_nodes(root, nodes, InstallSemantics::native_package(format))
+}
+
 pub(super) fn resolve_payload_nodes(
     root: &Path,
     nodes: impl IntoIterator<Item = PayloadNode>,

--- a/apps/conary/src/commands/mod.rs
+++ b/apps/conary/src/commands/mod.rs
@@ -70,8 +70,8 @@ pub mod verify;
 // Re-export all command handlers
 pub use adopt::{
     NativeHandoffOptions, NativeHandoffOutcome, NativeHandoffSummary, UnadoptOptions, cmd_adopt,
-    cmd_adopt_refresh, cmd_adopt_status, cmd_adopt_system, cmd_conflicts, cmd_native_handoff,
-    cmd_sync_hook_install, cmd_unadopt,
+    cmd_adopt_convert, cmd_adopt_refresh, cmd_adopt_status, cmd_adopt_system, cmd_conflicts,
+    cmd_native_handoff, cmd_sync_hook_install, cmd_unadopt,
 };
 pub use automation::{
     cmd_automation_apply, cmd_automation_check, cmd_automation_configure, cmd_automation_daemon,

--- a/apps/conary/src/dispatch/system.rs
+++ b/apps/conary/src/dispatch/system.rs
@@ -115,6 +115,9 @@ pub(super) async fn dispatch_system_command(sys_cmd: cli::SystemCommands) -> Res
             exclude,
             explicit_only,
             refresh,
+            convert,
+            version,
+            arch,
             sync_hook,
             remove_hook,
             quiet,
@@ -123,6 +126,15 @@ pub(super) async fn dispatch_system_command(sys_cmd: cli::SystemCommands) -> Res
             let package_manager = package_manager.map(Into::into);
             if sync_hook {
                 commands::cmd_sync_hook_install(remove_hook, package_manager).await
+            } else if convert {
+                commands::cmd_adopt_convert(
+                    &packages,
+                    version.as_deref(),
+                    arch.as_deref(),
+                    &db.db_path,
+                    dry_run,
+                )
+                .await
             } else if status {
                 commands::cmd_adopt_status(&db.db_path, package_manager).await
             } else if refresh {

--- a/crates/conary-core/src/db/current_schema/sql/remi.sql
+++ b/crates/conary-core/src/db/current_schema/sql/remi.sql
@@ -32,7 +32,7 @@ CREATE TABLE converted_packages (
                     AND chunk_hashes_json IS NULL
                     AND total_size IS NULL
                     AND content_hash IS NULL
-                    AND ccs_path IS NULL
+                    AND (ccs_path IS NULL OR length(ccs_path) > 0)
                 )
                 OR (
                     artifact_kind = 'repository'

--- a/crates/conary-core/src/db/models/converted.rs
+++ b/crates/conary-core/src/db/models/converted.rs
@@ -333,6 +333,16 @@ impl ConvertedPackage {
         Ok(result)
     }
 
+    /// Delete conversion evidence for one installed trove.
+    pub fn delete_installed_by_trove(conn: &Connection, trove_id: i64) -> Result<usize> {
+        conn.execute(
+            "DELETE FROM converted_packages
+             WHERE artifact_kind = 'installed' AND trove_id = ?1",
+            [trove_id],
+        )
+        .map_err(Into::into)
+    }
+
     /// Check if a package needs re-conversion (algorithm upgraded)
     pub fn needs_reconversion(&self) -> bool {
         self.conversion_version != CONVERSION_VERSION
@@ -528,10 +538,15 @@ impl ConvertedPackage {
                     || self.chunk_hashes_json.is_some()
                     || self.total_size.is_some()
                     || self.content_hash.is_some()
-                    || self.ccs_path.is_some()
                 {
                     return Err(crate::Error::InternalError(format!(
                         "installed converted package {} carries repository-serving fields",
+                        self.record_identity()
+                    )));
+                }
+                if self.ccs_path.as_deref().is_some_and(str::is_empty) {
+                    return Err(crate::Error::InternalError(format!(
+                        "installed converted package {} carries an empty CCS path",
                         self.record_identity()
                     )));
                 }
@@ -547,6 +562,17 @@ impl ConvertedPackage {
                 self.repository_artifact().map(|_| ())
             }
         }
+    }
+
+    /// Attach the durable signed CCS output retained for an adopted package.
+    pub fn set_installed_ccs_path(&mut self, path: String) -> Result<()> {
+        if self.artifact_kind != ConvertedArtifactKind::Installed || path.is_empty() {
+            return Err(crate::Error::InternalError(
+                "installed CCS path requires a non-empty installed conversion".to_string(),
+            ));
+        }
+        self.ccs_path = Some(path);
+        Ok(())
     }
 
     /// Store passive scriptlet metadata generated during conversion.

--- a/crates/conary-core/src/db/models/converted.rs
+++ b/crates/conary-core/src/db/models/converted.rs
@@ -14,6 +14,9 @@ use rusqlite::{Connection, OptionalExtension, Row, params};
 use std::collections::BTreeSet;
 use strum_macros::{AsRefStr, Display, EnumString};
 
+mod validation;
+use validation::{bare_sha256, default_scriptlet_summary_json, validate_current_scriptlet_summary};
+
 /// Current conversion algorithm version
 /// Bump this when making changes that require re-conversion of existing packages.
 ///
@@ -81,8 +84,8 @@ pub struct ConvertedPackage {
     /// When enhancement was last attempted
     pub enhancement_attempted_at: Option<String>,
 
-    // Server-side conversion identity and storage fields.
-    /// Package name (for server-side lookups)
+    // Repository conversion identity plus durable installed-conversion output.
+    /// Package name (for repository lookups)
     pub package_name: Option<String>,
     /// Package version (for server-side lookups)
     pub package_version: Option<String>,
@@ -96,7 +99,8 @@ pub struct ConvertedPackage {
     pub total_size: Option<i64>,
     /// Content hash of the CCS package
     pub content_hash: Option<String>,
-    /// Path to the CCS package file
+    /// Path to the CCS package file. Repository records require it; installed
+    /// records may retain the verified adopted-package conversion output.
     pub ccs_path: Option<String>,
 
     // Foreign-package scriptlet evidence fields.
@@ -982,28 +986,6 @@ impl ConvertedPackage {
         self.enhancement_status == "pending"
             || (self.enhancement_status == "complete" && self.enhancement_version < current_version)
     }
-}
-
-fn bare_sha256(value: &str) -> &str {
-    value.strip_prefix("sha256:").unwrap_or(value)
-}
-
-fn default_scriptlet_summary_json() -> String {
-    serde_json::to_string(&ScriptletBundleSummary::default())
-        .expect("default lifecycle summary must serialize")
-}
-
-fn validate_current_scriptlet_summary(summary: &ScriptletBundleSummary) -> Result<()> {
-    if !matches!(
-        summary.scriptlet_fidelity.as_str(),
-        "native-free" | "native-lifecycle"
-    ) {
-        return Err(crate::Error::InternalError(format!(
-            "unsupported current lifecycle fidelity {:?}",
-            summary.scriptlet_fidelity
-        )));
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/conary-core/src/db/models/converted/tests.rs
+++ b/crates/conary-core/src/db/models/converted/tests.rs
@@ -223,6 +223,29 @@ fn installed_conversion_rejects_repository_serving_fields() {
 }
 
 #[test]
+fn installed_conversion_round_trips_a_durable_ccs_path() {
+    let (_temp, conn) = create_test_db();
+    let mut converted = installed_package(&conn, "rpm", "sha256:installed-path");
+    converted
+        .set_installed_ccs_path("/var/lib/conary/packages/adopted/exact.ccs".to_string())
+        .unwrap();
+    converted.insert(&conn).unwrap();
+
+    let found = ConvertedPackage::find_by_trove(&conn, converted.trove_id.unwrap())
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        found.ccs_path.as_deref(),
+        Some("/var/lib/conary/packages/adopted/exact.ccs")
+    );
+
+    let mut empty = installed_package(&conn, "deb", "sha256:empty-path");
+    assert!(empty.set_installed_ccs_path(String::new()).is_err());
+    empty.ccs_path = Some(String::new());
+    assert!(empty.insert(&conn).is_err());
+}
+
+#[test]
 fn repository_artifact_rejects_corrupt_chunk_json() {
     let (_temp, conn) = create_test_db();
     let mut converted = server_package("sha256:source", "sha256:chunk");

--- a/crates/conary-core/src/db/models/converted/validation.rs
+++ b/crates/conary-core/src/db/models/converted/validation.rs
@@ -1,0 +1,26 @@
+// conary-core/src/db/models/converted/validation.rs
+
+use crate::ccs::convert::ScriptletBundleSummary;
+use crate::error::Result;
+
+pub(super) fn bare_sha256(value: &str) -> &str {
+    value.strip_prefix("sha256:").unwrap_or(value)
+}
+
+pub(super) fn default_scriptlet_summary_json() -> String {
+    serde_json::to_string(&ScriptletBundleSummary::default())
+        .expect("default lifecycle summary must serialize")
+}
+
+pub(super) fn validate_current_scriptlet_summary(summary: &ScriptletBundleSummary) -> Result<()> {
+    if !matches!(
+        summary.scriptlet_fidelity.as_str(),
+        "native-free" | "native-lifecycle"
+    ) {
+        return Err(crate::Error::InternalError(format!(
+            "unsupported current lifecycle fidelity {:?}",
+            summary.scriptlet_fidelity
+        )));
+    }
+    Ok(())
+}

--- a/crates/conary-core/src/db/schema.rs
+++ b/crates/conary-core/src/db/schema.rs
@@ -17,7 +17,7 @@ use tracing::info;
 /// Revision 34 removes the global distro pin and makes diagnostic affinity
 /// explicitly source-identity based. Earlier pre-alpha databases must be
 /// rebuilt; no compatibility migration is provided.
-pub const SCHEMA_VERSION: i32 = 34;
+pub const SCHEMA_VERSION: i32 = 35;
 /// Stable identity that distinguishes this epoch from retired schema revisions.
 pub const SCHEMA_EPOCH: &str = "conary-current-v1";
 
@@ -237,7 +237,7 @@ mod tests {
     }
 
     #[test]
-    fn revision_33_requires_rebuild_for_revision_34() {
+    fn revision_34_requires_rebuild_for_revision_35() {
         let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(
             "CREATE TABLE schema_identity (
@@ -245,19 +245,19 @@ mod tests {
                 revision INTEGER NOT NULL
             );
             INSERT INTO schema_identity (epoch, revision)
-                VALUES ('conary-current-v1', 33);
+                VALUES ('conary-current-v1', 34);
             CREATE TABLE schema_version (
                 version INTEGER PRIMARY KEY,
                 applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             );
-            INSERT INTO schema_version (version) VALUES (33);",
+            INSERT INTO schema_version (version) VALUES (34);",
         )
         .unwrap();
 
         let error = ensure_current(&conn).unwrap_err();
         assert_eq!(
             error.to_string(),
-            "Database schema rebuild required: database uses schema epoch conary-current-v1 revision 33; this pre-alpha build supports only schema epoch conary-current-v1 revision 34"
+            "Database schema rebuild required: database uses schema epoch conary-current-v1 revision 34; this pre-alpha build supports only schema epoch conary-current-v1 revision 35"
         );
     }
 

--- a/crates/conary-core/src/repository/download.rs
+++ b/crates/conary-core/src/repository/download.rs
@@ -240,6 +240,21 @@ pub async fn download_package_verified(
     download_package_inner(repo_pkg, dest_dir, Some(options), None, false).await
 }
 
+/// Re-verify a checksum-addressed cached native artifact through the same
+/// checksum, size, and ecosystem-native package authority as a fresh download.
+pub async fn verify_cached_package_verified(
+    repo_pkg: &RepositoryPackage,
+    path: &Path,
+    options: &DownloadOptions,
+) -> Result<()> {
+    verify_checksum(path, &repo_pkg.checksum)?;
+    let expected_size = u64::try_from(repo_pkg.size).map_err(|_| {
+        Error::DownloadError("negative package size in repository metadata".to_string())
+    })?;
+    verify_file_size(path, expected_size)?;
+    verify_native_package(repo_pkg, path, options).await
+}
+
 /// Download a package from a verified static repository.
 ///
 /// Static repositories may legitimately publish local `file://` or bare-path

--- a/crates/conary-core/src/repository/download.rs
+++ b/crates/conary-core/src/repository/download.rs
@@ -37,6 +37,14 @@ pub struct DownloadOptions {
     trust: PreparedOpenPgpTrust,
 }
 
+/// A verified package download plus any detached authority required for
+/// checksum-addressed offline cache verification.
+#[derive(Debug)]
+pub struct VerifiedPackageDownload {
+    pub path: PathBuf,
+    pub detached_authority: Option<Vec<u8>>,
+}
+
 impl DownloadOptions {
     pub fn for_repository(repo: &Repository, keyring_dir: &Path) -> Result<Self> {
         Ok(Self {
@@ -63,7 +71,7 @@ async fn download_package_inner(
     options: Option<&DownloadOptions>,
     progress: Option<&ProgressBar>,
     allow_local_file_reference: bool,
-) -> Result<PathBuf> {
+) -> Result<VerifiedPackageDownload> {
     let expected_size = u64::try_from(repo_pkg.size).map_err(|_| {
         Error::DownloadError("negative package size in repository metadata".to_string())
     })?;
@@ -77,24 +85,32 @@ async fn download_package_inner(
             repo_pkg.download_url
         )));
     }
-    let download_path = if is_local_file_reference {
-        staged_static_dest_path(&dest_path)
-    } else {
-        dest_path.clone()
-    };
+    std::fs::create_dir_all(dest_dir).map_err(|error| {
+        Error::IoError(format!(
+            "Failed to create download directory {}: {error}",
+            dest_dir.display()
+        ))
+    })?;
+    let staging = tempfile::tempdir_in(dest_dir).map_err(|error| {
+        Error::IoError(format!(
+            "Failed to create package staging directory in {}: {error}",
+            dest_dir.display()
+        ))
+    })?;
+    let download_path = staging.path().join(
+        dest_path
+            .file_name()
+            .unwrap_or_else(|| std::ffi::OsStr::new("package")),
+    );
 
     // Download the file (with or without progress)
     if is_local_file_reference {
-        if let Err(e) = download_static_or_http_file_with_expected_size(
+        download_static_or_http_file_with_expected_size(
             &repo_pkg.download_url,
             &download_path,
             Some(expected_size),
         )
-        .await
-        {
-            let _ = std::fs::remove_file(&download_path);
-            return Err(e);
-        }
+        .await?;
     } else if let Some(pb) = progress {
         let client = RepositoryClient::new()?;
         client
@@ -110,43 +126,33 @@ async fn download_package_inner(
     }
 
     // Verify checksum - clean up invalid file on failure
-    if let Err(e) = verify_checksum(&download_path, &repo_pkg.checksum) {
-        let _ = std::fs::remove_file(&download_path);
-        return Err(e);
-    }
+    verify_checksum(&download_path, &repo_pkg.checksum)?;
 
-    if let Err(e) = verify_file_size(&download_path, expected_size) {
-        let _ = std::fs::remove_file(&download_path);
-        return Err(e);
-    }
-
-    if is_local_file_reference && let Err(e) = std::fs::rename(&download_path, &dest_path) {
-        let _ = std::fs::remove_file(&download_path);
-        return Err(Error::IoError(format!(
-            "Failed to move {} to {}: {e}",
-            download_path.display(),
-            dest_path.display()
-        )));
-    }
+    verify_file_size(&download_path, expected_size)?;
 
     // Native package authority is mandatory whenever this is not a static
     // TUF download.
-    if let Some(opts) = options
-        && let Err(error) = verify_native_package(repo_pkg, &dest_path, opts).await
-    {
-        let _ = std::fs::remove_file(&dest_path);
-        return Err(error);
-    }
+    let detached_authority = if let Some(opts) = options {
+        match verify_native_package(repo_pkg, &download_path, opts).await {
+            Ok(authority) => authority,
+            Err(error) => return Err(error),
+        }
+    } else {
+        None
+    };
 
-    Ok(dest_path)
-}
+    std::fs::rename(&download_path, &dest_path).map_err(|error| {
+        Error::IoError(format!(
+            "Failed to publish verified package {} as {}: {error}",
+            download_path.display(),
+            dest_path.display()
+        ))
+    })?;
 
-fn staged_static_dest_path(dest_path: &Path) -> PathBuf {
-    let file_name = dest_path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("package");
-    dest_path.with_file_name(format!(".{file_name}.tmp"))
+    Ok(VerifiedPackageDownload {
+        path: dest_path,
+        detached_authority,
+    })
 }
 
 /// Extract and sanitize a filename from a URL, falling back to a default.
@@ -176,12 +182,12 @@ async fn verify_native_package(
     repo_pkg: &RepositoryPackage,
     dest_path: &Path,
     opts: &DownloadOptions,
-) -> Result<()> {
+) -> Result<Option<Vec<u8>>> {
     match opts.trust.policy() {
         RepositoryTrustPolicy::Debian { .. } => {
             // The authenticated Release -> Packages SHA256 -> package SHA256
             // chain terminates in the checksum already verified above.
-            Ok(())
+            Ok(None)
         }
         RepositoryTrustPolicy::Rpm { .. } => {
             let package = rpm::Package::open(dest_path).map_err(|error| {
@@ -197,33 +203,46 @@ async fn verify_native_package(
                         "embedded RPM signature verification failed for '{}': {error}",
                         repo_pkg.name
                     ))
-                })
+                })?;
+            Ok(None)
         }
         RepositoryTrustPolicy::Arch { sig_level, .. } => {
-            let signature_url = format!("{}.sig", repo_pkg.download_url);
-            let client = RepositoryClient::new()?;
-            match client.download_to_bytes(&signature_url).await {
-                Ok(signature) => opts.trust.verify_detached(
-                    TrustRole::ArchPackage,
-                    &std::fs::read(dest_path).map_err(|error| {
-                        Error::IoError(format!(
-                            "failed to read downloaded Arch package {}: {error}",
-                            dest_path.display()
-                        ))
-                    })?,
-                    &signature,
-                ),
-                Err(Error::HttpStatus {
-                    status: 403 | 404, ..
-                }) if sig_level.package == ArchSignatureRequirement::Optional => Ok(()),
-                Err(Error::HttpStatus {
-                    status: 403 | 404, ..
-                }) => Err(Error::GpgVerificationFailed(format!(
-                    "Arch SigLevel requires package signature {signature_url}"
-                ))),
-                Err(error) => Err(error),
-            }
+            fetch_and_verify_arch_signature(repo_pkg, dest_path, opts, sig_level.package).await
         }
+    }
+}
+
+async fn fetch_and_verify_arch_signature(
+    repo_pkg: &RepositoryPackage,
+    package_path: &Path,
+    options: &DownloadOptions,
+    requirement: ArchSignatureRequirement,
+) -> Result<Option<Vec<u8>>> {
+    let signature_url = format!("{}.sig", repo_pkg.download_url);
+    let client = RepositoryClient::new()?;
+    match client.download_to_bytes(&signature_url).await {
+        Ok(signature) => {
+            options.trust.verify_detached(
+                TrustRole::ArchPackage,
+                &std::fs::read(package_path).map_err(|error| {
+                    Error::IoError(format!(
+                        "failed to read downloaded Arch package {}: {error}",
+                        package_path.display()
+                    ))
+                })?,
+                &signature,
+            )?;
+            Ok(Some(signature))
+        }
+        Err(Error::HttpStatus {
+            status: 403 | 404, ..
+        }) if requirement == ArchSignatureRequirement::Optional => Ok(None),
+        Err(Error::HttpStatus {
+            status: 403 | 404, ..
+        }) => Err(Error::GpgVerificationFailed(format!(
+            "Arch SigLevel requires package signature {signature_url}"
+        ))),
+        Err(error) => Err(error),
     }
 }
 
@@ -237,6 +256,18 @@ pub async fn download_package_verified(
     dest_dir: &Path,
     options: &DownloadOptions,
 ) -> Result<PathBuf> {
+    download_package_with_authority_verified(repo_pkg, dest_dir, options)
+        .await
+        .map(|download| download.path)
+}
+
+/// Download a package and retain any detached authority needed for an offline
+/// checksum-addressed cache entry.
+pub async fn download_package_with_authority_verified(
+    repo_pkg: &RepositoryPackage,
+    dest_dir: &Path,
+    options: &DownloadOptions,
+) -> Result<VerifiedPackageDownload> {
     download_package_inner(repo_pkg, dest_dir, Some(options), None, false).await
 }
 
@@ -246,13 +277,42 @@ pub async fn verify_cached_package_verified(
     repo_pkg: &RepositoryPackage,
     path: &Path,
     options: &DownloadOptions,
+    detached_signature: Option<&Path>,
 ) -> Result<()> {
     verify_checksum(path, &repo_pkg.checksum)?;
     let expected_size = u64::try_from(repo_pkg.size).map_err(|_| {
         Error::DownloadError("negative package size in repository metadata".to_string())
     })?;
     verify_file_size(path, expected_size)?;
-    verify_native_package(repo_pkg, path, options).await
+    match options.trust.policy() {
+        RepositoryTrustPolicy::Arch { .. } => {
+            let signature_path = detached_signature.ok_or_else(|| {
+                Error::GpgVerificationFailed(format!(
+                    "cached Arch package {} has no detached package signature",
+                    path.display()
+                ))
+            })?;
+            let signature = std::fs::read(signature_path).map_err(|error| {
+                Error::IoError(format!(
+                    "failed to read cached Arch package signature {}: {error}",
+                    signature_path.display()
+                ))
+            })?;
+            options.trust.verify_detached(
+                TrustRole::ArchPackage,
+                &std::fs::read(path).map_err(|error| {
+                    Error::IoError(format!(
+                        "failed to read cached Arch package {}: {error}",
+                        path.display()
+                    ))
+                })?,
+                &signature,
+            )
+        }
+        _ => verify_native_package(repo_pkg, path, options)
+            .await
+            .map(|_| ()),
+    }
 }
 
 /// Download a package from a verified static repository.
@@ -266,7 +326,9 @@ pub async fn download_static_package_verified(
     dest_dir: &Path,
     options: Option<&DownloadOptions>,
 ) -> Result<PathBuf> {
-    download_package_inner(repo_pkg, dest_dir, options, None, true).await
+    download_package_inner(repo_pkg, dest_dir, options, None, true)
+        .await
+        .map(|download| download.path)
 }
 
 /// Download a delta update file
@@ -294,6 +356,23 @@ pub async fn download_delta(
     let filename = safe_filename_from_url(&delta_info.delta_url, &default_filename);
 
     let dest_path = dest_dir.join(filename);
+    std::fs::create_dir_all(dest_dir).map_err(|error| {
+        Error::IoError(format!(
+            "Failed to create delta download directory {}: {error}",
+            dest_dir.display()
+        ))
+    })?;
+    let staging = tempfile::tempdir_in(dest_dir).map_err(|error| {
+        Error::IoError(format!(
+            "Failed to create delta staging directory in {}: {error}",
+            dest_dir.display()
+        ))
+    })?;
+    let staged_path = staging.path().join(
+        dest_path
+            .file_name()
+            .unwrap_or_else(|| std::ffi::OsStr::new("delta")),
+    );
 
     info!(
         "Downloading delta for {} ({} -> {})",
@@ -302,11 +381,18 @@ pub async fn download_delta(
 
     // Download the delta file
     client
-        .download_file(&delta_info.delta_url, &dest_path)
+        .download_file(&delta_info.delta_url, &staged_path)
         .await?;
 
     // Verify checksum
-    verify_checksum(&dest_path, &delta_info.delta_checksum)?;
+    verify_checksum(&staged_path, &delta_info.delta_checksum)?;
+    std::fs::rename(&staged_path, &dest_path).map_err(|error| {
+        Error::IoError(format!(
+            "Failed to publish verified delta {} as {}: {error}",
+            staged_path.display(),
+            dest_path.display()
+        ))
+    })?;
 
     info!(
         "Delta downloaded successfully: {} bytes (compression ratio: {:.1}%)",
@@ -380,7 +466,9 @@ pub async fn download_package_verified_with_progress(
     options: &DownloadOptions,
     progress_bar: Option<&ProgressBar>,
 ) -> Result<PathBuf> {
-    download_package_inner(repo_pkg, dest_dir, Some(options), progress_bar, false).await
+    download_package_inner(repo_pkg, dest_dir, Some(options), progress_bar, false)
+        .await
+        .map(|download| download.path)
 }
 
 /// Download a verified static-repository package with progress reporting.
@@ -390,7 +478,9 @@ pub async fn download_static_package_verified_with_progress(
     options: Option<&DownloadOptions>,
     progress_bar: Option<&ProgressBar>,
 ) -> Result<PathBuf> {
-    download_package_inner(repo_pkg, dest_dir, options, progress_bar, true).await
+    download_package_inner(repo_pkg, dest_dir, options, progress_bar, true)
+        .await
+        .map(|download| download.path)
 }
 
 /// Multi-progress manager for parallel downloads
@@ -507,6 +597,9 @@ impl Default for DownloadProgress {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod durability_tests;
 
 #[cfg(test)]
 mod tests {
@@ -684,6 +777,69 @@ mod tests {
             "expected size mismatch, got: {error}"
         );
         assert!(!dest_dir.join("generic-http.ccs").exists());
+    }
+
+    #[tokio::test]
+    async fn cached_debian_package_rechecks_checksum_and_size_without_network() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cached.deb");
+        let content = b"authenticated Debian package bytes";
+        std::fs::write(&path, content).unwrap();
+        let package = package_for_download(
+            "https://offline.example.test/cached.deb".to_string(),
+            content,
+            i64::try_from(content.len()).unwrap(),
+        );
+        let options = DownloadOptions {
+            trust: PreparedOpenPgpTrust::for_test(RepositoryTrustPolicy::Debian {
+                release_keys: vec![crate::repository::OpenPgpTrustRoot {
+                    url: "https://keys.example.test/debian.gpg".to_string(),
+                    fingerprint: "A".repeat(40),
+                }],
+            }),
+        };
+
+        verify_cached_package_verified(&package, &path, &options, None)
+            .await
+            .unwrap();
+        std::fs::write(&path, b"different bytes").unwrap();
+        assert!(
+            verify_cached_package_verified(&package, &path, &options, None)
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn cached_arch_package_requires_detached_authority() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cached.pkg.tar.zst");
+        let content = b"arch package placeholder";
+        std::fs::write(&path, content).unwrap();
+        let package = package_for_download(
+            "https://offline.example.test/cached.pkg.tar.zst".to_string(),
+            content,
+            i64::try_from(content.len()).unwrap(),
+        );
+        let options = DownloadOptions {
+            trust: PreparedOpenPgpTrust::for_test(RepositoryTrustPolicy::Arch {
+                keyring: crate::repository::ArchKeyringTrust {
+                    url: "https://keys.example.test/archlinux-keyring.pkg.tar.zst".to_string(),
+                    format: crate::repository::ArchKeyringFormat::AlpmPackageZstd,
+                    master_fingerprints: vec!["A".repeat(40)],
+                    packager_key_threshold: 1,
+                },
+                sig_level: crate::repository::ArchSigLevel::distribution_default(),
+            }),
+        };
+
+        let error = verify_cached_package_verified(&package, &path, &options, None)
+            .await
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("no detached package signature"),
+            "{error}"
+        );
     }
 
     #[tokio::test]

--- a/crates/conary-core/src/repository/download/durability_tests.rs
+++ b/crates/conary-core/src/repository/download/durability_tests.rs
@@ -1,0 +1,101 @@
+// conary-core/src/repository/download/durability_tests.rs
+
+use super::{download_delta, download_package_inner};
+use crate::db::models::RepositoryPackage;
+use crate::hash::sha256;
+use crate::repository::metadata::DeltaInfo;
+use crate::repository::versioning::VersionScheme;
+
+fn package_for_download(url: String, content: &[u8], size: i64) -> RepositoryPackage {
+    RepositoryPackage::new(
+        1,
+        "http-fixture".to_string(),
+        "1.0.0".to_string(),
+        VersionScheme::Conary,
+        sha256(content),
+        size,
+        url,
+    )
+}
+
+async fn serve_http_bytes_once(content: Vec<u8>) -> String {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut request = Vec::new();
+        let mut buffer = [0u8; 1024];
+        loop {
+            let read = stream.read(&mut buffer).await.unwrap();
+            if read == 0 {
+                break;
+            }
+            request.extend_from_slice(&buffer[..read]);
+            if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+        let headers = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            content.len()
+        );
+        stream.write_all(headers.as_bytes()).await.unwrap();
+        stream.write_all(&content).await.unwrap();
+    });
+    format!("http://{addr}/fixture.delta")
+}
+
+#[tokio::test]
+async fn download_package_preserves_existing_file_on_http_size_mismatch() {
+    let dir = tempfile::tempdir().unwrap();
+    let dest_dir = dir.path().join("downloads");
+    let dest_path = dest_dir.join("fixture.delta");
+    let content = b"generic HTTP package";
+    std::fs::create_dir_all(&dest_dir).unwrap();
+    std::fs::write(&dest_path, b"previous verified package").unwrap();
+    let package = package_for_download(
+        serve_http_bytes_once(content.to_vec()).await,
+        content,
+        i64::try_from(content.len() + 1).unwrap(),
+    );
+
+    let error = download_package_inner(&package, &dest_dir, None, None, false)
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("size"), "{error}");
+    assert_eq!(
+        std::fs::read(&dest_path).unwrap(),
+        b"previous verified package"
+    );
+}
+
+#[tokio::test]
+async fn download_delta_preserves_existing_file_on_checksum_mismatch() {
+    let dir = tempfile::tempdir().unwrap();
+    let dest_dir = dir.path().join("downloads");
+    let dest_path = dest_dir.join("fixture.delta");
+    std::fs::create_dir_all(&dest_dir).unwrap();
+    std::fs::write(&dest_path, b"previous verified delta").unwrap();
+    let delta = DeltaInfo {
+        from_version: "1".to_string(),
+        from_hash: sha256(b"original package"),
+        delta_url: serve_http_bytes_once(b"corrupt delta".to_vec()).await,
+        delta_size: 13,
+        delta_checksum: sha256(b"expected delta"),
+        compression_ratio: 0.5,
+    };
+
+    let error = download_delta(&delta, "fixture", "2", &dest_dir)
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("Checksum"), "{error}");
+    assert_eq!(
+        std::fs::read(&dest_path).unwrap(),
+        b"previous verified delta"
+    );
+}

--- a/crates/conary-core/src/repository/mod.rs
+++ b/crates/conary-core/src/repository/mod.rs
@@ -54,7 +54,8 @@ pub use dependencies::download_dependencies;
 pub use download::{
     DownloadOptions, DownloadProgress, download_delta, download_package_verified,
     download_package_verified_with_progress, download_static_package_verified,
-    download_static_package_verified_with_progress, verify_checksum,
+    download_static_package_verified_with_progress, verify_cached_package_verified,
+    verify_checksum,
 };
 pub use effective_policy::{EffectiveSourcePolicy, load_effective_policy};
 pub use management::{add_repository, remove_repository, search_packages, set_repository_enabled};

--- a/crates/conary-core/src/repository/mod.rs
+++ b/crates/conary-core/src/repository/mod.rs
@@ -53,9 +53,9 @@ pub(crate) use client::{MAX_BYTES_RESPONSE_SIZE, read_response_bytes_with_limit}
 pub use dependencies::download_dependencies;
 pub use download::{
     DownloadOptions, DownloadProgress, download_delta, download_package_verified,
-    download_package_verified_with_progress, download_static_package_verified,
-    download_static_package_verified_with_progress, verify_cached_package_verified,
-    verify_checksum,
+    download_package_verified_with_progress, download_package_with_authority_verified,
+    download_static_package_verified, download_static_package_verified_with_progress,
+    verify_cached_package_verified, verify_checksum,
 };
 pub use effective_policy::{EffectiveSourcePolicy, load_effective_policy};
 pub use management::{add_repository, remove_repository, search_packages, set_repository_enabled};

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-08-09
-revision: 45
-summary: Document selected-generation lifecycle proof and the current Fedora supported-host generation export gates
+last_updated: 2026-08-12
+revision: 46
+summary: Document selected-generation lifecycle proof, exact adopted-artifact CCS lifecycle proof, and the current Fedora supported-host generation export gates
 ---
 
 # Integration Testing
@@ -547,8 +547,8 @@ Corpus coverage boundaries (not product support exemptions):
 
 The focused `native-cross-source-lifecycle` manifest contains three non-flaky
 corpus cases, one for each exact source format. A failed case does not suppress
-the remaining source-format evidence. Each case executes
-the same shared lifecycle helper as `TNPM02X`, writes a versioned evidence
+the remaining source-format evidence. Each case executes the same shared
+lifecycle helper as `TNPM02X`, writes a versioned evidence
 envelope carrying both install and update artifact digests, the typed fixture
 build-manifest authority that produced them, and stage checkpoints. It is
 projected by `conary-test` into a typed
@@ -556,6 +556,20 @@ projected by `conary-test` into a typed
 ordinary test results and records the manifest-declared case count; a missing,
 malformed, skipped, failed, or unclassified corpus case makes the command fail
 even if generic command output happened to look successful.
+
+The adopted-artifact bridge has a separate hermetic command test:
+
+```bash
+cargo test -p conary --lib commands::adopt::convert
+```
+
+Its lifecycle case re-executes in an unprivileged user and private mount
+namespace when the parent test is not root. For RPM, Debian, and Arch it
+publishes two adoption-produced signed CCS versions, installs and updates them
+in a clean selected root, rolls the update back, removes the restored package,
+and confirms the persisted native lifecycle bundle. The execution path uses
+only CCS operations after publication and therefore never consults a source
+package manager or its database at runtime.
 The `pr-gate` workflow builds each configured distro image first and then runs
 that focused manifest across `fedora44`, `ubuntu-26.04`, and `arch`. Together,
 the required lanes authenticate all three checked-in source-ABI traces and run

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-08-11
-revision: 66
-summary: Route typed database rebuilds, exact native source identity and update policy, lossless source authority and trust-import planning, exact Remi signing, selected-root mutation, rollback lineage, canonical-map authority, carrier security, generation GC, release authority, and subsystem proof through current feature owners.
+last_updated: 2026-08-12
+revision: 67
+summary: Route typed database rebuilds, exact native source identity and adopted-artifact conversion, lossless source authority and trust-import planning, exact Remi signing, selected-root mutation, rollback lineage, canonical-map authority, carrier security, generation GC, release authority, and subsystem proof through current feature owners.
 ---
 
 # Assistant Subsystem Map
@@ -241,6 +241,11 @@ commands.
 - Single-package adoption preview and apply share the planner in
   `apps/conary/src/commands/adopt/packages.rs`; preview stops before every
   SQLite, checkpoint, CAS, native-PM, hook, generation, and live-root write.
+- Adopted-package CCS conversion starts in
+  `apps/conary/src/commands/adopt/convert.rs`; it requires exact enrolled
+  artifact authority and complete adopted-payload equivalence before reusing
+  the direct native converter, then verifies and atomically retains the signed
+  CCS without changing the adopted trove's external ownership.
 - Trust is typed authority, not a default toggle. Native repositories require
   their ecosystem-specific metadata-to-package chain; static repositories
   require TUF. Missing proof fails closed and has no runtime disable command.

--- a/docs/modules/ccs.md
+++ b/docs/modules/ccs.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-08-03
-revision: 58
-summary: Convert foreign packages through lossless source authority, typed authoring, host capability, lifecycle, and native export contracts
+last_updated: 2026-08-12
+revision: 59
+summary: Convert direct and exactly re-resolved adopted foreign packages through lossless source authority, typed authoring, host capability, lifecycle, and native export contracts
 ---
 
 # CCS Module (conary-core/src/ccs/)
@@ -230,6 +230,19 @@ The implemented hook inventory currently records init/systemd, sysusers,
 tmpfiles, sysctl, and ldconfig interfaces; the remaining capability families
 stay typed implementation work rather than distro-name fallbacks. Distro names
 do not select pairwise converters, compatibility profiles, or string gates.
+
+The adopted-package entrypoint is
+`apps/conary/src/commands/adopt/convert.rs`. It does not reconstruct a package
+from live files or installed database metadata. It re-resolves the exact
+authenticated RPM, Debian, or Arch source artifact from an enrolled repository
+or verified Conary cache, proves exact installed identity and payload
+equivalence, and then calls the same direct native converter above. The signed
+CCS is verified in same-directory staging before an installed-conversion row
+and durable path commit together. Conversion failure, archive verification
+failure, or SQLite failure removes the new output. Current installed
+conversion records are reusable only while their conversion version, source
+format/checksum, signed identity, architecture, version scheme, and lifecycle
+source checksum remain exact.
 
 `convert/converter.rs` is the conversion orchestration hub.
 `convert/scriptlet_bundle/{builder,entries,format_metadata,native_contracts}.rs`

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-08-11
-revision: 68
-summary: Route feature ownership through typed database rebuilds, exact native source identity and update policy, native declaration and trust-import planning, exact Remi signing, streaming package payloads, serialized selected-root mutation, typed rollback lineage, exact lifecycle, canonical-map authority, carrier security, generation GC, exact release authority, and current canonical docs
+last_updated: 2026-08-12
+revision: 69
+summary: Route feature ownership through typed database rebuilds, exact native source identity and adopted-artifact conversion, native declaration and trust-import planning, exact Remi signing, streaming package payloads, serialized selected-root mutation, typed rollback lineage, exact lifecycle, canonical-map authority, carrier security, generation GC, exact release authority, and current canonical docs
 ---
 
 # Feature Ownership And Interaction Gates
@@ -337,8 +337,10 @@ directory-materialization contracts.
 
 **Capability:** preserve migration continuity for existing native
 package-manager state, support explicit takeover, recover selected-generation
-handoff state, and provide non-destructive escape hatches. Adoption is not the
-foreign-package acquisition or cross-distro execution path.
+handoff state, provide non-destructive escape hatches, and convert an adopted
+package only after exact native-artifact re-resolution and payload equivalence.
+Adoption itself is not the foreign-package acquisition or cross-distro
+execution path; the verified resulting CCS enters that path separately.
 
 **Start here:** `apps/conary/src/cli/system.rs` ->
 `apps/conary/src/dispatch/system.rs` ->
@@ -351,10 +353,10 @@ foreign-package acquisition or cross-distro execution path.
 `apps/conary/src/commands/adopt/status.rs`;
 `apps/conary/src/commands/adopt/unadopt.rs`;
 `apps/conary/src/commands/adopt/native_handoff.rs`;
-`docs/modules/source-selection.md`; `docs/ARCHITECTURE.md`. Reintroducing
-adopted-package CCS conversion requires exact native-artifact re-resolution
-and is tracked by GitHub issue #68; installed state alone is not lifecycle
-authority.
+`apps/conary/src/commands/adopt/convert.rs` and
+`apps/conary/src/commands/adopt/convert/tests/`;
+`docs/modules/source-selection.md`; `docs/ARCHITECTURE.md`. Installed state
+alone is never lifecycle authority.
 
 **Neighbor systems:** `apps/conary/src/commands/update/mod.rs`;
 `apps/conary/src/commands/update/package.rs`;
@@ -368,7 +370,8 @@ authority.
 **Paths:** `apps/conary/src/commands/adopt/*`.
 
 **Focused proof:** `cargo test -p conary --lib adopt::native_handoff`;
-`cargo test -p conary --lib adopt::unadopt`.
+`cargo test -p conary --lib adopt::unadopt`;
+`cargo test -p conary --lib commands::adopt::convert`.
 
 **Interaction gate:** `cargo run -p conary-test -- list`;
 `cargo run -p conary-test -- run --suite phase3-active-generation-handoff --distro fedora44 --phase 3`
@@ -378,7 +381,11 @@ when selected-generation handoff behavior changes.
 `docs/llms/subsystem-map.md`; `docs/INTEGRATION-TESTING.md`.
 
 **Safety notes:** do not silently take over adopted packages or erase native
-package-manager authority without an explicit takeover path.
+package-manager authority without an explicit takeover path. Adopted
+conversion must hold the runtime mutation lock before installed authority
+reads; accept only exact enrolled source/trust/stream authority; verify identity
+and the complete payload before conversion; and publish the signed CCS path and
+database record atomically.
 
 ## Declarative System Models And Replatform Planning
 

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-12
-revision: 36
-summary: Document opaque native source identity, repository-scoped follow or pin authority, capability-driven targets, Remi feed presets, and lifecycle handoff
+revision: 37
+summary: Document opaque native source identity, repository-scoped follow or pin authority, exact adopted-artifact conversion, capability-driven targets, Remi feed presets, and lifecycle handoff
 ---
 
 # Source Selection Module (conary-core/src/repository/ + conary-core/src/model/)
@@ -595,6 +595,27 @@ Adoption preserves migration continuity for a machine that already has native
 package-manager state. It is not Conary's foreign-package acquisition path and
 does not prove source-independent cross-distro conversion or lifecycle
 execution.
+
+`conary system adopt <pkg> --convert` is the explicit bridge from that
+migration state to a portable CCS artifact. It selects the adopted trove by
+exact name/version/architecture, requires its persisted native identity and
+complete `AdoptedFull` payload ownership (`conary system adopt <pkg> --full`
+establishes it), and resolves one exact package row from an enabled,
+stream-bound enrolled native repository. The artifact is acquired into the
+Conary cache under its authenticated SHA-256 authority; cached RPM, Debian,
+and Arch artifacts are reverified with their ecosystem-specific package
+authority before reuse. The parser identity and every adopted payload node,
+resolved owner, content digest, symlink, hardlink topology edge, and explicit
+directory must match before the canonical native converter runs.
+
+Conversion does not transfer ownership of the currently adopted trove. It
+publishes a separately installable signed CCS under the Conary runtime root and
+records that path only after immediate strict verification. Same-directory
+staging plus one SQLite transaction ensures a failed conversion or persistence
+step leaves neither a newly published artifact nor an applied changeset. A
+later install, update, rollback, or remove consumes that CCS through Conary's
+ordinary source-independent transaction path without consulting the source
+package manager or its database.
 
 System-wide adoption preserves the native manager's explicit-versus-dependency
 reason for every installed package. On RPM systems, Conary uses each

--- a/docs/roadmaps/development-roadmap.md
+++ b/docs/roadmaps/development-roadmap.md
@@ -491,10 +491,9 @@ accepted here.
 
 - **Outcome:** Conary enrolls native repositories transactionally and supports
   package ecosystems without a distro-name routing matrix.
-- **Execution status:** final conformance remains gated on W9. #62 is tracked as
-  bounded child slices: #377 and #379 through #381 are merged; #382 is in
-  progress, while #383 and #384 own capability-compatibility and
-  distro-conformance work. #68 follows.
+- **Execution status:** #62 is tracked as bounded child slices. #377 and #379
+  through #383 are merged. #68 provides exact adopted-artifact conversion;
+  #384 remains the final derivative and rolling-distro conformance slice.
 - **Issues:** #62 as epic; #377 and #379-#384 as tracked children; #68 follows.
 - **Decomposition:**
   - Lossless native repository declarations, with separate parsers and models

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-12
-revision: 44
-summary: Define source-independent lifecycle, source-authority handoff, generation activation, and configuration transactions for RPM, Debian, and Arch packages
+revision: 45
+summary: Define source-independent lifecycle, exact adopted-artifact conversion, source-authority handoff, generation activation, and configuration transactions for RPM, Debian, and Arch packages
 ---
 
 # Foreign Package Lifecycle Contracts
@@ -58,6 +58,12 @@ contract.
 System adoption is a migration-continuity feature for machines that already
 have native package-manager state. It is not the cross-distro product path and
 does not count as proof that conversion or source-independent execution works.
+The explicit adoption-to-CCS bridge is valid only after Conary re-resolves an
+immutable source artifact from enrolled authority and proves its typed identity
+and complete payload equal the adopted record. It then enters the same parser,
+converter, signed CCS, and source-independent lifecycle path shown above; live
+files or the installed package database alone can never establish lifecycle
+equivalence.
 
 ### Orthogonal Source And Target Axes
 
@@ -1627,6 +1633,10 @@ Current ownership:
 - exact CCS authority removed by native upgrades or relations:
   `apps/conary/src/commands/install/ccs_removal_hooks.rs` and
   `apps/conary/src/commands/remove/ccs_hook.rs`;
+- exact adopted-artifact resolution, payload equivalence, verified CCS
+  publication, and installed-conversion persistence:
+  `apps/conary/src/commands/adopt/convert.rs` and
+  `apps/conary/src/commands/adopt/convert/tests/`;
 - shared config decisions and durable snapshot:
   `crates/conary-core/src/config_transaction.rs`;
 - selected-root config planner:
@@ -1668,3 +1678,10 @@ package manager and compares the observable lifecycle trace with an
 authoritative source-manager fixture. A green command-classification corpus,
 same-distro run, hand-picked pairwise converter, or adoption flow is not
 lifecycle proof.
+
+The adopted bridge additionally proves cache reuse and authenticated fetch;
+unavailable, ambiguous, identity-mismatched, and path-specific payload drift;
+directory, symlink, and hardlink topology; lifecycle-bearing conversion; and
+failure-atomic publication for each source format. Its target-root test must
+consume the published signed CCS through install, update, rollback, and remove
+for RPM, Debian, and Arch without entering any native query or mutation module.


### PR DESCRIPTION
## Problem

Adopted installed state cannot reconstruct a source package lifecycle ABI. Conversion must resolve and verify the exact enrolled native artifact before using the canonical RPM, Debian, or Arch conversion pipeline.

## What changed

- restore `conary system adopt <package> --convert` for prior `--full` adoptions, with exact version and architecture disambiguation plus read-only preview
- resolve only exact typed repository rows whose source policy, trust policy, stream binding, version scheme, architecture, and format all agree
- acquire packages through ecosystem-native verification and a checksum-addressed offline cache, retaining and reverifying Arch detached authority
- require exact adopted payload paths, node metadata, ownership, content authority, and hardlink topology before conversion
- recheck the checksum consumed by the canonical converter against the selected repository artifact
- publish strictly verified signed CCS through same-directory staging, then atomically record the durable path and applied changeset
- preserve per-package failure atomicity, including database-failure cleanup and verified-cache durability
- hard-cut the current database schema to revision 35 for durable installed CCS paths
- route the exact contract through canonical source-selection, CCS, lifecycle, integration, roadmap, and assistant-facing docs
- pin upstream `rpm` 0.27.1 at the reviewed Sequoia-backend commit until that backend reaches a crates.io release; this preserves real OpenPGP RPM proof while removing the vulnerable rPGP draft-PQC/ML-DSA dependency subtree

## Proof

- representative signed RPM, authenticated Debian, and signed Arch repository fetch plus offline cache-hit proof
- typed unavailable, ambiguity, identity-drift, payload-drift, hardlink, symlink, directory, lifecycle, and database-failure tests across all three native formats
- adoption-produced CCS install, update, rollback, and remove in an isolated target root without any source package-manager runtime
- dependency graph contains neither rPGP nor ML-DSA, while the real embedded-RPM-signature acquisition test remains green
- two adversarial DeepSeek V4 Flash reviews; actionable checksum/cache/hardlink findings were fixed and regression-tested
- every touched or added Rust file is at or below 1,000 lines

## Verification

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p conary`
- `cargo test -p conary-core`
- `cargo test -p remi`
- `python3 scripts/check-rust-dependency-consistency.py`
- `cargo metadata --locked --no-deps --format-version 1`
- `bash scripts/agent-context.sh --feature adopt --run focused`
- `bash scripts/agent-context.sh --feature resolution --run focused`
- `bash scripts/agent-context.sh --feature ccs --run focused`
- `bash scripts/check-doc-truth.sh`
- `cargo run -p conary-test -- list`
- `git diff --check`

Closes #68
