### PR TITLE
fix(ccs): serialize local-dev key initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,6 +1017,7 @@ dependencies = [
  "const-oid 0.10.2",
  "ed25519-dalek",
  "flate2",
+ "fs2",
  "glob",
  "hex",
  "indicatif",

--- a/apps/conary/Cargo.toml
+++ b/apps/conary/Cargo.toml
@@ -41,6 +41,7 @@ chrono.workspace = true
 indicatif.workspace = true
 console = "0.16"
 tempfile.workspace = true
+fs2.workspace = true
 uuid.workspace = true
 base64.workspace = true
 toml.workspace = true

--- a/apps/conary/src/commands/ccs/local_dev.rs
+++ b/apps/conary/src/commands/ccs/local_dev.rs
@@ -2,11 +2,14 @@
 
 use anyhow::{Context, Result};
 use conary_core::ccs::signing::SigningKeyPair;
+use fs2::FileExt;
+use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 
 pub struct LocalDevKeyPaths {
     pub private: PathBuf,
     pub public: PathBuf,
+    lock: PathBuf,
 }
 
 pub fn local_dev_key_paths() -> Result<LocalDevKeyPaths> {
@@ -20,21 +23,85 @@ pub fn local_dev_key_paths() -> Result<LocalDevKeyPaths> {
     Ok(LocalDevKeyPaths {
         private: base.join("local-dev-key.private.toml"),
         public: base.join("local-dev-key.public.toml"),
+        lock: base.join("local-dev-key.lock"),
     })
 }
 
 pub fn load_or_create_local_dev_key() -> Result<SigningKeyPair> {
     let paths = local_dev_key_paths()?;
-    if paths.private.exists() {
-        return SigningKeyPair::load_from_file(&paths.private)
-            .map_err(anyhow::Error::from)
-            .with_context(|| format!("load local-dev key {}", paths.private.display()));
+    load_or_create_local_dev_key_at(&paths)
+}
+
+fn load_or_create_local_dev_key_at(paths: &LocalDevKeyPaths) -> Result<SigningKeyPair> {
+    let _lock = acquire_initialization_lock(&paths.lock)?;
+    if let Some(key) = load_authoritative_key(paths)? {
+        return Ok(key);
     }
+
     let key = SigningKeyPair::generate().with_key_id("local-dev");
     key.save_to_files(&paths.private, &paths.public)
         .map_err(anyhow::Error::from)
         .with_context(|| format!("write local-dev key {}", paths.private.display()))?;
     Ok(key)
+}
+
+fn load_authoritative_key(paths: &LocalDevKeyPaths) -> Result<Option<SigningKeyPair>> {
+    let private_exists = paths
+        .private
+        .try_exists()
+        .with_context(|| format!("inspect local-dev key {}", paths.private.display()))?;
+
+    if !private_exists {
+        return Ok(None);
+    }
+
+    let key = SigningKeyPair::load_from_file(&paths.private)
+        .map_err(anyhow::Error::from)
+        .with_context(|| format!("load local-dev key {}", paths.private.display()))?;
+    key.save_public_key_to_file(&paths.public)
+        .map_err(anyhow::Error::from)
+        .with_context(|| {
+            format!(
+                "repair local-dev public key {} from {}",
+                paths.public.display(),
+                paths.private.display()
+            )
+        })?;
+    Ok(Some(key))
+}
+
+fn acquire_initialization_lock(path: &Path) -> Result<File> {
+    let parent = path
+        .parent()
+        .context("local-dev key lock must have a parent directory")?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("create local-dev key directory {}", parent.display()))?;
+
+    let mut options = OpenOptions::new();
+    options.read(true).write(true).create(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options
+            .mode(0o600)
+            .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+    }
+    let file = options
+        .open(path)
+        .with_context(|| format!("open local-dev key lock {}", path.display()))?;
+    if !file
+        .metadata()
+        .with_context(|| format!("inspect local-dev key lock {}", path.display()))?
+        .is_file()
+    {
+        anyhow::bail!(
+            "local-dev key lock is not a regular file: {}",
+            path.display()
+        );
+    }
+    file.lock_exclusive()
+        .with_context(|| format!("lock local-dev key initialization {}", path.display()))?;
+    Ok(file)
 }
 
 pub fn write_local_dev_policy(path: &Path, key: &SigningKeyPair) -> Result<()> {
@@ -50,27 +117,45 @@ pub fn write_local_dev_policy(path: &Path, key: &SigningKeyPair) -> Result<()> {
 
 pub fn local_dev_trust_policy() -> Result<Option<conary_core::ccs::verify::TrustPolicy>> {
     let paths = local_dev_key_paths()?;
-    if !paths.public.exists() {
+    let private_exists = paths
+        .private
+        .try_exists()
+        .with_context(|| format!("inspect local-dev key {}", paths.private.display()))?;
+    let lock_exists = paths
+        .lock
+        .try_exists()
+        .with_context(|| format!("inspect local-dev key lock {}", paths.lock.display()))?;
+    if !private_exists && !lock_exists {
         return Ok(None);
     }
+    local_dev_trust_policy_at(&paths)
+}
 
-    #[derive(serde::Deserialize)]
-    struct PublicKeyFile {
-        key: String,
-    }
-
-    let public_text = std::fs::read_to_string(&paths.public)
-        .with_context(|| format!("read local-dev public key {}", paths.public.display()))?;
-    let public_key: PublicKeyFile = toml::from_str(&public_text)
-        .with_context(|| format!("parse local-dev public key {}", paths.public.display()))?;
+fn local_dev_trust_policy_at(
+    paths: &LocalDevKeyPaths,
+) -> Result<Option<conary_core::ccs::verify::TrustPolicy>> {
+    let _lock = acquire_initialization_lock(&paths.lock)?;
+    let Some(key) = load_authoritative_key(paths)? else {
+        return Ok(None);
+    };
     Ok(Some(conary_core::ccs::verify::TrustPolicy::strict(vec![
-        public_key.key,
+        key.public_key_base64(),
     ])))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use conary_core::ccs::signing::load_signing_public_key;
+    use std::sync::{Arc, Barrier};
+
+    fn key_paths(directory: &Path) -> LocalDevKeyPaths {
+        LocalDevKeyPaths {
+            private: directory.join("local-dev-key.private.toml"),
+            public: directory.join("local-dev-key.public.toml"),
+            lock: directory.join("local-dev-key.lock"),
+        }
+    }
 
     #[test]
     fn local_dev_policy_trusts_generated_public_key() {
@@ -82,5 +167,107 @@ mod tests {
         let policy = conary_core::ccs::verify::TrustPolicy::from_file(&policy_path).unwrap();
 
         assert_eq!(policy.trusted_keys(), &[key.public_key_base64()]);
+    }
+
+    #[test]
+    fn old_check_then_write_order_returns_distinct_first_use_authorities() {
+        const CALLERS: usize = 8;
+        let temp = tempfile::tempdir().unwrap();
+        let paths = Arc::new(key_paths(temp.path()));
+        let checked_missing = Arc::new(Barrier::new(CALLERS));
+
+        let handles = (0..CALLERS)
+            .map(|_| {
+                let paths = Arc::clone(&paths);
+                let checked_missing = Arc::clone(&checked_missing);
+                std::thread::spawn(move || {
+                    assert!(!paths.private.exists());
+                    checked_missing.wait();
+                    let key = SigningKeyPair::generate().with_key_id("local-dev");
+                    key.save_to_files(&paths.private, &paths.public).unwrap();
+                    key.public_key_base64()
+                })
+            })
+            .collect::<Vec<_>>();
+        let authorities = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .collect::<std::collections::BTreeSet<_>>();
+
+        assert_eq!(authorities.len(), CALLERS);
+    }
+
+    #[test]
+    fn concurrent_first_use_returns_one_authoritative_key() {
+        const CALLERS: usize = 16;
+        let temp = tempfile::tempdir().unwrap();
+        let paths = Arc::new(key_paths(temp.path()));
+        let start = Arc::new(Barrier::new(CALLERS));
+
+        let handles = (0..CALLERS)
+            .map(|_| {
+                let paths = Arc::clone(&paths);
+                let start = Arc::clone(&start);
+                std::thread::spawn(move || {
+                    start.wait();
+                    load_or_create_local_dev_key_at(&paths)
+                        .unwrap()
+                        .public_key_base64()
+                })
+            })
+            .collect::<Vec<_>>();
+        let authorities = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .collect::<std::collections::BTreeSet<_>>();
+
+        assert_eq!(authorities.len(), 1);
+        let persisted = load_signing_public_key(&paths.public).unwrap();
+        assert_eq!(persisted.public_key_base64(), authorities.first().unwrap());
+    }
+
+    #[test]
+    fn existing_private_key_repairs_mismatched_public_projection() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = key_paths(temp.path());
+        let authoritative = SigningKeyPair::generate().with_key_id("local-dev");
+        let stale = SigningKeyPair::generate().with_key_id("local-dev");
+        authoritative
+            .save_to_files(&paths.private, &paths.public)
+            .unwrap();
+        stale.save_public_key_to_file(&paths.public).unwrap();
+
+        let loaded = load_or_create_local_dev_key_at(&paths).unwrap();
+        let projected = load_signing_public_key(&paths.public).unwrap();
+
+        assert_eq!(
+            loaded.public_key_base64(),
+            authoritative.public_key_base64()
+        );
+        assert_eq!(
+            projected.public_key_base64(),
+            authoritative.public_key_base64()
+        );
+    }
+
+    #[test]
+    fn trust_policy_repairs_and_uses_authoritative_private_key() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = key_paths(temp.path());
+        let authoritative = SigningKeyPair::generate().with_key_id("local-dev");
+        let stale = SigningKeyPair::generate().with_key_id("local-dev");
+        authoritative
+            .save_to_files(&paths.private, &paths.public)
+            .unwrap();
+        stale.save_public_key_to_file(&paths.public).unwrap();
+
+        let policy = local_dev_trust_policy_at(&paths).unwrap().unwrap();
+        let projected = load_signing_public_key(&paths.public).unwrap();
+
+        assert_eq!(policy.trusted_keys(), &[authoritative.public_key_base64()]);
+        assert_eq!(
+            projected.public_key_base64(),
+            authoritative.public_key_base64()
+        );
     }
 }

--- a/crates/conary-core/src/ccs/signing.rs
+++ b/crates/conary-core/src/ccs/signing.rs
@@ -16,7 +16,9 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 static PRIVATE_KEY_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+static PUBLIC_KEY_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 const PRIVATE_KEY_TEMP_ATTEMPTS: usize = 1024;
+const PUBLIC_KEY_TEMP_ATTEMPTS: usize = 1024;
 
 /// A signing key pair for CCS packages
 pub struct SigningKeyPair {
@@ -96,7 +98,15 @@ impl SigningKeyPair {
             .map_err(|e| Error::ParseError(format!("Failed to serialize private key: {}", e)))?;
         write_private_key_atomic(private_path, &private_toml)?;
 
-        // Save public key
+        self.save_public_key_to_file(public_path)
+    }
+
+    /// Atomically save the public half of this key pair.
+    ///
+    /// The private key remains the signing authority. This method allows
+    /// callers to repair a missing or mismatched public projection from that
+    /// authority without rewriting the secret.
+    pub fn save_public_key_to_file(&self, public_path: &Path) -> Result<()> {
         let public_data = KeyFile {
             algorithm: "ed25519".to_string(),
             key: self.public_key_base64(),
@@ -104,16 +114,7 @@ impl SigningKeyPair {
         };
         let public_toml = toml::to_string_pretty(&public_data)
             .map_err(|e| Error::ParseError(format!("Failed to serialize public key: {}", e)))?;
-        ensure_parent_dir(public_path)?;
-        fs::write(public_path, &public_toml).map_err(|e| {
-            Error::IoError(format!(
-                "Failed to write public key {}: {}",
-                public_path.display(),
-                e
-            ))
-        })?;
-
-        Ok(())
+        write_public_key_atomic(public_path, &public_toml)
     }
 
     /// Load a key pair from a private key file
@@ -255,6 +256,80 @@ fn rename_private_key(tmp_private_path: &Path, private_path: &Path) -> Result<()
             private_path.display(),
             tmp_private_path.display(),
             e
+        ))
+    })
+}
+
+fn write_public_key_atomic(public_path: &Path, public_toml: &str) -> Result<()> {
+    ensure_parent_dir(public_path)?;
+
+    let (tmp_public_path, mut file) = create_public_key_temp_file(public_path)?;
+    if let Err(error) = write_public_key_temp_file(&tmp_public_path, &mut file, public_toml) {
+        drop(file);
+        let _ = fs::remove_file(&tmp_public_path);
+        return Err(error);
+    }
+    drop(file);
+
+    let result = fs::rename(&tmp_public_path, public_path).map_err(|error| {
+        Error::IoError(format!(
+            "Failed to replace public key {} with temp file {}: {}",
+            public_path.display(),
+            tmp_public_path.display(),
+            error
+        ))
+    });
+    if result.is_err() {
+        let _ = fs::remove_file(&tmp_public_path);
+    }
+    result
+}
+
+fn create_public_key_temp_file(public_path: &Path) -> Result<(PathBuf, fs::File)> {
+    for _ in 0..PUBLIC_KEY_TEMP_ATTEMPTS {
+        let suffix = PUBLIC_KEY_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let tmp_public_path =
+            public_path.with_extension(format!("public.tmp.{}.{}", std::process::id(), suffix));
+        let mut options = fs::OpenOptions::new();
+        options.write(true).create_new(true);
+
+        match options.open(&tmp_public_path) {
+            Ok(file) => return Ok((tmp_public_path, file)),
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(Error::IoError(format!(
+                    "Failed to write public key temp file {}: {}",
+                    tmp_public_path.display(),
+                    error
+                )));
+            }
+        }
+    }
+
+    Err(Error::IoError(format!(
+        "Failed to create unique public key temp file next to {} after {} attempts",
+        public_path.display(),
+        PUBLIC_KEY_TEMP_ATTEMPTS
+    )))
+}
+
+fn write_public_key_temp_file(
+    tmp_public_path: &Path,
+    file: &mut fs::File,
+    public_toml: &str,
+) -> Result<()> {
+    file.write_all(public_toml.as_bytes()).map_err(|error| {
+        Error::IoError(format!(
+            "Failed to write public key temp file {}: {}",
+            tmp_public_path.display(),
+            error
+        ))
+    })?;
+    file.sync_all().map_err(|error| {
+        Error::IoError(format!(
+            "Failed to sync public key temp file {}: {}",
+            tmp_public_path.display(),
+            error
         ))
     })
 }

