### PR TITLE
perf(generation): run selected-root mutations through OverlayFS

### DIFF
--- a/apps/conary/src/commands/generation/selected_root.rs
+++ b/apps/conary/src/commands/generation/selected_root.rs
@@ -38,7 +38,7 @@ enum SelectedRootBacking {
     Materialized,
 }
 
-/// One isolated selected-root view backed by a single filesystem journal.
+/// One isolated selected-root view with one transaction-owned rollback authority.
 ///
 /// The caller retains its SQLite transaction. This session never changes the
 /// host's `current` generation link; final generation publication happens only

--- a/apps/conary/src/commands/generation/selected_root.rs
+++ b/apps/conary/src/commands/generation/selected_root.rs
@@ -3,14 +3,24 @@
 //! Rollback-safe writable roots for generation-aware transaction execution.
 
 mod deferred_ima;
+mod overlay_session;
+mod publication_candidate;
+
+pub(crate) use publication_candidate::{
+    load_publication_candidate, persist_captured_publication_candidate,
+    remove_backed_up_publication_candidates, remove_publication_candidate,
+};
+#[cfg(test)]
+pub(crate) use publication_candidate::{
+    publication_candidate_dir, remove_terminal_publication_candidates,
+};
 
 use crate::commands::{LiveRootFile, LiveRootStats, LiveRootTransaction};
 use anyhow::{Context, Result, bail};
 use conary_core::db::models::GenerationPublication;
 use conary_core::filesystem::CasStore;
 use conary_core::generation::root_manifest::{
-    CapturedSelectedRoot, GenerationRootManifest, MutableStateManifest,
-    materialize_captured_selected_root, scan_selected_root,
+    CapturedSelectedRoot, materialize_captured_selected_root, scan_selected_root,
 };
 use conary_core::runtime_root::ConaryRuntimeRoot;
 use conary_core::transaction::{TransactionConfig, TransactionEngine};
@@ -18,6 +28,15 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use deferred_ima::DeferredImaAuthority;
+use overlay_session::SelectedRootOverlaySession;
+use publication_candidate::{latest_selected_root_candidate, persist_publication_candidate};
+
+enum SelectedRootBacking {
+    Overlay(SelectedRootOverlaySession),
+    /// Try sessions retain a complete tree for later namespace exposure. The
+    /// test mount bypass exercises that same explicit non-production boundary.
+    Materialized,
+}
 
 /// One isolated selected-root view backed by a single filesystem journal.
 ///
@@ -30,6 +49,8 @@ pub(crate) struct SelectedRootSession {
     transaction: Option<LiveRootTransaction>,
     transaction_engine: TransactionEngine,
     deferred_ima: DeferredImaAuthority,
+    prior: CapturedSelectedRoot,
+    backing: SelectedRootBacking,
 }
 
 /// The runtime mutation lock, held before any package authority is read.
