### PR TITLE
test: add CachyOS and Tumbleweed acceptance

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -146,7 +146,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [fedora44, ubuntu-26.04, arch, artix, linux-mint-22.3, pop-os-24.04]
+        distro: [fedora44, ubuntu-26.04, arch, artix, cachyos, opensuse-tumbleweed, linux-mint-22.3, pop-os-24.04]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-rust-workspace
@@ -190,7 +190,7 @@ jobs:
           result="apps/conary/tests/integration/remi/results/${{ matrix.distro }}-phase4.json"
           bash scripts/check-conary-test-result-gate.sh "$result"
           jq -e '
-            .target_release.schema_version == 1 and
+            .target_release.schema_version == 2 and
             .target_release.target_profile == "${{ matrix.distro }}" and
             .target_release.checkout_commit == "${{ github.sha }}" and
             .target_release.checkout_dirty == false and
@@ -221,6 +221,40 @@ jobs:
                      .role == "keyring_package" or
                      .role == "identity_package") |
               .digest_source] | all(. == "pinned_build_input"))
+          ' "$result"
+      - name: Prove authentic rolling derivative state and native repository behavior
+        if: ${{ matrix.distro == 'cachyos' || matrix.distro == 'opensuse-tumbleweed' }}
+        env:
+          CONARY_TEST_REUSE_IMAGE: "1"
+        run: >-
+          cargo run -p conary-test --
+          run
+          --distro "${{ matrix.distro }}"
+          --phase 4
+          --suite rolling-derivative-acceptance
+      - name: Verify rolling derivative evidence
+        if: ${{ matrix.distro == 'cachyos' || matrix.distro == 'opensuse-tumbleweed' }}
+        run: |
+          result="apps/conary/tests/integration/remi/results/${{ matrix.distro }}-phase4.json"
+          bash scripts/check-conary-test-result-gate.sh "$result"
+          jq -e '
+            .target_release.schema_version == 2 and
+            .target_release.target_profile == "${{ matrix.distro }}" and
+            .target_release.checkout_commit == "${{ github.sha }}" and
+            .target_release.checkout_dirty == false and
+            (.target_release.packages | length >= 4) and
+            (.target_release.stages | all(.passed == true)) and
+            ([.target_release.artifacts[].role] |
+              index("base_image") != null and
+              index("native_repository_declaration") != null and
+              index("signing_root") != null and
+              index("conary_executable") != null) and
+            ([.target_release.artifacts[] |
+              select(.role == "native_repository_declaration" or .role == "signing_root") |
+              .digest_source] | all(. == "running_target_bytes")) and
+            ([.target_release.artifacts[] |
+              select(.role == "signing_root") |
+              (.fingerprints | length > 0)] | all)
           ' "$result"
 
   native-cross-source-lifecycle-gate:

--- a/apps/conary-test/src/cli.rs
+++ b/apps/conary-test/src/cli.rs
@@ -500,6 +500,19 @@ fn run_single_distro(
                 )
                 .await?,
             );
+        } else if let Some(target_root) = &distro_config.target_root {
+            let (checkout_commit, checkout_dirty) = checkout_identity()?;
+            aggregate_suite.target_release = Some(
+                conary_test::engine::release_root::capture_authenticated_target_evidence(
+                    &backend,
+                    &container_id,
+                    distro,
+                    target_root,
+                    checkout_commit,
+                    checkout_dirty,
+                )
+                .await?,
+            );
         }
         let remi_run =
             conary_test::remi_stream::LocalRemiRun::start(&aggregate_suite_name, distro, phase)

--- a/apps/conary-test/src/cli/image_config.rs
+++ b/apps/conary-test/src/cli/image_config.rs
@@ -37,6 +37,10 @@ pub(super) fn base_image_reference(config: &GlobalConfig, distro: &str) -> Resul
         release_root.validate()?;
         return Ok(release_root.base_image.clone());
     }
+    if let Some(target_root) = &distro_config.target_root {
+        target_root.validate()?;
+        return Ok(target_root.base_image.clone());
+    }
 
     let containerfile = containerfile_path(config, distro)?;
     let source = std::fs::read_to_string(&containerfile)

--- a/apps/conary-test/src/config/distro.rs
+++ b/apps/conary-test/src/config/distro.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use serde::Deserialize;
 use std::collections::HashMap;
 
-use super::release_root::DistroReleaseRoot;
+use super::release_root::{AuthenticatedTargetRoot, DistroReleaseRoot};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct GlobalConfig {
@@ -75,6 +75,8 @@ pub struct DistroConfig {
     pub test_packages: Vec<TestPackage>,
     #[serde(default)]
     pub release_root: Option<DistroReleaseRoot>,
+    #[serde(default)]
+    pub target_root: Option<AuthenticatedTargetRoot>,
 }
 
 /// Which Conary binary a distro image build context stages.

--- a/apps/conary-test/src/config/mod.rs
+++ b/apps/conary-test/src/config/mod.rs
@@ -8,9 +8,10 @@ pub mod release_root;
 pub use distro::{DistroBuildContext, DistroConfig, GlobalConfig, TestPackage};
 pub use manifest::{Assertion, StepType, TestDef, TestManifest};
 pub use release_root::{
-    AptGlobalTrustBinding, DistroReleaseRoot, ExpectedOsRelease, PinnedTargetFile,
-    ReleaseMediaAuthority, TargetArtifactIdentity, TargetArtifactRole, TargetReleaseEvidence,
-    TargetReleaseStage, TargetReleaseStageResult,
+    AptGlobalTrustBinding, AuthenticatedTargetRoot, DistroReleaseRoot, ExpectedNativePackage,
+    ExpectedOsRelease, NativePackageQuery, NativeRepositoryTrustBinding, PinnedTargetFile,
+    ReleaseMediaAuthority, TargetArtifactIdentity, TargetArtifactRole, TargetPackageIdentity,
+    TargetReleaseEvidence, TargetReleaseStage, TargetReleaseStageResult,
 };
 
 use anyhow::{Result, bail};

--- a/apps/conary-test/src/config/release_root.rs
+++ b/apps/conary-test/src/config/release_root.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeSet, HashMap};
 use anyhow::{Result, bail};
 use serde::{Deserialize, Serialize};
 
