### PR TITLE
fix(ci): restore resolver and Tumbleweed gates

### DIFF
--- a/apps/conary-test/src/config/tests/release_roots.rs
+++ b/apps/conary-test/src/config/tests/release_roots.rs
@@ -121,15 +121,15 @@ fn rolling_roots_carry_authenticated_native_authority() {
             .as_deref(),
         Some("arch")
     );
-    assert_eq!(
-        config.distros["opensuse-tumbleweed"]
-            .target_root
-            .as_ref()
-            .unwrap()
-            .expected_os_release
-            .id,
-        "opensuse-tumbleweed"
-    );
+    let tumbleweed = config.distros["opensuse-tumbleweed"]
+        .target_root
+        .as_ref()
+        .unwrap();
+    assert_eq!(tumbleweed.expected_os_release.id, "opensuse-tumbleweed");
+    assert!(tumbleweed.base_image.contains(&format!(
+        ":{}@sha256:",
+        tumbleweed.expected_os_release.version_id
+    )));
 }
 
 #[test]

--- a/apps/conary/tests/integration/remi/config.toml
+++ b/apps/conary/tests/integration/remi/config.toml
@@ -114,7 +114,7 @@ test_packages = [
 ]
 
 [distros."opensuse-tumbleweed".target_root]
-base_image = "registry.opensuse.org/opensuse/tumbleweed:latest@sha256:ed1053df8889aa5a6191aa19f9af9593d1c783674e8ca1dbb55d6c75e75dc306"
+base_image = "registry.opensuse.org/opensuse/tumbleweed:20260811@sha256:47903f56b5c63e7a000db16649cc4e9f71f1293e4aac8adc0df7e1a44c26212e"
 package_query = "rpm"
 identity_packages = [
     { name = "openSUSE-release", version = "20260811-4247.1" },

--- a/crates/conary-core/src/resolver/provider/expression.rs
+++ b/crates/conary-core/src/resolver/provider/expression.rs
@@ -24,7 +24,7 @@ struct Literal {
 
 #[derive(Debug, Clone)]
 enum NormalExpression {
-    Literal(Literal),
+    Literal(Box<Literal>),
     And(Vec<NormalExpression>),
     Or(Vec<NormalExpression>),
 }
@@ -183,10 +183,10 @@ impl ConaryProvider<'_> {
 
 fn to_normal_form(expression: &SolverExpression, negated: bool) -> NormalExpression {
     match expression {
-        SolverExpression::Atom(atom) => NormalExpression::Literal(Literal {
+        SolverExpression::Atom(atom) => NormalExpression::Literal(Box::new(Literal {
             atom: atom.clone(),
             positive: !negated,
-        }),
+        })),
         SolverExpression::And(operands) => {
             let operands = operands
                 .iter()
@@ -215,7 +215,7 @@ fn to_normal_form(expression: &SolverExpression, negated: bool) -> NormalExpress
 
 fn to_cnf(expression: &NormalExpression) -> Vec<Vec<Literal>> {
     match expression {
-        NormalExpression::Literal(literal) => vec![vec![literal.clone()]],
+        NormalExpression::Literal(literal) => vec![vec![literal.as_ref().clone()]],
         NormalExpression::And(operands) => operands.iter().flat_map(to_cnf).collect(),
         NormalExpression::Or(operands) => {
             let mut operands = operands.iter();


### PR DESCRIPTION
## Outcome

Restore the required workspace and lifecycle gates on current main:

- box the private normalized-expression literal leaf so Rust 1.97 accepts the resolver under `-D warnings`;
- bind the openSUSE Tumbleweed root to retained release `20260811` and its immutable manifest-list digest, with a contract assertion tying the tag to expected `VERSION_ID`.

The public solver grammar, CNF normalization, persisted state, and repository contracts are unchanged.

Closes #404
Closes #407

## Root causes

`NormalExpression::Literal` stored a large `Literal` inline while `And` and `Or` store 24-byte vectors. Rust 1.97's `large_enum_variant` lint rejected that representation under the required workspace gate.

The Tumbleweed fixture asserted release `20260811` but referenced moving tag `latest` with a digest subsequently removed by the official registry. The retained release tag resolves at immutable manifest-list digest `sha256:47903f56b5c63e7a000db16649cc4e9f71f1293e4aac8adc0df7e1a44c26212e`.

## Verification

- `CARGO_TARGET_DIR=/conary/dev/cache/target/Conary-404 cargo test -p conary-core resolver::provider -- --nocapture` - 32 passed.
- `CARGO_TARGET_DIR=/conary/dev/cache/target/Conary-404 cargo clippy --workspace --all-targets -- -D warnings` - passed.
- `cargo test -p conary-test config::tests::release_roots -- --nocapture` - 6 passed.
- Official registry manifest request - HTTP 200 and exact `Docker-Content-Digest` match.
- Combined exact-head `pr-gate` run 31667615336 - all 20 jobs passed, including Tumbleweed image pull/build, Cartesian lifecycle parity, attributable evidence, authenticated rolling-repository behavior, and evidence verification.
- `cargo fmt --all --check` - passed.
- `git diff --check` - passed.

PR #408 supplied the separately reviewed Tumbleweed fixture patch and was squash-merged into this branch after the combined-head gate passed. This main-targeted PR now owns final integration and exact-head CI for both fixes.
