### PR TITLE
perf(generation): decode selected-root overlay uppers

### DIFF
--- a/apps/conary/tests/fixtures/selected-root-overlay-profile/probe.py
+++ b/apps/conary/tests/fixtures/selected-root-overlay-profile/probe.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Guest conformance proof for the selected-root OverlayFS profile."""
+
+import errno
+import json
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+
+
+root = tempfile.mkdtemp(prefix="conary-overlay-profile-")
+lower = os.path.join(root, "lower")
+upper = os.path.join(root, "upper")
+work = os.path.join(root, "work")
+merged = os.path.join(root, "merged")
+for path in (lower, upper, work, merged):
+    os.mkdir(path)
+
+with open(os.path.join(lower, "hardlink-a"), "wb") as stream:
+    stream.write(b"hardlink-content")
+os.link(os.path.join(lower, "hardlink-a"), os.path.join(lower, "hardlink-b"))
+with open(os.path.join(lower, "remove-me"), "wb") as stream:
+    stream.write(b"remove")
+os.mkdir(os.path.join(lower, "replace-me"))
+with open(os.path.join(lower, "replace-me", "lower-child"), "wb") as stream:
+    stream.write(b"lower")
+os.mkdir(os.path.join(lower, "rename-me"))
+with open(os.path.join(lower, "rename-me", "lower-child"), "wb") as stream:
+    stream.write(b"lower")
+
+options = ",".join(
+    [
+        f"lowerdir={lower}",
+        f"upperdir={upper}",
+        f"workdir={work}",
+        "index=on",
+        "redirect_dir=nofollow",
+        "metacopy=off",
+        "xino=off",
+        "nfs_export=off",
+        "verity=off",
+    ]
+)
+mounted = False
+try:
+    subprocess.run(
+        ["mount", "-t", "overlay", "overlay", "-o", options, merged], check=True
+    )
+    mounted = True
+
+    changed = os.path.join(merged, "hardlink-a")
+    alias = os.path.join(merged, "hardlink-b")
+    os.chmod(changed, 0o600)
+    changed_stat = os.lstat(changed)
+    alias_stat = os.lstat(alias)
+    assert (changed_stat.st_dev, changed_stat.st_ino) == (
+        alias_stat.st_dev,
+        alias_stat.st_ino,
+    )
+    assert stat.S_IMODE(changed_stat.st_mode) == 0o600
+    assert stat.S_IMODE(alias_stat.st_mode) == 0o600
+    with open(os.path.join(upper, "hardlink-a"), "rb") as stream:
+        assert stream.read() == b"hardlink-content"
+    assert os.getxattr(os.path.join(upper, "hardlink-a"), "trusted.overlay.origin")
+    try:
+        os.getxattr(os.path.join(upper, "hardlink-a"), "trusted.overlay.metacopy")
+    except OSError as error:
+        assert error.errno in (errno.ENODATA, errno.EOPNOTSUPP)
+    else:
+        raise AssertionError("metacopy marker emitted despite metacopy=off")
+
+    os.unlink(os.path.join(merged, "remove-me"))
+    whiteout = os.path.join(upper, "remove-me")
+    whiteout_stat = os.lstat(whiteout)
+    if stat.S_ISCHR(whiteout_stat.st_mode) and whiteout_stat.st_rdev == 0:
+        whiteout_encoding = "character-device-zero-zero"
+    else:
+        assert stat.S_ISREG(whiteout_stat.st_mode) and whiteout_stat.st_size == 0
+        os.getxattr(whiteout, "trusted.overlay.whiteout")
+        whiteout_encoding = "zero-size-regular-xattr"
+
+    shutil.rmtree(os.path.join(merged, "replace-me"))
+    os.mkdir(os.path.join(merged, "replace-me"))
+    assert (
+        os.getxattr(os.path.join(upper, "replace-me"), "trusted.overlay.opaque")
+        == b"y"
+    )
+
+    try:
+        os.rename(os.path.join(merged, "rename-me"), os.path.join(merged, "renamed"))
+    except OSError as error:
+        assert error.errno == errno.EXDEV
+    else:
+        raise AssertionError("lower directory renamed despite redirect_dir=nofollow")
+
+    os.sync()
+    print(
+        json.dumps(
+            {
+                "kernel": os.uname().release,
+                "whiteout_encoding": whiteout_encoding,
+                "opaque_directory": "logical-y",
+                "hardlink_copy_up": "preserved",
+                "lower_directory_rename": "cross-device",
+                "metadata_copy_up": "complete-data",
+            },
+            sort_keys=True,
+        )
+    )
+finally:
+    if mounted:
+        subprocess.run(["umount", merged], check=True)
+    shutil.rmtree(root)

--- a/apps/conary/tests/integration/remi/manifests/selected-root-overlay-profile-solus.toml
+++ b/apps/conary/tests/integration/remi/manifests/selected-root-overlay-profile-solus.toml
@@ -1,0 +1,37 @@
+# Selected-root OverlayFS capability proof on the published Solus fixture.
+
+[suite]
+name = "Solus Overlay Profile Proof"
+phase = 4
+timeout = 1200
+
+[[test]]
+id = "TNPME403"
+name = "solus_overlay_profile_probe"
+description = "The Solus 7.1 kernel and ext4 runtime filesystem satisfy the exact selected-root OverlayFS profile"
+timeout = 1200
+fatal = true
+group = "selected-root-overlay-profile-solus"
+
+[[test.step]]
+[test.step.qemu_boot]
+image = "solus-4.9-polaris-2026-08-12-v3"
+memory_mb = 2048
+timeout_seconds = 900
+ssh_port = 2252
+stage_conary = false
+copy_to_guest = [
+    { source = "apps/conary/tests/fixtures/selected-root-overlay-profile/probe.py", dest = "/tmp/overlay-profile-probe.py" },
+]
+commands = [
+    "test \"$(uname -r)\" = 7.1.7-351.current",
+    "python3 /tmp/overlay-profile-probe.py",
+]
+expect_output = [
+    "\"hardlink_copy_up\": \"preserved\"",
+    "\"metadata_copy_up\": \"complete-data\"",
+    "\"opaque_directory\": \"logical-y\"",
+]
+
+[test.step.assert]
+exit_code = 0

--- a/crates/conary-core/src/generation/root_manifest.rs
+++ b/crates/conary-core/src/generation/root_manifest.rs
@@ -5,6 +5,7 @@
 mod composefs;
 mod delta;
 mod materialize;
+mod overlay;
 mod scan;
 
 use crate::payload::{PayloadContentAuthority, PayloadNode, PayloadNodeKind, ResolvedPayloadNode};
@@ -18,6 +19,10 @@ pub use materialize::{
     apply_resolved_payload_metadata, materialize_captured_selected_root,
     materialize_config_state_upper, materialize_generation_root, materialize_state_root,
     overlay_payload_entries,
+};
+pub use overlay::{
+    OverlayXattrNamespace, SELECTED_ROOT_OVERLAY_PROFILE_VERSION, SelectedRootOverlayProfile,
+    decode_selected_root_overlay_upper,
 };
 pub use scan::{
     SelectedRootCaptureExclusions, capture_existing_payload_node, capture_root_node,

--- a/crates/conary-core/src/generation/root_manifest.rs
+++ b/crates/conary-core/src/generation/root_manifest.rs
@@ -21,8 +21,11 @@ pub use materialize::{
     overlay_payload_entries,
 };
 pub use overlay::{
-    OverlayXattrNamespace, SELECTED_ROOT_OVERLAY_PROFILE_VERSION, SelectedRootOverlayProfile,
-    decode_selected_root_overlay_upper,
+    OverlayHardlinkCopyUp, OverlayLowerDirectoryRename, OverlayMetadataCopyUp,
+    OverlayOpaqueDirectory, OverlayWhiteoutEncoding, OverlayXattrNamespace,
+    SELECTED_ROOT_OVERLAY_CAPABILITIES_VERSION, SELECTED_ROOT_OVERLAY_PROFILE_VERSION,
+    SelectedRootOverlayCapabilities, SelectedRootOverlayProfile,
+    decode_selected_root_overlay_upper, probe_selected_root_overlay_profile,
 };
 pub use scan::{
     SelectedRootCaptureExclusions, capture_existing_payload_node, capture_root_node,

--- a/crates/conary-core/src/generation/root_manifest/overlay.rs
+++ b/crates/conary-core/src/generation/root_manifest/overlay.rs
@@ -2,6 +2,14 @@
 
 //! OverlayFS upper-tree decoding for delta-sized selected-root transactions.
 
+mod probe;
+
+pub use probe::{
+    OverlayHardlinkCopyUp, OverlayLowerDirectoryRename, OverlayMetadataCopyUp,
+    OverlayOpaqueDirectory, OverlayWhiteoutEncoding, SELECTED_ROOT_OVERLAY_CAPABILITIES_VERSION,
+    SelectedRootOverlayCapabilities, probe_selected_root_overlay_profile,
+};
+
 use super::{
     CapturedSelectedRoot, GenerationRootEntry, SELECTED_ROOT_MANIFEST_DELTA_VERSION,
     SelectedRootManifestDelta, scan_payload_tree,

--- a/crates/conary-core/src/generation/root_manifest/overlay.rs
+++ b/crates/conary-core/src/generation/root_manifest/overlay.rs
@@ -358,37 +358,78 @@ fn expand_prior_hardlink_authority(
 
     for (identity, mut members) in groups {
         members.sort_by(|left, right| left.path.cmp(&right.path));
-        let affected_by_copy_up = members.iter().find_map(|member| {
-            copied_up_origins
-                .contains(&member.path)
-                .then_some(member.path.as_str())
-        });
-        let primary_removed = members.iter().any(|member| {
-            matches!(
-                member.node.source.kind,
-                PayloadNodeKind::Regular {
-                    hardlink_identity: Some(_)
-                }
-            ) && path_removed(&member.path, removals, opaque_directories)
-        });
-        if affected_by_copy_up.is_none() && !primary_removed {
-            continue;
-        }
-
-        let survivors = members
+        let copied_prior_paths = members
             .iter()
-            .copied()
-            .filter(|member| !path_removed(&member.path, removals, opaque_directories))
+            .filter(|member| copied_up_origins.contains(&member.path))
+            .map(|member| member.path.as_str())
             .collect::<Vec<_>>();
-        if survivors.is_empty() {
+        let upper_identities = copied_prior_paths
+            .iter()
+            .filter_map(|path| upserts.get(*path).and_then(entry_hardlink_identity))
+            .collect::<BTreeSet<_>>();
+        if upper_identities.len() > 1
+            || (copied_prior_paths.len() > 1 && upper_identities.is_empty())
+        {
+            return Err(crate::Error::InvalidPath(format!(
+                "OverlayFS index did not preserve copied-up prior hardlink group {identity}"
+            )));
+        }
+        let upper_identity = upper_identities.first().copied();
+        let upper_group_paths = if let Some(upper_identity) = upper_identity {
+            upserts
+                .values()
+                .filter(|entry| entry_hardlink_identity(entry) == Some(upper_identity))
+                .map(|entry| entry.path.clone())
+                .collect::<BTreeSet<_>>()
+        } else {
+            copied_prior_paths
+                .iter()
+                .map(|path| (*path).to_string())
+                .collect::<BTreeSet<_>>()
+        };
+
+        let mut membership_changed = false;
+        let mut member_paths = BTreeSet::new();
+        for member in &members {
+            if path_removed(&member.path, removals, opaque_directories) {
+                membership_changed = true;
+                continue;
+            }
+            if upserts.contains_key(&member.path) && !upper_group_paths.contains(&member.path) {
+                // Replacing one name with a new inode intentionally breaks
+                // that name out of the prior group. The remaining names still
+                // need a valid primary if the replaced path owned it.
+                membership_changed = true;
+                continue;
+            }
+            member_paths.insert(member.path.clone());
+        }
+        for path in &upper_group_paths {
+            if !members.iter().any(|member| member.path == *path) {
+                membership_changed = true;
+            }
+            if !path_removed(path, removals, opaque_directories) {
+                member_paths.insert(path.clone());
+            }
+        }
+        let copied_up = !copied_prior_paths.is_empty();
+        if !copied_up && !membership_changed {
             continue;
         }
-        let source = if let Some(path) = affected_by_copy_up {
-            upserts.get(path).cloned().ok_or_else(|| {
-                crate::Error::InvalidPath(format!(
-                    "overlay origin marker on {path} has no surviving complete upsert"
-                ))
-            })?
+        if member_paths.is_empty() {
+            continue;
+        }
+        let source = if copied_up {
+            upper_group_paths
+                .iter()
+                .filter_map(|path| upserts.get(path))
+                .find(|entry| entry.content.is_some())
+                .cloned()
+                .ok_or_else(|| {
+                    crate::Error::InvalidPath(format!(
+                        "copied-up hardlink group {identity} lacks complete content authority"
+                    ))
+                })?
         } else {
             members
                 .iter()
@@ -400,13 +441,15 @@ fn expand_prior_hardlink_authority(
                     ))
                 })?
         };
-        let Some(content) = source.content.clone() else {
-            return Err(crate::Error::InvalidPath(format!(
-                "copied-up hardlink group {identity} lacks complete content authority"
-            )));
-        };
-        let primary_path = survivors[0].path.clone();
-        let has_aliases = survivors.len() > 1;
+        let content = source.content.clone().ok_or_else(|| {
+            crate::Error::InvalidPath(format!(
+                "hardlink group {identity} lacks complete content authority"
+            ))
+        })?;
+        let primary_path = member_paths.first().cloned().ok_or_else(|| {
+            crate::Error::InvalidPath(format!("hardlink group {identity} has no surviving member"))
+        })?;
+        let has_aliases = member_paths.len() > 1;
         let mut primary_node = source.node.clone();
         primary_node.source.kind = PayloadNodeKind::Regular {
             hardlink_identity: has_aliases.then(|| identity.clone()),
@@ -419,16 +462,16 @@ fn expand_prior_hardlink_authority(
                 content: Some(content),
             },
         );
-        for member in survivors.into_iter().skip(1) {
+        for path in member_paths.into_iter().skip(1) {
             let mut node = primary_node.clone();
             node.source.kind = PayloadNodeKind::Hardlink {
                 target: primary_path.clone(),
                 identity: identity.clone(),
             };
             upserts.insert(
-                member.path.clone(),
+                path.clone(),
                 GenerationRootEntry {
-                    path: member.path.clone(),
+                    path,
                     node,
                     content: None,
                 },
@@ -436,6 +479,16 @@ fn expand_prior_hardlink_authority(
         }
     }
     Ok(())
+}
+
+fn entry_hardlink_identity(entry: &GenerationRootEntry) -> Option<&str> {
+    match &entry.node.source.kind {
+        PayloadNodeKind::Regular {
+            hardlink_identity: Some(identity),
+        }
+        | PayloadNodeKind::Hardlink { identity, .. } => Some(identity),
+        _ => None,
+    }
 }
 
 fn path_removed(path: &str, removals: &[String], opaque_directories: &[String]) -> bool {
@@ -674,6 +727,149 @@ mod tests {
                 hardlink_identity: None
             }
         ));
+    }
+
+    #[test]
+    fn removing_only_prior_alias_clears_primary_group_identity() {
+        let identity = "prior:hardlink:1";
+        let mut primary = regular_entry("/usr/lib/a", content('a', 4));
+        primary.node.source.kind = PayloadNodeKind::Regular {
+            hardlink_identity: Some(identity.into()),
+        };
+        let mut alias = primary.clone();
+        alias.path = "/usr/lib/b".into();
+        alias.content = None;
+        alias.node.source.kind = PayloadNodeKind::Hardlink {
+            target: primary.path.clone(),
+            identity: identity.into(),
+        };
+        let prior = captured(vec![
+            directory_entry("/usr"),
+            directory_entry("/usr/lib"),
+            primary,
+            alias,
+        ]);
+        let mut whiteout = regular_entry("/usr/lib/b", content('0', 0));
+        whiteout
+            .node
+            .source
+            .xattrs
+            .insert("user.overlay.whiteout".into(), Vec::new());
+        let applied =
+            decode_captured_upper(directory_node(), vec![whiteout], &prior, &user_profile())
+                .unwrap()
+                .apply(&prior)
+                .unwrap();
+        assert!(entry(&applied, "/usr/lib/b").is_none());
+        assert!(matches!(
+            &entry(&applied, "/usr/lib/a").unwrap().node.source.kind,
+            PayloadNodeKind::Regular {
+                hardlink_identity: None
+            }
+        ));
+    }
+
+    #[test]
+    fn new_alias_joins_copied_up_prior_hardlink_group() {
+        let prior_identity = "prior:hardlink:1";
+        let upper_identity = "selected-root-overlay-v1:hardlink:1";
+        let mut primary = regular_entry("/usr/lib/a", content('a', 4));
+        primary.node.source.kind = PayloadNodeKind::Regular {
+            hardlink_identity: Some(prior_identity.into()),
+        };
+        let mut alias = primary.clone();
+        alias.path = "/usr/lib/b".into();
+        alias.content = None;
+        alias.node.source.kind = PayloadNodeKind::Hardlink {
+            target: primary.path.clone(),
+            identity: prior_identity.into(),
+        };
+        let prior = captured(vec![
+            directory_entry("/usr"),
+            directory_entry("/usr/lib"),
+            primary,
+            alias,
+        ]);
+        let mut copied = regular_entry("/usr/lib/a", content('c', 7));
+        copied.node.source.kind = PayloadNodeKind::Regular {
+            hardlink_identity: Some(upper_identity.into()),
+        };
+        copied
+            .node
+            .source
+            .xattrs
+            .insert("user.overlay.origin".into(), b"opaque-handle".to_vec());
+        let mut new_alias = copied.clone();
+        new_alias.path = "/usr/lib/c".into();
+        new_alias.content = None;
+        new_alias.node.source.kind = PayloadNodeKind::Hardlink {
+            target: copied.path.clone(),
+            identity: upper_identity.into(),
+        };
+        let applied = decode_captured_upper(
+            directory_node(),
+            vec![copied, new_alias],
+            &prior,
+            &user_profile(),
+        )
+        .unwrap()
+        .apply(&prior)
+        .unwrap();
+        for path in ["/usr/lib/b", "/usr/lib/c"] {
+            assert!(matches!(
+                &entry(&applied, path).unwrap().node.source.kind,
+                PayloadNodeKind::Hardlink { target, identity }
+                    if target == "/usr/lib/a" && identity == prior_identity
+            ));
+        }
+    }
+
+    #[test]
+    fn independent_primary_replacement_reanchors_old_alias() {
+        let identity = "prior:hardlink:1";
+        let mut primary = regular_entry("/usr/lib/a", content('a', 4));
+        primary.node.source.kind = PayloadNodeKind::Regular {
+            hardlink_identity: Some(identity.into()),
+        };
+        let mut alias = primary.clone();
+        alias.path = "/usr/lib/b".into();
+        alias.content = None;
+        alias.node.source.kind = PayloadNodeKind::Hardlink {
+            target: primary.path.clone(),
+            identity: identity.into(),
+        };
+        let prior = captured(vec![
+            directory_entry("/usr"),
+            directory_entry("/usr/lib"),
+            primary,
+            alias,
+        ]);
+        let replacement = regular_entry("/usr/lib/a", content('c', 9));
+        let applied =
+            decode_captured_upper(directory_node(), vec![replacement], &prior, &user_profile())
+                .unwrap()
+                .apply(&prior)
+                .unwrap();
+        assert_eq!(
+            entry(&applied, "/usr/lib/a")
+                .and_then(|entry| entry.content.as_ref())
+                .map(|content| content.size),
+            Some(9)
+        );
+        assert_eq!(
+            entry(&applied, "/usr/lib/b")
+                .and_then(|entry| entry.content.as_ref())
+                .map(|content| content.size),
+            Some(4)
+        );
+        for path in ["/usr/lib/a", "/usr/lib/b"] {
+            assert!(matches!(
+                &entry(&applied, path).unwrap().node.source.kind,
+                PayloadNodeKind::Regular {
+                    hardlink_identity: None
+                }
+            ));
+        }
     }
 
     #[test]

--- a/crates/conary-core/src/generation/root_manifest/overlay.rs
+++ b/crates/conary-core/src/generation/root_manifest/overlay.rs
@@ -1,0 +1,770 @@
+// conary-core/src/generation/root_manifest/overlay.rs
+
+//! OverlayFS upper-tree decoding for delta-sized selected-root transactions.
+
+use super::{
+    CapturedSelectedRoot, GenerationRootEntry, SELECTED_ROOT_MANIFEST_DELTA_VERSION,
+    SelectedRootManifestDelta, scan_payload_tree,
+};
+use crate::filesystem::PrivateCasWriter;
+use crate::payload::{PayloadNodeKind, ResolvedPayloadNode};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+pub const SELECTED_ROOT_OVERLAY_PROFILE_VERSION: u32 = 1;
+
+/// Namespace used by one transaction-owned OverlayFS mount.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OverlayXattrNamespace {
+    Trusted,
+    User,
+}
+
+/// Exact OverlayFS behavior admitted by the selected-root delta decoder.
+///
+/// The runtime must functionally prove this profile on the actual lower and
+/// upper filesystems before lifecycle mutation. Kernel versions and module
+/// defaults are not capability authority.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SelectedRootOverlayProfile {
+    pub version: u32,
+    pub xattr_namespace: OverlayXattrNamespace,
+    pub index: bool,
+    pub redirect_dir: bool,
+    pub metacopy: bool,
+    pub xino: bool,
+    pub nfs_export: bool,
+    pub verity: bool,
+}
+
+impl SelectedRootOverlayProfile {
+    /// Privileged profile used for selected-root transactions.
+    pub fn trusted() -> Self {
+        Self {
+            version: SELECTED_ROOT_OVERLAY_PROFILE_VERSION,
+            xattr_namespace: OverlayXattrNamespace::Trusted,
+            index: true,
+            redirect_dir: false,
+            metacopy: false,
+            xino: false,
+            nfs_export: false,
+            verity: false,
+        }
+    }
+
+    /// Exact options whose mounted behavior must be checked by preflight.
+    pub fn mount_options(&self) -> crate::Result<Vec<&'static str>> {
+        self.validate()?;
+        let mut options = vec![
+            "index=on",
+            "redirect_dir=nofollow",
+            "metacopy=off",
+            "xino=off",
+            "nfs_export=off",
+            "verity=off",
+        ];
+        if self.xattr_namespace == OverlayXattrNamespace::User {
+            options.push("userxattr");
+        }
+        Ok(options)
+    }
+
+    pub fn validate(&self) -> crate::Result<()> {
+        if self.version != SELECTED_ROOT_OVERLAY_PROFILE_VERSION {
+            return Err(crate::Error::InvalidPath(format!(
+                "selected-root overlay profile has unsupported version {}; expected {}",
+                self.version, SELECTED_ROOT_OVERLAY_PROFILE_VERSION
+            )));
+        }
+        if !self.index
+            || self.redirect_dir
+            || self.metacopy
+            || self.xino
+            || self.nfs_export
+            || self.verity
+        {
+            return Err(crate::Error::NotImplemented(
+                "selected-root overlay profile must use index=on, redirect_dir=nofollow, metacopy=off, xino=off, nfs_export=off, and verity=off"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn private_prefix(&self) -> &'static str {
+        match self.xattr_namespace {
+            OverlayXattrNamespace::Trusted => "trusted.overlay.",
+            OverlayXattrNamespace::User => "user.overlay.",
+        }
+    }
+}
+
+/// Capture and decode one frozen transaction upper without reading unchanged
+/// lower content.
+///
+/// Callers seed the upper root metadata from `prior` before mounting. A root
+/// metadata difference can then be represented without guessing whether it
+/// was transaction-owned.
+pub fn decode_selected_root_overlay_upper(
+    upper: &Path,
+    prior: &CapturedSelectedRoot,
+    cas: &dyn PrivateCasWriter,
+    profile: &SelectedRootOverlayProfile,
+) -> crate::Result<SelectedRootManifestDelta> {
+    profile.validate()?;
+    prior.generation.validate()?;
+    prior.state.validate()?;
+    let (root, entries) = scan_payload_tree(upper, cas, "selected-root-overlay-v1")?;
+    decode_captured_upper(root, entries, prior, profile)
+}
+
+#[derive(Debug, Default)]
+struct OverlayMarkers {
+    whiteout: bool,
+    opaque: Option<OpaqueMarker>,
+    origin: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OpaqueMarker {
+    Logical,
+    WhiteoutScan,
+}
+
+fn decode_captured_upper(
+    mut root: ResolvedPayloadNode,
+    entries: Vec<GenerationRootEntry>,
+    prior: &CapturedSelectedRoot,
+    profile: &SelectedRootOverlayProfile,
+) -> crate::Result<SelectedRootManifestDelta> {
+    let root_markers = decode_overlay_xattrs("/", &mut root, profile)?;
+    if root_markers.whiteout || root_markers.opaque.is_some() {
+        return Err(crate::Error::InvalidPath(
+            "selected-root overlay upper root contains transaction markers that are not representable as root metadata"
+                .to_string(),
+        ));
+    }
+
+    let mut removals = Vec::new();
+    let mut opaque_directories = Vec::new();
+    let mut upserts = BTreeMap::new();
+    let mut copied_up_origins = BTreeSet::new();
+
+    for mut entry in entries {
+        let markers = decode_overlay_xattrs(&entry.path, &mut entry.node, profile)?;
+        if is_whiteout(&entry, markers.whiteout)? {
+            if markers.opaque.is_some() || markers.origin {
+                return Err(crate::Error::InvalidPath(format!(
+                    "overlay whiteout {} carries incompatible private markers",
+                    entry.path
+                )));
+            }
+            removals.push(entry.path);
+            continue;
+        }
+        if markers.whiteout {
+            return Err(crate::Error::InvalidPath(format!(
+                "overlay xattr whiteout {} is not a zero-size regular file",
+                entry.path
+            )));
+        }
+        if let Some(opaque) = markers.opaque {
+            if !matches!(entry.node.source.kind, PayloadNodeKind::Directory) {
+                return Err(crate::Error::InvalidPath(format!(
+                    "overlay opaque marker is attached to non-directory {}",
+                    entry.path
+                )));
+            }
+            if opaque == OpaqueMarker::Logical {
+                opaque_directories.push(entry.path.clone());
+            }
+        }
+        if markers.origin {
+            copied_up_origins.insert(entry.path.clone());
+        }
+        upserts.insert(entry.path.clone(), entry);
+    }
+
+    normalize_removals(&mut removals);
+    expand_prior_hardlink_authority(
+        prior,
+        &removals,
+        &opaque_directories,
+        &copied_up_origins,
+        &mut upserts,
+    )?;
+
+    let delta = SelectedRootManifestDelta {
+        version: SELECTED_ROOT_MANIFEST_DELTA_VERSION,
+        root: (root != prior.generation.root).then_some(root),
+        removals,
+        opaque_directories,
+        upserts: upserts.into_values().collect(),
+    };
+    delta.validate()?;
+    // Validate the complete resulting authority now, before a caller can
+    // persist this changed-path representation.
+    delta.apply(prior)?;
+    Ok(delta)
+}
+
+fn decode_overlay_xattrs(
+    path: &str,
+    node: &mut ResolvedPayloadNode,
+    profile: &SelectedRootOverlayProfile,
+) -> crate::Result<OverlayMarkers> {
+    let prefix = profile.private_prefix();
+    let escaped_prefix = format!("{prefix}overlay.");
+    let mut decoded = BTreeMap::new();
+    let mut markers = OverlayMarkers::default();
+
+    for (name, value) in std::mem::take(&mut node.source.xattrs) {
+        if let Some(suffix) = name.strip_prefix(&escaped_prefix) {
+            insert_payload_xattr(path, &mut decoded, format!("{prefix}{suffix}"), value)?;
+            continue;
+        }
+        let Some(marker) = name.strip_prefix(prefix) else {
+            insert_payload_xattr(path, &mut decoded, name, value)?;
+            continue;
+        };
+        match marker {
+            "whiteout" => markers.whiteout = true,
+            "opaque" => {
+                markers.opaque = Some(match value.as_slice() {
+                    b"y" => OpaqueMarker::Logical,
+                    b"x" => OpaqueMarker::WhiteoutScan,
+                    _ => {
+                        return Err(crate::Error::InvalidPath(format!(
+                            "overlay opaque marker on {path} has unknown value"
+                        )));
+                    }
+                });
+            }
+            "origin" => markers.origin = true,
+            // These are OverlayFS bookkeeping only and do not describe a
+            // payload node. Their semantics are constrained by the profile.
+            "impure" | "nlink" | "upper" | "uuid" => {}
+            "redirect" => {
+                return Err(crate::Error::NotImplemented(format!(
+                    "overlay redirect marker on {path} is forbidden by the selected-root profile"
+                )));
+            }
+            "metacopy" => {
+                return Err(crate::Error::NotImplemented(format!(
+                    "overlay metacopy marker on {path} is forbidden by the selected-root profile"
+                )));
+            }
+            "protattr" => {
+                return Err(crate::Error::NotImplemented(format!(
+                    "overlay protected inode attributes on {path} are not represented by PayloadNode"
+                )));
+            }
+            unknown => {
+                return Err(crate::Error::NotImplemented(format!(
+                    "unknown overlay private xattr {prefix}{unknown} on {path}"
+                )));
+            }
+        }
+    }
+    node.source.xattrs = decoded;
+    Ok(markers)
+}
+
+fn insert_payload_xattr(
+    path: &str,
+    decoded: &mut BTreeMap<String, Vec<u8>>,
+    name: String,
+    value: Vec<u8>,
+) -> crate::Result<()> {
+    if decoded.insert(name.clone(), value).is_some() {
+        return Err(crate::Error::InvalidPath(format!(
+            "overlay xattr escaping produces duplicate payload xattr {name} on {path}"
+        )));
+    }
+    Ok(())
+}
+
+fn is_whiteout(entry: &GenerationRootEntry, xattr_whiteout: bool) -> crate::Result<bool> {
+    if matches!(
+        entry.node.source.kind,
+        PayloadNodeKind::CharacterDevice { major: 0, minor: 0 }
+    ) {
+        return Ok(true);
+    }
+    if !xattr_whiteout {
+        return Ok(false);
+    }
+    Ok(
+        matches!(entry.node.source.kind, PayloadNodeKind::Regular { .. })
+            && entry
+                .content
+                .as_ref()
+                .is_some_and(|content| content.size == 0),
+    )
+}
+
+fn normalize_removals(removals: &mut Vec<String>) {
+    removals.sort();
+    removals.dedup();
+    let mut normalized = Vec::<String>::new();
+    for path in removals.drain(..) {
+        if normalized
+            .iter()
+            .any(|ancestor| is_path_or_descendant(&path, ancestor))
+        {
+            continue;
+        }
+        normalized.push(path);
+    }
+    *removals = normalized;
+}
+
+fn expand_prior_hardlink_authority(
+    prior: &CapturedSelectedRoot,
+    removals: &[String],
+    opaque_directories: &[String],
+    copied_up_origins: &BTreeSet<String>,
+    upserts: &mut BTreeMap<String, GenerationRootEntry>,
+) -> crate::Result<()> {
+    let prior_entries = prior
+        .generation
+        .entries
+        .iter()
+        .chain(&prior.state.entries)
+        .map(|entry| (entry.path.as_str(), entry))
+        .collect::<BTreeMap<_, _>>();
+    let mut groups = BTreeMap::<String, Vec<&GenerationRootEntry>>::new();
+    for entry in prior_entries.values() {
+        let identity = match &entry.node.source.kind {
+            PayloadNodeKind::Regular {
+                hardlink_identity: Some(identity),
+            }
+            | PayloadNodeKind::Hardlink { identity, .. } => identity,
+            _ => continue,
+        };
+        groups.entry(identity.clone()).or_default().push(entry);
+    }
+
+    for (identity, mut members) in groups {
+        members.sort_by(|left, right| left.path.cmp(&right.path));
+        let affected_by_copy_up = members.iter().find_map(|member| {
+            copied_up_origins
+                .contains(&member.path)
+                .then_some(member.path.as_str())
+        });
+        let primary_removed = members.iter().any(|member| {
+            matches!(
+                member.node.source.kind,
+                PayloadNodeKind::Regular {
+                    hardlink_identity: Some(_)
+                }
+            ) && path_removed(&member.path, removals, opaque_directories)
+        });
+        if affected_by_copy_up.is_none() && !primary_removed {
+            continue;
+        }
+
+        let survivors = members
+            .iter()
+            .copied()
+            .filter(|member| !path_removed(&member.path, removals, opaque_directories))
+            .collect::<Vec<_>>();
+        if survivors.is_empty() {
+            continue;
+        }
+        let source = if let Some(path) = affected_by_copy_up {
+            upserts.get(path).cloned().ok_or_else(|| {
+                crate::Error::InvalidPath(format!(
+                    "overlay origin marker on {path} has no surviving complete upsert"
+                ))
+            })?
+        } else {
+            members
+                .iter()
+                .find(|member| member.content.is_some())
+                .map(|entry| (*entry).clone())
+                .ok_or_else(|| {
+                    crate::Error::InvalidPath(format!(
+                        "prior hardlink group {identity} has no content primary"
+                    ))
+                })?
+        };
+        let Some(content) = source.content.clone() else {
+            return Err(crate::Error::InvalidPath(format!(
+                "copied-up hardlink group {identity} lacks complete content authority"
+            )));
+        };
+        let primary_path = survivors[0].path.clone();
+        let has_aliases = survivors.len() > 1;
+        let mut primary_node = source.node.clone();
+        primary_node.source.kind = PayloadNodeKind::Regular {
+            hardlink_identity: has_aliases.then(|| identity.clone()),
+        };
+        upserts.insert(
+            primary_path.clone(),
+            GenerationRootEntry {
+                path: primary_path.clone(),
+                node: primary_node.clone(),
+                content: Some(content),
+            },
+        );
+        for member in survivors.into_iter().skip(1) {
+            let mut node = primary_node.clone();
+            node.source.kind = PayloadNodeKind::Hardlink {
+                target: primary_path.clone(),
+                identity: identity.clone(),
+            };
+            upserts.insert(
+                member.path.clone(),
+                GenerationRootEntry {
+                    path: member.path.clone(),
+                    node,
+                    content: None,
+                },
+            );
+        }
+    }
+    Ok(())
+}
+
+fn path_removed(path: &str, removals: &[String], opaque_directories: &[String]) -> bool {
+    removals
+        .iter()
+        .any(|removed| is_path_or_descendant(path, removed))
+        || opaque_directories
+            .iter()
+            .any(|opaque| path != opaque && is_path_or_descendant(path, opaque))
+}
+
+fn is_path_or_descendant(candidate: &str, ancestor: &str) -> bool {
+    candidate == ancestor
+        || candidate
+            .strip_prefix(ancestor)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::filesystem::CasStore;
+    use crate::payload::{PayloadContentAuthority, PayloadIdentity, PayloadNode};
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn profile_is_explicit_and_rejects_hardlink_breaking_index_off() {
+        let profile = SelectedRootOverlayProfile::trusted();
+        assert_eq!(
+            profile.mount_options().unwrap(),
+            [
+                "index=on",
+                "redirect_dir=nofollow",
+                "metacopy=off",
+                "xino=off",
+                "nfs_export=off",
+                "verity=off",
+            ]
+        );
+        let mut invalid = profile;
+        invalid.index = false;
+        assert!(invalid.validate().is_err());
+    }
+
+    #[test]
+    fn decodes_documented_whiteouts_and_opaque_markers() {
+        let prior = captured(vec![
+            directory_entry("/opt"),
+            directory_entry("/opt/tree"),
+            regular_entry("/opt/tree/lower", content('a', 1)),
+            regular_entry("/opt/remove", content('b', 2)),
+        ]);
+        let profile = user_profile();
+        let mut opaque = directory_entry("/opt/tree");
+        opaque
+            .node
+            .source
+            .xattrs
+            .insert("user.overlay.opaque".into(), b"y".to_vec());
+        let mut whiteout = regular_entry("/opt/remove", content('0', 0));
+        whiteout
+            .node
+            .source
+            .xattrs
+            .insert("user.overlay.whiteout".into(), Vec::new());
+        let delta =
+            decode_captured_upper(directory_node(), vec![opaque, whiteout], &prior, &profile)
+                .unwrap();
+
+        assert_eq!(delta.removals, ["/opt/remove"]);
+        assert_eq!(delta.opaque_directories, ["/opt/tree"]);
+        let applied = delta.apply(&prior).unwrap();
+        assert!(entry(&applied, "/opt/remove").is_none());
+        assert!(entry(&applied, "/opt/tree/lower").is_none());
+    }
+
+    #[test]
+    fn opaque_x_only_enables_whiteout_scanning() {
+        let prior = captured(vec![
+            directory_entry("/opt"),
+            directory_entry("/opt/tree"),
+            regular_entry("/opt/tree/lower", content('a', 1)),
+        ]);
+        let mut directory = directory_entry("/opt/tree");
+        directory
+            .node
+            .source
+            .xattrs
+            .insert("user.overlay.opaque".into(), b"x".to_vec());
+        let delta =
+            decode_captured_upper(directory_node(), vec![directory], &prior, &user_profile())
+                .unwrap();
+        assert!(delta.opaque_directories.is_empty());
+        assert!(entry(&delta.apply(&prior).unwrap(), "/opt/tree/lower").is_some());
+    }
+
+    #[test]
+    fn unescapes_payload_xattrs_and_rejects_unknown_private_markers() {
+        let prior = captured(vec![directory_entry("/usr")]);
+        let mut escaped = directory_entry("/usr");
+        escaped
+            .node
+            .source
+            .xattrs
+            .insert("user.overlay.overlay.metacopy".into(), b"payload".to_vec());
+        let delta = decode_captured_upper(directory_node(), vec![escaped], &prior, &user_profile())
+            .unwrap();
+        assert_eq!(
+            delta.upserts[0]
+                .node
+                .source
+                .xattrs
+                .get("user.overlay.metacopy")
+                .map(Vec::as_slice),
+            Some(b"payload".as_slice())
+        );
+
+        let mut unknown = directory_entry("/usr");
+        unknown
+            .node
+            .source
+            .xattrs
+            .insert("user.overlay.future".into(), b"1".to_vec());
+        assert!(
+            decode_captured_upper(directory_node(), vec![unknown], &prior, &user_profile(),)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn strips_index_origin_from_upper_root_metadata() {
+        let prior = captured(vec![directory_entry("/usr")]);
+        let mut upper_root = directory_node();
+        upper_root
+            .source
+            .xattrs
+            .insert("user.overlay.origin".into(), b"root-handle".to_vec());
+        let delta = decode_captured_upper(upper_root, Vec::new(), &prior, &user_profile()).unwrap();
+        assert!(delta.root.is_none());
+    }
+
+    #[test]
+    fn rejects_redirect_metacopy_and_protected_inode_markers() {
+        let prior = captured(vec![directory_entry("/usr")]);
+        for marker in ["redirect", "metacopy", "protattr"] {
+            let mut entry = directory_entry("/usr");
+            entry
+                .node
+                .source
+                .xattrs
+                .insert(format!("user.overlay.{marker}"), b"value".to_vec());
+            assert!(
+                decode_captured_upper(directory_node(), vec![entry], &prior, &user_profile(),)
+                    .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn copied_up_prior_hardlink_expands_complete_group_authority() {
+        let identity = "prior:hardlink:1";
+        let mut primary = regular_entry("/usr/lib/a", content('a', 4));
+        primary.node.source.kind = PayloadNodeKind::Regular {
+            hardlink_identity: Some(identity.into()),
+        };
+        let mut alias = primary.clone();
+        alias.path = "/usr/lib/b".into();
+        alias.content = None;
+        alias.node.source.kind = PayloadNodeKind::Hardlink {
+            target: primary.path.clone(),
+            identity: identity.into(),
+        };
+        let prior = captured(vec![
+            directory_entry("/usr"),
+            directory_entry("/usr/lib"),
+            primary,
+            alias,
+        ]);
+        let mut changed = regular_entry("/usr/lib/b", content('c', 7));
+        changed
+            .node
+            .source
+            .xattrs
+            .insert("user.overlay.origin".into(), b"opaque-handle".to_vec());
+        let delta = decode_captured_upper(directory_node(), vec![changed], &prior, &user_profile())
+            .unwrap();
+        let applied = delta.apply(&prior).unwrap();
+        assert_eq!(
+            entry(&applied, "/usr/lib/a")
+                .and_then(|entry| entry.content.as_ref())
+                .map(|content| content.size),
+            Some(7)
+        );
+        assert!(matches!(
+            &entry(&applied, "/usr/lib/b").unwrap().node.source.kind,
+            PayloadNodeKind::Hardlink { target, identity: found }
+                if target == "/usr/lib/a" && found == identity
+        ));
+    }
+
+    #[test]
+    fn removing_prior_hardlink_primary_reanchors_survivors() {
+        let identity = "prior:hardlink:1";
+        let mut primary = regular_entry("/usr/lib/a", content('a', 4));
+        primary.node.source.kind = PayloadNodeKind::Regular {
+            hardlink_identity: Some(identity.into()),
+        };
+        let mut alias = primary.clone();
+        alias.path = "/usr/lib/b".into();
+        alias.content = None;
+        alias.node.source.kind = PayloadNodeKind::Hardlink {
+            target: primary.path.clone(),
+            identity: identity.into(),
+        };
+        let prior = captured(vec![
+            directory_entry("/usr"),
+            directory_entry("/usr/lib"),
+            primary,
+            alias,
+        ]);
+        let mut whiteout = regular_entry("/usr/lib/a", content('0', 0));
+        whiteout
+            .node
+            .source
+            .xattrs
+            .insert("user.overlay.whiteout".into(), Vec::new());
+        let applied =
+            decode_captured_upper(directory_node(), vec![whiteout], &prior, &user_profile())
+                .unwrap()
+                .apply(&prior)
+                .unwrap();
+        assert!(entry(&applied, "/usr/lib/a").is_none());
+        assert!(matches!(
+            &entry(&applied, "/usr/lib/b").unwrap().node.source.kind,
+            PayloadNodeKind::Regular {
+                hardlink_identity: None
+            }
+        ));
+    }
+
+    #[test]
+    fn filesystem_decoder_reads_only_upper_content() {
+        let temp = tempfile::tempdir().unwrap();
+        let upper = temp.path().join("upper");
+        std::fs::create_dir_all(upper.join("usr/bin")).unwrap();
+        std::fs::set_permissions(&upper, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::write(upper.join("usr/bin/changed"), b"changed only").unwrap();
+        let prior = captured(vec![
+            directory_entry("/usr"),
+            directory_entry("/usr/bin"),
+            regular_entry("/usr/bin/unchanged", content('a', 1_000_000)),
+        ]);
+        let cas = CasStore::new(temp.path().join("objects")).unwrap();
+        let delta =
+            decode_selected_root_overlay_upper(&upper, &prior, &cas, &user_profile()).unwrap();
+        assert_eq!(delta.upserts.len(), 3);
+        assert!(delta.upserts.iter().any(|entry| {
+            entry.path == "/usr/bin/changed"
+                && entry
+                    .content
+                    .as_ref()
+                    .is_some_and(|content| content.size == 12)
+        }));
+        assert!(entry(&delta.apply(&prior).unwrap(), "/usr/bin/unchanged").is_some());
+    }
+
+    fn user_profile() -> SelectedRootOverlayProfile {
+        SelectedRootOverlayProfile {
+            xattr_namespace: OverlayXattrNamespace::User,
+            ..SelectedRootOverlayProfile::trusted()
+        }
+    }
+
+    fn captured(entries: Vec<GenerationRootEntry>) -> CapturedSelectedRoot {
+        let (generation, state): (Vec<_>, Vec<_>) = entries.into_iter().partition(|entry| {
+            super::super::classify_root_path(&entry.path).unwrap()
+                == super::super::RootPathDomain::Immutable
+        });
+        CapturedSelectedRoot {
+            generation: super::super::GenerationRootManifest {
+                version: super::super::GENERATION_ROOT_MANIFEST_VERSION,
+                root: directory_node(),
+                entries: sorted(generation),
+            },
+            state: super::super::MutableStateManifest {
+                version: super::super::GENERATION_ROOT_MANIFEST_VERSION,
+                entries: sorted(state),
+            },
+        }
+    }
+
+    fn sorted(mut entries: Vec<GenerationRootEntry>) -> Vec<GenerationRootEntry> {
+        entries.sort_by(|left, right| left.path.cmp(&right.path));
+        entries
+    }
+
+    fn entry<'a>(
+        captured: &'a CapturedSelectedRoot,
+        path: &str,
+    ) -> Option<&'a GenerationRootEntry> {
+        captured
+            .generation
+            .entries
+            .iter()
+            .chain(&captured.state.entries)
+            .find(|entry| entry.path == path)
+    }
+
+    fn directory_entry(path: &str) -> GenerationRootEntry {
+        GenerationRootEntry {
+            path: path.into(),
+            node: directory_node(),
+            content: None,
+        }
+    }
+
+    fn regular_entry(path: &str, content: PayloadContentAuthority) -> GenerationRootEntry {
+        GenerationRootEntry {
+            path: path.into(),
+            node: ResolvedPayloadNode::from_numeric_source(PayloadNode::regular(0o644)).unwrap(),
+            content: Some(content),
+        }
+    }
+
+    fn directory_node() -> ResolvedPayloadNode {
+        let mut node = PayloadNode::regular(0o755);
+        node.kind = PayloadNodeKind::Directory;
+        node.mode = libc::S_IFDIR | 0o755;
+        node.user = PayloadIdentity::Numeric { id: 0 };
+        node.group = PayloadIdentity::Numeric { id: 0 };
+        ResolvedPayloadNode::from_numeric_source(node).unwrap()
+    }
+
+    fn content(byte: char, size: u64) -> PayloadContentAuthority {
+        PayloadContentAuthority {
+            sha256: byte.to_string().repeat(64),
+            size,
+        }
+    }
+}

--- a/crates/conary-core/src/generation/root_manifest/overlay/probe.rs
+++ b/crates/conary-core/src/generation/root_manifest/overlay/probe.rs
@@ -1,0 +1,370 @@
+// conary-core/src/generation/root_manifest/overlay/probe.rs
+
+//! Functional host/filesystem preflight for the selected-root OverlayFS profile.
+
+use super::{OverlayXattrNamespace, SelectedRootOverlayProfile};
+use nix::mount::{MntFlags, MsFlags, mount, umount2};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+
+pub const SELECTED_ROOT_OVERLAY_CAPABILITIES_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OverlayWhiteoutEncoding {
+    CharacterDeviceZeroZero,
+    ZeroSizeRegularXattr,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OverlayHardlinkCopyUp {
+    Preserved,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OverlayLowerDirectoryRename {
+    CrossDevice,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OverlayMetadataCopyUp {
+    CompleteData,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OverlayOpaqueDirectory {
+    LogicalY,
+}
+
+/// Exact behavior observed on one candidate runtime filesystem.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SelectedRootOverlayCapabilities {
+    pub version: u32,
+    pub profile: SelectedRootOverlayProfile,
+    pub whiteout_encoding: OverlayWhiteoutEncoding,
+    pub opaque_directory: OverlayOpaqueDirectory,
+    pub hardlink_copy_up: OverlayHardlinkCopyUp,
+    pub lower_directory_rename: OverlayLowerDirectoryRename,
+    pub metadata_copy_up: OverlayMetadataCopyUp,
+}
+
+/// Functionally prove the selected-root profile on `workspace`'s filesystem.
+///
+/// The probe creates one private disposable lower/upper/work/mount tuple,
+/// mounts the exact requested options, exercises semantic operations, syncs,
+/// unmounts, and lets `TempDir` discard every artifact. A mount/version/module
+/// name is never accepted as a substitute for this behavior.
+pub fn probe_selected_root_overlay_profile(
+    workspace: &Path,
+    profile: &SelectedRootOverlayProfile,
+) -> crate::Result<SelectedRootOverlayCapabilities> {
+    profile.validate()?;
+    fs::create_dir_all(workspace).map_err(|error| {
+        crate::Error::IoError(format!(
+            "failed to create selected-root overlay probe workspace {}: {error}",
+            workspace.display()
+        ))
+    })?;
+    let probe = tempfile::Builder::new()
+        .prefix(".overlay-capability-")
+        .tempdir_in(workspace)
+        .map_err(|error| {
+            crate::Error::IoError(format!(
+                "failed to create selected-root overlay probe in {}: {error}",
+                workspace.display()
+            ))
+        })?;
+    let lower = probe.path().join("lower");
+    let upper = probe.path().join("upper");
+    let work = probe.path().join("work");
+    let merged = probe.path().join("merged");
+    for directory in [&lower, &upper, &work, &merged] {
+        fs::create_dir(directory)?;
+    }
+    seed_lower(&lower)?;
+
+    let options = mount_data(&lower, &upper, &work, profile)?;
+    mount(
+        Some("overlay"),
+        &merged,
+        Some("overlay"),
+        MsFlags::empty(),
+        Some(options.as_str()),
+    )
+    .map_err(|error| {
+        crate::Error::NotImplemented(format!(
+            "selected-root OverlayFS profile mount failed on {}: {error}",
+            workspace.display()
+        ))
+    })?;
+    let mounted = MountedOverlay::new(merged.clone());
+
+    prove_hardlink_copy_up(&merged, &upper, profile)?;
+    let whiteout_encoding = prove_whiteout(&merged, &upper, profile)?;
+    prove_opaque_replacement(&merged, &upper, profile)?;
+    prove_redirect_disabled(&merged)?;
+    sync_filesystem(&upper)?;
+    mounted.unmount()?;
+
+    Ok(SelectedRootOverlayCapabilities {
+        version: SELECTED_ROOT_OVERLAY_CAPABILITIES_VERSION,
+        profile: profile.clone(),
+        whiteout_encoding,
+        opaque_directory: OverlayOpaqueDirectory::LogicalY,
+        hardlink_copy_up: OverlayHardlinkCopyUp::Preserved,
+        lower_directory_rename: OverlayLowerDirectoryRename::CrossDevice,
+        metadata_copy_up: OverlayMetadataCopyUp::CompleteData,
+    })
+}
+
+fn seed_lower(lower: &Path) -> crate::Result<()> {
+    fs::write(lower.join("hardlink-a"), b"hardlink-content")?;
+    fs::hard_link(lower.join("hardlink-a"), lower.join("hardlink-b"))?;
+    fs::write(lower.join("remove-me"), b"remove")?;
+    fs::create_dir(lower.join("replace-me"))?;
+    fs::write(lower.join("replace-me/lower-child"), b"lower")?;
+    fs::create_dir(lower.join("rename-me"))?;
+    fs::write(lower.join("rename-me/lower-child"), b"lower")?;
+    Ok(())
+}
+
+fn mount_data(
+    lower: &Path,
+    upper: &Path,
+    work: &Path,
+    profile: &SelectedRootOverlayProfile,
+) -> crate::Result<String> {
+    let mut components = Vec::new();
+    for (name, path) in [("lowerdir", lower), ("upperdir", upper), ("workdir", work)] {
+        let value = path.to_str().ok_or_else(|| {
+            crate::Error::NotImplemented(format!(
+                "selected-root OverlayFS {name} is not UTF-8: {}",
+                path.display()
+            ))
+        })?;
+        if value
+            .bytes()
+            .any(|byte| matches!(byte, b',' | b':' | b'\\' | b'\n' | b'\r'))
+        {
+            return Err(crate::Error::InvalidPath(format!(
+                "selected-root OverlayFS {name} contains a mount-option delimiter: {}",
+                path.display()
+            )));
+        }
+        components.push(format!("{name}={value}"));
+    }
+    components.extend(profile.mount_options()?.into_iter().map(str::to_string));
+    Ok(components.join(","))
+}
+
+fn prove_hardlink_copy_up(
+    merged: &Path,
+    upper: &Path,
+    profile: &SelectedRootOverlayProfile,
+) -> crate::Result<()> {
+    let changed = merged.join("hardlink-a");
+    fs::set_permissions(&changed, fs::Permissions::from_mode(0o600))?;
+    let changed_metadata = fs::symlink_metadata(&changed)?;
+    let alias_metadata = fs::symlink_metadata(merged.join("hardlink-b"))?;
+    if changed_metadata.dev() != alias_metadata.dev()
+        || changed_metadata.ino() != alias_metadata.ino()
+        || changed_metadata.mode() & 0o7777 != 0o600
+        || alias_metadata.mode() & 0o7777 != 0o600
+    {
+        return Err(crate::Error::NotImplemented(
+            "selected-root OverlayFS index did not preserve a copied-up hardlink group".to_string(),
+        ));
+    }
+    let upper_path = upper.join("hardlink-a");
+    if fs::read(&upper_path)? != b"hardlink-content" {
+        return Err(crate::Error::NotImplemented(
+            "selected-root OverlayFS metadata operation did not perform complete data copy-up"
+                .to_string(),
+        ));
+    }
+    if private_xattr(&upper_path, profile, "metacopy")?.is_some() {
+        return Err(crate::Error::NotImplemented(
+            "selected-root OverlayFS emitted metacopy despite metacopy=off".to_string(),
+        ));
+    }
+    if private_xattr(&upper_path, profile, "origin")?.is_none() {
+        return Err(crate::Error::NotImplemented(
+            "selected-root OverlayFS index did not emit copy-up origin authority".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn prove_whiteout(
+    merged: &Path,
+    upper: &Path,
+    profile: &SelectedRootOverlayProfile,
+) -> crate::Result<OverlayWhiteoutEncoding> {
+    fs::remove_file(merged.join("remove-me"))?;
+    let whiteout = upper.join("remove-me");
+    let metadata = fs::symlink_metadata(&whiteout)?;
+    if metadata.file_type().is_char_device() && metadata.rdev() == 0 {
+        return Ok(OverlayWhiteoutEncoding::CharacterDeviceZeroZero);
+    }
+    if metadata.file_type().is_file()
+        && metadata.len() == 0
+        && private_xattr(&whiteout, profile, "whiteout")?.is_some()
+    {
+        return Ok(OverlayWhiteoutEncoding::ZeroSizeRegularXattr);
+    }
+    Err(crate::Error::NotImplemented(
+        "selected-root OverlayFS emitted an unknown whiteout representation".to_string(),
+    ))
+}
+
+fn prove_opaque_replacement(
+    merged: &Path,
+    upper: &Path,
+    profile: &SelectedRootOverlayProfile,
+) -> crate::Result<()> {
+    fs::remove_dir_all(merged.join("replace-me"))?;
+    fs::create_dir(merged.join("replace-me"))?;
+    let value = private_xattr(&upper.join("replace-me"), profile, "opaque")?;
+    if value.as_deref() != Some(b"y".as_slice()) {
+        return Err(crate::Error::NotImplemented(
+            "selected-root OverlayFS did not encode lower-directory replacement as opaque=y"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn prove_redirect_disabled(merged: &Path) -> crate::Result<()> {
+    let error = match fs::rename(merged.join("rename-me"), merged.join("renamed")) {
+        Ok(()) => {
+            return Err(crate::Error::NotImplemented(
+                "selected-root OverlayFS created a redirect despite redirect_dir=nofollow"
+                    .to_string(),
+            ));
+        }
+        Err(error) => error,
+    };
+    if error.raw_os_error() != Some(libc::EXDEV) {
+        return Err(crate::Error::NotImplemented(format!(
+            "selected-root OverlayFS lower-directory rename returned {error}; expected EXDEV"
+        )));
+    }
+    Ok(())
+}
+
+fn private_xattr(
+    path: &Path,
+    profile: &SelectedRootOverlayProfile,
+    marker: &str,
+) -> crate::Result<Option<Vec<u8>>> {
+    let namespace = match profile.xattr_namespace {
+        OverlayXattrNamespace::Trusted => "trusted.overlay.",
+        OverlayXattrNamespace::User => "user.overlay.",
+    };
+    xattr::get(path, format!("{namespace}{marker}")).map_err(Into::into)
+}
+
+fn sync_filesystem(path: &Path) -> crate::Result<()> {
+    let directory = fs::File::open(path)?;
+    let result = unsafe { libc::syncfs(directory.as_raw_fd()) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    Ok(())
+}
+
+struct MountedOverlay {
+    target: PathBuf,
+    mounted: bool,
+}
+
+impl MountedOverlay {
+    fn new(target: PathBuf) -> Self {
+        Self {
+            target,
+            mounted: true,
+        }
+    }
+
+    fn unmount(mut self) -> crate::Result<()> {
+        umount2(&self.target, MntFlags::empty()).map_err(|error| {
+            crate::Error::IoError(format!(
+                "failed to unmount selected-root OverlayFS probe {}: {error}",
+                self.target.display()
+            ))
+        })?;
+        self.mounted = false;
+        Ok(())
+    }
+}
+
+impl Drop for MountedOverlay {
+    fn drop(&mut self) {
+        if self.mounted {
+            let _ = umount2(&self.target, MntFlags::MNT_DETACH);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mount_data_is_exact_and_rejects_delimiter_paths() {
+        let profile = SelectedRootOverlayProfile {
+            xattr_namespace: OverlayXattrNamespace::User,
+            ..SelectedRootOverlayProfile::trusted()
+        };
+        assert_eq!(
+            mount_data(
+                Path::new("/probe/lower"),
+                Path::new("/probe/upper"),
+                Path::new("/probe/work"),
+                &profile,
+            )
+            .unwrap(),
+            "lowerdir=/probe/lower,upperdir=/probe/upper,workdir=/probe/work,index=on,redirect_dir=nofollow,metacopy=off,xino=off,nfs_export=off,verity=off,userxattr"
+        );
+        assert!(
+            mount_data(
+                Path::new("/probe/with,comma"),
+                Path::new("/probe/upper"),
+                Path::new("/probe/work"),
+                &profile,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    #[ignore = "requires CAP_SYS_ADMIN and an OverlayFS-capable kernel"]
+    fn functionally_probes_selected_root_overlay_profile() {
+        let workspace = tempfile::tempdir().unwrap();
+        let capabilities = probe_selected_root_overlay_profile(
+            workspace.path(),
+            &SelectedRootOverlayProfile::trusted(),
+        )
+        .unwrap();
+        assert_eq!(
+            capabilities.hardlink_copy_up,
+            OverlayHardlinkCopyUp::Preserved
+        );
+        assert_eq!(
+            capabilities.lower_directory_rename,
+            OverlayLowerDirectoryRename::CrossDevice
+        );
+        assert_eq!(
+            capabilities.metadata_copy_up,
+            OverlayMetadataCopyUp::CompleteData
+        );
+    }
+}

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -631,6 +631,14 @@ root carries the `verity` feature before the suite starts, and the suite proves
 that fixture contract before Conary initialization so generation publication
 cannot degrade to an unprotected composefs mount.
 
+The bounded `selected-root-overlay-profile-solus` QEMU suite reuses that
+immutable fixture without running takeover. It functionally mounts the exact
+selected-root OverlayFS profile and proves indexed hardlink copy-up, complete
+metadata copy-up, character-device whiteouts, logical opaque replacement, and
+`EXDEV` for lower-directory rename. This is the positive kernel/filesystem
+counterpart to the runtime typed preflight; a kernel version or registered
+filesystem name alone is not capability evidence.
+
 Each full parity run must pass `scripts/check-conary-test-result-gate.sh` and
 `scripts/check-conary-corpus-result-gate.sh`,
 which requires zero failed, skipped, and cancelled results before the matrix


### PR DESCRIPTION
## Problem

Selected-root transactions need to convert one frozen OverlayFS upper into the normalized manifest delta merged in #409. Kernel/module defaults and filesystem names are not sufficient compatibility authority, and copying up one hardlink with OverlayFS indexing disabled breaks the group.

## Slice

- add versioned typed OverlayFS profile and capability evidence
- require `index=on`; constrain redirects, metacopy, xino, NFS export, and verity
- functionally probe the candidate upper/work filesystem through a disposable exact-profile mount
- capture only the frozen upper tree and decode documented whiteout/opaque artifacts
- preserve escaped payload xattrs while stripping exact private bookkeeping
- fail closed on unknown, redirect, metacopy, or unrepresented protected-inode markers
- normalize changed prior hardlink groups, new aliases, independent replacements, and removed primaries/aliases
- validate the fully applied manifest before returning the delta
- retain a capability-only Solus QEMU conformance lane against the published immutable fixture

This remains a bounded #403 slice. It does not yet switch selected-root transaction mounting or claim zero-full-scan acceptance.

## Upstream authority

- current stable Linux: 7.1.8 (2026-08-09)
- current OverlayFS documentation
- Linux v7.1 `fs/overlayfs/overlayfs.h`, `params.c`, `util.c`, and `xattrs.c`

## Verification

- `cargo test -p conary-core --lib generation::root_manifest` — 37 passed, 0 failed, 1 privileged probe ignored
- `cargo clippy -p conary-core --all-targets -- -D warnings` — passed
- `cargo run -p conary-test -- list` — parsed `Solus Overlay Profile Proof`
- `cargo run -p conary-test -- run --suite selected-root-overlay-profile-solus --distro solus --phase 4` — 1 passed in 28.2s on kernel 7.1.7; hardlinks preserved, complete metadata copy-up, character-device 0/0 whiteout, opaque=y, lower rename EXDEV
- `bash scripts/check-doc-truth.sh` — passed
- `cargo fmt --check`
- `git diff --check`

An initial attempt to execute the host-built Rust test binary in the guest failed before the probe because it required GLIBC_2.44. The durable guest lane uses a dependency-free Python probe and passed; the ABI mismatch is not reported as OverlayFS evidence.

Refs #403