-pub const TARGET_RELEASE_EVIDENCE_SCHEMA: u32 = 1;
+pub const TARGET_RELEASE_EVIDENCE_SCHEMA: u32 = 2;
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -21,8 +21,45 @@ pub struct PinnedDebPackage {
 pub struct ExpectedOsRelease {
     pub id: String,
     pub version_id: String,
-    pub version_codename: String,
-    pub ubuntu_codename: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version_codename: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ubuntu_codename: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id_like: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExpectedNativePackage {
+    pub name: String,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum NativePackageQuery {
+    Dpkg,
+    Pacman,
+    Rpm,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(tag = "ecosystem", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum NativeRepositoryTrustBinding {
+    Arch {
+        repository: String,
+        metadata_url: String,
+        keyring_url: String,
+        master_fingerprints: Vec<String>,
+        packager_key_threshold: u32,
+    },
+    RpmGlobal {
+        repository: String,
+        signing_root_paths: Vec<String>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -75,6 +112,20 @@ pub struct DistroReleaseRoot {
     pub release_media: ReleaseMediaAuthority,
 }
 
+/// Authenticated identity and repository inputs for a first-party container
+/// image whose root does not need to be reconstructed from release media.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthenticatedTargetRoot {
+    pub base_image: String,
+    pub package_query: NativePackageQuery,
+    pub expected_os_release: ExpectedOsRelease,
+    pub identity_packages: Vec<ExpectedNativePackage>,
+    pub repository_declarations: Vec<PinnedTargetFile>,
+    pub signing_roots: Vec<PinnedTargetFile>,
+    pub repository_trust: Vec<NativeRepositoryTrustBinding>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TargetArtifactRole {
@@ -83,6 +134,7 @@ pub enum TargetArtifactRole {
     KeyringPackage,
     IdentityPackage,
     AptDeclaration,
+    NativeRepositoryDeclaration,
     SigningRoot,
     ConaryExecutable,
 }
@@ -103,6 +155,12 @@ pub struct TargetArtifactIdentity {
     pub sha256: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub fingerprints: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TargetPackageIdentity {
+    pub name: String,
+    pub version: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -129,6 +187,7 @@ pub struct TargetReleaseEvidence {
     pub checkout_commit: String,
     pub checkout_dirty: bool,
     pub conary_version: String,
+    pub packages: Vec<TargetPackageIdentity>,
     pub artifacts: Vec<TargetArtifactIdentity>,
     pub stages: Vec<TargetReleaseStageResult>,
 }
@@ -151,14 +210,7 @@ impl DistroReleaseRoot {
             &self.expected_os_release.version_id,
             "expected_os_release.version_id",
         )?;
-        validate_token(
-            &self.expected_os_release.version_codename,
-            "expected_os_release.version_codename",
-        )?;
-        validate_token(
-            &self.expected_os_release.ubuntu_codename,
-            "expected_os_release.ubuntu_codename",
-        )?;
+        validate_os_release(&self.expected_os_release)?;
         if self.required_apt_uris.is_empty() {
             bail!("release-root required_apt_uris must not be empty");
         }
@@ -255,11 +307,17 @@ impl DistroReleaseRoot {
             ),
             (
                 "EXPECTED_VERSION_CODENAME".into(),
-                self.expected_os_release.version_codename.clone(),
+                self.expected_os_release
+                    .version_codename
+                    .clone()
+                    .unwrap_or_default(),
             ),
             (
                 "EXPECTED_UBUNTU_CODENAME".into(),
-                self.expected_os_release.ubuntu_codename.clone(),
+                self.expected_os_release
+                    .ubuntu_codename
+                    .clone()
+                    .unwrap_or_default(),
             ),
             ("REQUIRED_APT_URIS".into(), self.required_apt_uris.join(" ")),
             (
@@ -272,6 +330,134 @@ impl DistroReleaseRoot {
             ),
         ]))
     }
+}
+
+impl AuthenticatedTargetRoot {
+    pub fn validate(&self) -> Result<()> {
+        validate_base_image(&self.base_image, "target-root")?;
+        validate_os_release(&self.expected_os_release)?;
+        if self.identity_packages.is_empty() {
+            bail!("target-root identity_packages must not be empty");
+        }
+        for package in &self.identity_packages {
+            validate_token(&package.name, "identity_packages.name")?;
+            validate_token(&package.version, "identity_packages.version")?;
+        }
+        if self.repository_declarations.is_empty() {
+            bail!("target-root repository_declarations must not be empty");
+        }
+        validate_target_files(&self.repository_declarations, false)?;
+        if self.signing_roots.is_empty() {
+            bail!("target-root signing_roots must not be empty");
+        }
+        validate_target_files(&self.signing_roots, true)?;
+        if self.repository_trust.is_empty() {
+            bail!("target-root repository_trust must not be empty");
+        }
+        let mut repositories = BTreeSet::new();
+        for binding in &self.repository_trust {
+            let (repository, paths) = match binding {
+                NativeRepositoryTrustBinding::Arch {
+                    repository,
+                    metadata_url,
+                    keyring_url,
+                    master_fingerprints,
+                    packager_key_threshold,
+                } => {
+                    validate_https_url(metadata_url, "repository_trust.metadata_url")?;
+                    validate_https_url(keyring_url, "repository_trust.keyring_url")?;
+                    if master_fingerprints.is_empty() || *packager_key_threshold == 0 {
+                        bail!("Arch repository trust requires master fingerprints and a threshold");
+                    }
+                    for fingerprint in master_fingerprints {
+                        validate_fingerprint(fingerprint)?;
+                    }
+                    (repository, None)
+                }
+                NativeRepositoryTrustBinding::RpmGlobal {
+                    repository,
+                    signing_root_paths,
+                } => (repository, Some(signing_root_paths)),
+            };
+            validate_token(repository, "repository_trust.repository")?;
+            if !repositories.insert(repository) {
+                bail!("target-root repository_trust repeats a repository");
+            }
+            if let Some(paths) = paths
+                && (paths.is_empty()
+                    || paths
+                        .iter()
+                        .any(|path| !self.signing_roots.iter().any(|root| &root.path == path)))
+            {
+                bail!("RPM global trust must refer to declared signing roots");
+            }
+        }
+        Ok(())
+    }
+
+    pub fn docker_build_args(&self) -> Result<HashMap<String, String>> {
+        self.validate()?;
+        Ok(HashMap::from([(
+            "BASE_IMAGE".into(),
+            self.base_image.clone(),
+        )]))
+    }
+}
+
+fn validate_base_image(value: &str, owner: &str) -> Result<()> {
+    let Some((image_name, image_digest)) = value.rsplit_once("@sha256:") else {
+        bail!("{owner} base_image must be digest-pinned");
+    };
+    if image_name.is_empty() {
+        bail!("{owner} base_image must name an image before its digest");
+    }
+    validate_sha256(image_digest, "base_image digest")?;
+    validate_token(value, "base_image")
+}
+
+fn validate_os_release(release: &ExpectedOsRelease) -> Result<()> {
+    validate_token(&release.id, "expected_os_release.id")?;
+    validate_token(&release.version_id, "expected_os_release.version_id")?;
+    for (field, value) in [
+        ("version_codename", &release.version_codename),
+        ("ubuntu_codename", &release.ubuntu_codename),
+        ("id_like", &release.id_like),
+        ("build_id", &release.build_id),
+    ] {
+        if let Some(value) = value
+            && (value.is_empty() || value.chars().any(char::is_control))
+        {
+            bail!("expected_os_release.{field} must be a nonempty scalar");
+        }
+    }
+    Ok(())
+}
+
+fn validate_target_files(files: &[PinnedTargetFile], require_fingerprints: bool) -> Result<()> {
+    for file in files {
+        if !file.path.starts_with('/') || file.path.contains("..") {
+            bail!("target-root files must use absolute non-traversing paths");
+        }
+        validate_token(&file.path, "target-root file path")?;
+        validate_sha256(&file.sha256, "target-root file sha256")?;
+        if require_fingerprints && file.fingerprints.is_empty() {
+            bail!("target-root signing roots require fingerprints");
+        }
+        for fingerprint in &file.fingerprints {
+            validate_fingerprint(fingerprint)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_fingerprint(fingerprint: &str) -> Result<()> {
+    if fingerprint.len() != 40
+        || !fingerprint.chars().all(|ch| ch.is_ascii_hexdigit())
+        || fingerprint != fingerprint.to_ascii_uppercase()
+    {
+        bail!("target-root fingerprints must be uppercase 40-digit values");
+    }
+    Ok(())
 }
 
 fn validate_media(media: &ReleaseMediaAuthority) -> Result<()> {

--- a/apps/conary-test/src/config/tests/release_roots.rs
+++ b/apps/conary-test/src/config/tests/release_roots.rs
@@ -49,7 +49,10 @@ fn derivative_roots_carry_typed_release_and_package_authority() {
         assert_eq!(root.fixture, distro);
         assert_eq!(root.keyring_package.sha256.len(), 64);
         assert_eq!(root.identity_package.sha256.len(), 64);
-        assert_eq!(root.expected_os_release.ubuntu_codename, "noble");
+        assert_eq!(
+            root.expected_os_release.ubuntu_codename.as_deref(),
+            Some("noble")
+        );
         assert!(root.signing_roots.iter().all(|item| {
             item.fingerprints
                 .iter()
@@ -87,6 +90,69 @@ fn derivative_roots_carry_typed_release_and_package_authority() {
         ReleaseMediaAuthority::HttpsMetadata { metadata_url, .. }
             if metadata_url == "https://api.pop-os.org/builds/24.04/generic?arch=amd64"
     ));
+}
+
+#[test]
+fn rolling_roots_carry_authenticated_native_authority() {
+    let config = shipped_config();
+    for distro in ["cachyos", "opensuse-tumbleweed"] {
+        let root = config.distros[distro]
+            .target_root
+            .as_ref()
+            .unwrap_or_else(|| panic!("{distro} must declare target-root authority"));
+        root.validate()
+            .unwrap_or_else(|error| panic!("{distro} target root is invalid: {error}"));
+        assert!(root.base_image.contains("@sha256:"));
+        assert!(root.identity_packages.len() >= 4);
+        assert!(!root.repository_declarations.is_empty());
+        assert!(!root.signing_roots.is_empty());
+        assert_eq!(
+            root.repository_trust.len(),
+            if distro == "cachyos" { 4 } else { 6 }
+        );
+    }
+    assert_eq!(
+        config.distros["cachyos"]
+            .target_root
+            .as_ref()
+            .unwrap()
+            .expected_os_release
+            .id_like
+            .as_deref(),
+        Some("arch")
+    );
+    assert_eq!(
+        config.distros["opensuse-tumbleweed"]
+            .target_root
+            .as_ref()
+            .unwrap()
+            .expected_os_release
+            .id,
+        "opensuse-tumbleweed"
+    );
+}
+
+#[test]
+fn rolling_takeover_helper_uses_typed_configuration_not_distro_names() {
+    let path =
+        integration_root().join("../../fixtures/distro-roots/run-native-repository-takeover.py");
+    let source = std::fs::read_to_string(&path).expect("read native takeover helper");
+    for forbidden in ["cachyos", "tumbleweed", "opensuse"] {
+        assert!(
+            !source.to_ascii_lowercase().contains(forbidden),
+            "{} must not select product behavior from {forbidden}",
+            path.display()
+        );
+    }
+    for required in [
+        "preview_sha256",
+        "repository_trust",
+        "repository-takeover",
+        "projection_sha256",
+        "packager_key_threshold",
+    ] {
+        assert!(source.contains(required), "helper must require {required}");
+    }
 }
 
 #[test]

--- a/apps/conary-test/src/config/tests/workflow.rs
+++ b/apps/conary-test/src/config/tests/workflow.rs
@@ -165,6 +165,8 @@ fn native_cross_source_pr_gate_executes_every_supported_target_lane() {
             "ubuntu-26.04",
             "arch",
             "artix",
+            "cachyos",
+            "opensuse-tumbleweed",
             "linux-mint-22.3",
             "pop-os-24.04",
         ]
@@ -242,6 +244,34 @@ fn native_cross_source_pr_gate_executes_every_supported_target_lane() {
         assert!(
             evidence.run.as_deref().unwrap().contains(required),
             "derivative evidence gate must require {required}"
+        );
+    }
+
+    let rolling = named_step(
+        &job.steps,
+        "Prove authentic rolling derivative state and native repository behavior",
+    );
+    assert_eq!(
+        rolling.condition.as_deref(),
+        Some("${{ matrix.distro == 'cachyos' || matrix.distro == 'opensuse-tumbleweed' }}")
+    );
+    assert!(
+        rolling
+            .run
+            .as_deref()
+            .is_some_and(|command| command.contains("--suite rolling-derivative-acceptance"))
+    );
+    let rolling_evidence = named_step(&job.steps, "Verify rolling derivative evidence");
+    assert_eq!(rolling_evidence.condition, rolling.condition);
+    for required in [
+        ".target_release.packages",
+        "native_repository_declaration",
+        "running_target_bytes",
+        "fingerprints",
+    ] {
+        assert!(
+            rolling_evidence.run.as_deref().unwrap().contains(required),
+            "rolling evidence gate must require {required}"
         );
     }
 }

--- a/apps/conary-test/src/container/image.rs
+++ b/apps/conary-test/src/container/image.rs
@@ -414,9 +414,13 @@ async fn build_distro_image_inner(
         distro_config.build_context,
         native_package,
     )?;
-    let mut build_args = match &distro_config.release_root {
-        Some(release_root) => release_root.docker_build_args()?,
-        None => HashMap::new(),
+    let mut build_args = match (&distro_config.release_root, &distro_config.target_root) {
+        (Some(_), Some(_)) => {
+            anyhow::bail!("distro {distro} cannot declare both release_root and target_root")
+        }
+        (Some(release_root), None) => release_root.docker_build_args()?,
+        (None, Some(target_root)) => target_root.docker_build_args()?,
+        (None, None) => HashMap::new(),
     };
     if native_package.is_some() {
         build_args.insert("INSTALL_MODE".to_string(), "package".to_string());

--- a/apps/conary-test/src/engine/release_root.rs
+++ b/apps/conary-test/src/engine/release_root.rs
@@ -9,9 +9,13 @@ use anyhow::{Context, Result, bail};
 
 use crate::config::release_root::{
     TARGET_RELEASE_EVIDENCE_SCHEMA, TargetArtifactDigestSource, TargetArtifactIdentity,
-    TargetArtifactRole, TargetReleaseEvidence, TargetReleaseStage, TargetReleaseStageResult,
+    TargetArtifactRole, TargetPackageIdentity, TargetReleaseEvidence, TargetReleaseStage,
+    TargetReleaseStageResult,
 };
-use crate::config::{DistroReleaseRoot, ExpectedOsRelease};
+use crate::config::{
+    AuthenticatedTargetRoot, DistroReleaseRoot, ExpectedNativePackage, ExpectedOsRelease,
+    NativePackageQuery, PinnedTargetFile,
+};
 use crate::container::{ContainerBackend, ContainerId};
 
 const PROBE_TIMEOUT: Duration = Duration::from_secs(30);
@@ -43,8 +47,10 @@ pub async fn capture_target_release_evidence(
     let observed_release = ExpectedOsRelease {
         id: values[0].to_string(),
         version_id: values[1].to_string(),
-        version_codename: values[2].to_string(),
-        ubuntu_codename: values[3].to_string(),
+        version_codename: nonempty(values[2]),
+        ubuntu_codename: nonempty(values[3]),
+        id_like: None,
+        build_id: None,
     };
     if observed_release != root.expected_os_release {
         bail!(
@@ -241,6 +247,13 @@ pub async fn capture_target_release_evidence(
         checkout_commit,
         checkout_dirty,
         conary_version,
+        packages: [&root.keyring_package, &root.identity_package]
+            .into_iter()
+            .map(|package| TargetPackageIdentity {
+                name: package.name.clone(),
+                version: package.version.clone(),
+            })
+            .collect(),
         artifacts,
         stages: [
             TargetReleaseStage::ReleaseIdentity,
@@ -255,6 +268,235 @@ pub async fn capture_target_release_evidence(
         })
         .collect(),
     })
+}
+
+pub async fn capture_authenticated_target_evidence(
+    backend: &dyn ContainerBackend,
+    container_id: &ContainerId,
+    target_profile: &str,
+    root: &AuthenticatedTargetRoot,
+    checkout_commit: String,
+    checkout_dirty: bool,
+) -> Result<TargetReleaseEvidence> {
+    root.validate()?;
+    let observed_release = probe_os_release(backend, container_id).await?;
+    if observed_release != root.expected_os_release {
+        bail!(
+            "target os-release identity mismatch: expected {:?}, observed {:?}",
+            root.expected_os_release,
+            observed_release
+        );
+    }
+
+    let mut packages = Vec::new();
+    for expected in &root.identity_packages {
+        let version = query_package(backend, container_id, root.package_query, expected).await?;
+        packages.push(TargetPackageIdentity {
+            name: expected.name.clone(),
+            version,
+        });
+    }
+
+    let mut artifacts = Vec::new();
+    let (_, base_digest) = root
+        .base_image
+        .rsplit_once("@sha256:")
+        .context("validated base image has no digest")?;
+    artifacts.push(TargetArtifactIdentity {
+        role: TargetArtifactRole::BaseImage,
+        digest_source: TargetArtifactDigestSource::PinnedBuildInput,
+        identity: root.base_image.clone(),
+        sha256: base_digest.to_string(),
+        fingerprints: Vec::new(),
+    });
+    for declaration in &root.repository_declarations {
+        artifacts.push(
+            verify_target_file(
+                backend,
+                container_id,
+                declaration,
+                TargetArtifactRole::NativeRepositoryDeclaration,
+                false,
+            )
+            .await?,
+        );
+    }
+    for signing_root in &root.signing_roots {
+        artifacts.push(
+            verify_target_file(
+                backend,
+                container_id,
+                signing_root,
+                TargetArtifactRole::SigningRoot,
+                true,
+            )
+            .await?,
+        );
+    }
+
+    let conary_digest = exec_stdout(backend, container_id, &["sha256sum", "/usr/bin/conary"])
+        .await?
+        .split_ascii_whitespace()
+        .next()
+        .context("conary SHA-256 probe returned no digest")?
+        .to_string();
+    validate_sha256(&conary_digest, "running conary executable")?;
+    let conary_version = exec_stdout(backend, container_id, &["/usr/bin/conary", "--version"])
+        .await?
+        .trim()
+        .to_string();
+    if conary_version.is_empty() {
+        bail!("running conary version is empty");
+    }
+    artifacts.push(TargetArtifactIdentity {
+        role: TargetArtifactRole::ConaryExecutable,
+        digest_source: TargetArtifactDigestSource::RunningTargetBytes,
+        identity: "/usr/bin/conary".to_string(),
+        sha256: conary_digest,
+        fingerprints: Vec::new(),
+    });
+
+    Ok(TargetReleaseEvidence {
+        schema_version: TARGET_RELEASE_EVIDENCE_SCHEMA,
+        target_profile: target_profile.to_string(),
+        release: observed_release,
+        checkout_commit,
+        checkout_dirty,
+        conary_version,
+        packages,
+        artifacts,
+        stages: [
+            TargetReleaseStage::ReleaseIdentity,
+            TargetReleaseStage::PackageIdentity,
+            TargetReleaseStage::RepositoryDeclarations,
+            TargetReleaseStage::ConaryRuntime,
+        ]
+        .into_iter()
+        .map(|stage| TargetReleaseStageResult {
+            stage,
+            passed: true,
+        })
+        .collect(),
+    })
+}
+
+async fn probe_os_release(
+    backend: &dyn ContainerBackend,
+    container_id: &ContainerId,
+) -> Result<ExpectedOsRelease> {
+    let output = exec_stdout(
+        backend,
+        container_id,
+        &[
+            "sh",
+            "-c",
+            ". /etc/os-release; printf '%s\\n%s\\n%s\\n%s\\n%s\\n%s\\n' \"$ID\" \"$VERSION_ID\" \"${VERSION_CODENAME:-}\" \"${UBUNTU_CODENAME:-}\" \"${ID_LIKE:-}\" \"${BUILD_ID:-}\"",
+        ],
+    )
+    .await?;
+    let values = output.lines().collect::<Vec<_>>();
+    if values.len() != 6 {
+        bail!("target os-release probe returned {} fields", values.len());
+    }
+    Ok(ExpectedOsRelease {
+        id: values[0].to_string(),
+        version_id: values[1].to_string(),
+        version_codename: nonempty(values[2]),
+        ubuntu_codename: nonempty(values[3]),
+        id_like: nonempty(values[4]),
+        build_id: nonempty(values[5]),
+    })
+}
+
+async fn query_package(
+    backend: &dyn ContainerBackend,
+    container_id: &ContainerId,
+    query: NativePackageQuery,
+    package: &ExpectedNativePackage,
+) -> Result<String> {
+    let command: Vec<&str> = match query {
+        NativePackageQuery::Dpkg => vec![
+            "dpkg-query",
+            "--showformat=${Version}",
+            "--show",
+            &package.name,
+        ],
+        NativePackageQuery::Pacman => vec!["pacman", "-Q", &package.name],
+        NativePackageQuery::Rpm => vec!["rpm", "-q", "--qf", "%{EVR}", &package.name],
+    };
+    let output = exec_stdout(backend, container_id, &command)
+        .await
+        .with_context(|| format!("query target package {}", package.name))?;
+    let observed = match query {
+        NativePackageQuery::Pacman => output
+            .split_ascii_whitespace()
+            .nth(1)
+            .context("pacman package query returned no version")?,
+        NativePackageQuery::Dpkg | NativePackageQuery::Rpm => output.trim(),
+    };
+    if observed != package.version {
+        bail!(
+            "target package {} version mismatch: expected {}, observed {}",
+            package.name,
+            package.version,
+            observed
+        );
+    }
+    Ok(observed.to_string())
+}
+
+async fn verify_target_file(
+    backend: &dyn ContainerBackend,
+    container_id: &ContainerId,
+    file: &PinnedTargetFile,
+    role: TargetArtifactRole,
+    inspect_fingerprints: bool,
+) -> Result<TargetArtifactIdentity> {
+    let output = exec_stdout(backend, container_id, &["sha256sum", &file.path]).await?;
+    let observed = output
+        .split_ascii_whitespace()
+        .next()
+        .context("target file SHA-256 probe returned no digest")?;
+    if observed != file.sha256 {
+        bail!(
+            "target file {} digest mismatch: expected {}, observed {}",
+            file.path,
+            file.sha256,
+            observed
+        );
+    }
+    let fingerprints = if inspect_fingerprints {
+        let listing = exec_stdout(
+            backend,
+            container_id,
+            &["gpg", "--batch", "--with-colons", "--show-keys", &file.path],
+        )
+        .await?;
+        let observed = primary_openpgp_fingerprints(&listing)?;
+        let expected = file.fingerprints.iter().cloned().collect::<BTreeSet<_>>();
+        if observed != expected {
+            bail!(
+                "target signing root {} fingerprint mismatch: expected {:?}, observed {:?}",
+                file.path,
+                expected,
+                observed
+            );
+        }
+        observed.into_iter().collect()
+    } else {
+        Vec::new()
+    };
+    Ok(TargetArtifactIdentity {
+        role,
+        digest_source: TargetArtifactDigestSource::RunningTargetBytes,
+        identity: file.path.clone(),
+        sha256: file.sha256.clone(),
+        fingerprints,
+    })
+}
+
+fn nonempty(value: &str) -> Option<String> {
+    (!value.is_empty()).then(|| value.to_string())
 }
 
 async fn exec_stdout(

--- a/apps/conary-test/src/engine/runner/tests.rs
+++ b/apps/conary-test/src/engine/runner/tests.rs
@@ -27,6 +27,7 @@ fn test_config() -> GlobalConfig {
                 binary: "/usr/bin/true".to_string(),
             }],
             release_root: None,
+            target_root: None,
         },
     );
 

--- a/apps/conary-test/src/engine/variables.rs
+++ b/apps/conary-test/src/engine/variables.rs
@@ -272,6 +272,7 @@ mod tests {
                     binary: "/usr/bin/true".to_string(),
                 }],
                 release_root: None,
+                target_root: None,
             },
         );
 

--- a/apps/conary-test/src/report/json.rs
+++ b/apps/conary-test/src/report/json.rs
@@ -113,17 +113,20 @@ mod tests {
     fn target_release_report_keeps_artifact_and_stage_authority_typed() {
         let mut suite = TestSuite::new("derivative", 4);
         suite.target_release = Some(TargetReleaseEvidence {
-            schema_version: 1,
+            schema_version: 2,
             target_profile: "linux-mint-22.3".into(),
             release: ExpectedOsRelease {
                 id: "linuxmint".into(),
                 version_id: "22.3".into(),
-                version_codename: "zena".into(),
-                ubuntu_codename: "noble".into(),
+                version_codename: Some("zena".into()),
+                ubuntu_codename: Some("noble".into()),
+                id_like: None,
+                build_id: None,
             },
             checkout_commit: "a".repeat(40),
             checkout_dirty: false,
             conary_version: "conary 0.14.0".into(),
+            packages: Vec::new(),
             artifacts: vec![TargetArtifactIdentity {
                 role: TargetArtifactRole::SigningRoot,
                 digest_source: TargetArtifactDigestSource::RunningTargetBytes,
@@ -139,7 +142,7 @@ mod tests {
 
         let parsed: serde_json::Value =
             serde_json::from_str(&to_json_report(&suite).unwrap()).unwrap();
-        assert_eq!(parsed["target_release"]["schema_version"], 1);
+        assert_eq!(parsed["target_release"]["schema_version"], 2);
         assert_eq!(
             parsed["target_release"]["artifacts"][0]["role"],
             "signing_root"

--- a/apps/conary/tests/fixtures/distro-roots/run-native-repository-takeover.py
+++ b/apps/conary/tests/fixtures/distro-roots/run-native-repository-takeover.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+# tests/fixtures/distro-roots/run-native-repository-takeover.py
+
+"""Exercise typed ALPM or Zypper takeover against a live distro root."""
+
+import argparse
+import configparser
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import tomllib
+
+
+def run(command: list[str]) -> str:
+    result = subprocess.run(command, check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"command failed ({result.returncode}): {command!r}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result.stdout
+
+
+def preview(conary: str, db: str, root: str, manifest: dict) -> dict:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as handle:
+        json.dump(manifest, handle, sort_keys=True)
+        handle.flush()
+        stdout = run(
+            [
+                conary,
+                "system",
+                "repository-takeover",
+                "--db-path",
+                db,
+                "--root",
+                root,
+                "--manifest",
+                handle.name,
+                "--dry-run",
+            ]
+        )
+    envelope, _ = json.JSONDecoder().raw_decode(stdout.lstrip())
+    if envelope.get("schema") != 1 or len(envelope.get("preview_sha256", "")) != 64:
+        raise RuntimeError("takeover preview lacks its typed schema or exact digest")
+    return envelope
+
+
+def file_url(root: Path, guest_path: str) -> str:
+    return (root / guest_path.lstrip("/")).resolve().as_uri()
+
+
+def zypper_values(root: Path, reference: dict) -> tuple[str, int]:
+    parser = configparser.ConfigParser(interpolation=None)
+    parser.read(root / reference["location"]["path"].lstrip("/"))
+    section = parser[reference["alias"]]
+    return section["baseurl"], int(section.get("priority", "99"))
+
+
+def binding_by_repository(target_root: dict) -> dict[str, dict]:
+    bindings = {}
+    for binding in target_root["repository_trust"]:
+        repository = binding["repository"]
+        if repository in bindings:
+            raise RuntimeError(f"duplicate repository trust binding: {repository}")
+        bindings[repository] = binding
+    return bindings
+
+
+def arch_trust(binding: dict) -> dict:
+    return {
+        "ecosystem": "arch",
+        "keyring": {
+            "url": binding["keyring_url"],
+            "format": "alpm-package-zstd",
+            "master_fingerprints": binding["master_fingerprints"],
+            "packager_key_threshold": binding["packager_key_threshold"],
+        },
+        "sig_level": {
+            "database": "optional",
+            "package": "required",
+            "trust": "trusted-only",
+        },
+    }
+
+
+def rpm_trust(root: Path, binding: dict, signing_roots: dict[str, dict]) -> dict:
+    roots = []
+    for path in binding["signing_root_paths"]:
+        authority = signing_roots[path]
+        roots.extend(
+            {"url": file_url(root, path), "fingerprint": fingerprint}
+            for fingerprint in authority["fingerprints"]
+        )
+    return {
+        "ecosystem": "rpm",
+        "metadata": {"kind": "open-pgp", "keys": roots},
+        "package_keys": roots,
+    }
+
+
+def build_manifest(target: str, target_root: dict, root: Path, initial: dict) -> dict:
+    bindings = binding_by_repository(target_root)
+    signing_roots = {item["path"]: item for item in target_root["signing_roots"]}
+    repositories = []
+    for index, plan in enumerate(initial["trust"]["repositories"], start=1):
+        reference = plan["repository"]
+        ecosystem = reference["ecosystem"]
+        repository = reference.get("name") or reference.get("alias")
+        binding = bindings.pop(repository, None)
+        if binding is None:
+            raise RuntimeError(f"no exact trust binding for native repository {repository}")
+        identity = f"{target}:{repository}:x86_64"
+        if ecosystem == "alpm" and binding["ecosystem"] == "arch":
+            metadata_url = binding["metadata_url"]
+            parser = {"package_format": "arch", "database": repository}
+            trust = arch_trust(binding)
+            priority = 20 + index
+        elif ecosystem == "zypper" and binding["ecosystem"] == "rpm-global":
+            metadata_url, priority = zypper_values(root, reference)
+            parser = {"package_format": "rpm", "architecture": "x86_64"}
+            trust = rpm_trust(root, binding, signing_roots)
+        else:
+            raise RuntimeError(
+                f"trust binding {binding['ecosystem']} does not match {ecosystem}"
+            )
+        repositories.append(
+            {
+                "declaration": reference,
+                "name": f"native-{repository}",
+                "source_identity": f"{target}:rolling:x86_64",
+                "repository_identity": identity,
+                "scope": {"kind": "repository", "identity": identity},
+                "stream": {"kind": "rolling", "identity": target},
+                "update": {"mode": "follow"},
+                "metadata_url": metadata_url,
+                "content_url": None,
+                "parser": parser,
+                "trust": trust,
+                "enabled": plan.get("enabled", True),
+                "priority": priority,
+                "metadata_expire": 3600,
+                "source_profile": None,
+            }
+        )
+    if bindings:
+        raise RuntimeError(f"unused repository trust bindings: {sorted(bindings)}")
+    if not repositories:
+        raise RuntimeError("native discovery produced no repositories")
+    return {"schema": 1, "repositories": repositories}
+
+
+def projection_state(root: Path, preview_value: dict) -> dict[str, str]:
+    observed = {}
+    for projection in preview_value["projections"]:
+        path = projection["path"]
+        digest = hashlib.sha256((root / path.lstrip("/")).read_bytes()).hexdigest()
+        if digest != projection["sha256"]:
+            raise RuntimeError(f"projection digest mismatch: {path}")
+        observed[path] = digest
+    return observed
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--conary", required=True)
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--db", required=True)
+    parser.add_argument("--root", default="/")
+    parser.add_argument("--evidence", required=True)
+    args = parser.parse_args()
+
+    with open(args.config, "rb") as handle:
+        target_root = tomllib.load(handle)["distros"][args.target]["target_root"]
+    root = Path(args.root)
+    initial = preview(args.conary, args.db, args.root, {"schema": 1, "repositories": []})
+    manifest = build_manifest(args.target, target_root, root, initial["preview"])
+    envelope = preview(args.conary, args.db, args.root, manifest)
+    if envelope["preview"]["blockers"]:
+        raise RuntimeError(f"takeover preview has blockers: {envelope['preview']['blockers']!r}")
+    before = projection_state(root, envelope["preview"])
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as handle:
+        json.dump(manifest, handle, sort_keys=True)
+        handle.flush()
+        command = [
+            args.conary,
+            "system",
+            "repository-takeover",
+            "--db-path",
+            args.db,
+            "--root",
+            args.root,
+            "--manifest",
+            handle.name,
+            "--preview-sha256",
+            envelope["preview_sha256"],
+            "--yes",
+        ]
+        run(command)
+        run(command)
+
+    if projection_state(root, envelope["preview"]) != before:
+        raise RuntimeError("repository projection bytes changed after apply/repeat")
+    run(
+        [
+            args.conary,
+            "system",
+            "repository-takeover",
+            "--db-path",
+            args.db,
+            "--root",
+            args.root,
+            "--rollback",
+            "--yes",
+        ]
+    )
+    if projection_state(root, envelope["preview"]) != before:
+        raise RuntimeError("repository projection bytes changed after rollback")
+
+    evidence = {
+        "schema_version": 1,
+        "target_profile": args.target,
+        "preview_sha256": envelope["preview_sha256"],
+        "repositories": len(manifest["repositories"]),
+        "projection_sha256": before,
+        "stages": ["preview", "apply", "repeat", "rollback"],
+    }
+    Path(args.evidence).write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/conary/tests/integration/remi/config.toml
+++ b/apps/conary/tests/integration/remi/config.toml
@@ -70,7 +70,7 @@ identity_packages = [
     { name = "cachyos-keyring", version = "20240331-1" },
     { name = "cachyos-mirrorlist", version = "27-1" },
     { name = "archlinux-keyring", version = "1:20260727-1" },
-    { name = "pacman", version = "20260610-1" },
+    { name = "pacman", version = "7.1.0.r9.g54d9411-4" },
 ]
 repository_declarations = [
     { path = "/etc/pacman.conf", sha256 = "ba79096e0f0dda0f275d809acb0ab5bd1ddceb526f4797a8fcf568a6993a3ad8", fingerprints = [] },

--- a/apps/conary/tests/integration/remi/config.toml
+++ b/apps/conary/tests/integration/remi/config.toml
@@ -53,6 +53,46 @@ test_packages = [
     { package = "jq", binary = "/usr/bin/jq" },
 ]
 
+[distros.cachyos]
+remi_distro = "arch"
+repo_name = "remi-arch"
+build_context = "static-binary"
+test_packages = [
+    { package = "which", binary = "/usr/bin/which" },
+    { package = "tree", binary = "/usr/bin/tree" },
+    { package = "jq", binary = "/usr/bin/jq" },
+]
+
+[distros.cachyos.target_root]
+base_image = "docker.io/cachyos/cachyos:latest@sha256:c589a66edda145d183c421a1d6f24293dd13088efa65451bb426a3614fc65a71"
+package_query = "pacman"
+identity_packages = [
+    { name = "cachyos-keyring", version = "20240331-1" },
+    { name = "cachyos-mirrorlist", version = "27-1" },
+    { name = "archlinux-keyring", version = "1:20260727-1" },
+    { name = "pacman", version = "20260610-1" },
+]
+repository_declarations = [
+    { path = "/etc/pacman.conf", sha256 = "ba79096e0f0dda0f275d809acb0ab5bd1ddceb526f4797a8fcf568a6993a3ad8", fingerprints = [] },
+    { path = "/etc/pacman.d/cachyos-mirrorlist", sha256 = "3f7547a9c5a5769d970b4bbfbb2a8cf5c6a5fb27d27649e3a26abcc1f996c1cc", fingerprints = [] },
+    { path = "/etc/pacman.d/mirrorlist", sha256 = "2a2f89c3f48e80f626bb5e6eb7e5f13ee36b3938048b3634f53dfbedbd944b2f", fingerprints = [] },
+]
+signing_roots = [
+    { path = "/usr/share/pacman/keyrings/cachyos.gpg", sha256 = "7f17cd0469e2b986d6c11ad8481a67705a20c5f968b198321a603567c4005576", fingerprints = ["882DCFE48E2051D48E2562ABF3B607488DB35A47"] },
+]
+repository_trust = [
+    { ecosystem = "arch", repository = "cachyos", metadata_url = "https://cdn77.cachyos.org/repo/x86_64/cachyos", keyring_url = "https://cdn77.cachyos.org/repo/x86_64/cachyos/cachyos-keyring-20240331-1-any.pkg.tar.zst", master_fingerprints = ["882DCFE48E2051D48E2562ABF3B607488DB35A47"], packager_key_threshold = 1 },
+    { ecosystem = "arch", repository = "core", metadata_url = "https://fastly.mirror.pkgbuild.com/core/os/x86_64", keyring_url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20260727-1-any.pkg.tar.zst", master_fingerprints = ["2AC0A42EFB0B5CBC7A0402ED4DC95B6D7BE9892E", "3572FA2A1B067F22C58AF155F8B821B42A6FDCD7", "69E6471E3AE065297529832E6BA0F5A2037F4F41", "99B6618472A3B3B814185BAED7D3D823B88BDB9B", "D8AFDDA07A5B6EDFA7D8CCDAD6D055F927843F1C"], packager_key_threshold = 3 },
+    { ecosystem = "arch", repository = "extra", metadata_url = "https://fastly.mirror.pkgbuild.com/extra/os/x86_64", keyring_url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20260727-1-any.pkg.tar.zst", master_fingerprints = ["2AC0A42EFB0B5CBC7A0402ED4DC95B6D7BE9892E", "3572FA2A1B067F22C58AF155F8B821B42A6FDCD7", "69E6471E3AE065297529832E6BA0F5A2037F4F41", "99B6618472A3B3B814185BAED7D3D823B88BDB9B", "D8AFDDA07A5B6EDFA7D8CCDAD6D055F927843F1C"], packager_key_threshold = 3 },
+    { ecosystem = "arch", repository = "multilib", metadata_url = "https://fastly.mirror.pkgbuild.com/multilib/os/x86_64", keyring_url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20260727-1-any.pkg.tar.zst", master_fingerprints = ["2AC0A42EFB0B5CBC7A0402ED4DC95B6D7BE9892E", "3572FA2A1B067F22C58AF155F8B821B42A6FDCD7", "69E6471E3AE065297529832E6BA0F5A2037F4F41", "99B6618472A3B3B814185BAED7D3D823B88BDB9B", "D8AFDDA07A5B6EDFA7D8CCDAD6D055F927843F1C"], packager_key_threshold = 3 },
+]
+
+[distros.cachyos.target_root.expected_os_release]
+id = "cachyos"
+version_id = "20260809.0.570793"
+id_like = "arch"
+build_id = "rolling"
+
 [distros.artix]
 remi_distro = "arch"
 repo_name = "remi-arch"
@@ -62,6 +102,54 @@ test_packages = [
     { package = "tree", binary = "/usr/bin/tree" },
     { package = "jq", binary = "/usr/bin/jq" },
 ]
+
+[distros."opensuse-tumbleweed"]
+remi_distro = "fedora-44"
+repo_name = "remi-fedora-44"
+build_context = "static-binary"
+test_packages = [
+    { package = "which", binary = "/usr/bin/which" },
+    { package = "tree", binary = "/usr/bin/tree" },
+    { package = "jq", binary = "/usr/bin/jq" },
+]
+
+[distros."opensuse-tumbleweed".target_root]
+base_image = "registry.opensuse.org/opensuse/tumbleweed:latest@sha256:ed1053df8889aa5a6191aa19f9af9593d1c783674e8ca1dbb55d6c75e75dc306"
+package_query = "rpm"
+identity_packages = [
+    { name = "openSUSE-release", version = "20260811-4247.1" },
+    { name = "libzypp", version = "17.38.14-1.2" },
+    { name = "zypper", version = "1.14.98-1.3" },
+    { name = "rpm", version = "4.20.1-9.2" },
+]
+repository_declarations = [
+    { path = "/etc/zypp/repos.d/repo-debug.repo", sha256 = "a634cb148a3e870c6fa86735e41ce36ae9be7970c73c3a8d14cec1a9e7093865", fingerprints = [] },
+    { path = "/etc/zypp/repos.d/repo-non-oss.repo", sha256 = "593619efa17fb8b0e69bdb3f5000327faa92e91d104ef741b14e2991003e6ebc", fingerprints = [] },
+    { path = "/etc/zypp/repos.d/repo-openh264.repo", sha256 = "76c43eb1357746bf9214c4101c49db437b394b245103d90e1b97ccb4a5320ebd", fingerprints = [] },
+    { path = "/etc/zypp/repos.d/repo-oss.repo", sha256 = "2530d649a42c140f7ec0d16edb4538494d66de01ad3eabe2f884ac08eb928f2c", fingerprints = [] },
+    { path = "/etc/zypp/repos.d/repo-source.repo", sha256 = "2dddf51cd4a794237599512cbf33c522e9a86c5248660e02f0f7a5b9f5962e98", fingerprints = [] },
+    { path = "/etc/zypp/repos.d/repo-update.repo", sha256 = "d3bbf288d0abee4e53c20514ba0c61d1f42d512d5c49fd6878a13cd52b734277", fingerprints = [] },
+]
+signing_roots = [
+    { path = "/usr/lib/rpm/gnupg/keys/gpg-pubkey-09d9ea69-68595a8c.asc", sha256 = "dece9365f3c78139c0aa6df9c263db2fe7898526162af8d1c1a68cd46136d30c", fingerprints = ["1C59D66FCD52563A16933DBCFEC28EAF09D9EA69"] },
+    { path = "/usr/lib/rpm/gnupg/keys/gpg-pubkey-287a0027-682477e3.asc", sha256 = "8f57411f86db33c398928ad7b2e28769c659532770c57194587ad5c514fce6e3", fingerprints = ["BF3F9A67D3A2FF98A73F5E07488C583D287A0027"] },
+    { path = "/usr/lib/rpm/gnupg/keys/gpg-pubkey-29b700a4-6a17fa38.asc", sha256 = "b5745739ebfb95b25b8e810f9bcb847fe750ccda598bd85f02f0e974599a6d7e", fingerprints = ["AD485664E901B867051AB15F35A2F86E29B700A4"] },
+    { path = "/usr/lib/rpm/gnupg/keys/gpg-pubkey-39db7c82-66c5d91a.asc", sha256 = "21ebd74ac3f50f892f0c7038d534a645d0468ce741f3cc8633d66ae01abef9a7", fingerprints = ["FEAB502539D846DB2C0961CA70AF9E8139DB7C82"] },
+    { path = "/usr/lib/rpm/gnupg/keys/gpg-pubkey-3fa1d6ce-67c856ee.asc", sha256 = "3c5ce29fa98ff886911741d28195269df401099c70acbf84da575422df8523d9", fingerprints = ["7F009157B127B994D5CFBE76F74F09BC3FA1D6CE"] },
+]
+repository_trust = [
+    { ecosystem = "rpm-global", repository = "repo-debug", signing_root_paths = ["/usr/lib/rpm/gnupg/keys/gpg-pubkey-09d9ea69-68595a8c.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-287a0027-682477e3.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-29b700a4-6a17fa38.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-39db7c82-66c5d91a.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-3fa1d6ce-67c856ee.asc"] },
+    { ecosystem = "rpm-global", repository = "repo-non-oss", signing_root_paths = ["/usr/lib/rpm/gnupg/keys/gpg-pubkey-09d9ea69-68595a8c.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-287a0027-682477e3.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-29b700a4-6a17fa38.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-39db7c82-66c5d91a.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-3fa1d6ce-67c856ee.asc"] },
+    { ecosystem = "rpm-global", repository = "repo-openh264", signing_root_paths = ["/usr/lib/rpm/gnupg/keys/gpg-pubkey-09d9ea69-68595a8c.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-287a0027-682477e3.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-29b700a4-6a17fa38.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-39db7c82-66c5d91a.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-3fa1d6ce-67c856ee.asc"] },
+    { ecosystem = "rpm-global", repository = "repo-oss", signing_root_paths = ["/usr/lib/rpm/gnupg/keys/gpg-pubkey-09d9ea69-68595a8c.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-287a0027-682477e3.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-29b700a4-6a17fa38.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-39db7c82-66c5d91a.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-3fa1d6ce-67c856ee.asc"] },
+    { ecosystem = "rpm-global", repository = "repo-source", signing_root_paths = ["/usr/lib/rpm/gnupg/keys/gpg-pubkey-09d9ea69-68595a8c.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-287a0027-682477e3.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-29b700a4-6a17fa38.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-39db7c82-66c5d91a.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-3fa1d6ce-67c856ee.asc"] },
+    { ecosystem = "rpm-global", repository = "repo-update", signing_root_paths = ["/usr/lib/rpm/gnupg/keys/gpg-pubkey-09d9ea69-68595a8c.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-287a0027-682477e3.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-29b700a4-6a17fa38.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-39db7c82-66c5d91a.asc", "/usr/lib/rpm/gnupg/keys/gpg-pubkey-3fa1d6ce-67c856ee.asc"] },
+]
+
+[distros."opensuse-tumbleweed".target_root.expected_os_release]
+id = "opensuse-tumbleweed"
+version_id = "20260811"
+id_like = "opensuse suse"
 
 [distros."linux-mint-22.3"]
 remi_distro = "ubuntu-26.04"

--- a/apps/conary/tests/integration/remi/containers/Containerfile.cachyos
+++ b/apps/conary/tests/integration/remi/containers/Containerfile.cachyos
@@ -1,0 +1,36 @@
+# tests/integration/remi/containers/Containerfile.cachyos
+# Authentic CachyOS rolling container for package-ecosystem acceptance.
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG INSTALL_MODE=binary
+
+COPY conary* /tmp/install/
+
+RUN if [ "$INSTALL_MODE" = "package" ] && [ -f /tmp/install/conary-release.pkg.tar.zst ]; then \
+        pacman -U --noconfirm /tmp/install/conary-release.pkg.tar.zst; \
+    elif [ -f /tmp/install/conary ]; then \
+        install -m 755 /tmp/install/conary /usr/bin/conary; \
+    else \
+        echo "No conary binary or package found in build context" >&2; exit 1; \
+    fi && rm -rf /tmp/install
+
+RUN /usr/bin/conary --version \
+    && command -v cmp \
+    && command -v diff \
+    && command -v gpg \
+    && command -v python3 \
+    && test -e /lib64/ld-linux-x86-64.so.2
+
+COPY config.toml /opt/remi-tests/config.toml
+COPY fixtures/ /opt/remi-tests/fixtures/
+
+RUN mkdir -p /var/lib/conary /results
+
+ENV DISTRO=cachyos
+ENV DB_PATH=/var/lib/conary/conary.db
+ENV RESULTS_DIR=/results
+ENV CONARY_BIN=/usr/bin/conary
+
+CMD ["sleep", "infinity"]

--- a/apps/conary/tests/integration/remi/containers/Containerfile.opensuse-tumbleweed
+++ b/apps/conary/tests/integration/remi/containers/Containerfile.opensuse-tumbleweed
@@ -1,0 +1,45 @@
+# tests/integration/remi/containers/Containerfile.opensuse-tumbleweed
+# Authentic openSUSE Tumbleweed rolling container for package acceptance.
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG INSTALL_MODE=binary
+
+RUN zypper --non-interactive install --no-recommends \
+        ca-certificates \
+        diffutils \
+        libseccomp2 \
+        python3 \
+        shadow \
+        sqlite3 \
+    && zypper clean --all
+
+COPY conary* /tmp/install/
+
+RUN if [ "$INSTALL_MODE" = "package" ] && [ -f /tmp/install/conary-release.rpm ]; then \
+        zypper --non-interactive install --allow-unsigned-rpm /tmp/install/conary-release.rpm; \
+    elif [ -f /tmp/install/conary ]; then \
+        install -m 755 /tmp/install/conary /usr/bin/conary; \
+    else \
+        echo "No conary binary or package found in build context" >&2; exit 1; \
+    fi && rm -rf /tmp/install
+
+RUN /usr/bin/conary --version \
+    && command -v cmp \
+    && command -v diff \
+    && command -v gpg \
+    && command -v python3 \
+    && test -e /lib64/ld-linux-x86-64.so.2
+
+COPY config.toml /opt/remi-tests/config.toml
+COPY fixtures/ /opt/remi-tests/fixtures/
+
+RUN mkdir -p /var/lib/conary /results
+
+ENV DISTRO=opensuse-tumbleweed
+ENV DB_PATH=/var/lib/conary/conary.db
+ENV RESULTS_DIR=/results
+ENV CONARY_BIN=/usr/bin/conary
+
+CMD ["sleep", "infinity"]

--- a/apps/conary/tests/integration/remi/containers/Containerfile.opensuse-tumbleweed
+++ b/apps/conary/tests/integration/remi/containers/Containerfile.opensuse-tumbleweed
@@ -9,6 +9,7 @@ ARG INSTALL_MODE=binary
 RUN zypper --non-interactive install --no-recommends \
         ca-certificates \
         diffutils \
+        findutils \
         libseccomp2 \
         python3 \
         shadow \
@@ -28,6 +29,7 @@ RUN if [ "$INSTALL_MODE" = "package" ] && [ -f /tmp/install/conary-release.rpm ]
 RUN /usr/bin/conary --version \
     && command -v cmp \
     && command -v diff \
+    && command -v find \
     && command -v gpg \
     && command -v python3 \
     && test -e /lib64/ld-linux-x86-64.so.2

--- a/apps/conary/tests/integration/remi/containers/Containerfile.opensuse-tumbleweed
+++ b/apps/conary/tests/integration/remi/containers/Containerfile.opensuse-tumbleweed
@@ -10,6 +10,7 @@ RUN zypper --non-interactive install --no-recommends \
         ca-certificates \
         diffutils \
         findutils \
+        gawk \
         libseccomp2 \
         python3 \
         shadow \
@@ -27,6 +28,7 @@ RUN if [ "$INSTALL_MODE" = "package" ] && [ -f /tmp/install/conary-release.rpm ]
     fi && rm -rf /tmp/install
 
 RUN /usr/bin/conary --version \
+    && command -v awk \
     && command -v cmp \
     && command -v diff \
     && command -v find \

--- a/apps/conary/tests/integration/remi/manifests/native-cross-source-lifecycle.toml
+++ b/apps/conary/tests/integration/remi/manifests/native-cross-source-lifecycle.toml
@@ -19,9 +19,17 @@ target_init_system = "systemd"
 native_lifecycle_oracle_format = "arch"
 target_init_system = "systemd"
 
+[distro_overrides.cachyos]
+native_lifecycle_oracle_format = "arch"
+target_init_system = "systemd"
+
 [distro_overrides.artix]
 native_lifecycle_oracle_format = "arch"
 target_init_system = "openrc"
+
+[distro_overrides."opensuse-tumbleweed"]
+native_lifecycle_oracle_format = "rpm"
+target_init_system = "systemd"
 
 [distro_overrides."linux-mint-22.3"]
 native_lifecycle_oracle_format = "deb"

--- a/apps/conary/tests/integration/remi/manifests/rolling-derivative-acceptance.toml
+++ b/apps/conary/tests/integration/remi/manifests/rolling-derivative-acceptance.toml
@@ -1,0 +1,101 @@
+# tests/integration/remi/manifests/rolling-derivative-acceptance.toml
+
+[suite]
+name = "Rolling Derivative Acceptance"
+phase = 4
+timeout = 2400
+
+[distro_overrides.cachyos]
+native_package_manager = "pacman"
+native_install = "pacman -Sy --noconfirm jq"
+native_query = "pacman -Q jq"
+native_remove = "pacman -Rns --noconfirm jq"
+
+[distro_overrides."opensuse-tumbleweed"]
+native_package_manager = "rpm"
+native_install = "zypper --non-interactive refresh && zypper --non-interactive install --no-recommends jq"
+native_query = "rpm -q jq"
+native_remove = "zypper --non-interactive remove --clean-deps jq"
+
+[[test]]
+id = "TNPMR01"
+name = "actual_native_repository_takeover_round_trip"
+description = "The target's real ALPM or Zypper declarations and signing roots pass typed preview, apply, repeat, and byte-exact rollback"
+timeout = 900
+fatal = true
+group = "rolling-derivative-acceptance"
+
+[[test.step]]
+run = "python3 /opt/remi-tests/fixtures/distro-roots/run-native-repository-takeover.py --conary ${CONARY_BIN} --config /opt/remi-tests/config.toml --target ${DISTRO} --db ${DB_PATH} --root / --evidence /tmp/conary-native-takeover-evidence.json"
+
+[test.step.assert]
+exit_code = 0
+
+[[test.step]]
+run = "python3 -c 'import json; value=json.load(open(\"/tmp/conary-native-takeover-evidence.json\")); assert value[\"schema_version\"] == 1; assert value[\"target_profile\"] == \"${DISTRO}\"; assert value[\"repositories\"] > 0; assert value[\"stages\"] == [\"preview\", \"apply\", \"repeat\", \"rollback\"]'"
+
+[test.step.assert]
+exit_code = 0
+
+[[test]]
+id = "TNPMR02"
+name = "native_query_adopt_refresh_unadopt_remove"
+description = "A real native package remains queryable across Conary adoption refresh, takeover preview, and unadoption, then native removal"
+timeout = 1200
+fatal = true
+group = "rolling-derivative-acceptance"
+depends_on = ["TNPMR01"]
+
+[[test.step]]
+run = "${native_install} && ${native_query}"
+
+[test.step.assert]
+exit_code = 0
+
+[[test.step]]
+run = "${CONARY_BIN} system adopt jq --package-manager ${native_package_manager} --db-path ${DB_PATH} --dry-run"
+
+[test.step.assert]
+exit_code = 0
+
+[[test.step]]
+run = "${CONARY_BIN} system adopt jq --package-manager ${native_package_manager} --db-path ${DB_PATH}"
+
+[test.step.assert]
+exit_code = 0
+
+[[test.step]]
+run = "${CONARY_BIN} system adopt --status --db-path ${DB_PATH}"
+
+[test.step.assert]
+exit_code = 0
+
+[[test.step]]
+run = "${CONARY_BIN} system adopt --refresh --package-manager ${native_package_manager} --db-path ${DB_PATH}"
+
+[test.step.assert]
+exit_code = 0
+
+[[test.step]]
+run = "${CONARY_BIN} system takeover --package-manager ${native_package_manager} --db-path ${DB_PATH} --dry-run"
+
+[test.step.assert]
+exit_code = 0
+
+[[test.step]]
+run = "${CONARY_BIN} system unadopt jq --db-path ${DB_PATH} --dry-run"
+
+[test.step.assert]
+exit_code = 0
+
+[[test.step]]
+run = "${CONARY_BIN} system unadopt jq --db-path ${DB_PATH} --yes"
+
+[test.step.assert]
+exit_code = 0
+
+[[test.step]]
+run = "${native_remove} && ! ${native_query}"
+
+[test.step.assert]
+exit_code = 0

--- a/crates/conary-core/src/packages/pacman_query.rs
+++ b/crates/conary-core/src/packages/pacman_query.rs
@@ -319,6 +319,13 @@ fn parse_pacman_info_field(output: &str, requested_key: &str) -> Result<String> 
     let mut value: Option<String> = None;
     let mut collecting = false;
     for (index, line) in output.lines().enumerate() {
+        if line.is_empty() {
+            // Pacman terminates each `-Qi` record with an empty separator
+            // line. An exact-name query still emits that delimiter after its
+            // sole record.
+            collecting = false;
+            continue;
+        }
         if line
             .as_bytes()
             .first()
@@ -694,6 +701,24 @@ Provides        : fixture-abi
             "glibc>=2.41  openssl zlib"
         );
         assert!(parse_pacman_info_field(output, "Missing").is_err());
+    }
+
+    #[test]
+    fn info_field_parser_accepts_pacman_record_separator() {
+        let output = "\
+Installed From  : extra
+Name            : jq
+Version         : 1.8.2-1
+Architecture    : x86_64
+Depends On      : glibc  oniguruma
+Validated By    : Signature
+
+";
+
+        assert_eq!(
+            parse_pacman_info_field(output, "Depends On").unwrap(),
+            "glibc  oniguruma"
+        );
     }
 
     #[test]

--- a/crates/conary-core/src/packages/rpm_query.rs
+++ b/crates/conary-core/src/packages/rpm_query.rs
@@ -19,7 +19,7 @@ use std::process::Command;
 use tracing::debug;
 
 const RPM_PACKAGE_RECORD_FORMAT: &str = "%{NEVRA}\x1e%{NAME}\x1e%{VERSION}\x1e%{RELEASE}\x1e%{EPOCH}\x1e%{ARCH}\x1e%{DESCRIPTION}\x1e%{SUMMARY}\x1e%{LICENSE}\x1e%{URL}\x1e%{VENDOR}\x1e%{SOURCERPM}\x1e%{BUILDHOST}\x1e%{INSTALLTIME}\x1f";
-const RPM_FILE_RECORD_FORMAT: &str = "[%{FILENAMES}\x1e%{LONGFILESIZES}\x1e%{FILEMTIMES}\x1e%{FILEDIGESTS}\x1e%{FILEMODES:octal}\x1e%{FILEUSERNAME}\x1e%{FILEGROUPNAME}\x1e%{FILELINKTOS}\x1e%{FILEFLAGS:hex}\x1f]";
+const RPM_FILE_RECORD_FORMAT: &str = "[%{FILENAMES}\x1e%{LONGFILESIZES}\x1e%{FILEMTIMES}\x1e%{FILEDIGESTS}\x1e%{FILEMODES:octal}\x1e%{FILEUSERNAME}\x1e%{FILEGROUPNAME}\x1e%{FILELINKTOS}\x1e%{FILEFLAGS:hex}\x1e%{FILESTATES}\x1f]";
 const RPM_REQUIREMENT_RECORD_FORMAT: &str =
     "[%{REQUIRENAME}\x1e%{REQUIREFLAGS:hex}\x1e%{REQUIREVERSION}\x1f]";
 const RPM_OWNER_RECORD_FORMAT: &str = "%{NAME}\x1f";
@@ -306,89 +306,106 @@ fn parse_rpm_file_records(output: &str) -> Result<Vec<InstalledFileInfo>> {
         .split('\x1f')
         .filter(|record| !record.is_empty())
         .enumerate()
-        .map(|(index, record)| {
-            let parts = record.split('\x1e').collect::<Vec<_>>();
-            if parts.len() != 9 {
-                return Err(Error::ParseError(format!(
-                    "RPM file record {} has {} fields; expected exactly 9",
-                    index + 1,
-                    parts.len()
-                )));
-            }
-            if parts[0].is_empty() {
-                return Err(Error::ParseError(format!(
-                    "RPM file record {} has an empty path",
-                    index + 1
-                )));
-            }
-            let size = parts[1].parse::<i64>().map_err(|error| {
-                Error::ParseError(format!(
-                    "RPM file record {} has invalid size {:?}: {error}",
-                    index + 1,
-                    parts[1]
-                ))
-            })?;
-            let mtime = parts[2].parse::<i64>().map_err(|error| {
-                Error::ParseError(format!(
-                    "RPM file record {} has invalid mtime {:?}: {error}",
-                    index + 1,
-                    parts[2]
-                ))
-            })?;
-            let digest = match parts[3] {
-                "" | "(none)" => None,
-                value
-                    if value.len() % 2 == 0
-                        && value.chars().all(|character| character.is_ascii_hexdigit()) =>
-                {
-                    Some(value.to_string())
-                }
-                value => {
-                    return Err(Error::ParseError(format!(
-                        "RPM file record {} has invalid digest {value:?}",
-                        index + 1
-                    )));
-                }
-            };
-            let mode = i32::from_str_radix(parts[4], 8).map_err(|error| {
-                Error::ParseError(format!(
-                    "RPM file record {} has invalid octal mode {:?}: {error}",
-                    index + 1,
-                    parts[4]
-                ))
-            })?;
-            let user = required_rpm_field(parts[5], index + 1, "FILEUSERNAME")?;
-            let group = required_rpm_field(parts[6], index + 1, "FILEGROUPNAME")?;
-            let flags = u32::from_str_radix(parts[8], 16).map_err(|error| {
-                Error::ParseError(format!(
-                    "RPM file record {} has invalid hexadecimal flags {:?}: {error}",
-                    index + 1,
-                    parts[8]
-                ))
-            })?;
-            let flags = FileFlags::from_bits_retain(flags);
-            let absence_policy = match (
-                flags.contains(FileFlags::GHOST),
-                flags.contains(FileFlags::MISSINGOK),
-            ) {
-                (false, false) => InstalledFileAbsencePolicy::Required,
-                (true, false) => InstalledFileAbsencePolicy::RpmGhost,
-                (false, true) => InstalledFileAbsencePolicy::RpmMissingOk,
-                (true, true) => InstalledFileAbsencePolicy::RpmGhostAndMissingOk,
-            };
-            Ok(InstalledFileInfo {
-                path: parts[0].to_string(),
-                size,
-                mode,
-                digest,
-                user: Some(user),
-                group: Some(group),
-                link_target: rpm_none_to_option(&parts[7]),
-                mtime: Some(mtime),
-                absence_policy,
-            })
-        })
+        .map(|(index, record)| parse_rpm_file_record(index + 1, record))
+        .filter_map(Result::transpose)
         .collect()
+}
+
+fn parse_rpm_file_record(record_number: usize, record: &str) -> Result<Option<InstalledFileInfo>> {
+    let parts = record.split('\x1e').collect::<Vec<_>>();
+    if parts.len() != 10 {
+        return Err(Error::ParseError(format!(
+            "RPM file record {record_number} has {} fields; expected exactly 10",
+            parts.len()
+        )));
+    }
+    if parts[0].is_empty() {
+        return Err(Error::ParseError(format!(
+            "RPM file record {record_number} has an empty path"
+        )));
+    }
+    let size = parts[1].parse::<i64>().map_err(|error| {
+        Error::ParseError(format!(
+            "RPM file record {record_number} has invalid size {:?}: {error}",
+            parts[1]
+        ))
+    })?;
+    let mtime = parts[2].parse::<i64>().map_err(|error| {
+        Error::ParseError(format!(
+            "RPM file record {record_number} has invalid mtime {:?}: {error}",
+            parts[2]
+        ))
+    })?;
+    let digest = match parts[3] {
+        "" | "(none)" => None,
+        value
+            if value.len() % 2 == 0
+                && value.chars().all(|character| character.is_ascii_hexdigit()) =>
+        {
+            Some(value.to_string())
+        }
+        value => {
+            return Err(Error::ParseError(format!(
+                "RPM file record {record_number} has invalid digest {value:?}"
+            )));
+        }
+    };
+    let mode = i32::from_str_radix(parts[4], 8).map_err(|error| {
+        Error::ParseError(format!(
+            "RPM file record {record_number} has invalid octal mode {:?}: {error}",
+            parts[4]
+        ))
+    })?;
+    let user = required_rpm_field(parts[5], record_number, "FILEUSERNAME")?;
+    let group = required_rpm_field(parts[6], record_number, "FILEGROUPNAME")?;
+    let flags = u32::from_str_radix(parts[8], 16).map_err(|error| {
+        Error::ParseError(format!(
+            "RPM file record {record_number} has invalid hexadecimal flags {:?}: {error}",
+            parts[8]
+        ))
+    })?;
+
+    // RPM persists the transaction result for every header file in FILESTATES.
+    // Only NORMAL (0) and NETSHARED (3) are installed payload according to
+    // RPM's own RPMFILE_IS_INSTALLED contract. REPLACED (1), NOTINSTALLED (2),
+    // and WRONGCOLOR (4) remain package metadata, not live ownership authority.
+    match parts[9].parse::<i32>() {
+        Ok(0 | 3) => {}
+        Ok(1 | 2 | 4) => return Ok(None),
+        Ok(state) => {
+            return Err(Error::ParseError(format!(
+                "RPM file record {record_number} has unsupported FILESTATES value {state}"
+            )));
+        }
+        Err(error) => {
+            return Err(Error::ParseError(format!(
+                "RPM file record {record_number} has invalid FILESTATES value {:?}: {error}",
+                parts[9]
+            )));
+        }
+    }
+
+    let flags = FileFlags::from_bits_retain(flags);
+    let absence_policy = match (
+        flags.contains(FileFlags::GHOST),
+        flags.contains(FileFlags::MISSINGOK),
+    ) {
+        (false, false) => InstalledFileAbsencePolicy::Required,
+        (true, false) => InstalledFileAbsencePolicy::RpmGhost,
+        (false, true) => InstalledFileAbsencePolicy::RpmMissingOk,
+        (true, true) => InstalledFileAbsencePolicy::RpmGhostAndMissingOk,
+    };
+    Ok(Some(InstalledFileInfo {
+        path: parts[0].to_string(),
+        size,
+        mode,
+        digest,
+        user: Some(user),
+        group: Some(group),
+        link_target: rpm_none_to_option(&parts[7]),
+        mtime: Some(mtime),
+        absence_policy,
+    }))
 }
 
 /// Query RPM's complete installed `Requires` entries as exact typed groups.
@@ -834,8 +851,8 @@ mod tests {
     #[test]
     fn file_query_uses_exact_parallel_array_records() {
         let records = parse_rpm_file_records(
-            "/usr/lib/libfixture.so\x1e42\x1e1700000000\x1eabcdef12\x1e0120777\x1eroot\x1eroot\x1elibfixture.so.1\x1e0\x1f\
-             /usr/share/fixture data\x1e0\x1e1700000001\x1e\x1e040755\x1eroot\x1eroot\x1e\x1e40\x1f",
+            "/usr/lib/libfixture.so\x1e42\x1e1700000000\x1eabcdef12\x1e0120777\x1eroot\x1eroot\x1elibfixture.so.1\x1e0\x1e0\x1f\
+             /usr/share/fixture data\x1e0\x1e1700000001\x1e\x1e040755\x1eroot\x1eroot\x1e\x1e40\x1e3\x1f",
         )
         .unwrap();
 
@@ -855,7 +872,7 @@ mod tests {
         );
 
         let zero_digest = parse_rpm_file_records(
-            "/usr/bin/zero\x1e1\x1e1700000002\x1e00000000\x1e0100755\x1eroot\x1eroot\x1e\x1e48\x1f",
+            "/usr/bin/zero\x1e1\x1e1700000002\x1e00000000\x1e0100755\x1eroot\x1eroot\x1e\x1e48\x1e0\x1f",
         )
         .unwrap();
         assert_eq!(zero_digest[0].digest.as_deref(), Some("00000000"));
@@ -865,7 +882,7 @@ mod tests {
         );
 
         let missing_ok = parse_rpm_file_records(
-            "/etc/optional\x1e1\x1e1700000002\x1e00000000\x1e0100644\x1eroot\x1eroot\x1e\x1e8\x1f",
+            "/etc/optional\x1e1\x1e1700000002\x1e00000000\x1e0100644\x1eroot\x1eroot\x1e\x1e8\x1e0\x1f",
         )
         .unwrap();
         assert_eq!(
@@ -875,17 +892,43 @@ mod tests {
     }
 
     #[test]
+    fn file_query_uses_rpms_persisted_installation_state_as_live_authority() {
+        let records = parse_rpm_file_records(
+            "/normal\x1e1\x1e1\x1e00\x1e0100644\x1eroot\x1eroot\x1e\x1e0\x1e0\x1f\
+             /replaced\x1e1\x1e1\x1e00\x1e0100644\x1eroot\x1eroot\x1e\x1e0\x1e1\x1f\
+             /not-installed\x1e1\x1e1\x1e00\x1e0100644\x1eroot\x1eroot\x1e\x1e0\x1e2\x1f\
+             /net-shared\x1e1\x1e1\x1e00\x1e0100644\x1eroot\x1eroot\x1e\x1e0\x1e3\x1f\
+             /wrong-color\x1e1\x1e1\x1e00\x1e0100644\x1eroot\x1eroot\x1e\x1e0\x1e4\x1f",
+        )
+        .unwrap();
+
+        assert_eq!(
+            records
+                .iter()
+                .map(|record| record.path.as_str())
+                .collect::<Vec<_>>(),
+            ["/normal", "/net-shared"]
+        );
+    }
+
+    #[test]
     fn file_query_rejects_malformed_parallel_array_records() {
         assert!(parse_rpm_file_records("/usr/bin/fixture\x1e42\x1f").is_err());
         assert!(
             parse_rpm_file_records(
-                "/usr/bin/fixture\x1e42\x1e1700000000\x1enot-a-digest\x1e0100755\x1eroot\x1eroot\x1e\x1e0\x1f"
+                "/usr/bin/fixture\x1e42\x1e1700000000\x1enot-a-digest\x1e0100755\x1eroot\x1eroot\x1e\x1e0\x1e0\x1f"
             )
             .is_err()
         );
         assert!(
             parse_rpm_file_records(
-                "/usr/bin/fixture\x1e42\x1e1700000000\x1eabcdef12\x1e0100755\x1eroot\x1eroot\x1e\x1enot-hex\x1f"
+                "/usr/bin/fixture\x1e42\x1e1700000000\x1eabcdef12\x1e0100755\x1eroot\x1eroot\x1e\x1enot-hex\x1e0\x1f"
+            )
+            .is_err()
+        );
+        assert!(
+            parse_rpm_file_records(
+                "/usr/bin/fixture\x1e42\x1e1700000000\x1eabcdef12\x1e0100755\x1eroot\x1eroot\x1e\x1e0\x1e5\x1f"
             )
             .is_err()
         );

--- a/crates/conary-core/src/repository/declarations/takeover.rs
+++ b/crates/conary-core/src/repository/declarations/takeover.rs
@@ -34,7 +34,9 @@ use projection::{
     ensure_projection_inputs_unchanged, load_current_projections, load_prior_projections,
     persist_staged, projection_drift, restore_projection_bytes, stage_projection_writes,
 };
-use trust_policy::{expected_trust_policy, explicit_apt_global_trust_paths};
+use trust_policy::{
+    expected_trust_policy, explicit_apt_global_trust_paths, explicit_zypper_global_trust_paths,
+};
 
 pub const TAKEOVER_MANIFEST_SCHEMA: u32 = 1;
 pub const TAKEOVER_PREVIEW_SCHEMA: u32 = 1;

--- a/crates/conary-core/src/repository/declarations/takeover/conformance_tests.rs
+++ b/crates/conary-core/src/repository/declarations/takeover/conformance_tests.rs
@@ -236,13 +236,14 @@ fn tumbleweed_fixture() -> (
 ) {
     let root = tempfile::tempdir().unwrap();
     fs::create_dir_all(root.path().join("etc/zypp/repos.d")).unwrap();
-    fs::create_dir_all(root.path().join("etc/pki/rpm-gpg")).unwrap();
-    let (certificate, _) = certificate();
-    fs::write(root.path().join("etc/pki/rpm-gpg/TUMBLEWEED"), certificate).unwrap();
+    fs::create_dir_all(root.path().join("usr/lib/rpm/gnupg/keys")).unwrap();
+    let (certificate, fingerprint) = certificate();
+    let key_path = root.path().join("usr/lib/rpm/gnupg/keys/TUMBLEWEED");
+    fs::write(&key_path, certificate).unwrap();
     let declaration_path = root.path().join("etc/zypp/repos.d/tumbleweed.repo");
     fs::write(
         &declaration_path,
-        "[repo-oss]\nname=Main Repository (OSS)\nenabled=1\nautorefresh=1\nbaseurl=https://download.example/tumbleweed/repo/oss/\npriority=47\ngpgcheck=1\nrepo_gpgcheck=1\npkg_gpgcheck=1\ngpgkey=file:///etc/pki/rpm-gpg/TUMBLEWEED\n",
+        "[repo-oss]\nname=Main Repository (OSS)\nenabled=1\nautorefresh=1\nbaseurl=https://download.example/tumbleweed/repo/oss/\npriority=47\n",
     )
     .unwrap();
     let db_path = root.path().join("conary.db");
@@ -251,14 +252,22 @@ fn tumbleweed_fixture() -> (
     let declarations = discover_selected_root(root.path()).unwrap();
     let trust = plan_selected_root_trust(&declarations);
     let reference = trust.repositories[0].repository.clone();
-    let policy = expected_trust_policy(
-        root.path(),
-        &declarations,
-        &trust.repositories[0],
-        RepositoryFormat::Fedora,
-    )
-    .unwrap()
-    .unwrap();
+    assert!(matches!(
+        trust.repositories[0].disposition,
+        TrustImportDisposition::Ambiguous { ref findings }
+            if findings.iter().all(|finding|
+                finding.kind == TrustImportFindingKind::MissingRequiredAuthority)
+    ));
+    let roots = vec![OpenPgpTrustRoot {
+        url: url::Url::from_file_path(&key_path).unwrap().to_string(),
+        fingerprint,
+    }];
+    let policy = RepositoryTrustPolicy::Rpm {
+        metadata: RpmMetadataAuthority::OpenPgp {
+            keys: roots.clone(),
+        },
+        package_keys: roots,
+    };
     let manifest = NativeRepositoryTakeoverManifest {
         schema: TAKEOVER_MANIFEST_SCHEMA,
         repositories: vec![TakeoverRepositoryInput {
@@ -493,6 +502,22 @@ fn tumbleweed_preserves_zypper_authority_and_advances_rolling_snapshots() {
         Some(second)
     );
     assert_eq!(fs::read(declaration_path).unwrap(), declaration_before);
+}
+
+#[test]
+fn tumbleweed_global_trust_binding_rejects_unmodeled_zypp_overrides() {
+    let (root, conn, manifest) = tumbleweed_fixture();
+    fs::write(
+        root.path().join("etc/zypp/zypp.conf"),
+        "[main]\ngpgcheck = off\n",
+    )
+    .unwrap();
+
+    let preview = preview_native_repository_takeover(&conn, root.path(), &manifest).unwrap();
+    assert!(preview.blockers.iter().any(|blocker| matches!(
+        blocker,
+        TakeoverBlocker::EnabledTrust { .. } | TakeoverBlocker::TrustPolicyMismatch { .. }
+    )));
 }
 
 #[test]

--- a/crates/conary-core/src/repository/declarations/takeover/enrollment.rs
+++ b/crates/conary-core/src/repository/declarations/takeover/enrollment.rs
@@ -43,7 +43,13 @@ pub(super) fn validate_enrollments(
                 input.declaration == plan.repository
                     && (explicit_alpm_trust_resolves(plan, &input.trust)
                         || explicit_apt_global_trust_paths(&declarations.root, plan, &input.trust)
-                            .is_some())
+                            .is_some()
+                        || explicit_zypper_global_trust_paths(
+                            &declarations.root,
+                            plan,
+                            &input.trust,
+                        )
+                        .is_some())
             })
         {
             blockers.push(TakeoverBlocker::EnabledTrust {
@@ -111,6 +117,8 @@ fn validate_input_contract(
         } else {
             explicit_alpm_trust_resolves(plan, &input.trust)
                 || explicit_apt_global_trust_paths(&declarations.root, plan, &input.trust).is_some()
+                || explicit_zypper_global_trust_paths(&declarations.root, plan, &input.trust)
+                    .is_some()
         };
         if !trust_matches {
             blockers.push(TakeoverBlocker::TrustPolicyMismatch {

--- a/crates/conary-core/src/repository/declarations/takeover/projection.rs
+++ b/crates/conary-core/src/repository/declarations/takeover/projection.rs
@@ -93,6 +93,13 @@ pub(super) fn collect_projection_content(
                     sources.push((path.clone(), fs::read(safe_join(selected_root, &path)?)?));
                 }
             }
+            if let Some(paths) =
+                explicit_zypper_global_trust_paths(selected_root, plan, &input.trust)
+            {
+                for path in paths {
+                    sources.push((path.clone(), fs::read(safe_join(selected_root, &path)?)?));
+                }
+            }
         }
     }
     sources.sort_by(|left, right| left.0.cmp(&right.0));

--- a/crates/conary-core/src/repository/declarations/takeover/trust_policy.rs
+++ b/crates/conary-core/src/repository/declarations/takeover/trust_policy.rs
@@ -125,6 +125,86 @@ pub(super) fn explicit_apt_global_trust_paths(
     Some(paths.into_iter().collect())
 }
 
+/// Resolve Zypper's documented global-on signature defaults through an exact
+/// manifest binding to the native RPM key store. This is intentionally valid
+/// only when no global zypp.conf overrides exist and every ambiguous finding
+/// is one of the two facts the manifest closes: inherited verification or an
+/// absent per-repository gpgkey.
+pub(super) fn explicit_zypper_global_trust_paths(
+    selected_root: &Path,
+    plan: &NativeRepositoryTrustPlan,
+    trust: &RepositoryTrustPolicy,
+) -> Option<Vec<PathBuf>> {
+    if !matches!(plan.repository, NativeRepositoryReference::Zypper { .. })
+        || safe_join(selected_root, Path::new("/etc/zypp/zypp.conf"))
+            .ok()?
+            .exists()
+    {
+        return None;
+    }
+    let TrustImportDisposition::Ambiguous { findings } = &plan.disposition else {
+        return None;
+    };
+    if findings.is_empty()
+        || findings
+            .iter()
+            .any(|finding| finding.kind != TrustImportFindingKind::MissingRequiredAuthority)
+    {
+        return None;
+    }
+    let RepositoryTrustPolicy::Rpm {
+        metadata: RpmMetadataAuthority::OpenPgp {
+            keys: metadata_keys,
+        },
+        package_keys,
+    } = trust
+    else {
+        return None;
+    };
+    if metadata_keys.is_empty() || metadata_keys != package_keys {
+        return None;
+    }
+
+    exact_native_rpm_key_paths(selected_root, metadata_keys)
+}
+
+fn exact_native_rpm_key_paths(
+    selected_root: &Path,
+    roots: &[OpenPgpTrustRoot],
+) -> Option<Vec<PathBuf>> {
+    let mut paths = BTreeSet::new();
+    for root in roots {
+        root.validate().ok()?;
+        let url = url::Url::parse(&root.url).ok()?;
+        if url.scheme() != "file" {
+            return None;
+        }
+        let host_path = url.to_file_path().ok()?;
+        let relative = host_path.strip_prefix(selected_root).ok()?;
+        let guest_path = Path::new("/").join(relative);
+        if guest_path.parent() != Some(Path::new("/usr/lib/rpm/gnupg/keys"))
+            || safe_join(selected_root, &guest_path).ok()? != host_path
+        {
+            return None;
+        }
+        let bytes = fs::read(&host_path).ok()?;
+        let parser = CertParser::from_bytes(&bytes).ok()?;
+        let mut matched = false;
+        for certificate in parser {
+            let certificate = certificate.ok()?;
+            if certificate.fingerprint().to_hex() == root.fingerprint {
+                matched = true;
+                break;
+            }
+        }
+        if !matched {
+            return None;
+        }
+        paths.insert(guest_path);
+    }
+    Some(paths.into_iter().collect())
+}
+
 fn is_apt_global_trust_path(path: &Path) -> bool {
     if path == Path::new("/etc/apt/trusted.gpg") {
         return true;

--- a/docs/modules/test-fixtures.md
+++ b/docs/modules/test-fixtures.md
@@ -404,8 +404,12 @@ Each fixture family should record:
   lifecycle suite on every configured target for complete target-image
   coverage. Linux Mint 22.3 and Pop!_OS 24.04 additionally run
   `debian-derivative-acceptance`, which exercises their actual APT declarations,
-  trust roots, native package adoption, and repository takeover. `fedora44` is the
-  existing `conary-test` runner distro key; public CCS target IDs remain
+  trust roots, native package adoption, and repository takeover. CachyOS and
+  openSUSE Tumbleweed additionally run `rolling-derivative-acceptance`, which
+  authenticates their first-party image identity, native package versions,
+  repository declaration bytes, and signing roots before real pacman or Zypper
+  package adoption and exact repository takeover. `fedora44` is the existing
+  `conary-test` runner distro key; public CCS target IDs remain
   `fedora-44`, `ubuntu-26.04`, and `arch`.
   Published artifacts use
   `cargo run -p conary-test -- images build --distro <distro> --native-package <path>`

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -58,6 +58,14 @@ contract.
 System adoption is a migration-continuity feature for machines that already
 have native package-manager state. It is not the cross-distro product path and
 does not count as proof that conversion or source-independent execution works.
+For RPM adoption, the installed database's parallel `FILESTATES` array is the
+live-payload authority. Conary admits `NORMAL` and `NETSHARED`, the two states
+RPM itself defines as installed, and excludes `REPLACED`, `NOTINSTALLED`, and
+`WRONGCOLOR` records from capture. This preserves transactions such as
+`--excludedocs` without treating an intentionally uninstalled header entry as
+missing payload, and without capturing another package's replacement bytes.
+Unknown states fail closed. The pinned contract is RPM 4.20.1's
+[`rpmfileState` and `RPMFILE_IS_INSTALLED`](https://github.com/rpm-software-management/rpm/blob/c8dc5ea575a2e9c1488036d12f4b75f6a5a49120/include/rpm/rpmfiles.h#L31-L43).
 The explicit adoption-to-CCS bridge is valid only after Conary re-resolves an
 immutable source artifact from enrolled authority and proves its typed identity
 and complete payload equal the adopted record. It then enters the same parser,

--- a/docs/specs/native-repository-takeover.md
+++ b/docs/specs/native-repository-takeover.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-12
-revision: 4
-summary: Define deterministic native repository takeover, exact legacy APT trust binding, owned projections, drift detection, and rollback
+revision: 5
+summary: Define deterministic native repository takeover, exact APT and Zypper global trust binding, owned projections, drift detection, and rollback
 ---
 
 # Native Repository Takeover And Projections
@@ -10,7 +10,8 @@ summary: Define deterministic native repository takeover, exact legacy APT trust
 
 Issue #381 established the fourth bounded W10 slice. Issue #384 extended its
 model conformance boundary; issue #396 owns execution on authentic Linux Mint
-and Pop!_OS roots. Takeover consumes lossless selected-root
+and Pop!_OS roots, while issue #398 extends that proof to CachyOS and openSUSE
+Tumbleweed. Takeover consumes lossless selected-root
 declarations, their trust-import dispositions, and an explicit versioned
 enrollment manifest. It produces a complete preview before mutation and can
 then make Conary the sole repository authority while preserving the native
@@ -75,6 +76,18 @@ the named certificate must exist in those exact bytes, and every other trust
 finding remains non-overridable. This preserves legacy distro declarations
 without treating the whole global keyring or a filename as repository trust.
 
+Zypper repositories may omit per-repository `gpgcheck`, `repo_gpgcheck`,
+`pkg_gpgcheck`, and `gpgkey` because
+[libzypp's canonical configuration](https://github.com/openSUSE/libzypp/blob/master/zypp.conf)
+documents globally enabled signature checking and per-repository overrides. An enrollment manifest may resolve only the
+resulting `MissingRequiredAuthority` findings when `/etc/zypp/zypp.conf` is
+absent, both RPM roles name the same exact primary fingerprints, and every file
+URL resolves directly below `/usr/lib/rpm/gnupg/keys/` in the selected root.
+Any explicit global override, disabled verification, different ambiguity, key
+outside that native store, or missing certificate remains a blocker. This
+models Tumbleweed's native authority without inferring trust from its distro
+name or repository aliases.
+
 ## Apply And Projection Ownership
 
 Apply consumes the exact preview digest. Before mutation it repeats discovery
@@ -84,7 +97,7 @@ the lossless grammar. Selected-root key files referenced by importable trust
 evidence become owned projections too. APT embedded OpenPGP blocks remain in
 their exact declaration projection and are persisted as bounded exact
 `application/pgp-keys` data authority for Conary's pinned certificate loader.
-Exact native global-keyring files admitted by an explicit legacy APT binding
+Exact native global-keyring files admitted by an explicit APT or Zypper binding
 also become owned projections.
 Projection content is persisted beside its SHA-256 and prior path state;
 subsequent operations render from that persisted Conary authority rather than
@@ -153,8 +166,10 @@ Clippy, formatting, current-schema rejection/rebuild proof, and documentation
 truth checks remain required.
 
 The model conformance corpus covers APT, ALPM, and Zypper derivative shapes.
-Authentic Linux Mint and Pop!_OS execution is a separate target gate: it must
-retain release-owned declaration and signing-root bytes, exercise typed
-preview/apply/repeat/rollback, and must not use a distro-name selector in
-product code. A configured lane is not verified evidence until its exact-head
+Authentic Linux Mint, Pop!_OS, CachyOS, and openSUSE Tumbleweed execution is a
+separate target gate: it must retain release-owned declaration and signing-root
+bytes, exercise typed preview/apply/repeat/rollback, and must not use a
+distro-name selector in product code. CachyOS additionally binds its CachyOS
+and Arch ALPM keyrings through exact master fingerprints and certification
+thresholds. A configured lane is not verified evidence until its exact-head
 hosted result passes.


### PR DESCRIPTION
Closes #398

## What changed

- add digest-pinned CachyOS and openSUSE Tumbleweed container lanes
- authenticate target os-release identity, installed package versions, repository declaration bytes, signing roots, and the running Conary artifact
- add real pacman/Zypper query, install, adoption, refresh, takeover-preview, unadoption, and removal acceptance
- add typed preview/apply/repeat/rollback proof for the native ALPM and Zypper repository universes
- model libzypp's documented global-on trust semantics with exact selected-root RPM key-store bindings
- honor RPM's persisted FILESTATES authority when capturing installed payload
- extend the required cross-source lifecycle matrix to both targets

## Why

CachyOS and Tumbleweed are important rolling derivatives of Conary's accepted ALPM and RPM package ecosystems. A distro-name alias is not proof: both targets need their authentic declarations, trust roots, package managers, and complete cross-source lifecycle exercised.

## Local verification

- `cargo run -p conary-test -- list`
- `cargo test -p conary-test` (304 passed, 1 ignored; CLI 14 passed)
- `cargo test -p conary-core repository::declarations:: -- --nocapture` (58 passed)
- `cargo test -p conary-core packages::rpm_query::tests` (18 passed)
- `cargo test -p conary adopt::cas_capture` (12 passed)
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p conary-core -p conary --all-targets -- -D warnings`
- `bash scripts/check-doc-truth.sh`
- live-root CachyOS repository takeover: 4 repositories, preview/apply/repeat/rollback, 3 byte-exact projections
- live-root Tumbleweed repository takeover: 6 repositories, preview/apply/repeat/rollback, 11 byte-exact projections

## Hosted verification

- exact head `45e942b5fb4402926f2585ece3e3d274336193b3`
- `pr-gate` run 31630545590: 20 of 20 jobs passed
- CachyOS: authenticated target evidence, Cartesian cross-source lifecycle, repository takeover, native query/adopt/refresh/unadopt/remove
- openSUSE Tumbleweed: authenticated target evidence, Cartesian cross-source lifecycle, repository takeover, native query/adopt/refresh/unadopt/remove