@@ -96,26 +117,49 @@ impl LockedRuntimeRoot {
         conn: &rusqlite::Connection,
         operation: impl Into<String>,
     ) -> Result<SelectedRootSession> {
+        let materialized_backing = use_materialized_selected_root_backing();
+        self.materialize_with_backing(conn, operation, materialized_backing)
+    }
+
+    fn materialize_retained(
+        self,
+        conn: &rusqlite::Connection,
+        operation: impl Into<String>,
+    ) -> Result<SelectedRootSession> {
+        self.materialize_with_backing(conn, operation, true)
+    }
+
+    fn materialize_with_backing(
+        self,
+        conn: &rusqlite::Connection,
+        operation: impl Into<String>,
+        materialized_backing: bool,
+    ) -> Result<SelectedRootSession> {
         let Self {
             runtime_root,
             session_dir,
             session_id,
             transaction_engine,
         } = self;
-        let selected_root = session_dir.join("root");
-        fs::create_dir_all(&selected_root).with_context(|| {
+        let materialization_root = if materialized_backing {
+            session_dir.join("root")
+        } else {
+            session_dir.join("lower")
+        };
+        fs::create_dir_all(&materialization_root).with_context(|| {
             format!(
-                "failed to create selected generation root {}",
-                selected_root.display()
+                "failed to create selected-root materialization destination {}",
+                materialization_root.display()
             )
         })?;
-        let materialized = match materialize_current_root(conn, &runtime_root, &selected_root) {
-            Ok(materialized) => materialized,
-            Err(error) => {
-                let _ = fs::remove_dir_all(&session_dir);
-                return Err(error);
-            }
-        };
+        let materialized =
+            match materialize_current_root(conn, &runtime_root, &materialization_root) {
+                Ok(materialized) => materialized,
+                Err(error) => {
+                    let _ = fs::remove_dir_all(&session_dir);
+                    return Err(error);
+                }
+            };
         let deferred_ima = match DeferredImaAuthority::from_captured(&materialized) {
             Ok(authority) => authority,
             Err(error) => {
@@ -123,14 +167,36 @@ impl LockedRuntimeRoot {
                 return Err(error);
             }
         };
-        let transaction = match LiveRootTransaction::begin(
-            runtime_root.root(),
-            &selected_root,
-            session_id,
-            operation,
-        ) {
+        let mut backing = if materialized_backing {
+            SelectedRootBacking::Materialized
+        } else {
+            match SelectedRootOverlaySession::begin(&session_dir, &materialized) {
+                Ok(overlay) => SelectedRootBacking::Overlay(overlay),
+                Err(error) => {
+                    let _ = fs::remove_dir_all(&session_dir);
+                    return Err(error);
+                }
+            }
+        };
+        let selected_root = match &backing {
+            SelectedRootBacking::Overlay(overlay) => overlay.selected_root().to_path_buf(),
+            SelectedRootBacking::Materialized => session_dir.join("root"),
+        };
+        let transaction = match if matches!(&backing, SelectedRootBacking::Overlay(_)) {
+            LiveRootTransaction::begin_disposable_overlay(
+                runtime_root.root(),
+                &selected_root,
+                session_id,
+                operation,
+            )
+        } else {
+            LiveRootTransaction::begin(runtime_root.root(), &selected_root, session_id, operation)
+        } {
             Ok(transaction) => transaction,
             Err(error) => {
+                if let SelectedRootBacking::Overlay(overlay) = &mut backing {
+                    let _ = overlay.unmount_for_discard();
+                }
                 let _ = fs::remove_dir_all(&session_dir);
                 return Err(error);
             }
@@ -141,6 +207,8 @@ impl LockedRuntimeRoot {
             transaction: Some(transaction),
             transaction_engine,
             deferred_ima,
+            prior: materialized,
+            backing,
         })
     }
 }
@@ -182,7 +250,8 @@ impl SelectedRootSession {
     ) -> Result<Self> {
         validate_try_session_dir(runtime_root, &session_dir)?;
         let session_id = uuid::Uuid::new_v4().to_string();
-        Self::begin_in_session_dir(conn, runtime_root, session_dir, session_id, operation)
+        LockedRuntimeRoot::acquire_in_session_dir(runtime_root.clone(), session_dir, session_id)?
+            .materialize_retained(conn, operation)
     }
 
     fn begin_in_session_dir(
@@ -204,14 +273,12 @@ impl SelectedRootSession {
         self.transaction_engine.cas()
     }
 
-    /// Capture the complete selected-root authority before a transaction mutates it.
+    /// Return the exact typed authority selected before mutation.
     ///
-    /// Rollback persists this manifest with the changeset. Rebuilding from package
-    /// rows alone would lose exact parent-directory and lifecycle-created state.
+    /// The lower is immutable, so rollback needs neither a complete scan nor a
+    /// reconstruction from package rows.
     pub(crate) fn capture_rollback_authority(&self) -> Result<CapturedSelectedRoot> {
-        let mut captured = scan_selected_root(&self.selected_root, self.transaction_engine.cas())?;
-        self.deferred_ima.restore_into(&mut captured)?;
-        Ok(captured)
+        Ok(self.prior.clone())
     }
 
     pub(crate) fn apply_install_files(&mut self, files: &[LiveRootFile]) -> Result<()> {
@@ -247,6 +314,9 @@ impl SelectedRootSession {
             .take()
             .context("selected-root transaction already completed")?
             .commit()?;
+        if !matches!(&self.backing, SelectedRootBacking::Materialized) {
+            bail!("only an explicit retained try-session root can be preserved");
+        }
         let cas = CasStore::new(runtime_root.objects_dir())?;
         let mut captured = scan_selected_root(&self.selected_root, &cas)?;
         self.deferred_ima.restore_into(&mut captured)?;
@@ -269,9 +339,15 @@ impl SelectedRootSession {
                 .context("selected-root transaction already completed")?
                 .commit()?;
             let cas = CasStore::new(runtime_root.objects_dir())?;
-            let mut captured = scan_selected_root(&self.selected_root, &cas)?;
+            let mut captured = match &mut self.backing {
+                SelectedRootBacking::Overlay(overlay) => overlay
+                    .freeze_and_decode(&self.prior, &cas)?
+                    .apply(&self.prior)?,
+                SelectedRootBacking::Materialized => scan_selected_root(&self.selected_root, &cas)?,
+            };
             self.deferred_ima.restore_into(&mut captured)?;
-            persist_publication_candidate(runtime_root, debt, &self.session_dir, &captured)?;
+            persist_publication_candidate(runtime_root, debt, &captured)?;
+            remove_session_dir(&self.session_dir)?;
             Ok(captured)
         })();
         if result.is_err() {
@@ -281,10 +357,22 @@ impl SelectedRootSession {
     }
 
     pub(crate) fn rollback(&mut self) -> Result<()> {
-        if let Some(mut transaction) = self.transaction.take() {
-            transaction.rollback()?;
-        }
-        remove_session_dir(&self.session_dir)
+        let transaction_result = if let Some(transaction) = self.transaction.take() {
+            // The merged root is disposable. Completing the journal and
+            // discarding the upper is both safer and cheaper than replaying
+            // path-by-path restoration into a tree that cannot be published.
+            transaction.commit()
+        } else {
+            Ok(())
+        };
+        let unmount_result = match &mut self.backing {
+            SelectedRootBacking::Overlay(overlay) => overlay.unmount_for_discard(),
+            SelectedRootBacking::Materialized => Ok(()),
+        };
+        let removal_result = remove_session_dir(&self.session_dir);
+        transaction_result?;
+        unmount_result?;
+        removal_result
     }
 
     fn transaction_mut(&mut self) -> Result<&mut LiveRootTransaction> {
@@ -292,6 +380,10 @@ impl SelectedRootSession {
             .as_mut()
             .context("selected-root transaction already completed")
     }
+}
+
+fn use_materialized_selected_root_backing() -> bool {
+    cfg!(test) || std::env::var_os("CONARY_TEST_SKIP_GENERATION_MOUNT").is_some()
 }
 
 impl Drop for SelectedRootSession {
@@ -333,189 +425,6 @@ fn materialize_current_root(
         selected_root,
     )
     .map_err(Into::into)
-}
-
-pub(crate) fn publication_candidate_dir(
-    runtime_root: &ConaryRuntimeRoot,
-    debt: &GenerationPublication,
-) -> Result<PathBuf> {
-    let id = debt
-        .id
-        .context("generation publication candidate requires a persisted debt id")?;
-    Ok(runtime_root
-        .root()
-        .join("publication-roots")
-        .join(id.to_string()))
-}
-
-pub(crate) fn load_publication_candidate(
-    runtime_root: &ConaryRuntimeRoot,
-    debt: &GenerationPublication,
-) -> Result<CapturedSelectedRoot> {
-    let candidate = publication_candidate_dir(runtime_root, debt)?;
-    if !candidate.join("root").is_dir() {
-        bail!(
-            "selected-root publication candidate is missing for debt {} at {}",
-            debt.id.unwrap_or_default(),
-            candidate.display()
-        );
-    }
-    Ok(CapturedSelectedRoot {
-        generation: GenerationRootManifest::read_from(&candidate)?,
-        state: MutableStateManifest::read_from(&candidate)?,
-    })
-}
-
-pub(crate) fn remove_publication_candidate(
-    runtime_root: &ConaryRuntimeRoot,
-    debt: &GenerationPublication,
-) -> Result<()> {
-    let candidate = publication_candidate_dir(runtime_root, debt)?;
-    match fs::remove_dir_all(&candidate) {
-        Ok(()) => {
-            conary_core::filesystem::durable::sync_parent_directory(&candidate)?;
-            Ok(())
-        }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(error.into()),
-    }
-}
-
-/// Persist an already-captured selected root as retryable publication input.
-///
-/// Rollback carries this authority in changeset metadata, so it has no live
-/// selected-root session directory to transfer into the candidate.
-pub(crate) fn persist_captured_publication_candidate(
-    runtime_root: &ConaryRuntimeRoot,
-    debt: &GenerationPublication,
-    captured: &CapturedSelectedRoot,
-) -> Result<()> {
-    let candidate = publication_candidate_dir(runtime_root, debt)?;
-    remove_uncommitted_candidate_collision(&candidate)?;
-    let candidates_root = candidate
-        .parent()
-        .context("publication candidate has no parent")?;
-    fs::create_dir_all(candidates_root)?;
-    let temporary = candidates_root.join(format!(".candidate-{}.tmp", uuid::Uuid::new_v4()));
-    fs::create_dir(&temporary)?;
-    let result = (|| -> Result<()> {
-        captured.generation.write_to(&temporary)?;
-        captured.state.write_to(&temporary)?;
-        let candidate_root = temporary.join("root");
-        let cas = CasStore::new(runtime_root.objects_dir())?;
-        materialize_captured_selected_root(captured, &cas, &candidate_root)?;
-        fs::rename(&temporary, &candidate)?;
-        conary_core::filesystem::durable::sync_parent_directory(&candidate)?;
-        Ok(())
-    })();
-    if result.is_err() {
-        let _ = fs::remove_dir_all(&temporary);
-        let _ = fs::remove_dir_all(&candidate);
-    }
-    result
-}
-
-#[cfg(test)]
-pub(crate) fn remove_terminal_publication_candidates(
-    conn: &rusqlite::Connection,
-    runtime_root: &ConaryRuntimeRoot,
-    candidates: &[GenerationPublication],
-) -> Result<()> {
-    for candidate in candidates {
-        let id = candidate
-            .id
-            .context("publication candidate cleanup requires a persisted debt id")?;
-        let current = GenerationPublication::find_by_id(conn, id)?
-            .context("publication candidate cleanup debt disappeared")?;
-        if current.recoverable {
-            continue;
-        }
-        remove_publication_candidate(runtime_root, &current)?;
-    }
-    Ok(())
-}
-
-/// Remove publication inputs after the aggregate generation backup is durable.
-///
-/// A debt in `DatabaseBackedUp` replays from the generation artifact and
-/// verified backup, so it no longer depends on its selected-root candidate.
-/// Deleting candidates before the terminal DB update makes the crash tail
-/// idempotent: retry can repeat deletion and only then complete the debt.
-pub(crate) fn remove_backed_up_publication_candidates(
-    runtime_root: &ConaryRuntimeRoot,
-    candidates: &[GenerationPublication],
-) -> Result<()> {
-    for candidate in candidates {
-        candidate
-            .id
-            .context("backed-up publication candidate requires a persisted debt id")?;
-        remove_publication_candidate(runtime_root, candidate)?;
-    }
-    Ok(())
-}
-
-fn latest_selected_root_candidate(
-    conn: &rusqlite::Connection,
-    runtime_root: &ConaryRuntimeRoot,
-) -> Result<Option<CapturedSelectedRoot>> {
-    let debts = GenerationPublication::pending_recoverable(conn)?;
-    let Some(latest) = debts.last() else {
-        return Ok(None);
-    };
-    load_publication_candidate(runtime_root, latest).map(Some)
-}
-
-fn persist_publication_candidate(
-    runtime_root: &ConaryRuntimeRoot,
-    debt: &GenerationPublication,
-    session_dir: &Path,
-    captured: &CapturedSelectedRoot,
-) -> Result<()> {
-    let candidate = publication_candidate_dir(runtime_root, debt)?;
-    remove_uncommitted_candidate_collision(&candidate)?;
-    let candidates_root = candidate
-        .parent()
-        .context("publication candidate has no parent")?;
-    fs::create_dir_all(candidates_root)?;
-    let temporary = candidates_root.join(format!(".candidate-{}.tmp", uuid::Uuid::new_v4()));
-    fs::create_dir(&temporary)?;
-    let result = (|| -> Result<()> {
-        captured.generation.write_to(&temporary)?;
-        captured.state.write_to(&temporary)?;
-        fs::rename(session_dir.join("root"), temporary.join("root"))?;
-        remove_session_dir(session_dir)?;
-        fs::rename(&temporary, &candidate)?;
-        conary_core::filesystem::durable::sync_parent_directory(&candidate)?;
-        Ok(())
-    })();
-    if result.is_err() {
-        let _ = fs::remove_dir_all(&temporary);
-    }
-    result
-}
-
-/// Remove a candidate left by a process that died before its SQLite insert
-/// committed.
-///
-/// Candidate IDs come from an uncommitted AUTOINCREMENT row and are therefore
-/// reusable after SQLite rolls that transaction back. Every caller reaches
-/// this boundary while holding the single runtime mutation lock and immediately
-/// after creating a new debt row, so an existing directory at the same ID
-/// cannot belong to another live or committed transaction.
-fn remove_uncommitted_candidate_collision(candidate: &Path) -> Result<()> {
-    match fs::symlink_metadata(candidate) {
-        Ok(metadata) if metadata.file_type().is_dir() => {
-            fs::remove_dir_all(candidate)?;
-            conary_core::filesystem::durable::sync_parent_directory(candidate)?;
-            Ok(())
-        }
-        Ok(_) => bail!(
-            "selected-root publication candidate has an unexpected file type: {}",
-            candidate.display()
-        ),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(error.into()),
-    }
 }
 
 fn remove_session_dir(path: &Path) -> Result<()> {
@@ -664,6 +573,29 @@ mod tests {
     }
 
     #[test]
+    fn rollback_authority_is_the_immutable_prior_not_a_mutated_root_scan() {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("conary.db");
+        conary_core::db::init(&db_path).unwrap();
+        let conn = conary_core::db::open(&db_path).unwrap();
+        let mut session =
+            SelectedRootSession::begin(&conn, db_path.to_str().unwrap(), "rollback prior").unwrap();
+        let before = session.capture_rollback_authority().unwrap();
+        session
+            .apply_install_files(&[live_regular("/opt/new", b"new", 0o644)])
+            .unwrap();
+
+        assert_eq!(session.capture_rollback_authority().unwrap(), before);
+        assert!(
+            !before
+                .generation
+                .entries
+                .iter()
+                .any(|entry| entry.path == "/opt/new")
+        );
+    }
+
+    #[test]
     fn selected_root_candidate_is_retryable_until_debt_driven_cleanup() {
         let temp = tempfile::tempdir().unwrap();
         let db_path = temp.path().join("conary.db");
@@ -694,18 +626,18 @@ mod tests {
             .persist_for_publication(&runtime_root, &debt)
             .unwrap();
         let candidate = publication_candidate_dir(&runtime_root, &debt).unwrap();
-        assert_eq!(
-            fs::read(candidate.join("root/opt/lifecycle-created")).unwrap(),
-            b"exact lifecycle output"
-        );
+        assert!(!candidate.join("root").exists());
+        fs::create_dir(candidate.join("root")).unwrap();
+        assert!(load_publication_candidate(&runtime_root, &debt).is_err());
+        fs::remove_dir(candidate.join("root")).unwrap();
         let captured = load_publication_candidate(&runtime_root, &debt).unwrap();
-        assert!(
-            captured
-                .generation
-                .entries
-                .iter()
-                .any(|entry| entry.path == "/opt/lifecycle-created")
-        );
+        let entry = captured
+            .generation
+            .entries
+            .iter()
+            .find(|entry| entry.path == "/opt/lifecycle-created")
+            .unwrap();
+        assert_eq!(entry.content.as_ref().map(|content| content.size), Some(22));
 
         remove_terminal_publication_candidates(&conn, &runtime_root, std::slice::from_ref(&debt))
             .unwrap();

--- a/apps/conary/src/commands/generation/selected_root/overlay_session.rs
+++ b/apps/conary/src/commands/generation/selected_root/overlay_session.rs
@@ -1,0 +1,103 @@
+// apps/conary/src/commands/generation/selected_root/overlay_session.rs
+
+//! Transaction-owned OverlayFS lifetime for a selected-root session.
+
+use anyhow::{Context, Result};
+use conary_core::filesystem::CasStore;
+use conary_core::generation::root_manifest::{
+    CapturedSelectedRoot, MountedSelectedRootOverlay, SelectedRootManifestDelta,
+    SelectedRootOverlayCapabilities, SelectedRootOverlayProfile, apply_resolved_payload_metadata,
+    decode_selected_root_overlay_upper, encode_selected_root_overlay_upper_node,
+    probe_selected_root_overlay_profile,
+};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// A mounted merged root whose only writable authority is `upper`.
+pub(super) struct SelectedRootOverlaySession {
+    selected_root: PathBuf,
+    upper: PathBuf,
+    mounted: Option<MountedSelectedRootOverlay>,
+    capabilities: SelectedRootOverlayCapabilities,
+}
+
+impl SelectedRootOverlaySession {
+    /// Probe the actual workspace, materialize the immutable lower, and mount
+    /// the exact admitted profile before lifecycle mutation can begin.
+    pub(super) fn begin(session_dir: &Path, prior: &CapturedSelectedRoot) -> Result<Self> {
+        fs::create_dir_all(session_dir).with_context(|| {
+            format!(
+                "failed to create selected-root overlay workspace {}",
+                session_dir.display()
+            )
+        })?;
+        let profile = SelectedRootOverlayProfile::trusted();
+        let capabilities = probe_selected_root_overlay_profile(session_dir, &profile)
+            .context("selected-root OverlayFS capability preflight failed")?;
+
+        let lower = session_dir.join("lower");
+        let upper = session_dir.join("upper");
+        let work = session_dir.join("work");
+        let selected_root = session_dir.join("root");
+        if !lower.is_dir() {
+            anyhow::bail!(
+                "selected-root immutable lower authority is missing at {}",
+                lower.display()
+            );
+        }
+        for directory in [&upper, &work, &selected_root] {
+            fs::create_dir(directory).with_context(|| {
+                format!(
+                    "failed to create selected-root overlay directory {}",
+                    directory.display()
+                )
+            })?;
+        }
+        // The upper directory itself represents the merged root node. Seeding
+        // it prevents an unchanged root from becoming a synthetic delta.
+        let upper_root = encode_selected_root_overlay_upper_node(&prior.generation.root, &profile)
+            .context("failed to encode selected-root overlay root metadata")?;
+        apply_resolved_payload_metadata(&upper, &upper_root)
+            .context("failed to seed selected-root overlay root metadata")?;
+        let mounted =
+            MountedSelectedRootOverlay::mount(&lower, &upper, &work, &selected_root, &profile)
+                .context("failed to mount selected-root OverlayFS session")?;
+
+        Ok(Self {
+            selected_root,
+            upper,
+            mounted: Some(mounted),
+            capabilities,
+        })
+    }
+
+    pub(super) fn selected_root(&self) -> &Path {
+        &self.selected_root
+    }
+
+    /// Freeze the upper with a strict unmount, then decode changed paths only.
+    pub(super) fn freeze_and_decode(
+        &mut self,
+        prior: &CapturedSelectedRoot,
+        cas: &CasStore,
+    ) -> Result<SelectedRootManifestDelta> {
+        self.mounted
+            .take()
+            .context("selected-root OverlayFS session is already frozen")?
+            .freeze(&self.upper)
+            .context("failed to freeze selected-root OverlayFS session")?;
+        decode_selected_root_overlay_upper(&self.upper, prior, cas, &self.capabilities.profile)
+            .context("failed to decode selected-root OverlayFS upper")
+    }
+
+    /// Strictly unmount without decoding; the caller then discards the
+    /// transaction directory and the prior manifest remains authoritative.
+    pub(super) fn unmount_for_discard(&mut self) -> Result<()> {
+        if let Some(mounted) = self.mounted.take() {
+            mounted
+                .unmount()
+                .context("failed to unmount discarded selected-root OverlayFS session")?;
+        }
+        Ok(())
+    }
+}

--- a/apps/conary/src/commands/generation/selected_root/overlay_session.rs
+++ b/apps/conary/src/commands/generation/selected_root/overlay_session.rs
@@ -22,8 +22,8 @@ pub(super) struct SelectedRootOverlaySession {
 }
 
 impl SelectedRootOverlaySession {
-    /// Probe the actual workspace, materialize the immutable lower, and mount
-    /// the exact admitted profile before lifecycle mutation can begin.
+    /// Probe the actual workspace, admit the materialized immutable lower, and
+    /// mount the exact profile before lifecycle mutation can begin.
     pub(super) fn begin(session_dir: &Path, prior: &CapturedSelectedRoot) -> Result<Self> {
         fs::create_dir_all(session_dir).with_context(|| {
             format!(

--- a/apps/conary/src/commands/generation/selected_root/publication_candidate.rs
+++ b/apps/conary/src/commands/generation/selected_root/publication_candidate.rs
@@ -1,0 +1,188 @@
+// apps/conary/src/commands/generation/selected_root/publication_candidate.rs
+
+//! Durable manifest-only inputs for selected-root publication replay.
+
+use anyhow::{Context, Result, bail};
+use conary_core::db::models::GenerationPublication;
+use conary_core::generation::root_manifest::{
+    CapturedSelectedRoot, GenerationRootManifest, MutableStateManifest,
+};
+use conary_core::runtime_root::ConaryRuntimeRoot;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub(crate) fn publication_candidate_dir(
+    runtime_root: &ConaryRuntimeRoot,
+    debt: &GenerationPublication,
+) -> Result<PathBuf> {
+    let id = debt
+        .id
+        .context("generation publication candidate requires a persisted debt id")?;
+    Ok(runtime_root
+        .root()
+        .join("publication-roots")
+        .join(id.to_string()))
+}
+
+pub(crate) fn load_publication_candidate(
+    runtime_root: &ConaryRuntimeRoot,
+    debt: &GenerationPublication,
+) -> Result<CapturedSelectedRoot> {
+    let candidate = publication_candidate_dir(runtime_root, debt)?;
+    if !candidate.is_dir() {
+        bail!(
+            "selected-root publication candidate is missing for debt {} at {}",
+            debt.id.unwrap_or_default(),
+            candidate.display()
+        );
+    }
+    if candidate.join("root").exists() {
+        bail!(
+            "selected-root publication candidate {} uses retired materialized-root storage; discard pending pre-alpha publication state and rebuild it from current authority",
+            candidate.display()
+        );
+    }
+    Ok(CapturedSelectedRoot {
+        generation: GenerationRootManifest::read_from(&candidate)?,
+        state: MutableStateManifest::read_from(&candidate)?,
+    })
+}
+
+pub(crate) fn remove_publication_candidate(
+    runtime_root: &ConaryRuntimeRoot,
+    debt: &GenerationPublication,
+) -> Result<()> {
+    let candidate = publication_candidate_dir(runtime_root, debt)?;
+    match fs::remove_dir_all(&candidate) {
+        Ok(()) => {
+            conary_core::filesystem::durable::sync_parent_directory(&candidate)?;
+            Ok(())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+/// Persist an already-captured selected root as retryable publication input.
+///
+/// Rollback carries this authority in changeset metadata, so it has no live
+/// selected-root session directory to transfer into the candidate.
+pub(crate) fn persist_captured_publication_candidate(
+    runtime_root: &ConaryRuntimeRoot,
+    debt: &GenerationPublication,
+    captured: &CapturedSelectedRoot,
+) -> Result<()> {
+    persist_publication_candidate_inner(runtime_root, debt, captured, true)
+}
+
+#[cfg(test)]
+pub(crate) fn remove_terminal_publication_candidates(
+    conn: &rusqlite::Connection,
+    runtime_root: &ConaryRuntimeRoot,
+    candidates: &[GenerationPublication],
+) -> Result<()> {
+    for candidate in candidates {
+        let id = candidate
+            .id
+            .context("publication candidate cleanup requires a persisted debt id")?;
+        let current = GenerationPublication::find_by_id(conn, id)?
+            .context("publication candidate cleanup debt disappeared")?;
+        if current.recoverable {
+            continue;
+        }
+        remove_publication_candidate(runtime_root, &current)?;
+    }
+    Ok(())
+}
+
+/// Remove publication inputs after the aggregate generation backup is durable.
+///
+/// A debt in `DatabaseBackedUp` replays from the generation artifact and
+/// verified backup, so it no longer depends on its selected-root candidate.
+/// Deleting candidates before the terminal DB update makes the crash tail
+/// idempotent: retry can repeat deletion and only then complete the debt.
+pub(crate) fn remove_backed_up_publication_candidates(
+    runtime_root: &ConaryRuntimeRoot,
+    candidates: &[GenerationPublication],
+) -> Result<()> {
+    for candidate in candidates {
+        candidate
+            .id
+            .context("backed-up publication candidate requires a persisted debt id")?;
+        remove_publication_candidate(runtime_root, candidate)?;
+    }
+    Ok(())
+}
+
+pub(super) fn latest_selected_root_candidate(
+    conn: &rusqlite::Connection,
+    runtime_root: &ConaryRuntimeRoot,
+) -> Result<Option<CapturedSelectedRoot>> {
+    let debts = GenerationPublication::pending_recoverable(conn)?;
+    let Some(latest) = debts.last() else {
+        return Ok(None);
+    };
+    load_publication_candidate(runtime_root, latest).map(Some)
+}
+
+pub(super) fn persist_publication_candidate(
+    runtime_root: &ConaryRuntimeRoot,
+    debt: &GenerationPublication,
+    captured: &CapturedSelectedRoot,
+) -> Result<()> {
+    persist_publication_candidate_inner(runtime_root, debt, captured, false)
+}
+
+fn persist_publication_candidate_inner(
+    runtime_root: &ConaryRuntimeRoot,
+    debt: &GenerationPublication,
+    captured: &CapturedSelectedRoot,
+    remove_candidate_on_error: bool,
+) -> Result<()> {
+    let candidate = publication_candidate_dir(runtime_root, debt)?;
+    remove_uncommitted_candidate_collision(&candidate)?;
+    let candidates_root = candidate
+        .parent()
+        .context("publication candidate has no parent")?;
+    fs::create_dir_all(candidates_root)?;
+    let temporary = candidates_root.join(format!(".candidate-{}.tmp", uuid::Uuid::new_v4()));
+    fs::create_dir(&temporary)?;
+    let result = (|| -> Result<()> {
+        captured.generation.write_to(&temporary)?;
+        captured.state.write_to(&temporary)?;
+        fs::rename(&temporary, &candidate)?;
+        conary_core::filesystem::durable::sync_parent_directory(&candidate)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_dir_all(&temporary);
+        if remove_candidate_on_error {
+            let _ = fs::remove_dir_all(&candidate);
+        }
+    }
+    result
+}
+
+/// Remove a candidate left by a process that died before its SQLite insert
+/// committed.
+///
+/// Candidate IDs come from an uncommitted AUTOINCREMENT row and are therefore
+/// reusable after SQLite rolls that transaction back. Every caller reaches
+/// this boundary while holding the single runtime mutation lock and immediately
+/// after creating a new debt row, so an existing directory at the same ID
+/// cannot belong to another live or committed transaction.
+fn remove_uncommitted_candidate_collision(candidate: &Path) -> Result<()> {
+    match fs::symlink_metadata(candidate) {
+        Ok(metadata) if metadata.file_type().is_dir() => {
+            fs::remove_dir_all(candidate)?;
+            conary_core::filesystem::durable::sync_parent_directory(candidate)?;
+            Ok(())
+        }
+        Ok(_) => bail!(
+            "selected-root publication candidate has an unexpected file type: {}",
+            candidate.display()
+        ),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}

--- a/apps/conary/src/commands/live_root.rs
+++ b/apps/conary/src/commands/live_root.rs
@@ -250,7 +250,9 @@ impl LiveRootTransaction {
             }
             Ok(_) => {
                 self.backup_existing(&target)?;
-                self.created_paths.push(target.clone());
+                if self.recovery == LiveRootRecovery::Journaled {
+                    self.created_paths.push(target.clone());
+                }
                 self.write_journal("in_progress")?;
                 create_dir_and_sync(&target)?;
                 stats.dirs_created += 1;

--- a/apps/conary/src/commands/live_root.rs
+++ b/apps/conary/src/commands/live_root.rs
@@ -1,7 +1,7 @@
 // apps/conary/src/commands/live_root.rs
 
 use anyhow::{Context, Result, bail};
-use conary_core::filesystem::durable::{sync_parent_directory, write_json_atomic};
+use conary_core::filesystem::durable::write_json_atomic;
 use conary_core::generation::root_manifest::{apply_resolved_payload_metadata, capture_root_node};
 use conary_core::payload::{PayloadNodeKind, ResolvedPayloadNode};
 use serde::{Deserialize, Serialize};
@@ -14,8 +14,12 @@ use std::os::unix::net::UnixListener;
 use std::path::{Component, Path, PathBuf};
 
 mod content;
+mod durability;
+mod path;
 mod recovery;
 pub(crate) use content::LiveRootContent;
+use durability::*;
+pub(crate) use path::target_path;
 pub(crate) use recovery::recover_pending_journals;
 #[cfg(test)]
 pub(crate) use recovery::recover_pending_journals_with_changesets;
@@ -70,39 +74,17 @@ pub(crate) struct LiveRootTransaction {
     created_paths: Vec<PathBuf>,
     removed_dirs: Vec<PathBuf>,
     modified_directories: Vec<DirectoryMetadataRecord>,
+    recovery: LiveRootRecovery,
     committed: bool,
 }
 
-pub(crate) fn target_path(root: &Path, package_path: &str) -> Result<PathBuf> {
-    let relative = package_path.strip_prefix('/').unwrap_or(package_path);
-    let relative_path = Path::new(relative);
-    let mut has_path_below_root = false;
-    for component in relative_path.components() {
-        match component {
-            Component::Normal(_) => has_path_below_root = true,
-            Component::CurDir => {
-                bail!(
-                    "package path {package_path} must name a file or directory below the target root"
-                );
-            }
-            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
-                bail!("package path {package_path} escapes the target root");
-            }
-        }
-    }
-    if !has_path_below_root {
-        bail!("package path {package_path} must name a file or directory below the target root");
-    }
-    Ok(root.join(relative_path))
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LiveRootRecovery {
+    Journaled,
+    DisposableOverlay,
 }
 
-fn selected_root_target_path(root: &Path, package_path: &str) -> Result<PathBuf> {
-    let effective = conary_core::filesystem::selected_root::selected_root_effective_package_path(
-        root,
-        package_path,
-    )?;
-    target_path(root, &effective)
-}
+use path::selected_root_target_path;
 
 impl LiveRootTransaction {
     pub(crate) fn begin(
@@ -111,9 +93,47 @@ impl LiveRootTransaction {
         tx_uuid: String,
         operation: impl Into<String>,
     ) -> Result<Self> {
+        Self::begin_with_recovery(
+            runtime_root,
+            root,
+            tx_uuid,
+            operation,
+            LiveRootRecovery::Journaled,
+        )
+    }
+
+    /// Mutate a transaction-owned overlay without duplicating rollback state.
+    ///
+    /// The upper is the sole rollback record and its owner must discard it on
+    /// failure. Moving lower-backed nodes into an external journal would cross
+    /// filesystems and would duplicate authority even where rename succeeded.
+    pub(crate) fn begin_disposable_overlay(
+        runtime_root: &Path,
+        root: &Path,
+        tx_uuid: String,
+        operation: impl Into<String>,
+    ) -> Result<Self> {
+        Self::begin_with_recovery(
+            runtime_root,
+            root,
+            tx_uuid,
+            operation,
+            LiveRootRecovery::DisposableOverlay,
+        )
+    }
+
+    fn begin_with_recovery(
+        runtime_root: &Path,
+        root: &Path,
+        tx_uuid: String,
+        operation: impl Into<String>,
+        recovery: LiveRootRecovery,
+    ) -> Result<Self> {
         validate_tx_uuid(&tx_uuid)?;
         let journal_dir = runtime_root.join("live-root-journals");
-        create_dir_all_and_sync(&journal_dir)?;
+        if recovery == LiveRootRecovery::Journaled {
+            create_dir_all_and_sync(&journal_dir)?;
+        }
         let operation = operation.into();
         let journal_path = journal_dir.join(format!("{tx_uuid}.json"));
         let transaction = Self {
@@ -125,6 +145,7 @@ impl LiveRootTransaction {
             created_paths: Vec::new(),
             removed_dirs: Vec::new(),
             modified_directories: Vec::new(),
+            recovery,
             committed: false,
         };
         transaction.write_journal("pending")?;
@@ -213,10 +234,11 @@ impl LiveRootTransaction {
         self.ensure_parent(&target, stats)?;
         match fs::symlink_metadata(&target) {
             Ok(metadata) if metadata.file_type().is_dir() => {
-                if !self
-                    .modified_directories
-                    .iter()
-                    .any(|record| record.path == target.to_string_lossy())
+                if self.recovery == LiveRootRecovery::Journaled
+                    && !self
+                        .modified_directories
+                        .iter()
+                        .any(|record| record.path == target.to_string_lossy())
                 {
                     self.modified_directories.push(DirectoryMetadataRecord {
                         path: target.to_string_lossy().into_owned(),
@@ -292,7 +314,9 @@ impl LiveRootTransaction {
         dirs.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
         dirs.dedup();
         for dir in dirs {
-            self.removed_dirs.push(dir.clone());
+            if self.recovery == LiveRootRecovery::Journaled {
+                self.removed_dirs.push(dir.clone());
+            }
             self.write_journal("in_progress")?;
             match remove_dir_and_sync(&dir) {
                 Ok(()) => stats.dirs_removed += 1,
@@ -311,6 +335,10 @@ impl LiveRootTransaction {
     }
 
     pub(crate) fn rollback(&mut self) -> Result<()> {
+        if self.recovery == LiveRootRecovery::DisposableOverlay {
+            self.committed = true;
+            return Ok(());
+        }
         for created in self.created_paths.iter().rev() {
             if validate_existing_parent(&self.root, created).is_err() {
                 continue;
@@ -390,7 +418,9 @@ impl LiveRootTransaction {
                 }
                 Ok(_) => {}
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                    self.created_paths.push(full.clone());
+                    if self.recovery == LiveRootRecovery::Journaled {
+                        self.created_paths.push(full.clone());
+                    }
                     self.write_journal("in_progress")?;
                     create_dir_and_sync(&full)?;
                     stats.dirs_created += 1;
@@ -405,6 +435,17 @@ impl LiveRootTransaction {
     }
 
     fn backup_existing(&mut self, target: &Path) -> Result<()> {
+        if self.recovery == LiveRootRecovery::DisposableOverlay {
+            return match fs::symlink_metadata(target) {
+                Ok(metadata) if metadata.file_type().is_dir() => bail!(
+                    "disposable selected-root leaf {} became a directory",
+                    target.display()
+                ),
+                Ok(_) => remove_file_and_sync(target).map_err(Into::into),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(error.into()),
+            };
+        }
         if self.created_paths.iter().any(|created| created == target)
             || self
                 .backups
@@ -449,6 +490,9 @@ impl LiveRootTransaction {
     }
 
     fn write_journal(&self, state: &str) -> Result<()> {
+        if self.recovery == LiveRootRecovery::DisposableOverlay {
+            return Ok(());
+        }
         let journal = LiveRootJournal {
             schema: JOURNAL_SCHEMA.to_string(),
             tx_uuid: self.tx_uuid.clone(),
@@ -482,6 +526,9 @@ impl LiveRootTransaction {
     }
 
     fn cleanup_transaction_files(&self) -> Result<()> {
+        if self.recovery == LiveRootRecovery::DisposableOverlay {
+            return Ok(());
+        }
         match remove_file_and_sync(&self.journal_path) {
             Ok(()) => {}
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
@@ -940,55 +987,6 @@ fn ensure_safe_directory(root: &Path, dir: &Path) -> Result<()> {
             }
         }
     }
-    Ok(())
-}
-
-fn rename_and_sync(source: &Path, target: &Path) -> io::Result<()> {
-    fs::rename(source, target)?;
-    sync_parent_directory_io(target)?;
-    if let (Some(source_parent), Some(target_parent)) = (source.parent(), target.parent())
-        && source_parent != target_parent
-    {
-        sync_directory_io(source_parent)?;
-    }
-    Ok(())
-}
-
-fn remove_file_and_sync(path: &Path) -> io::Result<()> {
-    fs::remove_file(path)?;
-    sync_parent_directory_io(path)
-}
-
-fn remove_dir_and_sync(path: &Path) -> io::Result<()> {
-    fs::remove_dir(path)?;
-    sync_parent_directory_io(path)
-}
-
-fn remove_dir_all_and_sync(path: &Path) -> io::Result<()> {
-    fs::remove_dir_all(path)?;
-    sync_parent_directory_io(path)
-}
-
-fn create_dir_and_sync(path: &Path) -> io::Result<()> {
-    fs::create_dir(path)?;
-    sync_parent_directory_io(path)
-}
-
-fn create_dir_all_and_sync(path: &Path) -> io::Result<()> {
-    fs::create_dir_all(path)?;
-    sync_parent_directory_io(path)
-}
-
-fn sync_parent_directory_io(path: &Path) -> io::Result<()> {
-    sync_parent_directory(path).map_err(|error| io::Error::other(error.to_string()))
-}
-
-fn sync_directory_io(path: &Path) -> io::Result<()> {
-    File::open(path)?.sync_all()
-}
-
-fn sync_directory(path: &Path) -> Result<()> {
-    sync_directory_io(path).with_context(|| format!("Failed to sync {}", path.display()))?;
     Ok(())
 }
 

--- a/apps/conary/src/commands/live_root/durability.rs
+++ b/apps/conary/src/commands/live_root/durability.rs
@@ -1,0 +1,58 @@
+// apps/conary/src/commands/live_root/durability.rs
+
+//! Filesystem mutation helpers that make parent-directory durability explicit.
+
+use anyhow::{Context, Result};
+use conary_core::filesystem::durable::sync_parent_directory;
+use std::fs::{self, File};
+use std::io;
+use std::path::Path;
+
+pub(super) fn rename_and_sync(source: &Path, target: &Path) -> io::Result<()> {
+    fs::rename(source, target)?;
+    sync_parent_directory_io(target)?;
+    if let (Some(source_parent), Some(target_parent)) = (source.parent(), target.parent())
+        && source_parent != target_parent
+    {
+        sync_directory_io(source_parent)?;
+    }
+    Ok(())
+}
+
+pub(super) fn remove_file_and_sync(path: &Path) -> io::Result<()> {
+    fs::remove_file(path)?;
+    sync_parent_directory_io(path)
+}
+
+pub(super) fn remove_dir_and_sync(path: &Path) -> io::Result<()> {
+    fs::remove_dir(path)?;
+    sync_parent_directory_io(path)
+}
+
+pub(super) fn remove_dir_all_and_sync(path: &Path) -> io::Result<()> {
+    fs::remove_dir_all(path)?;
+    sync_parent_directory_io(path)
+}
+
+pub(super) fn create_dir_and_sync(path: &Path) -> io::Result<()> {
+    fs::create_dir(path)?;
+    sync_parent_directory_io(path)
+}
+
+pub(super) fn create_dir_all_and_sync(path: &Path) -> io::Result<()> {
+    fs::create_dir_all(path)?;
+    sync_parent_directory_io(path)
+}
+
+fn sync_parent_directory_io(path: &Path) -> io::Result<()> {
+    sync_parent_directory(path).map_err(|error| io::Error::other(error.to_string()))
+}
+
+fn sync_directory_io(path: &Path) -> io::Result<()> {
+    File::open(path)?.sync_all()
+}
+
+pub(super) fn sync_directory(path: &Path) -> Result<()> {
+    sync_directory_io(path).with_context(|| format!("Failed to sync {}", path.display()))?;
+    Ok(())
+}

--- a/apps/conary/src/commands/live_root/path.rs
+++ b/apps/conary/src/commands/live_root/path.rs
@@ -1,0 +1,37 @@
+// apps/conary/src/commands/live_root/path.rs
+
+//! Lexical package-path resolution for live and selected roots.
+
+use anyhow::{Result, bail};
+use std::path::{Component, Path, PathBuf};
+
+pub(crate) fn target_path(root: &Path, package_path: &str) -> Result<PathBuf> {
+    let relative = package_path.strip_prefix('/').unwrap_or(package_path);
+    let relative_path = Path::new(relative);
+    let mut has_path_below_root = false;
+    for component in relative_path.components() {
+        match component {
+            Component::Normal(_) => has_path_below_root = true,
+            Component::CurDir => {
+                bail!(
+                    "package path {package_path} must name a file or directory below the target root"
+                );
+            }
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                bail!("package path {package_path} escapes the target root");
+            }
+        }
+    }
+    if !has_path_below_root {
+        bail!("package path {package_path} must name a file or directory below the target root");
+    }
+    Ok(root.join(relative_path))
+}
+
+pub(super) fn selected_root_target_path(root: &Path, package_path: &str) -> Result<PathBuf> {
+    let effective = conary_core::filesystem::selected_root::selected_root_effective_package_path(
+        root,
+        package_path,
+    )?;
+    target_path(root, &effective)
+}

--- a/apps/conary/src/commands/live_root/recovery.rs
+++ b/apps/conary/src/commands/live_root/recovery.rs
@@ -102,6 +102,7 @@ fn live_root_transaction_from_journal(
             .map(PathBuf::from)
             .collect(),
         modified_directories: journal.modified_directories,
+        recovery: LiveRootRecovery::Journaled,
         committed: false,
     }
 }

--- a/apps/conary/src/commands/live_root/tests.rs
+++ b/apps/conary/src/commands/live_root/tests.rs
@@ -123,6 +123,38 @@ fn remove_file_and_sync_removes_target() {
 }
 
 #[test]
+fn disposable_overlay_removal_uses_no_external_recovery_authority() {
+    let temp = TempDir::new().unwrap();
+    let runtime = temp.path().join("runtime");
+    let root = temp.path().join("overlay-root");
+    fs::create_dir_all(root.join("usr/bin")).unwrap();
+    fs::write(root.join("usr/bin/fixture"), b"prior").unwrap();
+
+    let tx_uuid = Uuid::new_v4().to_string();
+    let mut tx = LiveRootTransaction::begin_disposable_overlay(
+        &runtime,
+        &root,
+        tx_uuid.clone(),
+        "remove fixture",
+    )
+    .unwrap();
+    let stats = tx
+        .apply_remove_paths(&["/usr/bin/fixture".to_string()])
+        .unwrap();
+    tx.commit().unwrap();
+
+    assert_eq!(stats.files_removed, 1);
+    assert!(!root.join("usr/bin/fixture").exists());
+    assert!(!runtime.join("live-root-journals").exists());
+    assert!(
+        !runtime
+            .join("live-root-journals")
+            .join(format!("{tx_uuid}.backups"))
+            .exists()
+    );
+}
+
+#[test]
 fn install_rejects_symlink_parent_without_writing_outside_root() {
     let temp = TempDir::new().unwrap();
     let runtime = temp.path().join("runtime");

--- a/apps/conary/tests/integration/remi/manifests/selected-root-overlay-profile-solus.toml
+++ b/apps/conary/tests/integration/remi/manifests/selected-root-overlay-profile-solus.toml
@@ -1,14 +1,14 @@
-# Selected-root OverlayFS capability proof on the published Solus fixture.
+# Selected-root OverlayFS capability and transaction proof on the published Solus fixture.
 
 [suite]
-name = "Solus Overlay Profile Proof"
+name = "Solus Selected-Root Overlay Proof"
 phase = 4
 timeout = 1200
 
 [[test]]
 id = "TNPME403"
 name = "solus_overlay_profile_probe"
-description = "The Solus 7.1 kernel and ext4 runtime filesystem satisfy the exact selected-root OverlayFS profile"
+description = "The Solus 7.1 kernel and ext4 runtime filesystem satisfy the exact profile and execute manifest-delta selected-root transactions"
 timeout = 1200
 fatal = true
 group = "selected-root-overlay-profile-solus"
@@ -19,18 +19,27 @@ image = "solus-4.9-polaris-2026-08-12-v3"
 memory_mb = 2048
 timeout_seconds = 900
 ssh_port = 2252
-stage_conary = false
+stage_conary = true
 copy_to_guest = [
     { source = "apps/conary/tests/fixtures/selected-root-overlay-profile/probe.py", dest = "/tmp/overlay-profile-probe.py" },
+    { source = "apps/conary/tests/fixtures/adversarial/deps/dep-base-v1/output/dep-base-1.0.0-1.ccs", dest = "/tmp/dep-base-1.0.0-1.ccs" },
+    { source = "apps/conary/tests/fixtures/ccs-test-authority/trust-policy.toml", dest = "/tmp/ccs-trust-policy.toml" },
 ]
 commands = [
     "test \"$(uname -r)\" = 7.1.7-351.current",
     "python3 /tmp/overlay-profile-probe.py",
+    "rm -rf /var/tmp/conary-403-overlay-runtime && mkdir -p /var/tmp/conary-403-overlay-runtime",
+    "conary system init --db-path /var/tmp/conary-403-overlay-runtime/conary.db",
+    "env -u CONARY_TEST_SKIP_GENERATION_MOUNT conary ccs install --yes /tmp/dep-base-1.0.0-1.ccs --policy /tmp/ccs-trust-policy.toml --sandbox always --db-path /var/tmp/conary-403-overlay-runtime/conary.db",
+    "CANDIDATE=$(find /var/tmp/conary-403-overlay-runtime/publication-roots -mindepth 1 -maxdepth 1 -type d | sort -V | tail -1); test -n \"$CANDIDATE\"; test -f \"$CANDIDATE/generation-root.json\"; test -f \"$CANDIDATE/mutable-state.json\"; test ! -e \"$CANDIDATE/root\"; grep -q '\"path\": \"/usr/bin/dep-base-v1\"' \"$CANDIDATE/generation-root.json\"; test -z \"$(find /var/tmp/conary-403-overlay-runtime/selected-root-sessions -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)\"; ! findmnt -rn -t overlay | grep -q '/var/tmp/conary-403-overlay-runtime/selected-root-sessions'",
+    "env -u CONARY_TEST_SKIP_GENERATION_MOUNT conary remove dep-base --yes --sandbox always --db-path /var/tmp/conary-403-overlay-runtime/conary.db",
+    "CANDIDATE=$(find /var/tmp/conary-403-overlay-runtime/publication-roots -mindepth 1 -maxdepth 1 -type d | sort -V | tail -1); test -n \"$CANDIDATE\"; ! grep -q '\"path\": \"/usr/bin/dep-base-v1\"' \"$CANDIDATE/generation-root.json\"; test ! -e \"$CANDIDATE/root\"; test -z \"$(find /var/tmp/conary-403-overlay-runtime/selected-root-sessions -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)\"; ! findmnt -rn -t overlay | grep -q '/var/tmp/conary-403-overlay-runtime/selected-root-sessions'; echo selected-root-overlay-transaction-ok",
 ]
 expect_output = [
     "\"hardlink_copy_up\": \"preserved\"",
     "\"metadata_copy_up\": \"complete-data\"",
     "\"opaque_directory\": \"logical-y\"",
+    "selected-root-overlay-transaction-ok",
 ]
 
 [test.step.assert]

--- a/apps/conary/tests/native_pm_daily_driver.rs
+++ b/apps/conary/tests/native_pm_daily_driver.rs
@@ -22,6 +22,7 @@ use std::process::{Command, Output};
 
 fn run_conary(args: &[&str]) -> Output {
     Command::new(env!("CARGO_BIN_EXE_conary"))
+        .env("CONARY_TEST_SKIP_GENERATION_MOUNT", "1")
         .args(args)
         .output()
         .expect("failed to run conary")

--- a/crates/conary-core/src/generation/root_manifest.rs
+++ b/crates/conary-core/src/generation/root_manifest.rs
@@ -21,11 +21,12 @@ pub use materialize::{
     overlay_payload_entries,
 };
 pub use overlay::{
-    OverlayHardlinkCopyUp, OverlayLowerDirectoryRename, OverlayMetadataCopyUp,
-    OverlayOpaqueDirectory, OverlayWhiteoutEncoding, OverlayXattrNamespace,
+    MountedSelectedRootOverlay, OverlayHardlinkCopyUp, OverlayLowerDirectoryRename,
+    OverlayMetadataCopyUp, OverlayOpaqueDirectory, OverlayWhiteoutEncoding, OverlayXattrNamespace,
     SELECTED_ROOT_OVERLAY_CAPABILITIES_VERSION, SELECTED_ROOT_OVERLAY_PROFILE_VERSION,
     SelectedRootOverlayCapabilities, SelectedRootOverlayProfile,
-    decode_selected_root_overlay_upper, probe_selected_root_overlay_profile,
+    decode_selected_root_overlay_upper, encode_selected_root_overlay_upper_node,
+    probe_selected_root_overlay_profile,
 };
 pub use scan::{
     SelectedRootCaptureExclusions, capture_existing_payload_node, capture_root_node,

--- a/crates/conary-core/src/generation/root_manifest/overlay.rs
+++ b/crates/conary-core/src/generation/root_manifest/overlay.rs
@@ -5,14 +5,16 @@
 mod probe;
 
 pub use probe::{
-    OverlayHardlinkCopyUp, OverlayLowerDirectoryRename, OverlayMetadataCopyUp,
-    OverlayOpaqueDirectory, OverlayWhiteoutEncoding, SELECTED_ROOT_OVERLAY_CAPABILITIES_VERSION,
-    SelectedRootOverlayCapabilities, probe_selected_root_overlay_profile,
+    MountedSelectedRootOverlay, OverlayHardlinkCopyUp, OverlayLowerDirectoryRename,
+    OverlayMetadataCopyUp, OverlayOpaqueDirectory, OverlayWhiteoutEncoding,
+    SELECTED_ROOT_OVERLAY_CAPABILITIES_VERSION, SelectedRootOverlayCapabilities,
+    probe_selected_root_overlay_profile,
 };
 
+use super::scan::scan_selected_root_overlay_upper;
 use super::{
     CapturedSelectedRoot, GenerationRootEntry, SELECTED_ROOT_MANIFEST_DELTA_VERSION,
-    SelectedRootManifestDelta, scan_payload_tree,
+    SelectedRootManifestDelta,
 };
 use crate::filesystem::PrivateCasWriter;
 use crate::payload::{PayloadNodeKind, ResolvedPayloadNode};
@@ -110,6 +112,32 @@ impl SelectedRootOverlayProfile {
     }
 }
 
+/// Encode payload xattrs on the upper root so OverlayFS does not interpret a
+/// payload-owned name in its private namespace as transaction bookkeeping.
+pub fn encode_selected_root_overlay_upper_node(
+    node: &ResolvedPayloadNode,
+    profile: &SelectedRootOverlayProfile,
+) -> crate::Result<ResolvedPayloadNode> {
+    profile.validate()?;
+    let prefix = profile.private_prefix();
+    let mut encoded = node.clone();
+    let mut xattrs = BTreeMap::new();
+    for (name, value) in &node.source.xattrs {
+        let encoded_name = if let Some(suffix) = name.strip_prefix(prefix) {
+            format!("{prefix}overlay.{suffix}")
+        } else {
+            name.clone()
+        };
+        if xattrs.insert(encoded_name.clone(), value.clone()).is_some() {
+            return Err(crate::Error::InvalidPath(format!(
+                "overlay upper-root xattr escaping produces duplicate {encoded_name}"
+            )));
+        }
+    }
+    encoded.source.xattrs = xattrs;
+    Ok(encoded)
+}
+
 /// Capture and decode one frozen transaction upper without reading unchanged
 /// lower content.
 ///
@@ -125,7 +153,7 @@ pub fn decode_selected_root_overlay_upper(
     profile.validate()?;
     prior.generation.validate()?;
     prior.state.validate()?;
-    let (root, entries) = scan_payload_tree(upper, cas, "selected-root-overlay-v1")?;
+    let (root, entries) = scan_selected_root_overlay_upper(upper, cas, "selected-root-overlay-v1")?;
     decode_captured_upper(root, entries, prior, profile)
 }
 
@@ -186,7 +214,7 @@ fn decode_captured_upper(
                     entry.path
                 )));
             }
-            if opaque == OpaqueMarker::Logical {
+            if opaque == OpaqueMarker::Logical && prior_directory_exists(prior, &entry.path) {
                 opaque_directories.push(entry.path.clone());
             }
         }
@@ -217,6 +245,17 @@ fn decode_captured_upper(
     // persist this changed-path representation.
     delta.apply(prior)?;
     Ok(delta)
+}
+
+fn prior_directory_exists(prior: &CapturedSelectedRoot, path: &str) -> bool {
+    prior
+        .generation
+        .entries
+        .iter()
+        .chain(&prior.state.entries)
+        .any(|entry| {
+            entry.path == path && matches!(entry.node.source.kind, PayloadNodeKind::Directory)
+        })
 }
 
 fn decode_overlay_xattrs(
@@ -534,6 +573,57 @@ mod tests {
     }
 
     #[test]
+    fn upper_root_encoding_round_trips_payload_private_namespace() {
+        let profile = user_profile();
+        let mut root = directory_node();
+        root.source
+            .xattrs
+            .insert("user.overlay.payload-owned".into(), b"exact".to_vec());
+        let encoded = encode_selected_root_overlay_upper_node(&root, &profile).unwrap();
+        assert_eq!(
+            encoded
+                .source
+                .xattrs
+                .get("user.overlay.overlay.payload-owned"),
+            Some(&b"exact".to_vec())
+        );
+        assert_eq!(
+            decode_captured_upper(encoded, Vec::new(), &captured(Vec::new()), &profile)
+                .unwrap()
+                .root,
+            Some(root)
+        );
+    }
+
+    #[test]
+    fn upper_capture_prunes_ephemeral_subtrees_before_delta_decode() {
+        let workspace = tempfile::tempdir().unwrap();
+        let upper = workspace.path().join("upper");
+        std::fs::create_dir_all(upper.join("usr/lib")).unwrap();
+        std::fs::create_dir_all(upper.join("run/conary-private")).unwrap();
+        std::fs::write(upper.join("usr/lib/changed"), b"publish").unwrap();
+        std::fs::write(upper.join("run/conary-private/ignored"), b"ephemeral").unwrap();
+        let cas = CasStore::new(workspace.path().join("objects")).unwrap();
+        let prior = captured(vec![directory_entry("/usr"), directory_entry("/usr/lib")]);
+
+        let delta =
+            decode_selected_root_overlay_upper(&upper, &prior, &cas, &user_profile()).unwrap();
+
+        assert!(
+            delta
+                .upserts
+                .iter()
+                .any(|entry| entry.path == "/usr/lib/changed")
+        );
+        assert!(
+            delta
+                .upserts
+                .iter()
+                .all(|entry| !entry.path.starts_with("/run"))
+        );
+    }
+
+    #[test]
     fn decodes_documented_whiteouts_and_opaque_markers() {
         let prior = captured(vec![
             directory_entry("/opt"),
@@ -583,6 +673,37 @@ mod tests {
                 .unwrap();
         assert!(delta.opaque_directories.is_empty());
         assert!(entry(&delta.apply(&prior).unwrap(), "/opt/tree/lower").is_some());
+    }
+
+    #[test]
+    fn opaque_y_on_new_upper_only_directory_is_redundant() {
+        let profile = user_profile();
+        let mut directory = directory_entry("/usr");
+        directory
+            .node
+            .source
+            .xattrs
+            .insert("user.overlay.opaque".into(), b"y".to_vec());
+
+        let delta = decode_captured_upper(
+            directory_node(),
+            vec![directory],
+            &captured(Vec::new()),
+            &profile,
+        )
+        .unwrap();
+
+        assert!(delta.opaque_directories.is_empty());
+        assert_eq!(delta.upserts[0].path, "/usr");
+        assert!(
+            delta
+                .apply(&captured(Vec::new()))
+                .unwrap()
+                .generation
+                .entries
+                .iter()
+                .any(|entry| entry.path == "/usr")
+        );
     }
 
     #[test]

--- a/crates/conary-core/src/generation/root_manifest/overlay/probe.rs
+++ b/crates/conary-core/src/generation/root_manifest/overlay/probe.rs
@@ -165,6 +165,76 @@ fn mount_data(
     Ok(components.join(","))
 }
 
+/// One mounted selected-root OverlayFS view.
+///
+/// A successful `freeze` is a strict synchronization and unmount boundary.
+/// `Drop` uses lazy detach only as crash-tail containment; callers may not
+/// decode or publish an upper unless strict unmount succeeded.
+pub struct MountedSelectedRootOverlay {
+    target: PathBuf,
+    mounted: bool,
+}
+
+impl MountedSelectedRootOverlay {
+    pub fn mount(
+        lower: &Path,
+        upper: &Path,
+        work: &Path,
+        target: &Path,
+        profile: &SelectedRootOverlayProfile,
+    ) -> crate::Result<Self> {
+        let options = mount_data(lower, upper, work, profile)?;
+        mount(
+            Some("overlay"),
+            target,
+            Some("overlay"),
+            MsFlags::empty(),
+            Some(options.as_str()),
+        )
+        .map_err(|error| {
+            crate::Error::NotImplemented(format!(
+                "selected-root OverlayFS mount failed at {}: {error}",
+                target.display()
+            ))
+        })?;
+        Ok(Self {
+            target: target.to_path_buf(),
+            mounted: true,
+        })
+    }
+
+    pub fn freeze(mut self, upper: &Path) -> crate::Result<()> {
+        sync_filesystem(upper)?;
+        umount2(&self.target, MntFlags::empty()).map_err(|error| {
+            crate::Error::IoError(format!(
+                "failed to strictly unmount selected-root OverlayFS {}: {error}",
+                self.target.display()
+            ))
+        })?;
+        self.mounted = false;
+        Ok(())
+    }
+
+    pub fn unmount(mut self) -> crate::Result<()> {
+        umount2(&self.target, MntFlags::empty()).map_err(|error| {
+            crate::Error::IoError(format!(
+                "failed to unmount selected-root OverlayFS {}: {error}",
+                self.target.display()
+            ))
+        })?;
+        self.mounted = false;
+        Ok(())
+    }
+}
+
+impl Drop for MountedSelectedRootOverlay {
+    fn drop(&mut self) {
+        if self.mounted {
+            let _ = umount2(&self.target, MntFlags::MNT_DETACH);
+        }
+    }
+}
+
 fn prove_hardlink_copy_up(
     merged: &Path,
     upper: &Path,

--- a/crates/conary-core/src/generation/root_manifest/scan.rs
+++ b/crates/conary-core/src/generation/root_manifest/scan.rs
@@ -144,6 +144,31 @@ pub fn scan_payload_tree(
     Ok((root_node, entries))
 }
 
+/// Capture only publishable paths from one selected-root OverlayFS upper.
+///
+/// Runtime-only `/dev`, `/proc`, `/run`, `/sys`, `/tmp`, and user-domain
+/// mutations are deliberately absent from generation authority. Keeping this
+/// filter inside the scanner also prunes those subtrees before any node or
+/// content capture work occurs.
+pub(super) fn scan_selected_root_overlay_upper(
+    root: &Path,
+    cas: &dyn PrivateCasWriter,
+    hardlink_namespace: &str,
+) -> crate::Result<(ResolvedPayloadNode, Vec<GenerationRootEntry>)> {
+    let (root_node, candidates) = capture_payload_tree(
+        root,
+        cas,
+        false,
+        hardlink_namespace,
+        &SelectedRootCaptureExclusions::empty(),
+    )?;
+    let entries = candidates
+        .into_iter()
+        .map(|candidate| candidate.entry)
+        .collect();
+    Ok((root_node, entries))
+}
+
 fn capture_payload_tree(
     root: &Path,
     cas: &dyn PrivateCasWriter,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -425,16 +425,16 @@ consulting a native package manager or its database.
 ```
 Generation-aware package mutation
        |
-  materialize latest authoritative selected root
+  materialize latest typed authority as immutable lower
        |
   +-----------+
-  | Isolated  |-- Apply payload, native lifecycle, CCS hooks, triggers,
-  | Root      |-- and config decisions without mutating the live root
+  | OverlayFS |-- Probed profile + transaction-owned upper/work
+  | Root      |-- Apply payload, lifecycle, hooks, triggers, and config
   +-----------+
        |
   +-----------+
-  | Capture   |-- Exact typed generation-root + mutable-state manifests
-  +-----------+-- Candidate is durable before the SQLite transaction commits
+  |  Decode   |-- Freeze/unmount, scan changed upper paths, apply typed delta
+  +-----------+-- Manifest-only candidate is durable before SQLite commit
        |
   +-----------+
   |  EROFS    |-- composefs-rs serializes the generation-root manifest
@@ -460,13 +460,22 @@ delta-sized selected-root transition. Overlay artifacts must be decoded into
 exact removals, opaque-directory replacement, complete node upserts, and
 optional root metadata before this boundary. Applying a delta preserves prior
 CAS identities for unchanged content, routes changed paths through the finite
-publication domains, and revalidates the complete resulting manifests. Runtime
-selected-root sessions still use complete materialization and capture until the
-overlay capability and upper-tree decoder slices replace that path.
+publication domains, and revalidates the complete resulting manifests. Normal
+runtime selected-root sessions mount the functionally proven OverlayFS profile
+over an immutable materialized lower, freeze and strictly unmount before
+decoding the transaction upper, and never perform complete before/after
+selected-root scans. Retained try-session trees remain an explicit
+materialization consumer until their namespace contract is migrated; they are
+not a fallback for normal mutation.
 
-1. **Select**: Materialize the latest cumulative selected-root candidate, or the current generation when no publication debt is pending
+Publication candidates are now manifest-only. A pre-alpha candidate carrying
+the retired copied `root/` tree fails closed and must be discarded and rebuilt
+from current typed generation/database authority; runtime code does not retain
+a dual reader for the superseded storage shape.
+
+1. **Select**: Materialize the latest cumulative selected-root candidate, or the current generation when no publication debt is pending, as immutable lower authority
 2. **Mutate**: Apply payload changes, typed native lifecycle, CCS hooks, triggers, and config decisions inside that isolated root
-3. **Record**: Capture exact immutable and mutable-state manifests, persist the selected-root candidate, and record recoverable publication debt before committing package state
+3. **Record**: Freeze and strictly unmount, decode the upper into a typed changed-path delta, apply it to the prior manifests, persist a manifest-only selected-root candidate, and record recoverable publication debt before committing package state
 4. **Build**: Validate the captured manifests and serialize the immutable manifest to EROFS using verified CAS content
 5. **Materialize state**: Project `/etc/...` manifest paths into the generation-local `/etc` overlay upper without retaining the `/etc` prefix, then apply the ordered typed config transactions; `/var` and `/srv` remain live mutable-root state
 6. **Publish**: Advance one persisted replay phase at a time: artifact ready, current link durable, configuration status projected, matching system state active, and generation-bound database backup durable. Only the final phase makes publication debt terminal

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -635,9 +635,13 @@ The bounded `selected-root-overlay-profile-solus` QEMU suite reuses that
 immutable fixture without running takeover. It functionally mounts the exact
 selected-root OverlayFS profile and proves indexed hardlink copy-up, complete
 metadata copy-up, character-device whiteouts, logical opaque replacement, and
-`EXDEV` for lower-directory rename. This is the positive kernel/filesystem
-counterpart to the runtime typed preflight; a kernel version or registered
-filesystem name alone is not capability evidence.
+`EXDEV` for lower-directory rename. It then stages the current static Conary
+binary, installs and removes a signed lifecycle-free CCS through the real
+selected-root session, verifies the changed path appears and disappears in
+successive manifest-only candidates, and proves that no session mount or
+workspace survives either commit. This is the positive kernel/filesystem and
+transaction counterpart to the runtime typed preflight; a kernel version or
+registered filesystem name alone is not capability evidence.
 
 Each full parity run must pass `scripts/check-conary-test-result-gate.sh` and
 `scripts/check-conary-corpus-result-gate.sh`,

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -68,7 +68,9 @@ commands.
   `crates/conary-core/src/config_transaction/`; selected-root config capture
   and publication are owned by
   `apps/conary/src/commands/generation/config_transaction.rs`,
-  `apps/conary/src/commands/generation/selected_root.rs`, and
+  `apps/conary/src/commands/generation/selected_root.rs`,
+  `apps/conary/src/commands/generation/selected_root/overlay_session.rs`,
+  `apps/conary/src/commands/generation/selected_root/publication_candidate.rs`, and
   `apps/conary/src/commands/generation/publication.rs`. Single-package install
   execution starts in
   `apps/conary/src/commands/install/transaction/selected_root.rs`; declarative
@@ -107,8 +109,11 @@ commands.
   and declared in `docs/specs/foreign-package-lifecycle-contracts.md`. Exact
   source-independent payload nodes start in
   `crates/conary-core/src/payload.rs`.
-  `apps/conary/src/commands/live_root/recovery.rs` is confined to the
-  selected-root session journal implementation.
+  `apps/conary/src/commands/live_root.rs` owns mutation orchestration;
+  `apps/conary/src/commands/live_root/path.rs` owns selected-root path
+  resolution, `apps/conary/src/commands/live_root/durability.rs` owns durable
+  filesystem primitives, and `apps/conary/src/commands/live_root/recovery.rs`
+  is confined to the journal recovery implementation.
 - Declarative models, source selection, and replatforming:
   `docs/modules/feature-ownership.md` slug `model`, plus
   `docs/modules/source-selection.md`.


### PR DESCRIPTION
## Summary

- run normal selected-root package mutations through the exact functionally probed OverlayFS profile, freeze with a strict unmount, and decode only the transaction upper into typed manifest authority
- retain the immutable prior manifest as rollback authority and hard-cut publication candidates to manifest-only storage
- give transaction-owned overlays a disposable live-root mode so their upper remains the sole rollback record instead of attempting cross-filesystem journal renames
- keep retained try sessions as an explicit materialized consumer and split selected-root/live-root ownership into focused modules
- extend the published Solus 7.1.7 fixture lane from capability probing to a real signed CCS install/remove transaction with candidate and mount-leak assertions

## Root cause

The typed OverlayFS profile and upper decoder existed, but normal transactions still materialized and scanned complete roots before and after mutation, then retained another complete root in each publication candidate. Wiring the overlay also exposed a structural mismatch in the existing live-root recovery journal: removing a lower-backed node tried to rename it from OverlayFS into an ext4 journal and failed with `EXDEV`. The transaction upper already is the rollback record, so duplicating that authority was both unnecessary and invalid across filesystems.

## Impact

Normal install/update/remove sessions no longer perform complete before/after selected-root scans, and retryable publication candidates contain only the two typed manifests. This is a bounded #403 slice: preparing the immutable lower still materializes current authority, so the issue remains open for eliminating that remaining total-root work and adding the #121 scaling gate.

Refs #403

## Verification

- `cargo test -p conary --lib commands::live_root::tests` — 26 passed
- `cargo test -p conary --lib commands::generation::selected_root` — 10 passed
- `cargo test -p conary-core --lib generation::root_manifest` — 40 passed, 1 privileged probe ignored
- `cargo test -p conary --lib commands::install` — 227 passed, 1 pinned network proof ignored
- `cargo test -p conary --lib commands::remove` — 14 passed
- install/remove ownership-card focused proof, including payload claims, config transactions, native transaction/lifecycle, and live-host safety — passed
- `cargo test -p conary --lib commands::generation::publication` — 5 passed
- `cargo run -p conary-test -- run --suite selected-root-overlay-profile-solus --distro solus --phase 4` — 1 passed, 0 failed/skipped/cancelled; kernel `7.1.7-351.current`; real install and removal completed; no session or mount leaked
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `bash scripts/check-doc-truth.sh`
- `cargo run -p conary-test -- list`