--- a/docs/modules/ccs.md
+++ b/docs/modules/ccs.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-12
-revision: 60
+revision: 61
 summary: Convert direct and exactly re-resolved adopted foreign packages through lossless source authority, typed authoring, host capability, lifecycle, and native export contracts
 ---
 
@@ -63,6 +63,13 @@ Apply typed install prefix (default `/`) to source-root children
 | `NativeExport` | manifest.rs, native_export/ | Format-specific RPM, Debian, and Arch export overrides and generators |
 | `BuildPolicy` (trait) | policy.rs | Pluggable build policy (DenyPaths, StripBinaries, FixShebangs, etc.) |
 | `EnhancementEngine` (trait) | enhancement/ | Exact post-conversion provenance recording |
+
+The `local-dev` signing authority is initialized under one process- and
+thread-safe file lock. Its private key is the sole persisted authority; every
+successful load atomically regenerates the public projection from that private
+key before signing or constructing a trust policy. Concurrent first use cannot
+replace an established signer, and a missing or mismatched public file never
+becomes independent trust authority.
 
 ## Submodules
 


### PR DESCRIPTION
## Problem

Parallel first use of the shared `local-dev` CCS signer used a check-then-create sequence. Racing callers could each generate, publish, and retain different signing keys, while the public file independently selected whichever write won last. Exact-head workspace runs on #394 and #409 both reproduced the resulting trust failures.

## Fix

- serialize the complete local-dev initialization transaction with a process- and thread-safe file lock
- make the persisted private key the sole signing authority after the lock is acquired
- atomically regenerate the public projection from that private authority on key loads and trust-policy construction
- add deterministic barrier proof of the old ordering and concurrent proof that the locked path returns one authority
- record the local-dev authority contract in the CCS module documentation

## Verification

- `cargo test -p conary-core --lib ccs::signing::tests` — 6 passed
- `cargo test -p conary --lib commands::ccs::local_dev::tests` — 5 passed
- `cargo test -p conary --lib commands::adopt::convert::tests::lifecycle::published_adopted_ccs_drives_full_lifecycle_without_native_manager_runtime -- --nocapture` — passed in both parent and user-namespace child
- `cargo test -p conary --lib` — 1,079 passed, 0 failed, 2 ignored
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo fmt --check` — passed
- `bash scripts/check-doc-truth.sh` — passed
- `git diff --check` — passed

Closes #395
