### PR TITLE
perf(generation): mount current generation as selected-root lower

### DIFF
--- a/apps/conary/src/commands/generation/selected_root.rs
+++ b/apps/conary/src/commands/generation/selected_root.rs
@@ -72,17 +72,17 @@ pub(crate) struct SelectedRootSession {
 
 /// The runtime mutation lock, held before any package authority is read.
 ///
-/// [`SelectedRootSession::begin`] takes this lock and materializes the selected
+/// [`SelectedRootSession::begin`] takes this lock and prepares the selected
 /// root in one step, which is what a caller whose planning is already complete
 /// wants. A caller that must certify a transaction against installed state --
 /// requirement satisfaction, promise reliance, negative relation effects --
 /// acquires this first and reads those facts with the lock already held, so
-/// nothing it certifies can change before it commits. Materialization is the
-/// expensive half, so keeping it separate also lets a rejected transaction fail
-/// without paying for a root it will never mutate.
+/// nothing it certifies can change before it commits. Root preparation is the
+/// expensive half, so keeping it separate also lets a rejected transaction
+/// fail without paying for a root it will never mutate.
 ///
-/// Dropping without materializing releases the lock and leaves no session
-/// directory behind, because the directory is created by `materialize`.
+/// Dropping without preparing releases the lock and leaves no session
+/// directory behind, because the directory is created by `prepare`.
 pub(crate) struct LockedRuntimeRoot {
     runtime_root: ConaryRuntimeRoot,
     session_dir: PathBuf,
@@ -113,7 +113,7 @@ impl LockedRuntimeRoot {
         // The runtime transaction lock is acquired before reading either
         // SQLite package authority or the selected generation. Holding it
         // through candidate persistence and the caller-owned DB commit makes
-        // the materialized root a serializable mutation base.
+        // the prepared root a serializable mutation base.
         let mut transaction_engine =
             TransactionEngine::new(TransactionConfig::for_runtime_root(&runtime_root))?;
         transaction_engine.begin()?;
@@ -125,28 +125,28 @@ impl LockedRuntimeRoot {
         })
     }
 
-    /// Materialize installed package state into a writable selected root.
+    /// Prepare installed package state as a writable selected root.
     ///
     /// Consumes the lock holder: the lock is not released here, it moves into
     /// the returned session and is released when that session finishes.
-    pub(crate) fn materialize(
+    pub(crate) fn prepare(
         self,
         conn: &rusqlite::Connection,
         operation: impl Into<String>,
     ) -> Result<SelectedRootSession> {
         let materialized_backing = use_materialized_selected_root_backing();
-        self.materialize_with_backing(conn, operation, materialized_backing)
+        self.prepare_with_backing(conn, operation, materialized_backing)
     }
 
-    fn materialize_retained(
+    fn prepare_retained(
         self,
         conn: &rusqlite::Connection,
         operation: impl Into<String>,
     ) -> Result<SelectedRootSession> {
-        self.materialize_with_backing(conn, operation, true)
+        self.prepare_with_backing(conn, operation, true)
     }
 
-    fn materialize_with_backing(
+    fn prepare_with_backing(
         self,
         conn: &rusqlite::Connection,
         operation: impl Into<String>,
@@ -276,7 +276,7 @@ impl SelectedRootSession {
         validate_try_session_dir(runtime_root, &session_dir)?;
         let session_id = uuid::Uuid::new_v4().to_string();
         LockedRuntimeRoot::acquire_in_session_dir(runtime_root.clone(), session_dir, session_id)?
-            .materialize_retained(conn, operation)
+            .prepare_retained(conn, operation)
     }
 
     fn begin_in_session_dir(
@@ -287,7 +287,7 @@ impl SelectedRootSession {
         operation: impl Into<String>,
     ) -> Result<Self> {
         LockedRuntimeRoot::acquire_in_session_dir(runtime_root.clone(), session_dir, session_id)?
-            .materialize(conn, operation)
+            .prepare(conn, operation)
     }
 
     pub(crate) fn selected_root(&self) -> &Path {

--- a/apps/conary/src/commands/generation/selected_root.rs
+++ b/apps/conary/src/commands/generation/selected_root.rs
@@ -19,6 +19,7 @@ use crate::commands::{LiveRootFile, LiveRootStats, LiveRootTransaction};
 use anyhow::{Context, Result, bail};
 use conary_core::db::models::GenerationPublication;
 use conary_core::filesystem::CasStore;
+use conary_core::generation::artifact::GenerationArtifact;
 use conary_core::generation::root_manifest::{
     CapturedSelectedRoot, materialize_captured_selected_root, scan_selected_root,
 };
@@ -36,6 +37,22 @@ enum SelectedRootBacking {
     /// Try sessions retain a complete tree for later namespace exposure. The
     /// test mount bypass exercises that same explicit non-production boundary.
     Materialized,
+}
+
+enum PreparedSelectedRoot {
+    Materialized(CapturedSelectedRoot),
+    CurrentGeneration {
+        artifact: GenerationArtifact,
+        captured: CapturedSelectedRoot,
+    },
+}
+
+impl PreparedSelectedRoot {
+    fn captured(&self) -> &CapturedSelectedRoot {
+        match self {
+            Self::Materialized(captured) | Self::CurrentGeneration { captured, .. } => captured,
+        }
+    }
 }
 
 /// One isolated selected-root view with one transaction-owned rollback authority.
@@ -141,40 +158,48 @@ impl LockedRuntimeRoot {
             session_id,
             transaction_engine,
         } = self;
-        let materialization_root = if materialized_backing {
-            session_dir.join("root")
-        } else {
-            session_dir.join("lower")
-        };
-        fs::create_dir_all(&materialization_root).with_context(|| {
-            format!(
-                "failed to create selected-root materialization destination {}",
-                materialization_root.display()
-            )
-        })?;
-        let materialized =
-            match materialize_current_root(conn, &runtime_root, &materialization_root) {
-                Ok(materialized) => materialized,
+        let prepared =
+            match prepare_current_root(conn, &runtime_root, &session_dir, materialized_backing) {
+                Ok(prepared) => prepared,
                 Err(error) => {
                     let _ = fs::remove_dir_all(&session_dir);
                     return Err(error);
                 }
             };
-        let deferred_ima = match DeferredImaAuthority::from_captured(&materialized) {
+        let prior = prepared.captured().clone();
+        let deferred_ima = match DeferredImaAuthority::from_captured(&prior) {
             Ok(authority) => authority,
             Err(error) => {
                 let _ = fs::remove_dir_all(&session_dir);
                 return Err(error);
             }
         };
-        let mut backing = if materialized_backing {
-            SelectedRootBacking::Materialized
-        } else {
-            match SelectedRootOverlaySession::begin(&session_dir, &materialized) {
-                Ok(overlay) => SelectedRootBacking::Overlay(overlay),
-                Err(error) => {
-                    let _ = fs::remove_dir_all(&session_dir);
-                    return Err(error);
+        let mut backing = match prepared {
+            PreparedSelectedRoot::Materialized(_) if materialized_backing => {
+                SelectedRootBacking::Materialized
+            }
+            PreparedSelectedRoot::Materialized(_) => {
+                match SelectedRootOverlaySession::begin_materialized(&session_dir, &prior) {
+                    Ok(overlay) => SelectedRootBacking::Overlay(overlay),
+                    Err(error) => {
+                        let _ = fs::remove_dir_all(&session_dir);
+                        return Err(error);
+                    }
+                }
+            }
+            PreparedSelectedRoot::CurrentGeneration { artifact, .. } => {
+                let cas = transaction_engine.cas();
+                match SelectedRootOverlaySession::begin_current_generation(
+                    &session_dir,
+                    &prior,
+                    &artifact,
+                    cas,
+                ) {
+                    Ok(overlay) => SelectedRootBacking::Overlay(overlay),
+                    Err(error) => {
+                        let _ = fs::remove_dir_all(&session_dir);
+                        return Err(error);
+                    }
                 }
             }
         };
@@ -207,7 +232,7 @@ impl LockedRuntimeRoot {
             transaction: Some(transaction),
             transaction_engine,
             deferred_ima,
-            prior: materialized,
+            prior,
             backing,
         })
     }
@@ -394,37 +419,70 @@ impl Drop for SelectedRootSession {
     }
 }
 
-fn materialize_current_root(
+fn prepare_current_root(
     conn: &rusqlite::Connection,
     runtime_root: &ConaryRuntimeRoot,
-    selected_root: &Path,
-) -> Result<CapturedSelectedRoot> {
+    session_dir: &Path,
+    require_materialized: bool,
+) -> Result<PreparedSelectedRoot> {
     let cas = CasStore::new(runtime_root.objects_dir())?;
     if let Some(candidate) = latest_selected_root_candidate(conn, runtime_root)? {
-        materialize_captured_selected_root(&candidate, &cas, selected_root)?;
-        return Ok(candidate);
+        let selected_root =
+            selected_root_materialization_destination(session_dir, require_materialized)?;
+        materialize_captured_selected_root(&candidate, &cas, &selected_root)?;
+        return Ok(PreparedSelectedRoot::Materialized(candidate));
     }
 
     if let Some(generation) =
         conary_core::generation::mount::current_generation(runtime_root.root())?
     {
-        let artifact = conary_core::generation::artifact::load_generation_artifact(
-            &runtime_root.generation_path(generation),
-        )?;
-        let captured = CapturedSelectedRoot {
-            generation: artifact.generation_root,
-            state: artifact.mutable_state,
+        let generation_path = runtime_root.generation_path(generation);
+        let artifact = if require_materialized {
+            conary_core::generation::artifact::load_generation_artifact(&generation_path)?
+        } else {
+            conary_core::generation::artifact::load_generation_artifact_for_activation(
+                &generation_path,
+            )?
         };
-        materialize_captured_selected_root(&captured, &cas, selected_root)?;
-        return Ok(captured);
+        let captured = CapturedSelectedRoot {
+            generation: artifact.generation_root.clone(),
+            state: artifact.mutable_state.clone(),
+        };
+        if require_materialized {
+            let selected_root = selected_root_materialization_destination(session_dir, true)?;
+            materialize_captured_selected_root(&captured, &cas, &selected_root)?;
+            return Ok(PreparedSelectedRoot::Materialized(captured));
+        }
+        return Ok(PreparedSelectedRoot::CurrentGeneration { artifact, captured });
     }
 
-    conary_core::generation::builder::materialize_selected_root_from_db_with_authority(
-        conn,
-        &runtime_root.objects_dir(),
-        selected_root,
-    )
-    .map_err(Into::into)
+    let selected_root =
+        selected_root_materialization_destination(session_dir, require_materialized)?;
+    let captured =
+        conary_core::generation::builder::materialize_selected_root_from_db_with_authority(
+            conn,
+            &runtime_root.objects_dir(),
+            &selected_root,
+        )?;
+    Ok(PreparedSelectedRoot::Materialized(captured))
+}
+
+fn selected_root_materialization_destination(
+    session_dir: &Path,
+    retained: bool,
+) -> Result<PathBuf> {
+    let destination = if retained {
+        session_dir.join("root")
+    } else {
+        session_dir.join("lower")
+    };
+    fs::create_dir_all(&destination).with_context(|| {
+        format!(
+            "failed to create selected-root materialization destination {}",
+            destination.display()
+        )
+    })?;
+    Ok(destination)
 }
 
 fn remove_session_dir(path: &Path) -> Result<()> {

--- a/apps/conary/src/commands/generation/selected_root.rs
+++ b/apps/conary/src/commands/generation/selected_root.rs
@@ -42,7 +42,7 @@ enum SelectedRootBacking {
 enum PreparedSelectedRoot {
     Materialized(CapturedSelectedRoot),
     CurrentGeneration {
-        artifact: GenerationArtifact,
+        artifact: Box<GenerationArtifact>,
         captured: CapturedSelectedRoot,
     },
 }
@@ -453,7 +453,10 @@ fn prepare_current_root(
             materialize_captured_selected_root(&captured, &cas, &selected_root)?;
             return Ok(PreparedSelectedRoot::Materialized(captured));
         }
-        return Ok(PreparedSelectedRoot::CurrentGeneration { artifact, captured });
+        return Ok(PreparedSelectedRoot::CurrentGeneration {
+            artifact: Box::new(artifact),
+            captured,
+        });
     }
 
     let selected_root =

--- a/apps/conary/src/commands/generation/selected_root/overlay_session.rs
+++ b/apps/conary/src/commands/generation/selected_root/overlay_session.rs
@@ -4,12 +4,15 @@
 
 use anyhow::{Context, Result};
 use conary_core::filesystem::CasStore;
+use conary_core::generation::artifact::GenerationArtifact;
+use conary_core::generation::mount::{MountOptions, mount_generation};
 use conary_core::generation::root_manifest::{
     CapturedSelectedRoot, MountedSelectedRootOverlay, SelectedRootManifestDelta,
     SelectedRootOverlayCapabilities, SelectedRootOverlayProfile, apply_resolved_payload_metadata,
     decode_selected_root_overlay_upper, encode_selected_root_overlay_upper_node,
-    probe_selected_root_overlay_profile,
+    materialize_state_root, probe_selected_root_overlay_profile,
 };
+use nix::mount::{MntFlags, umount2};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -18,13 +21,77 @@ pub(super) struct SelectedRootOverlaySession {
     selected_root: PathBuf,
     upper: PathBuf,
     mounted: Option<MountedSelectedRootOverlay>,
+    generation_lower: Option<MountedGenerationLower>,
     capabilities: SelectedRootOverlayCapabilities,
+}
+
+/// One composefs generation mounted only for the lifetime of a transaction.
+struct MountedGenerationLower {
+    mount_point: PathBuf,
+    mounted: bool,
 }
 
 impl SelectedRootOverlaySession {
     /// Probe the actual workspace, admit the materialized immutable lower, and
     /// mount the exact profile before lifecycle mutation can begin.
-    pub(super) fn begin(session_dir: &Path, prior: &CapturedSelectedRoot) -> Result<Self> {
+    pub(super) fn begin_materialized(
+        session_dir: &Path,
+        prior: &CapturedSelectedRoot,
+    ) -> Result<Self> {
+        Self::begin_with_lowers(session_dir, prior, &[session_dir.join("lower")], None)
+    }
+
+    /// Mount the current generation image directly beneath its typed mutable
+    /// state instead of reconstructing immutable CAS payload bytes.
+    pub(super) fn begin_current_generation(
+        session_dir: &Path,
+        prior: &CapturedSelectedRoot,
+        artifact: &GenerationArtifact,
+        cas: &CasStore,
+    ) -> Result<Self> {
+        fs::create_dir_all(session_dir)?;
+        let state_lower = session_dir.join("lower-state");
+        fs::create_dir(&state_lower).with_context(|| {
+            format!(
+                "failed to create selected-root mutable-state lower {}",
+                state_lower.display()
+            )
+        })?;
+        materialize_state_root(&prior.state, cas, &state_lower)
+            .context("failed to materialize selected-root mutable-state lower")?;
+        apply_resolved_payload_metadata(&state_lower, &prior.generation.root)
+            .context("failed to restore selected-root lower root metadata")?;
+        fs::File::open(&state_lower)?.sync_all()?;
+
+        let generation_mount = session_dir.join("lower-generation");
+        fs::create_dir(&generation_mount).with_context(|| {
+            format!(
+                "failed to create selected-root generation lower {}",
+                generation_mount.display()
+            )
+        })?;
+        let generation_lower = MountedGenerationLower::mount(artifact, generation_mount)
+            .context("failed to mount current generation as selected-root lower")?;
+        tracing::info!(
+            generation = artifact.generation,
+            immutable_entries = prior.generation.entries.len(),
+            mutable_state_entries = prior.state.entries.len(),
+            "mounted current generation directly as selected-root immutable lower"
+        );
+        Self::begin_with_lowers(
+            session_dir,
+            prior,
+            &[state_lower, generation_lower.mount_point.clone()],
+            Some(generation_lower),
+        )
+    }
+
+    fn begin_with_lowers(
+        session_dir: &Path,
+        prior: &CapturedSelectedRoot,
+        lowers: &[PathBuf],
+        generation_lower: Option<MountedGenerationLower>,
+    ) -> Result<Self> {
         fs::create_dir_all(session_dir).with_context(|| {
             format!(
                 "failed to create selected-root overlay workspace {}",
@@ -35,15 +102,16 @@ impl SelectedRootOverlaySession {
         let capabilities = probe_selected_root_overlay_profile(session_dir, &profile)
             .context("selected-root OverlayFS capability preflight failed")?;
 
-        let lower = session_dir.join("lower");
         let upper = session_dir.join("upper");
         let work = session_dir.join("work");
         let selected_root = session_dir.join("root");
-        if !lower.is_dir() {
-            anyhow::bail!(
-                "selected-root immutable lower authority is missing at {}",
-                lower.display()
-            );
+        for lower in lowers {
+            if !lower.is_dir() {
+                anyhow::bail!(
+                    "selected-root immutable lower authority is missing at {}",
+                    lower.display()
+                );
+            }
         }
         for directory in [&upper, &work, &selected_root] {
             fs::create_dir(directory).with_context(|| {
@@ -59,14 +127,21 @@ impl SelectedRootOverlaySession {
             .context("failed to encode selected-root overlay root metadata")?;
         apply_resolved_payload_metadata(&upper, &upper_root)
             .context("failed to seed selected-root overlay root metadata")?;
-        let mounted =
-            MountedSelectedRootOverlay::mount(&lower, &upper, &work, &selected_root, &profile)
-                .context("failed to mount selected-root OverlayFS session")?;
+        let lower_refs = lowers.iter().map(PathBuf::as_path).collect::<Vec<_>>();
+        let mounted = MountedSelectedRootOverlay::mount_lowers(
+            &lower_refs,
+            &upper,
+            &work,
+            &selected_root,
+            &profile,
+        )
+        .context("failed to mount selected-root OverlayFS session")?;
 
         Ok(Self {
             selected_root,
             upper,
             mounted: Some(mounted),
+            generation_lower,
             capabilities,
         })
     }
@@ -86,6 +161,7 @@ impl SelectedRootOverlaySession {
             .context("selected-root OverlayFS session is already frozen")?
             .freeze(&self.upper)
             .context("failed to freeze selected-root OverlayFS session")?;
+        self.unmount_generation_lower()?;
         decode_selected_root_overlay_upper(&self.upper, prior, cas, &self.capabilities.profile)
             .context("failed to decode selected-root OverlayFS upper")
     }
@@ -98,6 +174,60 @@ impl SelectedRootOverlaySession {
                 .unmount()
                 .context("failed to unmount discarded selected-root OverlayFS session")?;
         }
+        self.unmount_generation_lower()?;
         Ok(())
+    }
+
+    fn unmount_generation_lower(&mut self) -> Result<()> {
+        if let Some(lower) = &mut self.generation_lower {
+            lower.unmount()?;
+        }
+        Ok(())
+    }
+}
+
+impl MountedGenerationLower {
+    fn mount(artifact: &GenerationArtifact, mount_point: PathBuf) -> Result<Self> {
+        let requested_verity = super::super::builder::requested_generation_verity(
+            artifact.metadata.erofs_verity_digest.as_deref(),
+            artifact.metadata.fsverity_enabled,
+        );
+        mount_generation(&MountOptions {
+            image_path: artifact.erofs_path.clone(),
+            basedir: artifact.cas_dir.clone(),
+            mount_point: mount_point.clone(),
+            verity: requested_verity,
+            digest: requested_verity
+                .then(|| artifact.metadata.erofs_verity_digest.clone())
+                .flatten(),
+            upperdir: None,
+            workdir: None,
+        })?;
+        Ok(Self {
+            mount_point,
+            mounted: true,
+        })
+    }
+
+    fn unmount(&mut self) -> Result<()> {
+        if !self.mounted {
+            return Ok(());
+        }
+        umount2(&self.mount_point, MntFlags::empty()).with_context(|| {
+            format!(
+                "failed to strictly unmount selected-root generation lower {}",
+                self.mount_point.display()
+            )
+        })?;
+        self.mounted = false;
+        Ok(())
+    }
+}
+
+impl Drop for MountedGenerationLower {
+    fn drop(&mut self) {
+        if self.mounted {
+            let _ = umount2(&self.mount_point, MntFlags::MNT_DETACH);
+        }
     }
 }

--- a/apps/conary/src/commands/install/batch.rs
+++ b/apps/conary/src/commands/install/batch.rs
@@ -334,7 +334,7 @@ impl<'a> BatchInstaller<'a> {
         let locked_root =
             crate::commands::generation::selected_root::LockedRuntimeRoot::acquire(self.db_path)?;
         let mut promise_plan = self.validate_batch_transaction(&conn, &mut packages)?;
-        let mut selected_root = locked_root.materialize(&conn, &tx_description)?;
+        let mut selected_root = locked_root.prepare(&conn, &tx_description)?;
         let selected_path = selected_root.selected_root().to_path_buf();
         for package in &mut packages {
             package.normalize_ccs_for_selected_root(&selected_path)?;

--- a/apps/conary/src/commands/install/ccs_transaction.rs
+++ b/apps/conary/src/commands/install/ccs_transaction.rs
@@ -391,10 +391,10 @@ fn install_ccs_package_transactionally_inner(
         | UpgradeCheck::Replatform(trove) => Some(trove.as_ref()),
     };
     // Dry-run remains filesystem-read-only. Every real CCS mutation receives
-    // either its caller-owned try root or a freshly materialized selected root.
+    // either its caller-owned try root or a freshly prepared selected root.
     let mut owned_selected_root = locked_root
         .map(|locked_root| {
-            locked_root.materialize(conn, format!("Install {}-{}", pkg.name(), pkg.version()))
+            locked_root.prepare(conn, format!("Install {}-{}", pkg.name(), pkg.version()))
         })
         .transpose()?;
     let selected_root = match selected_root {

--- a/apps/conary/src/commands/install/command.rs
+++ b/apps/conary/src/commands/install/command.rs
@@ -259,7 +259,7 @@ async fn cmd_install_with_intent(
     );
     let mut selected_root = locked_root
         .context("real install has no locked runtime root")?
-        .materialize(&conn, format!("Install {}-{}", pkg.name(), pkg.version()))?;
+        .prepare(&conn, format!("Install {}-{}", pkg.name(), pkg.version()))?;
     let transaction_root = selected_root.selected_root().to_string_lossy().into_owned();
     native_transaction.preflight(Path::new(&transaction_root), &native_execution_mode)?;
     let preflighted_ccs_removal_hooks =

--- a/apps/conary/src/commands/remove/autoremove.rs
+++ b/apps/conary/src/commands/remove/autoremove.rs
@@ -176,7 +176,7 @@ fn preflight_autoremove_round(
                 );
             }
         };
-        let selected = locked_root.materialize(
+        let selected = locked_root.prepare(
             conn,
             format!("Autoremove preflight {}-{}", trove.name, trove.version),
         )?;

--- a/apps/conary/src/commands/remove/native_graph.rs
+++ b/apps/conary/src/commands/remove/native_graph.rs
@@ -45,8 +45,7 @@ pub(crate) fn execute_installed_trove_remove_graph(
     )?;
     conary_core::repository::enrollment::transaction::preflight_removal(conn, trove_id)
         .context("Package repository removal preflight failed")?;
-    let selected =
-        locked_root.materialize(conn, format!("Remove {}-{}", trove.name, trove.version))?;
+    let selected = locked_root.prepare(conn, format!("Remove {}-{}", trove.name, trove.version))?;
     native_transaction.preflight(selected.selected_root(), &ExecutionMode::Remove)?;
 
     execute_selected_root_graph(

--- a/apps/conary/tests/fixtures/selected-root-current-generation/prepare.py
+++ b/apps/conary/tests/fixtures/selected-root-current-generation/prepare.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# apps/conary/tests/fixtures/selected-root-current-generation/prepare.py
+
+"""Install a minimal exact generation artifact for selected-root mount proof."""
+
+import base64
+import pathlib
+import sys
+import zlib
+
+
+FILES = {
+    "generations/1/.conary-artifact.json": "eNp1ktFu2zAMRd/7FYGfl1SyKIrazxgUTa0umniw1KFF0X+f7LSIO3SAYfjykuKxyLe7w6H7o0uZ5kv38+B+rPqXXnTheg3ZLcSLPExVpT4v2oLdC+GA0G2e8LJMugzCvzlNT1OdtLSct+Z9Ody2wPtWcdbKI1deTzrJfOHl9dianh5LS9wydJnzeki3zHM9XdXNGMoD9x5X34qQEdNbVpucz2Mw0TqlnjwkI8ASDSBjCJADoBhJKaLTUT1wBt/988fD2nA482XKWura4eYdN5gb5P+qdngYrALZHFwSsYGcpDjmJD5BjkmNN2IVM7Q4Uu/6fn05jwlNQFK6Njo/V05POpTKVb/AfTjHzdmhfV+xA3NWXKas0WX24ExMaHsUyIY4Sy+RQkgkFKHBZBc0ETjHDKJJncufoy9D4rKtxOl03545PbYtKTd7T9v08VPvYPdpO8QUbfCiEcVCMD7FjJ5sjH0Aw+1yLDKkGN3Io4eW02ZuKeZ2hywGx4/tTOtkuBSt2z6t8niV99+g7LJ3JNQmEYPACJIjqcFA2XBj0uxH9K59gtAobb88crZoesemTTDESBDG7u79L+wOBLg=",
+    "generations/1/.conary-gen.json": "eNpdUctuwyAQvOcrLJ8biYexId/RUy/WArupG9tEQNqkVf+92E4fqoQE7GNmNPOxq6r6iDNGyEOY60PFH5YShThBLt/ahekcElKq1wbGQKlPwzuWZsNMu1YdpD7YF3Q59REJI84OfZlgG1p6xTjkW48z2HFtEIwJ/yDeB/xwxLTyMt3ajglQ3FjV+RZJAUJL2koSFkUjlXKek9Wy3JqRbVB6qbUVjVegNrkQ80Dgcj/BPFCB7tMzCNUuDKCNYCBBmYJipOWm49g0pnXIpbK+9aIjMt6rThvJGQfSjUcOCw1JvjEkdJdVuoMz2GFcnlfIOfYuXOb844GLCBl9v7kqmGj3TO+5fGTssJ6nDe8M7gRH/Ld9wjjjuLiUtphqGq75EvEu4jJNEG9LPeFYYkC/jyHkqmgrWeT9b8TVGN4wVt/ru88vqsaeyA==",
+    "generations/1/boot-assets/EFI/BOOT/BOOTX64.EFI": "eNpLy6woKS1K1U1NywQAG08EaQ==",
+    "generations/1/boot-assets/initramfs.img": "eNpLy6woKS1K1c3MyywpSsxNKwYAPyUHAg==",
+    "generations/1/boot-assets/manifest.json": "eNptkE9PG0EMxe98imivhWCP1/MnRyQq9cSFQ2+Rx+MJqyYbabNEEYjv3t1QlYC4WPJ79m/e+PVqsWiONhy6fd+sFng99xvrbZDxUpJBn7rRdHwebBKbU/Rr3zZn748NvW3XH5Smdqfz4IU9y8fdtuufXz5tHZ7EsZ9dFYNKbU5cuMZC1TsiY5LkOHpsDQNX4uACK6fsEJyqUUtcElnFd2zXd+Mgu3qYkf+bZbfbfPEvXnbBIRVKLkCaUmBFV1nYKAIqUsihxhgkRgVuQZXZkfdZfQRh8vJOttqt834/bvdSbJi59z9/3d49PDyey2/fLifhu9mLKNkyZiDUhJlzgba0KVfHRRiNFAJJFJ3yTLdSMEOY7qRkKtkQ4V8UHUxGK2sZz98D528g3iA9Iq+YVi4uY8IQOTr+AbACaK7e/gLwVZJB",
+    "generations/1/boot-assets/vmlinuz": "eNpLy6woKS1K1c1OLcpLzQEAK00Ftg==",
+    "generations/1/cas-manifest.json": "eNqr5lJQUCpLLSrOzM9TslIw1AHx01PzUosSS5CFEouSMzJLUpNLSotSgYJKFRZm8WYmSmC5/KQsoEQxUDg6lqsWAMfeF1M=",
+    "generations/1/generation-root.json": "eNqljrEOwjAMRPd+RZW5A10o4lcQQ5VYlYUSV46DQFX/nRhKCSobW+7e3TlTVdfmChyRgjnWbaOaiSSLKb+zipTYwqqzc8HgCp0duY+aMA4ZrBDfzcLm5l3y5DTS7g9dt5opAv9eCskDozXNB6Ee3W2GB6Y0/jviBT18j0SwFFzUeNEPfaCCbIZuvQgrmuaqICa9Di9qWL/x5AaCMILWTudqfgBg9Vza",
+    "generations/1/mutable-state.json": "eNqr5lJQUCpLLSrOzM9TslIw1AHxU/NKijJTi4H86FiuWgCveAno",
+    "generations/1/root.erofs": "eNqblVRxgZEBApgYRsEoGAUjCTx6+PUBiGYDYh4GFQZGLGoYaWg/KxC/dWRgkEYSU8GhFlv5BFMrAZSFsSWBbD09vdHIHQWjYBSMglEwCkbBKBgFowANAABj5giT",
+}
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: prepare.py RUNTIME_ROOT")
+    runtime_root = pathlib.Path(sys.argv[1])
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    (runtime_root / "objects").mkdir(exist_ok=True)
+    for relative, encoded in FILES.items():
+        destination = runtime_root / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(zlib.decompress(base64.b64decode(encoded)))
+    current = runtime_root / "current"
+    if current.exists() or current.is_symlink():
+        current.unlink()
+    current.symlink_to("generations/1")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/conary/tests/integration/remi/manifests/selected-root-overlay-profile-solus.toml
+++ b/apps/conary/tests/integration/remi/manifests/selected-root-overlay-profile-solus.toml
@@ -8,7 +8,7 @@ timeout = 1200
 [[test]]
 id = "TNPME403"
 name = "solus_overlay_profile_probe"
-description = "The Solus 7.1 kernel and ext4 runtime filesystem satisfy the exact profile and execute manifest-delta selected-root transactions"
+description = "The Solus 7.1 kernel and ext4 runtime filesystem satisfy the exact profile, mount the selected generation directly, and execute manifest-delta transactions"
 timeout = 1200
 fatal = true
 group = "selected-root-overlay-profile-solus"
@@ -28,6 +28,9 @@ copy_to_guest = [
 commands = [
     "test \"$(uname -r)\" = 7.1.7-351.current",
     "python3 /tmp/overlay-profile-probe.py",
+    "test -L /conary/current; test -f /conary/current/root.erofs; test -f /var/lib/conary/conary.db",
+    "bash -o pipefail -c 'env -u CONARY_TEST_SKIP_GENERATION_MOUNT CONARY_TEST_FAIL_GENERATION_REBUILD=selected-root-direct-lower-proof RUST_LOG=info conary ccs install --yes /tmp/dep-base-1.0.0-1.ccs --policy /tmp/ccs-trust-policy.toml --sandbox always --db-path /var/lib/conary/conary.db 2>&1 | tee /tmp/selected-root-direct-lower.log'",
+    "grep -Fq 'mounted current generation directly as selected-root immutable lower' /tmp/selected-root-direct-lower.log; test -z \"$(find /conary/selected-root-sessions -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)\"; ! findmnt -rn -t overlay,composefs | grep -q '/conary/selected-root-sessions'",
     "rm -rf /var/tmp/conary-403-overlay-runtime && mkdir -p /var/tmp/conary-403-overlay-runtime",
     "conary system init --db-path /var/tmp/conary-403-overlay-runtime/conary.db",
     "env -u CONARY_TEST_SKIP_GENERATION_MOUNT conary ccs install --yes /tmp/dep-base-1.0.0-1.ccs --policy /tmp/ccs-trust-policy.toml --sandbox always --db-path /var/tmp/conary-403-overlay-runtime/conary.db",
@@ -39,6 +42,7 @@ expect_output = [
     "\"hardlink_copy_up\": \"preserved\"",
     "\"metadata_copy_up\": \"complete-data\"",
     "\"opaque_directory\": \"logical-y\"",
+    "mounted current generation directly as selected-root immutable lower",
     "selected-root-overlay-transaction-ok",
 ]
 

--- a/apps/conary/tests/integration/remi/manifests/selected-root-overlay-profile-solus.toml
+++ b/apps/conary/tests/integration/remi/manifests/selected-root-overlay-profile-solus.toml
@@ -22,15 +22,18 @@ ssh_port = 2252
 stage_conary = true
 copy_to_guest = [
     { source = "apps/conary/tests/fixtures/selected-root-overlay-profile/probe.py", dest = "/tmp/overlay-profile-probe.py" },
+    { source = "apps/conary/tests/fixtures/selected-root-current-generation/prepare.py", dest = "/tmp/prepare-current-generation.py" },
     { source = "apps/conary/tests/fixtures/adversarial/deps/dep-base-v1/output/dep-base-1.0.0-1.ccs", dest = "/tmp/dep-base-1.0.0-1.ccs" },
     { source = "apps/conary/tests/fixtures/ccs-test-authority/trust-policy.toml", dest = "/tmp/ccs-trust-policy.toml" },
 ]
 commands = [
     "test \"$(uname -r)\" = 7.1.7-351.current",
     "python3 /tmp/overlay-profile-probe.py",
-    "test -L /conary/current; test -f /conary/current/root.erofs; test -f /var/lib/conary/conary.db",
-    "bash -o pipefail -c 'env -u CONARY_TEST_SKIP_GENERATION_MOUNT CONARY_TEST_FAIL_GENERATION_REBUILD=selected-root-direct-lower-proof RUST_LOG=info conary ccs install --yes /tmp/dep-base-1.0.0-1.ccs --policy /tmp/ccs-trust-policy.toml --sandbox always --db-path /var/lib/conary/conary.db 2>&1 | tee /tmp/selected-root-direct-lower.log'",
-    "grep -Fq 'mounted current generation directly as selected-root immutable lower' /tmp/selected-root-direct-lower.log; test -z \"$(find /conary/selected-root-sessions -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)\"; ! findmnt -rn -t overlay,composefs | grep -q '/conary/selected-root-sessions'",
+    "rm -rf /var/tmp/conary-403-current-runtime && mkdir -p /var/tmp/conary-403-current-runtime",
+    "conary system init --db-path /var/tmp/conary-403-current-runtime/conary.db",
+    "python3 /tmp/prepare-current-generation.py /var/tmp/conary-403-current-runtime; test -L /var/tmp/conary-403-current-runtime/current; test -f /var/tmp/conary-403-current-runtime/current/root.erofs",
+    "bash -o pipefail -c 'env -u CONARY_TEST_SKIP_GENERATION_MOUNT CONARY_TEST_FAIL_GENERATION_REBUILD=selected-root-direct-lower-proof RUST_LOG=info conary ccs install --yes /tmp/dep-base-1.0.0-1.ccs --policy /tmp/ccs-trust-policy.toml --sandbox always --db-path /var/tmp/conary-403-current-runtime/conary.db 2>&1 | tee /tmp/selected-root-direct-lower.log'",
+    "grep -Fq 'mounted current generation directly as selected-root immutable lower' /tmp/selected-root-direct-lower.log; test -z \"$(find /var/tmp/conary-403-current-runtime/selected-root-sessions -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)\"; ! findmnt -rn -t overlay,composefs | grep -q '/var/tmp/conary-403-current-runtime/selected-root-sessions'",
     "rm -rf /var/tmp/conary-403-overlay-runtime && mkdir -p /var/tmp/conary-403-overlay-runtime",
     "conary system init --db-path /var/tmp/conary-403-overlay-runtime/conary.db",
     "env -u CONARY_TEST_SKIP_GENERATION_MOUNT conary ccs install --yes /tmp/dep-base-1.0.0-1.ccs --policy /tmp/ccs-trust-policy.toml --sandbox always --db-path /var/tmp/conary-403-overlay-runtime/conary.db",

--- a/crates/conary-core/src/generation/root_manifest/overlay/probe.rs
+++ b/crates/conary-core/src/generation/root_manifest/overlay/probe.rs
@@ -91,7 +91,7 @@ pub fn probe_selected_root_overlay_profile(
     }
     seed_lower(&lower)?;
 
-    let options = mount_data(&lower, &upper, &work, profile)?;
+    let options = mount_data(&[&lower], &upper, &work, profile)?;
     mount(
         Some("overlay"),
         &merged,
@@ -137,32 +137,46 @@ fn seed_lower(lower: &Path) -> crate::Result<()> {
 }
 
 fn mount_data(
-    lower: &Path,
+    lowers: &[&Path],
     upper: &Path,
     work: &Path,
     profile: &SelectedRootOverlayProfile,
 ) -> crate::Result<String> {
+    if lowers.is_empty() {
+        return Err(crate::Error::InvalidPath(
+            "selected-root OverlayFS requires at least one lowerdir".to_string(),
+        ));
+    }
     let mut components = Vec::new();
-    for (name, path) in [("lowerdir", lower), ("upperdir", upper), ("workdir", work)] {
-        let value = path.to_str().ok_or_else(|| {
-            crate::Error::NotImplemented(format!(
-                "selected-root OverlayFS {name} is not UTF-8: {}",
-                path.display()
-            ))
-        })?;
-        if value
-            .bytes()
-            .any(|byte| matches!(byte, b',' | b':' | b'\\' | b'\n' | b'\r'))
-        {
-            return Err(crate::Error::InvalidPath(format!(
-                "selected-root OverlayFS {name} contains a mount-option delimiter: {}",
-                path.display()
-            )));
-        }
-        components.push(format!("{name}={value}"));
+    let mut lower_values = Vec::with_capacity(lowers.len());
+    for path in lowers {
+        lower_values.push(mount_path_value("lowerdir", path)?);
+    }
+    components.push(format!("lowerdir={}", lower_values.join(":")));
+    for (name, path) in [("upperdir", upper), ("workdir", work)] {
+        components.push(format!("{name}={}", mount_path_value(name, path)?));
     }
     components.extend(profile.mount_options()?.into_iter().map(str::to_string));
     Ok(components.join(","))
+}
+
+fn mount_path_value<'a>(name: &str, path: &'a Path) -> crate::Result<&'a str> {
+    let value = path.to_str().ok_or_else(|| {
+        crate::Error::NotImplemented(format!(
+            "selected-root OverlayFS {name} is not UTF-8: {}",
+            path.display()
+        ))
+    })?;
+    if value
+        .bytes()
+        .any(|byte| matches!(byte, b',' | b':' | b'\\' | b'\n' | b'\r'))
+    {
+        return Err(crate::Error::InvalidPath(format!(
+            "selected-root OverlayFS {name} contains a mount-option delimiter: {}",
+            path.display()
+        )));
+    }
+    Ok(value)
 }
 
 /// One mounted selected-root OverlayFS view.
@@ -183,7 +197,23 @@ impl MountedSelectedRootOverlay {
         target: &Path,
         profile: &SelectedRootOverlayProfile,
     ) -> crate::Result<Self> {
-        let options = mount_data(lower, upper, work, profile)?;
+        Self::mount_lowers(&[lower], upper, work, target, profile)
+    }
+
+    /// Mount one writable upper over ordered immutable lower directories.
+    ///
+    /// OverlayFS resolves the first lower as the topmost layer. Keeping the
+    /// ordering explicit lets selected-root sessions project mutable-state
+    /// authority above the immutable composefs generation without copying the
+    /// generation payload into the transaction workspace.
+    pub fn mount_lowers(
+        lowers: &[&Path],
+        upper: &Path,
+        work: &Path,
+        target: &Path,
+        profile: &SelectedRootOverlayProfile,
+    ) -> crate::Result<Self> {
+        let options = mount_data(lowers, upper, work, profile)?;
         mount(
             Some("overlay"),
             target,
@@ -396,7 +426,7 @@ mod tests {
         };
         assert_eq!(
             mount_data(
-                Path::new("/probe/lower"),
+                &[Path::new("/probe/lower")],
                 Path::new("/probe/upper"),
                 Path::new("/probe/work"),
                 &profile,
@@ -406,7 +436,26 @@ mod tests {
         );
         assert!(
             mount_data(
-                Path::new("/probe/with,comma"),
+                &[Path::new("/probe/with,comma")],
+                Path::new("/probe/upper"),
+                Path::new("/probe/work"),
+                &profile,
+            )
+            .is_err()
+        );
+        assert_eq!(
+            mount_data(
+                &[Path::new("/probe/state"), Path::new("/probe/generation")],
+                Path::new("/probe/upper"),
+                Path::new("/probe/work"),
+                &profile,
+            )
+            .unwrap(),
+            "lowerdir=/probe/state:/probe/generation,upperdir=/probe/upper,workdir=/probe/work,index=on,redirect_dir=nofollow,metacopy=off,xino=off,nfs_export=off,verity=off,userxattr"
+        );
+        assert!(
+            mount_data(
+                &[],
                 Path::new("/probe/upper"),
                 Path::new("/probe/work"),
                 &profile,

--- a/crates/conary-core/tests/selected_root_current_generation_fixture.rs
+++ b/crates/conary-core/tests/selected_root_current_generation_fixture.rs
@@ -1,0 +1,28 @@
+// conary-core/tests/selected_root_current_generation_fixture.rs
+
+use conary_core::generation::artifact::load_generation_artifact_for_activation;
+use conary_core::generation::mount::current_generation;
+use std::path::PathBuf;
+use std::process::Command;
+
+#[test]
+fn selected_root_current_generation_fixture_is_an_exact_mountable_artifact() {
+    let runtime_root = tempfile::tempdir().unwrap();
+    let script = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../apps/conary/tests/fixtures/selected-root-current-generation/prepare.py");
+    let status = Command::new("python3")
+        .arg(script)
+        .arg(runtime_root.path())
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    assert_eq!(current_generation(runtime_root.path()).unwrap(), Some(1));
+    let artifact =
+        load_generation_artifact_for_activation(&runtime_root.path().join("generations/1"))
+            .unwrap();
+    assert_eq!(artifact.generation, 1);
+    assert!(artifact.generation_root.entries.is_empty());
+    assert!(artifact.mutable_state.entries.is_empty());
+    assert_eq!(artifact.cas_dir, runtime_root.path().join("objects"));
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-12
-revision: 47
+last_updated: 2026-08-13
+revision: 48
 summary: Describe workspace architecture, exact native source authority, package transactions, lifecycle execution, typed carrier security, generation GC, and service boundaries
 ---
 
@@ -425,7 +425,8 @@ consulting a native package manager or its database.
 ```
 Generation-aware package mutation
        |
-  materialize latest typed authority as immutable lower
+  select latest typed authority as immutable lower
+  (current root.erofs mounts directly; typed state layers above it)
        |
   +-----------+
   | OverlayFS |-- Probed profile + transaction-owned upper/work
@@ -462,9 +463,14 @@ optional root metadata before this boundary. Applying a delta preserves prior
 CAS identities for unchanged content, routes changed paths through the finite
 publication domains, and revalidates the complete resulting manifests. Normal
 runtime selected-root sessions mount the functionally proven OverlayFS profile
-over an immutable materialized lower, freeze and strictly unmount before
+over exact immutable lower authority, freeze and strictly unmount before
 decoding the transaction upper, and never perform complete before/after
-selected-root scans. Retained try-session trees remain an explicit
+selected-root scans. With no pending publication debt, the current verified
+generation `root.erofs` mounts directly as the immutable-content lower and the
+typed `/etc`, `/var`, and `/srv` manifest is the top lower layer; the session
+strictly unmounts the transaction overlay before that nested composefs mount.
+Recoverable candidates and first-generation database authority still use an
+explicit materialized lower. Retained try-session trees remain a separate
 materialization consumer until their namespace contract is migrated; they are
 not a fallback for normal mutation.
 
@@ -473,7 +479,7 @@ the retired copied `root/` tree fails closed and must be discarded and rebuilt
 from current typed generation/database authority; runtime code does not retain
 a dual reader for the superseded storage shape.
 
-1. **Select**: Materialize the latest cumulative selected-root candidate, or the current generation when no publication debt is pending, as immutable lower authority
+1. **Select**: Use the latest cumulative selected-root candidate as lower authority when publication debt is pending. Otherwise mount the current generation's verified composefs image directly beneath its typed mutable-state layer; only first-generation database authority still reconstructs the complete lower
 2. **Mutate**: Apply payload changes, typed native lifecycle, CCS hooks, triggers, and config decisions inside that isolated root
 3. **Record**: Freeze and strictly unmount, decode the upper into a typed changed-path delta, apply it to the prior manifests, persist a manifest-only selected-root candidate, and record recoverable publication debt before committing package state
 4. **Build**: Validate the captured manifests and serialize the immutable manifest to EROFS using verified CAS content

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -638,6 +638,10 @@ metadata copy-up, character-device whiteouts, logical opaque replacement, and
 `EXDEV` for lower-directory rename. Against the fixture's selected generation,
 it proves the verified composefs image is mounted directly beneath typed mutable
 state and that both nested mounts are gone before publication failure returns.
+The bounded artifact is reconstructed by
+`apps/conary/tests/fixtures/selected-root-current-generation/prepare.py`; a
+core integration test loads that exact artifact contract before the privileged
+lane consumes it.
 It also stages an isolated first-generation runtime, installs and removes a
 signed lifecycle-free CCS through the materialized-candidate path, verifies the
 changed path appears and disappears in successive manifest-only candidates,

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-12
-revision: 48
+last_updated: 2026-08-13
+revision: 49
 summary: Document authenticated derivative targets, transport normalization, typed release evidence, and native lifecycle gates
 ---
 
@@ -635,13 +635,16 @@ The bounded `selected-root-overlay-profile-solus` QEMU suite reuses that
 immutable fixture without running takeover. It functionally mounts the exact
 selected-root OverlayFS profile and proves indexed hardlink copy-up, complete
 metadata copy-up, character-device whiteouts, logical opaque replacement, and
-`EXDEV` for lower-directory rename. It then stages the current static Conary
-binary, installs and removes a signed lifecycle-free CCS through the real
-selected-root session, verifies the changed path appears and disappears in
-successive manifest-only candidates, and proves that no session mount or
-workspace survives either commit. This is the positive kernel/filesystem and
-transaction counterpart to the runtime typed preflight; a kernel version or
-registered filesystem name alone is not capability evidence.
+`EXDEV` for lower-directory rename. Against the fixture's selected generation,
+it proves the verified composefs image is mounted directly beneath typed mutable
+state and that both nested mounts are gone before publication failure returns.
+It also stages an isolated first-generation runtime, installs and removes a
+signed lifecycle-free CCS through the materialized-candidate path, verifies the
+changed path appears and disappears in successive manifest-only candidates,
+and proves that no session mount or workspace survives either commit. This is
+the positive kernel/filesystem and transaction counterpart to the runtime typed
+preflight; a kernel version or registered filesystem name alone is not
+capability evidence.
 
 Each full parity run must pass `scripts/check-conary-test-result-gate.sh` and
 `scripts/check-conary-corpus-result-gate.sh`,

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-12
-revision: 67
+last_updated: 2026-08-13
+revision: 68
 summary: Route typed database rebuilds, exact native source identity and adopted-artifact conversion, lossless source authority and trust-import planning, exact Remi signing, selected-root mutation, rollback lineage, canonical-map authority, carrier security, generation GC, release authority, and subsystem proof through current feature owners.
 ---
 
@@ -78,8 +78,11 @@ commands.
   `apps/conary/src/commands/install/package_set.rs` and
   `apps/conary/src/commands/install/repository_batch.rs`; removal starts in
   `apps/conary/src/commands/remove/native_graph.rs`. The selected-root
-  session acquires and owns the canonical runtime mutation lock before
-  materialization; the lock implementation starts in
+  session acquires and owns the canonical runtime mutation lock before lower
+  preparation. Current-generation immutable content mounts directly from its
+  verified composefs artifact; pending-candidate, first-generation, and
+  retained-try paths keep explicit materialization boundaries. The lock
+  implementation starts in
   `crates/conary-core/src/transaction/mod.rs`. Exact rollback execution and
   typed compensating lineage start in
   `apps/conary/src/commands/system/rollback_command.rs` and

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-12
-revision: 69
+last_updated: 2026-08-13
+revision: 70
 summary: Route feature ownership through typed database rebuilds, exact native source identity and adopted-artifact conversion, native declaration and trust-import planning, exact Remi signing, streaming package payloads, serialized selected-root mutation, typed rollback lineage, exact lifecycle, canonical-map authority, carrier security, generation GC, exact release authority, and current canonical docs
 ---
 
@@ -315,8 +315,11 @@ redaction, the old-only payload visibility boundary, and execution without a
 source package manager or its database. Diagnostic shell or command
 classifications must not select, suppress, or reorder lifecycle events.
 The selected-root session owns the single runtime mutation lock before it
-materializes database or generation authority and retains that lock through
-candidate persistence, SQLite commit, and publication. Rollback is one
+prepares database or generation authority. A debt-free current generation uses
+its verified composefs artifact plus typed mutable state directly; recoverable
+candidates, first-generation database state, and retained try sessions keep
+explicit materialization boundaries. The lock remains held through candidate
+persistence, SQLite commit, and publication. Rollback is one
 serialized immediate SQLite transaction: forward mutations and compensating
 rollback rows have distinct typed lineage, and applied rollback rows never
 block the next effective LIFO rollback.
@@ -662,9 +665,9 @@ authority, and seed images before any deletion; every live digest must exist
 in the local CAS. `conary system generation gc` is the sole GC surface and
 runs under the canonical mutation lock. Runtime
 Selected-root mutation reads are serialized by the lock owned in
-`apps/conary/src/commands/generation/selected_root.rs`; a candidate may not be
-materialized before that lock is held, and it remains held until the matching
-database state and publication outcome are durable. Runtime
+`apps/conary/src/commands/generation/selected_root.rs`; lower authority may not
+be prepared or mounted before that lock is held, and it remains held until the
+matching database state and publication outcome are durable. Runtime
 lifecycle work is consumed only for the single generation proven by the kernel
 command line, matching artifact, and database state; skipped generations must
 carry forward unapplied requests. Booted-generation host-interface drift is


### PR DESCRIPTION
## Primary Issue

Refs #403

Design / Plan / Roadmap: [bounded fourth-slice issue record](https://github.com/ConaryLabs/Conary/issues/403#issuecomment-5282507489)

## Problem And Outcome

Normal selected-root transactions already decode only their writable OverlayFS upper, but they still reconstructed every immutable CAS payload byte before mounting that overlay. After this slice, the steady-state path with a selected generation and no publication debt mounts the generation's verified composefs/EROFS artifact directly. Only typed `/etc`, `/var`, and `/srv` state is reconstructed as the top lower layer.

The transaction owns both mounts. Commit or discard strictly unmounts the writable OverlayFS first and the nested generation lower second; lower-unmount failure stops delta decoding and publication.

## Changes

- select activation-verified current-generation artifacts as a distinct lower source instead of complete materialization
- admit an ordered mutable-state + composefs lower stack in the typed OverlayFS mount boundary
- retain manifest authority for rollback/delta application and avoid deep CAS payload re-verification on the direct mount path
- add a bounded exact generation-artifact fixture, a nonprivileged loader regression, and Solus QEMU direct-mount coverage
- hard-cut the lock-holder API from misleading `materialize()` naming to selected-root `prepare()`
- update architecture, integration, feature-ownership, and assistant routing truth

## Scope

- In scope: current-generation steady-state selected-root preparation
- Out of scope: pending manifest-only candidates, first-generation DB authority, retained try-session materialization, and #121 work-amplification counters

## Ownership / Boundary

- Owning subsystem: generation / selected-root transaction preparation
- Boundary changed or preserved: immutable generation bytes now remain behind verified composefs; typed mutable-state and delta authority are preserved
- Persisted state or public surface impact: none; publication candidates remain manifest-only and artifact format is unchanged
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Ran affected-package verification directly when touching service or daemon code (not applicable)
- [x] Updated subsystem docs or maps when the "look here first" path changed
- [x] Ran the broader interaction gate when the feature ownership card required it
- [x] Updated the primary issue with any acceptance criteria left for later PRs

```text
- cargo check -p conary --all-targets
- cargo test -p conary-core --lib generation::root_manifest::overlay
  - 16 passed; 1 privileged probe ignored
- cargo test -p conary --lib commands::generation::selected_root
  - 10 passed
- cargo test -p conary-core --test selected_root_current_generation_fixture
  - 1 passed
- cargo test -p conary-core
  - library: 3549 passed; 4 ignored; integration tests and doctests green
- cargo test -p conary
  - library: 1081 passed; 2 ignored; integration tests and doctests green
- cargo run -p conary-test -- list
  - Solus Selected-Root Overlay Proof discovered with 1 test
- CARGO_TARGET_DIR=/conary/dev/cache/target/issue403-current-lower cargo run -p conary-test -- run --suite selected-root-overlay-profile-solus --distro solus --phase 4
  - PASS 1/1 on the published Solus kernel 7.1.7 profile
  - observed direct composefs lower mount and selected-root current-generation log
  - observed no surviving OverlayFS/composefs mounts or selected-root session directories
  - existing first-generation/pending-candidate install/remove flow also passed
- CARGO_TARGET_DIR=/conary/dev/cache/target/issue403-current-lower cargo clippy --workspace --all-targets -- -D warnings
- bash scripts/check-doc-truth.sh
- bash scripts/test-doc-truth.sh
- bash scripts/test-agent-context.sh
- bash scripts/agent-context.sh --validate
- cargo fmt --all -- --check
- git diff --check
```

The first Solus run on `1dab37d6` failed 0/1 at its precondition, before the new code ran: the published base image intentionally has no default Conary database or selected generation until the separate takeover suite executes. The lane now constructs a bounded exact generation artifact in an isolated runtime; its loader contract is covered above. This failure was not retried unchanged.

Workspace Clippy then identified the inline `GenerationArtifact` as a 1,360-byte enum variant. Commit `31a24225` boxes that owned artifact, and the unchanged Clippy command plus the selected-root regression suite pass. Commit `d523d137` also aligns the canonical feature-ownership card with the direct-generation lower boundary; all four documentation/agent-routing gates pass. Final head `81eb095f` renames the lock-holder API to `prepare()` across install/remove callers; `cargo check -p conary --all-targets`, the 10 selected-root tests, formatting, and diff checks pass on that head.

## Review And Merge Notes

- Review focus: nested mount lifetime/unmount ordering, lower-stack order, fail-closed verity behavior, and the bounded fixture contract
- User or developer impact: steady-state package transactions no longer reconstruct immutable generation payload bytes before lifecycle execution
- Required-check bypass: not used
