### PR TITLE
fix(test): pin retained Tumbleweed release image

### DIFF
--- a/apps/conary-test/src/config/tests/release_roots.rs
+++ b/apps/conary-test/src/config/tests/release_roots.rs
@@ -121,15 +121,15 @@ fn rolling_roots_carry_authenticated_native_authority() {
             .as_deref(),
         Some("arch")
     );
-    assert_eq!(
-        config.distros["opensuse-tumbleweed"]
-            .target_root
-            .as_ref()
-            .unwrap()
-            .expected_os_release
-            .id,
-        "opensuse-tumbleweed"
-    );
+    let tumbleweed = config.distros["opensuse-tumbleweed"]
+        .target_root
+        .as_ref()
+        .unwrap();
+    assert_eq!(tumbleweed.expected_os_release.id, "opensuse-tumbleweed");
+    assert!(tumbleweed.base_image.contains(&format!(
+        ":{}@sha256:",
+        tumbleweed.expected_os_release.version_id
+    )));
 }
 
 #[test]

--- a/apps/conary/tests/integration/remi/config.toml
+++ b/apps/conary/tests/integration/remi/config.toml
@@ -114,7 +114,7 @@ test_packages = [
 ]
 
 [distros."opensuse-tumbleweed".target_root]
-base_image = "registry.opensuse.org/opensuse/tumbleweed:latest@sha256:ed1053df8889aa5a6191aa19f9af9593d1c783674e8ca1dbb55d6c75e75dc306"
+base_image = "registry.opensuse.org/opensuse/tumbleweed:20260811@sha256:47903f56b5c63e7a000db16649cc4e9f71f1293e4aac8adc0df7e1a44c26212e"
 package_query = "rpm"
 identity_packages = [
     { name = "openSUSE-release", version = "20260811-4247.1" },


### PR DESCRIPTION
## Outcome

Bind the openSUSE Tumbleweed integration root to the retained `20260811` registry tag and its exact immutable manifest-list digest. Add a contract assertion that the image tag stays aligned with the target root's expected `VERSION_ID`.

Closes #407

## Root cause

The fixture asserted Tumbleweed release `20260811` but referenced the moving `latest` tag with a digest that the official registry subsequently garbage-collected. Both #405 and #406 failed with `manifest unknown` after all three bounded pull attempts, before any Conary image build or test execution.

The official registry retains `20260811` at manifest-list digest `sha256:47903f56b5c63e7a000db16649cc4e9f71f1293e4aac8adc0df7e1a44c26212e`.

## Verification

- Official registry manifest request — HTTP 200; returned `Docker-Content-Digest` exactly matches the pinned digest.
- `cargo test -p conary-test config::tests::release_roots::rolling_roots_carry_authenticated_native_authority -- --exact --nocapture` — 1 passed.
- `cargo test -p conary-test config::tests::release_roots -- --nocapture` — 6 passed.
- `cargo run -p conary-test -- list` — Rolling Derivative Acceptance listed.
- `bash scripts/check-doc-truth.sh` — passed.
- `cargo fmt --all --check` — passed.
- `git diff --check` — passed.

The hosted Tumbleweed lifecycle lane remains the terminal pull, target-evidence, and behavior proof.
