### PR TITLE
perf(ccs): ingest verified objects into CAS

### DIFF
--- a/apps/conary/src/commands/ccs/install/command.rs
+++ b/apps/conary/src/commands/ccs/install/command.rs
@@ -64,8 +64,17 @@ pub async fn cmd_ccs_install(
             "CCS install requires --policy or an initialized local-dev signing key; unsigned and untrusted packages cannot be installed"
         );
     };
-    let verification = verify::verify_package(package_path, &trust_policy)
-        .context("CCS package authority verification failed")?;
+    let permanent_cas = (!dry_run)
+        .then(|| {
+            let runtime_root = conary_core::runtime_root::ConaryRuntimeRoot::from_db_path(db_path);
+            conary_core::filesystem::CasStore::new(runtime_root.objects_dir())
+        })
+        .transpose()?;
+    let verification = match &permanent_cas {
+        Some(cas) => verify::verify_package_into_cas(package_path, &trust_policy, cas),
+        None => verify::verify_package(package_path, &trust_policy),
+    }
+    .context("CCS package authority verification failed")?;
     println!(
         "Verified signed CCS v3 authority ({} payload files)",
         verification.files_checked()

--- a/apps/conary/src/commands/ccs/install/command_payload_tests.rs
+++ b/apps/conary/src/commands/ccs/install/command_payload_tests.rs
@@ -8,6 +8,72 @@ use super::test_support::{
 };
 
 #[tokio::test]
+async fn ccs_install_dry_run_keeps_permanent_cas_absent() {
+    use conary_core::ccs::{BuildResult, CcsManifest, ComponentData};
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let install_root = temp_dir.path().join("root");
+    let package_path = temp_dir.path().join("dry-run-payload.ccs");
+    let db_path = temp_dir.path().join("conary.db");
+    let db_path_str = db_path.to_str().unwrap();
+    std::fs::create_dir_all(&install_root).unwrap();
+    conary_core::db::init(db_path_str).unwrap();
+
+    let content = b"dry run must remain read only".to_vec();
+    let hash = conary_core::hash::sha256(&content);
+    let files = vec![ccs_regular_file(
+        "/usr/share/dry-run-proof".to_string(),
+        hash.clone(),
+        content.len() as u64,
+        0o100644,
+        "runtime".to_string(),
+    )];
+    let result = BuildResult {
+        manifest: CcsManifest::new_minimal("dry-run-payload", "1.0.0"),
+        components: HashMap::from([(
+            "runtime".to_string(),
+            ComponentData {
+                name: "runtime".to_string(),
+                files: files.clone(),
+                hash: "runtime".to_string(),
+                size: content.len() as u64,
+            },
+        )]),
+        files: files.clone(),
+        payloads: conary_core::ccs::builder::payloads_from_bounded_memory_for_tests(
+            &files,
+            HashMap::from([(hash, content)]),
+        )
+        .unwrap(),
+        total_size: files[0].content.as_ref().unwrap().size,
+        chunked: false,
+        chunk_stats: None,
+    };
+    let trust_policy_path = super::test_support::write_signed_test_package(&result, &package_path);
+    let objects_dir = temp_dir.path().join("objects");
+    assert!(!objects_dir.exists());
+
+    cmd_ccs_install(
+        package_path.to_str().unwrap(),
+        db_path_str,
+        install_root.to_str().unwrap(),
+        true,
+        Some(trust_policy_path.to_string_lossy().into_owned()),
+        None,
+        crate::commands::SandboxMode::Always,
+        true,
+        false,
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        !objects_dir.exists(),
+        "CCS dry-run verification must not create permanent CAS state"
+    );
+}
+
+#[tokio::test]
 async fn ccs_install_rejects_child_write_beneath_package_symlink() {
     use conary_core::ccs::{BuildResult, CcsManifest, ComponentData};
     use conary_core::hash;

--- a/apps/conary/src/commands/install/conversion.rs
+++ b/apps/conary/src/commands/install/conversion.rs
@@ -10,7 +10,9 @@ use super::PackageFormatType;
 use super::batch::{BatchInstaller, prepare_ccs_package_for_batch};
 use super::dep_resolution;
 use super::dependencies::resolved_repository_deps_from_sat_result;
-use super::repository_batch::{RepositoryBatchSelection, prepare_repository_batch};
+use super::repository_batch::{
+    RepositoryBatchMode, RepositoryBatchSelection, prepare_repository_batch,
+};
 use super::{
     CcsEnvelopeAuthority, CcsTransactionInstallOptions, InstallIntent, RepositoryInstallProvenance,
     verify_ccs_package_authority,
@@ -538,12 +540,27 @@ pub async fn install_ccs_artifact(opts: CcsArtifactInstallOptions<'_>) -> Result
         resolution_policy,
     } = opts;
 
-    let verified = verify_ccs_package_authority(
-        db_path,
-        Path::new(ccs_path),
-        &envelope_authority,
-        repository_provenance.as_ref(),
-    )?;
+    let permanent_cas = (!dry_run)
+        .then(|| {
+            let runtime_root = conary_core::runtime_root::ConaryRuntimeRoot::from_db_path(db_path);
+            conary_core::filesystem::CasStore::new(runtime_root.objects_dir())
+        })
+        .transpose()?;
+    let verified = match &permanent_cas {
+        Some(cas) => super::verify_ccs_package_authority_into_cas(
+            db_path,
+            Path::new(ccs_path),
+            &envelope_authority,
+            repository_provenance.as_ref(),
+            cas,
+        )?,
+        None => verify_ccs_package_authority(
+            db_path,
+            Path::new(ccs_path),
+            &envelope_authority,
+            repository_provenance.as_ref(),
+        )?,
+    };
 
     let ccs_pkg = CcsPackage::from_verified_archive(ccs_path, &verified)
         .context("Failed to construct verified CCS package")?;
@@ -640,7 +657,8 @@ pub async fn install_ccs_artifact(opts: CcsArtifactInstallOptions<'_>) -> Result
             intent,
         })
         .collect();
-    let mut prepared = prepare_repository_batch(db_path, selections).await?;
+    let mut prepared =
+        prepare_repository_batch(db_path, selections, RepositoryBatchMode::Install).await?;
     prepared.push(prepare_ccs_package_for_batch(
         &ccs_pkg,
         db_path,

--- a/apps/conary/src/commands/install/inner.rs
+++ b/apps/conary/src/commands/install/inner.rs
@@ -138,12 +138,26 @@ pub(super) fn store_extracted_files_in_cas(
                 let authority = file.content_authority.as_ref().ok_or_else(|| {
                     anyhow!("regular payload {} has no content authority", file.path)
                 })?;
-                let mut reader = file
-                    .open_content()
-                    .with_context(|| format!("Failed to open payload source for {}", file.path))?;
-                let stored = cas
-                    .store_reader_expected(reader.as_mut(), authority.size, &authority.sha256)
-                    .with_context(|| format!("Failed to store {} in CAS", file.path))?;
+                let source = file.source().ok_or_else(|| {
+                    anyhow!("regular payload {} has no reopenable source", file.path)
+                })?;
+                let stored = match source
+                    .verified_cas_identity_for(cas, authority)
+                    .with_context(|| format!("Verified CAS authority failed for {}", file.path))?
+                {
+                    Some(identity) => identity,
+                    None => {
+                        let mut reader = file.open_content().with_context(|| {
+                            format!("Failed to open payload source for {}", file.path)
+                        })?;
+                        cas.store_reader_expected(
+                            reader.as_mut(),
+                            authority.size,
+                            &authority.sha256,
+                        )
+                        .with_context(|| format!("Failed to store {} in CAS", file.path))?
+                    }
+                };
                 if stored != authority.sha256 {
                     anyhow::bail!(
                         "CAS returned {} for {}, expected authoritative digest {}",

--- a/apps/conary/src/commands/install/inner/tests.rs
+++ b/apps/conary/src/commands/install/inner/tests.rs
@@ -304,6 +304,50 @@ fn store_install_files_in_cas_preserves_symlink_targets() {
 }
 
 #[test]
+fn store_install_files_reuses_typed_verified_cas_authority() {
+    let temp = tempfile::tempdir().unwrap();
+    let cas = conary_core::filesystem::CasStore::new(temp.path().join("objects")).unwrap();
+    let bytes = b"already verified canonical bytes";
+    let hash = conary_core::hash::sha256(bytes);
+    let mut batch = cas
+        .verified_object_batch([(hash.clone(), bytes.len() as u64)])
+        .unwrap();
+    batch
+        .ingest(&hash, &mut std::io::Cursor::new(bytes))
+        .unwrap();
+    let set = std::sync::Arc::new(batch.commit().unwrap());
+    let source = conary_core::packages::payload::ReopenablePayload::from_verified_cas_object(
+        set,
+        hash.clone(),
+        bytes.len() as u64,
+    )
+    .unwrap();
+    // Prove storage does not open or reread the canonical object after it has
+    // consumed the exact typed identity. Metadata admission remains allowed.
+    let canonical = cas.hash_to_path(&hash).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&canonical, std::fs::Permissions::from_mode(0o000)).unwrap();
+    }
+    let payload = conary_core::packages::payload::PackagePayloadFile::new(
+        "/usr/bin/verified".to_string(),
+        PayloadNode::regular(0o755),
+        Some(PayloadContentAuthority {
+            sha256: hash.clone(),
+            size: bytes.len() as u64,
+        }),
+        Some(source),
+    )
+    .unwrap();
+
+    let stored = store_extracted_files_in_cas(&cas, &[payload]).unwrap();
+
+    assert_eq!(stored[0].cas_hash.as_deref(), Some(hash.as_str()));
+    assert!(canonical.exists());
+}
+
+#[test]
 fn install_inner_persists_declared_config_metadata() {
     let temp = tempfile::tempdir().unwrap();
     let root = temp.path().join("root");

--- a/apps/conary/src/commands/install/mod.rs
+++ b/apps/conary/src/commands/install/mod.rs
@@ -52,7 +52,7 @@ pub(crate) use native_lifecycle::NativeLifecycleInstallState;
 pub use options::InstallOptions;
 pub(crate) use options::{
     CcsEnvelopeAuthority, RepositoryInstallProvenance, repository_install_provenance_from_package,
-    verify_ccs_package_authority,
+    verify_ccs_package_authority, verify_ccs_package_authority_into_cas,
 };
 pub use prepare::{ComponentSelection, UpgradeCheck};
 pub(crate) use restore::{

--- a/apps/conary/src/commands/install/options.rs
+++ b/apps/conary/src/commands/install/options.rs
@@ -2,8 +2,9 @@
 
 use super::OwnershipMode;
 use anyhow::{Context, Result};
-use conary_core::ccs::verify::{TrustPolicy, verify_package};
+use conary_core::ccs::verify::{TrustPolicy, verify_package, verify_package_into_cas};
 use conary_core::db::models::{Repository, RepositoryPackage, RepositoryPackageKey};
+use conary_core::filesystem::CasStore;
 use conary_core::repository::RepositorySourceKind;
 use conary_core::repository::versioning::resolve_package_version_scheme;
 use conary_core::scriptlet::SandboxMode;
@@ -114,6 +115,36 @@ pub(crate) fn verify_ccs_package_authority(
     envelope_authority: &CcsEnvelopeAuthority,
     repository_provenance: Option<&RepositoryInstallProvenance>,
 ) -> Result<conary_core::ccs::VerifiedCcsArchive> {
+    let policy = ccs_trust_policy(db_path, envelope_authority, repository_provenance)?;
+    verify_package(ccs_path, &policy).with_context(|| {
+        format!(
+            "CCS package authority verification failed for {}",
+            ccs_path.display()
+        )
+    })
+}
+
+pub(crate) fn verify_ccs_package_authority_into_cas(
+    db_path: &str,
+    ccs_path: &Path,
+    envelope_authority: &CcsEnvelopeAuthority,
+    repository_provenance: Option<&RepositoryInstallProvenance>,
+    cas: &CasStore,
+) -> Result<conary_core::ccs::VerifiedCcsArchive> {
+    let policy = ccs_trust_policy(db_path, envelope_authority, repository_provenance)?;
+    verify_package_into_cas(ccs_path, &policy, cas).with_context(|| {
+        format!(
+            "CCS package authority verification and permanent CAS ingestion failed for {}",
+            ccs_path.display()
+        )
+    })
+}
+
+fn ccs_trust_policy(
+    db_path: &str,
+    envelope_authority: &CcsEnvelopeAuthority,
+    repository_provenance: Option<&RepositoryInstallProvenance>,
+) -> Result<TrustPolicy> {
     let keys = match envelope_authority {
         CcsEnvelopeAuthority::Repository => {
             let provenance = repository_provenance.context(
@@ -156,13 +187,7 @@ pub(crate) fn verify_ccs_package_authority(
             .to_vec(),
         CcsEnvelopeAuthority::ExactKey(key) => vec![key.clone()],
     };
-    let policy = TrustPolicy::strict(keys);
-    verify_package(ccs_path, &policy).with_context(|| {
-        format!(
-            "CCS package authority verification failed for {}",
-            ccs_path.display()
-        )
-    })
+    Ok(TrustPolicy::strict(keys))
 }
 
 #[cfg(test)]

--- a/apps/conary/src/commands/install/package_set.rs
+++ b/apps/conary/src/commands/install/package_set.rs
@@ -19,7 +19,9 @@ use conary_core::version::VersionConstraint;
 use super::InstallIntent;
 use super::batch::BatchInstaller;
 use super::dependencies::resolved_repository_deps_from_sat_result;
-use super::repository_batch::{RepositoryBatchSelection, prepare_repository_batch};
+use super::repository_batch::{
+    RepositoryBatchMode, RepositoryBatchSelection, prepare_repository_batch,
+};
 use super::source_policy::resolve_canonical_name;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -131,7 +133,11 @@ async fn process_package_set(
             }
         })
         .collect();
-    let prepared = prepare_repository_batch(db_path, selections).await?;
+    let preparation_mode = match &operation {
+        PackageSetOperation::Validate => RepositoryBatchMode::Validate,
+        PackageSetOperation::Install(_) => RepositoryBatchMode::Install,
+    };
+    let prepared = prepare_repository_batch(db_path, selections, preparation_mode).await?;
     let root_count = resolved_requests.len();
     match operation {
         PackageSetOperation::Validate => {

--- a/apps/conary/src/commands/install/repository_batch.rs
+++ b/apps/conary/src/commands/install/repository_batch.rs
@@ -11,7 +11,7 @@ use super::conversion::{
 };
 use super::{
     CcsEnvelopeAuthority, InstallIntent, repository_install_provenance_from_package,
-    verify_ccs_package_authority,
+    verify_ccs_package_authority, verify_ccs_package_authority_into_cas,
 };
 use anyhow::{Context, Result};
 use conary_core::ccs::CcsPackage;
@@ -28,6 +28,12 @@ pub(super) struct RepositoryBatchSelection {
     pub(super) selection_reason: String,
     pub(super) allow_downgrade: bool,
     pub(super) intent: InstallIntent,
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum RepositoryBatchMode {
+    Validate,
+    Install,
 }
 
 pub(super) struct PreparedRepositoryBatch {
@@ -59,6 +65,7 @@ impl PreparedRepositoryBatch {
 pub(super) async fn prepare_repository_batch(
     db_path: &str,
     selections: Vec<RepositoryBatchSelection>,
+    mode: RepositoryBatchMode,
 ) -> Result<PreparedRepositoryBatch> {
     let selected = selections
         .iter()
@@ -82,6 +89,13 @@ pub(super) async fn prepare_repository_batch(
             selections.len()
         );
     }
+
+    let permanent_cas = matches!(mode, RepositoryBatchMode::Install)
+        .then(|| {
+            let runtime_root = conary_core::runtime_root::ConaryRuntimeRoot::from_db_path(db_path);
+            conary_core::filesystem::CasStore::new(runtime_root.objects_dir())
+        })
+        .transpose()?;
 
     let mut packages = Vec::with_capacity(selections.len());
     for (((expected_name, package_with_repo), (downloaded_name, path)), selection) in
@@ -107,12 +121,21 @@ pub(super) async fn prepare_repository_batch(
             let ccs_path = path
                 .to_str()
                 .context("Invalid CCS package path (non-UTF8)")?;
-            let verified = verify_ccs_package_authority(
-                db_path,
-                path,
-                &CcsEnvelopeAuthority::Repository,
-                Some(&provenance),
-            )?;
+            let verified = match &permanent_cas {
+                Some(cas) => verify_ccs_package_authority_into_cas(
+                    db_path,
+                    path,
+                    &CcsEnvelopeAuthority::Repository,
+                    Some(&provenance),
+                    cas,
+                )?,
+                None => verify_ccs_package_authority(
+                    db_path,
+                    path,
+                    &CcsEnvelopeAuthority::Repository,
+                    Some(&provenance),
+                )?,
+            };
             let package =
                 CcsPackage::from_verified_archive(ccs_path, &verified).with_context(|| {
                     format!("Failed to construct verified CCS package {downloaded_name}")

--- a/apps/conary/src/commands/install/restore.rs
+++ b/apps/conary/src/commands/install/restore.rs
@@ -15,7 +15,7 @@ use super::resolve::{
 use super::{
     CcsEnvelopeAuthority, ExtractionResult, InstallIntent, InstallOptions, InstallPhase,
     InstallProgress, InstallSemantics, NativeLifecycleInstallState, build_resolution_policy,
-    extract_and_classify_files, resolve_canonical_name, verify_ccs_package_authority,
+    extract_and_classify_files, resolve_canonical_name, verify_ccs_package_authority_into_cas,
 };
 use anyhow::{Context, Result};
 use conary_core::ccs::CcsPackage;
@@ -343,11 +343,14 @@ pub(crate) async fn prepare_install_for_restore(
                     "Repository-resolved CCS restore package is missing exact repository provenance"
                 );
             };
-            let verified = verify_ccs_package_authority(
+            let runtime_root = conary_core::runtime_root::ConaryRuntimeRoot::from_db_path(db_path);
+            let cas = conary_core::filesystem::CasStore::new(runtime_root.objects_dir())?;
+            let verified = verify_ccs_package_authority_into_cas(
                 db_path,
                 &resolved.path,
                 &envelope_authority,
                 repository_provenance.as_ref(),
+                &cas,
             )?;
             let ccs_pkg = CcsPackage::from_verified_archive(path_str, &verified)
                 .context("Failed to construct verified CCS package")?;

--- a/crates/conary-core/src/ccs/verify.rs
+++ b/crates/conary-core/src/ccs/verify.rs
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use thiserror::Error;
 
+mod object_sink;
 mod stream;
 
 #[derive(Error, Debug)]
@@ -158,6 +159,7 @@ pub struct VerifiedCcsArchive {
     debug_toml: Option<Vec<u8>>,
     components: HashMap<String, crate::ccs::builder::ComponentData>,
     payload: crate::packages::payload::PackagePayload,
+    verified_object_metrics: Option<crate::filesystem::VerifiedObjectBatchMetrics>,
     files_checked: usize,
 }
 
@@ -180,6 +182,11 @@ impl VerifiedCcsArchive {
 
     pub fn files_checked(&self) -> usize {
         self.files_checked
+    }
+
+    /// Permanent-CAS work performed by install-oriented verification.
+    pub fn verified_object_metrics(&self) -> Option<crate::filesystem::VerifiedObjectBatchMetrics> {
+        self.verified_object_metrics
     }
 
     pub(crate) fn build_attestation(
@@ -210,8 +217,29 @@ impl VerifiedCcsArchive {
 /// Verify current CCS authority, signature trust, diagnostic projections, and
 /// every payload object before returning an install/publication capability.
 pub fn verify_package(path: &Path, policy: &TrustPolicy) -> Result<VerifiedCcsArchive> {
+    verify_package_to(path, policy, object_sink::ObjectDestination::Spool)
+}
+
+/// Verify a current CCS archive directly into one permanent SHA-256 CAS.
+///
+/// The returned payload sources carry the committed batch capability, allowing
+/// installation to reference their canonical identities without reopening and
+/// re-ingesting the same bytes.
+pub fn verify_package_into_cas(
+    path: &Path,
+    policy: &TrustPolicy,
+    cas: &crate::filesystem::CasStore,
+) -> Result<VerifiedCcsArchive> {
+    verify_package_to(path, policy, object_sink::ObjectDestination::Permanent(cas))
+}
+
+fn verify_package_to(
+    path: &Path,
+    policy: &TrustPolicy,
+    destination: object_sink::ObjectDestination<'_>,
+) -> Result<VerifiedCcsArchive> {
     policy.validate()?;
-    let verified = stream::verify_archive(path, policy)
+    let verified = stream::verify_archive(path, policy, destination)
         .with_context(|| format!("verify streaming CCS v3 archive {}", path.display()))?;
     Ok(VerifiedCcsArchive {
         authority: verified.authority,
@@ -221,6 +249,7 @@ pub fn verify_package(path: &Path, policy: &TrustPolicy) -> Result<VerifiedCcsAr
         debug_toml: verified.debug_toml,
         components: verified.components,
         payload: verified.payload,
+        verified_object_metrics: verified.verified_object_metrics,
         files_checked: verified.files_checked,
     })
 }
@@ -340,6 +369,59 @@ mod tests {
         assert_eq!(verified.package_name(), "verified");
         assert_eq!(verified.files_checked(), 1);
         assert_eq!(verified.signature().key_id.as_deref(), Some("release"));
+        assert_eq!(verified.verified_object_metrics(), None);
+    }
+
+    #[test]
+    fn permanent_verification_writes_cold_objects_once_and_warm_objects_zero_times() {
+        let signer = SigningKeyPair::generate().with_key_id("release");
+        let (temp, path, policy) = package(&signer);
+        let cas = crate::filesystem::CasStore::new(temp.path().join("permanent-objects")).unwrap();
+
+        let cold = verify_package_into_cas(&path, &policy, &cas).unwrap();
+        let cold_metrics = cold.verified_object_metrics().unwrap();
+        assert_eq!(cold_metrics.misses, 1);
+        assert_eq!(cold_metrics.hits, 0);
+        assert_eq!(
+            cold_metrics.persistent_bytes_written,
+            cold_metrics.incoming_bytes_hashed
+        );
+        assert!(cold_metrics.persistent_bytes_written > 0);
+        let cold_file = &cold.payload().files()[0];
+        let content = cold_file.content_authority.as_ref().unwrap();
+        assert_eq!(
+            cold_file
+                .source()
+                .unwrap()
+                .verified_cas_identity_for(&cas, content)
+                .unwrap()
+                .as_deref(),
+            Some(content.sha256.as_str())
+        );
+
+        let warm = verify_package_into_cas(&path, &policy, &cas).unwrap();
+        let warm_metrics = warm.verified_object_metrics().unwrap();
+        assert_eq!(warm_metrics.hits, 1);
+        assert_eq!(warm_metrics.misses, 0);
+        assert_eq!(warm_metrics.persistent_bytes_written, 0);
+        assert_eq!(warm_metrics.canonical_bytes_reread, 0);
+        assert!(warm_metrics.incoming_bytes_hashed > 0);
+    }
+
+    #[test]
+    fn permanent_payload_capability_fails_closed_for_another_cas() {
+        let signer = SigningKeyPair::generate();
+        let (temp, path, policy) = package(&signer);
+        let cas = crate::filesystem::CasStore::new(temp.path().join("objects")).unwrap();
+        let other = crate::filesystem::CasStore::new(temp.path().join("other-objects")).unwrap();
+        let verified = verify_package_into_cas(&path, &policy, &cas).unwrap();
+        let file = &verified.payload().files()[0];
+        let error = file
+            .source()
+            .unwrap()
+            .verified_cas_identity_for(&other, file.content_authority.as_ref().unwrap())
+            .unwrap_err();
+        assert!(error.to_string().contains("destination store"));
     }
 
     #[test]

--- a/crates/conary-core/src/ccs/verify/object_sink.rs
+++ b/crates/conary-core/src/ccs/verify/object_sink.rs
@@ -1,0 +1,134 @@
+// conary-core/src/ccs/verify/object_sink.rs
+
+//! Storage authority for signature-first CCS object verification.
+
+use super::VerifyError;
+use crate::filesystem::{
+    CasStore, VerifiedObjectBatch, VerifiedObjectBatchMetrics, VerifiedObjectSet,
+};
+use crate::packages::payload::{PayloadSpool, ReopenablePayload};
+use anyhow::{Context, Result};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::io::Read;
+use std::sync::Arc;
+
+#[derive(Clone, Copy)]
+pub(super) enum ObjectDestination<'a> {
+    Spool,
+    Permanent(&'a CasStore),
+}
+
+enum ObjectBacking<'a> {
+    Spool {
+        spool: PayloadSpool,
+        store: CasStore,
+        sources: HashMap<String, ReopenablePayload>,
+    },
+    Permanent(VerifiedObjectBatch<'a>),
+}
+
+pub(super) struct VerifiedObjectSink<'a> {
+    backing: ObjectBacking<'a>,
+    seen: BTreeSet<String>,
+}
+
+pub(super) struct VerifiedObjectOutput {
+    pub sources: HashMap<String, ReopenablePayload>,
+    pub metrics: Option<VerifiedObjectBatchMetrics>,
+}
+
+impl<'a> VerifiedObjectSink<'a> {
+    pub fn new(
+        destination: ObjectDestination<'a>,
+        expected: &BTreeMap<String, u64>,
+    ) -> Result<Self> {
+        let backing = match destination {
+            ObjectDestination::Spool => {
+                let required = expected
+                    .values()
+                    .try_fold(0_u64, |total, size| total.checked_add(*size));
+                let required = required.context("CCS signed object-size arithmetic overflow")?;
+                let spool = PayloadSpool::new(required)?;
+                let store = CasStore::new(spool.root().join("objects"))?;
+                ObjectBacking::Spool {
+                    spool,
+                    store,
+                    sources: HashMap::new(),
+                }
+            }
+            ObjectDestination::Permanent(cas) => ObjectBacking::Permanent(
+                cas.verified_object_batch(
+                    expected
+                        .iter()
+                        .map(|(sha256, size)| (sha256.clone(), *size)),
+                )?,
+            ),
+        };
+        Ok(Self {
+            backing,
+            seen: BTreeSet::new(),
+        })
+    }
+
+    pub fn seen(&self) -> &BTreeSet<String> {
+        &self.seen
+    }
+
+    pub fn ingest(&mut self, sha256: &str, size: u64, reader: &mut dyn Read) -> Result<()> {
+        if !self.seen.insert(sha256.to_string()) {
+            return Err(VerifyError::PackageError(format!(
+                "CCS archive contains duplicate object {sha256}"
+            ))
+            .into());
+        }
+        let result = match &mut self.backing {
+            ObjectBacking::Spool {
+                spool,
+                store,
+                sources,
+            } => store.store_reader_expected(reader, size, sha256).map(|_| {
+                let path = store
+                    .hash_to_path(sha256)
+                    .expect("validated SHA-256 has a canonical CAS path");
+                sources.insert(sha256.to_string(), spool.source(path));
+            }),
+            ObjectBacking::Permanent(batch) => batch.ingest(sha256, reader).map(|_| ()),
+        };
+        match result {
+            Ok(()) => Ok(()),
+            Err(crate::Error::ChecksumMismatch { expected, actual }) => {
+                Err(VerifyError::PayloadInvalid(format!(
+                    "CCS object path hash mismatch: expected {expected}, got {actual}"
+                ))
+                .into())
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    pub fn finish(self) -> Result<VerifiedObjectOutput> {
+        match self.backing {
+            ObjectBacking::Spool { sources, .. } => Ok(VerifiedObjectOutput {
+                sources,
+                metrics: None,
+            }),
+            ObjectBacking::Permanent(batch) => output_from_verified_set(batch.commit()?),
+        }
+    }
+}
+
+fn output_from_verified_set(set: VerifiedObjectSet) -> Result<VerifiedObjectOutput> {
+    let metrics = set.metrics();
+    let set = Arc::new(set);
+    let sources = set
+        .objects()
+        .map(|(sha256, size)| {
+            ReopenablePayload::from_verified_cas_object(Arc::clone(&set), sha256, size)
+                .map(|source| (sha256.to_string(), source))
+        })
+        .collect::<crate::Result<HashMap<_, _>>>()?;
+    Ok(VerifiedObjectOutput {
+        sources,
+        metrics: Some(metrics),
+    })
+}

--- a/crates/conary-core/src/ccs/verify/stream.rs
+++ b/crates/conary-core/src/ccs/verify/stream.rs
@@ -7,10 +7,7 @@ use crate::ccs::archive_layout::is_lower_hex;
 use crate::ccs::budget::{AuthorityCensus, BudgetDimension, CCS_BUDGET};
 use crate::ccs::builder::ComponentData;
 use crate::ccs::v3::schema::{AuthorityDocumentV3, PackageKindV3};
-use crate::filesystem::CasStore;
-use crate::packages::payload::{
-    PackagePayload, PackagePayloadFile, PayloadSpool, ReopenablePayload,
-};
+use crate::packages::payload::{PackagePayload, PackagePayloadFile, ReopenablePayload};
 use anyhow::{Context, Result};
 use flate2::bufread::GzDecoder;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -31,6 +28,7 @@ pub(super) struct StreamVerifiedArchive {
     pub debug_toml: Option<Vec<u8>>,
     pub components: HashMap<String, ComponentData>,
     pub payload: PackagePayload,
+    pub verified_object_metrics: Option<crate::filesystem::VerifiedObjectBatchMetrics>,
     pub files_checked: usize,
 }
 
@@ -59,15 +57,17 @@ struct AuthenticatedMetadata {
     files_checked: usize,
 }
 
-pub(super) fn verify_archive(path: &Path, policy: &TrustPolicy) -> Result<StreamVerifiedArchive> {
+pub(super) fn verify_archive<'a>(
+    path: &Path,
+    policy: &TrustPolicy,
+    destination: super::object_sink::ObjectDestination<'a>,
+) -> Result<StreamVerifiedArchive> {
     let file = File::open(path).with_context(|| format!("open CCS package {}", path.display()))?;
     let decoder = GzDecoder::new(BufReader::new(file));
     let mut archive = Archive::new(decoder);
     let mut metadata = MetadataState::default();
     let mut authenticated = None;
-    let mut spool = None;
-    let mut object_store = None;
-    let mut object_sources = HashMap::new();
+    let mut object_sink = None;
     let mut objects_started = false;
     let mut entries_seen = 0_u64;
 
@@ -90,25 +90,20 @@ pub(super) fn verify_archive(path: &Path, policy: &TrustPolicy) -> Result<Stream
         if is_object {
             if authenticated.is_none() {
                 authenticated = Some(authenticate_metadata(&metadata, policy)?);
-                let required = authenticated
-                    .as_ref()
-                    .expect("just authenticated")
-                    .expected_objects
-                    .values()
-                    .try_fold(0_u64, |total, size| total.checked_add(*size))
-                    .context("CCS signed object-size arithmetic overflow")?;
-                let payload_spool = PayloadSpool::new(required)?;
-                object_store = Some(CasStore::new(payload_spool.root().join("objects"))?);
-                spool = Some(payload_spool);
+                object_sink = Some(super::object_sink::VerifiedObjectSink::new(
+                    destination,
+                    &authenticated
+                        .as_ref()
+                        .expect("just authenticated")
+                        .expected_objects,
+                )?);
             }
             objects_started = true;
             read_object(
                 &mut entry,
                 &path,
                 authenticated.as_ref().expect("metadata authenticated"),
-                object_store.as_ref().expect("object store initialized"),
-                spool.as_ref().expect("payload spool initialized"),
-                &mut object_sources,
+                object_sink.as_mut().expect("object sink initialized"),
             )?;
             continue;
         }
@@ -120,7 +115,14 @@ pub(super) fn verify_archive(path: &Path, policy: &TrustPolicy) -> Result<Stream
         Some(value) => value,
         None => authenticate_metadata(&metadata, policy)?,
     };
-    let archived_objects = object_sources.keys().cloned().collect::<BTreeSet<_>>();
+    let object_sink = match object_sink {
+        Some(value) => value,
+        None => super::object_sink::VerifiedObjectSink::new(
+            destination,
+            &authenticated.expected_objects,
+        )?,
+    };
+    let archived_objects = object_sink.seen().clone();
     let expected_objects = authenticated
         .expected_objects
         .keys()
@@ -132,7 +134,8 @@ pub(super) fn verify_archive(path: &Path, policy: &TrustPolicy) -> Result<Stream
         ))
         .into());
     }
-    let payload = payload_from_authority(&authenticated.authority, &object_sources)?;
+    let object_output = object_sink.finish()?;
+    let payload = payload_from_authority(&authenticated.authority, &object_output.sources)?;
     // Components are derived from the signed authority, which is the source of
     // truth. Archive component entries are still parsed and validated on the
     // way past — name agreement, duplicates, and size budget — so a malformed
@@ -149,6 +152,7 @@ pub(super) fn verify_archive(path: &Path, policy: &TrustPolicy) -> Result<Stream
         debug_toml: metadata.debug_toml,
         components,
         payload,
+        verified_object_metrics: object_output.metrics,
         files_checked: authenticated.files_checked,
     })
 }
@@ -350,9 +354,7 @@ fn read_object(
     entry: &mut tar::Entry<'_, ArchiveDecoder>,
     path: &str,
     authenticated: &AuthenticatedMetadata,
-    store: &CasStore,
-    spool: &PayloadSpool,
-    sources: &mut HashMap<String, ReopenablePayload>,
+    sink: &mut super::object_sink::VerifiedObjectSink<'_>,
 ) -> Result<()> {
     require_regular(entry, path)?;
     let object = path
@@ -376,25 +378,7 @@ fn read_object(
         ))
         .into());
     }
-    if sources.contains_key(&hash) {
-        return Err(VerifyError::PackageError(format!(
-            "CCS archive contains duplicate object {hash}"
-        ))
-        .into());
-    }
-    match store.store_reader_expected(entry, *size, &hash) {
-        Ok(_) => {}
-        Err(crate::Error::ChecksumMismatch { expected, actual }) => {
-            return Err(VerifyError::PayloadInvalid(format!(
-                "CCS object path hash mismatch: expected {expected}, got {actual}"
-            ))
-            .into());
-        }
-        Err(error) => return Err(error.into()),
-    }
-    let path = store.hash_to_path(&hash)?;
-    sources.insert(hash, spool.source(path));
-    Ok(())
+    sink.ingest(&hash, *size, entry)
 }
 
 fn payload_from_authority(
@@ -675,7 +659,11 @@ mod tests {
     }
 
     fn error_text(path: &Path, policy: &TrustPolicy) -> String {
-        match verify_archive(path, policy) {
+        match verify_archive(
+            path,
+            policy,
+            super::super::object_sink::ObjectDestination::Spool,
+        ) {
             Ok(_) => panic!("mutated archive unexpectedly verified"),
             Err(error) => format!("{error:#}"),
         }
@@ -816,7 +804,14 @@ mod tests {
         let truncated = temp.path().join("truncated.ccs");
         let mut output = File::create(&truncated).unwrap();
         output.write_all(&bytes[..bytes.len() / 2]).unwrap();
-        assert!(verify_archive(&truncated, &policy).is_err());
+        assert!(
+            verify_archive(
+                &truncated,
+                &policy,
+                super::super::object_sink::ObjectDestination::Spool,
+            )
+            .is_err()
+        );
 
         // The aggregate control-document ceiling is derived from this
         // package's own census, so padding is refused without allocation.

--- a/crates/conary-core/src/filesystem/cas/verified_batch.rs
+++ b/crates/conary-core/src/filesystem/cas/verified_batch.rs
@@ -64,6 +64,12 @@ impl VerifiedObjectSet {
     pub fn metrics(&self) -> VerifiedObjectBatchMetrics {
         self.metrics
     }
+
+    pub(crate) fn authorizes(&self, cas: &CasStore, sha256: &str, size: u64) -> bool {
+        self.cas.algorithm == cas.algorithm
+            && self.cas.objects_dir == cas.objects_dir
+            && self.objects.get(sha256) == Some(&size)
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/conary-core/src/packages/payload.rs
+++ b/crates/conary-core/src/packages/payload.rs
@@ -7,6 +7,7 @@
 //! behind an explicit bounded in-memory API for tests and small tooling.
 
 use crate::error::{Error, Result};
+use crate::filesystem::{CasStore, VerifiedObjectSet};
 use crate::packages::traits::ExtractedFile;
 use crate::payload::{PayloadContentAuthority, PayloadNode, PayloadNodeKind};
 use std::fmt;
@@ -33,6 +34,13 @@ enum PayloadBacking {
         path: PathBuf,
         _spool: Option<Arc<tempfile::TempDir>>,
     },
+    /// A canonical object admitted by one complete, durable verified batch.
+    VerifiedCasObject {
+        path: PathBuf,
+        sha256: String,
+        size: u64,
+        authority: Arc<VerifiedObjectSet>,
+    },
     /// Bounded test/tooling backing. Install parsers and trusted archive
     /// readers must use file-backed sources.
     InMemoryBytes(Arc<[u8]>),
@@ -44,6 +52,14 @@ impl fmt::Debug for ReopenablePayload {
             PayloadBacking::File { path, .. } => formatter
                 .debug_tuple("ReopenablePayload::File")
                 .field(path)
+                .finish(),
+            PayloadBacking::VerifiedCasObject {
+                path, sha256, size, ..
+            } => formatter
+                .debug_struct("ReopenablePayload::VerifiedCasObject")
+                .field("path", path)
+                .field("sha256", sha256)
+                .field("size", size)
                 .finish(),
             PayloadBacking::InMemoryBytes(bytes) => formatter
                 .debug_struct("ReopenablePayload::InMemoryBytes")
@@ -76,6 +92,24 @@ impl ReopenablePayload {
         }
     }
 
+    /// Bind one canonical path to a committed verified-object capability.
+    pub fn from_verified_cas_object(
+        authority: Arc<VerifiedObjectSet>,
+        sha256: impl Into<String>,
+        size: u64,
+    ) -> Result<Self> {
+        let sha256 = sha256.into();
+        let path = authority.object_path(&sha256)?;
+        Ok(Self {
+            backing: PayloadBacking::VerifiedCasObject {
+                path,
+                sha256,
+                size,
+                authority,
+            },
+        })
+    }
+
     /// Explicit bounded in-memory source for tests and small tooling.
     #[must_use]
     pub fn from_in_memory_bytes(bytes: impl Into<Arc<[u8]>>) -> Self {
@@ -89,6 +123,9 @@ impl ReopenablePayload {
             PayloadBacking::File { path, .. } => File::open(path)
                 .map(|file| Box::new(file) as Box<dyn Read + Send>)
                 .map_err(Error::from),
+            PayloadBacking::VerifiedCasObject { path, .. } => File::open(path)
+                .map(|file| Box::new(file) as Box<dyn Read + Send>)
+                .map_err(Error::from),
             PayloadBacking::InMemoryBytes(bytes) => Ok(Box::new(Cursor::new(Arc::clone(bytes)))),
         }
     }
@@ -98,8 +135,48 @@ impl ReopenablePayload {
     pub fn path(&self) -> Option<&Path> {
         match &self.backing {
             PayloadBacking::File { path, .. } => Some(path),
+            PayloadBacking::VerifiedCasObject { path, .. } => Some(path),
             PayloadBacking::InMemoryBytes(_) => None,
         }
+    }
+
+    /// Consume typed verified-object authority for the exact destination CAS.
+    ///
+    /// `Ok(None)` means this is an ordinary source that still requires normal
+    /// ingestion. A verified-CAS source that disagrees with the destination or
+    /// signed content fails closed instead of silently falling back to a reread.
+    pub fn verified_cas_identity_for(
+        &self,
+        cas: &CasStore,
+        content: &PayloadContentAuthority,
+    ) -> Result<Option<String>> {
+        let PayloadBacking::VerifiedCasObject {
+            path,
+            sha256,
+            size,
+            authority,
+        } = &self.backing
+        else {
+            return Ok(None);
+        };
+        if sha256 != &content.sha256 || *size != content.size {
+            return Err(Error::InternalError(format!(
+                "verified CAS payload authority {sha256}/{size} disagrees with signed content {}/{}",
+                content.sha256, content.size
+            )));
+        }
+        if !authority.authorizes(cas, sha256, *size) {
+            return Err(Error::InternalError(format!(
+                "verified CAS object {sha256} does not authorize the requested destination store"
+            )));
+        }
+        let metadata = std::fs::symlink_metadata(path)?;
+        if !metadata.file_type().is_file() || metadata.len() != *size {
+            return Err(Error::InternalError(format!(
+                "verified CAS object {sha256} is absent or changed before installer admission"
+            )));
+        }
+        Ok(Some(sha256.clone()))
     }
 }
 

--- a/docs/modules/ccs.md
+++ b/docs/modules/ccs.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-12
-revision: 61
+revision: 62
 summary: Convert direct and exactly re-resolved adopted foreign packages through lossless source authority, typed authoring, host capability, lifecycle, and native export contracts
 ---
 
@@ -52,6 +52,7 @@ Apply typed install prefix (default `/`) to source-root children
 | v3 manifest identity projection | v3/manifest_projection.rs | Project one exact signed identity into install and untrusted-inspection compatibility manifests |
 | `CcsStructuralBudget` | budget.rs | Single owner of every CCS structural and operator-resource limit; authoring preflight and verification both admit against it |
 | `AuthorityCensus` | budget.rs | Exact structural measurement of one authority document; derives that package's byte ceilings |
+| Verified object sink | verify/object_sink.rs + filesystem/cas/verified_batch.rs | Streams signed objects to a read-only spool or transaction-owned permanent CAS batch and returns typed committed object authority |
 | Component view | v3/component_view.rs | Derives component and file views from signed authority instead of a duplicated archive projection |
 | `ComponentType` | components/types.rs | Closed typed names for standard component metadata; never inferred from payload paths |
 | `SigningKeyPair` | signing.rs | Ed25519 key generation, signing, file I/O |
@@ -465,6 +466,19 @@ cumulative payload, archive entries, metadata, and framing overhead; those
 dimensions replace a guessed global decompression ceiling without weakening
 decompression-bomb resistance. `docs/specs/ccs-format-v3.md` owns the contract.
 
+Verification-only and dry-run callers use a temporary payload spool and do not
+create permanent CAS state. Mutating CCS install, restore, and repository-batch
+preparation instead stream the signed complete object set into one permanent
+SHA-256 `VerifiedObjectBatch`. Missing bytes are hashed while written once,
+data-synced, published without replacement, and followed by shard/root
+directory durability barriers. Exact-size canonical hits write no payload
+bytes and are not reread solely for insertion; a concurrent publication winner
+is reread and must match its signed size and digest. Only the committed batch
+can create `ReopenablePayload` sources carrying `VerifiedObjectSet` authority,
+and installer storage accepts those canonical identities only for the same CAS
+root after a final regular-file/size metadata check. Ordinary sources retain
+the existing bounded reader-ingestion path.
+
 Configuration authority is exact per path. Each signed declaration retains
 its source-specific record and a `matched` or `absent` payload association;
 there is no package-wide config default. Matched declarations identify one
@@ -626,8 +640,10 @@ behavior.
 ## Install
 
 CCS packages are installed via `conary ccs install`. The installer verifies
-signatures, evaluates capability policy, stores content in CAS, reuses the
-shared composefs generation transaction, and runs declarative hooks.
+signatures, ingests authenticated missing objects directly into permanent CAS,
+evaluates capability policy, reuses the shared composefs generation
+transaction, and runs declarative hooks. Dry-run verification remains
+filesystem-read-only with respect to permanent CAS.
 
 ```bash
 conary ccs install package.ccs --policy ./ccs-trust.toml --yes


### PR DESCRIPTION
Refs #401

## Problem

Native CCS verification currently writes every authenticated object into a temporary spool. Mutating install then reopens the spool, hashes the same bytes again, and writes them into permanent CAS. Warm installs also perform that redundant ingestion even when the exact signed object is already trusted locally.

## Change

- add one CCS verified-object sink that selects temporary spool or permanent `VerifiedObjectBatch` explicitly
- expose `verify_package_into_cas` for mutating install preparation while preserving `verify_package` as the read-only verification API
- carry committed `VerifiedObjectSet` authority through `ReopenablePayload`
- let installer storage consume that exact capability after same-CAS, digest, size, regular-file, and current-metadata checks, without reopening or hashing the object again
- route real direct CCS install, converted CCS install, restore, and repository batch install through permanent ingestion
- keep CCS dry run, model/package-set validation, inspect/query/publish/signing/self-update preflight, and other verification-only callers on temporary spool storage
- document the authority and durability split in the CCS module contract

Cold permanent verification hashes/writes each missing byte once. Warm verification hashes the incoming authenticated archive stream but writes zero payload bytes and performs no canonical reread solely for insertion. A publication race still validates the canonical winner exactly.

## Verification

- `cargo test -p conary-core ccs::verify -- --nocapture` (13 passed)
- `cargo test -p conary store_install_files_reuses_typed_verified_cas_authority -- --nocapture` (1 passed; canonical file unreadable, proving no reopen)
- `cargo test -p conary ccs_install_dry_run_keeps_permanent_cas_absent -- --nocapture` (1 passed)
- `cargo test -p conary commands::ccs::install -- --nocapture` (30 passed)
- `cargo test -p conary commands::install::conversion::tests -- --nocapture` (20 passed)
- `cargo clippy -p conary-core -p conary --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bash scripts/check-doc-truth.sh`
