### PR TITLE
fix(remi): preserve source checksum authority

### DIFF
--- a/apps/remi/src/server/conversion/metadata.rs
+++ b/apps/remi/src/server/conversion/metadata.rs
@@ -166,62 +166,18 @@ pub(super) fn repository_package_conversion_inputs_match(
         && expected.package_release == current.package_release
         && expected.architecture == current.architecture
         && expected.debian_multi_arch == current.debian_multi_arch
-        && bare_sha256(&expected.checksum) == bare_sha256(&current.checksum)
+        && expected.checksum == current.checksum
         && expected.source_profile == current.source_profile
         && expected.version_scheme == current.version_scheme
 }
 
-fn bare_sha256(value: &str) -> &str {
-    value.strip_prefix("sha256:").unwrap_or(value)
-}
-
 #[cfg(test)]
 mod tests {
-    use super::super::test_support::{create_test_db, insert_repo};
+    use super::super::test_support::{create_test_db, eopkg_fixture, insert_repo};
     use super::*;
     use conary_core::ccs::convert::ForeignConversionInput;
     use conary_core::db::models::{RepositoryPackage, RepositoryProvide};
-    use std::io::{Cursor, Read, Write};
     use std::path::PathBuf;
-    use zip::write::SimpleFileOptions;
-
-    fn eopkg_fixture() -> tempfile::NamedTempFile {
-        let mut tar = tar::Builder::new(Vec::new());
-        let mut header = tar::Header::new_gnu();
-        header.set_path("usr/bin/demo").unwrap();
-        header.set_size(5);
-        header.set_mode(0o755);
-        header.set_uid(0);
-        header.set_gid(0);
-        header.set_mtime(0);
-        header.set_cksum();
-        tar.append(&header, Cursor::new(b"hello")).unwrap();
-        let tar = tar.into_inner().unwrap();
-        let stream =
-            liblzma::stream::Stream::new_easy_encoder(6, liblzma::stream::Check::Crc64).unwrap();
-        let mut encoder = liblzma::read::XzEncoder::new_stream(tar.as_slice(), stream);
-        let mut compressed = Vec::new();
-        encoder.read_to_end(&mut compressed).unwrap();
-
-        let metadata = br#"<PISI><Package><Name>demo</Name><Summary>demo</Summary><History><Update release="2"><Version>1.0</Version></Update></History><Distribution>Solus</Distribution><DistributionRelease>1</DistributionRelease><Architecture>x86_64</Architecture><PackageFormat>1.2</PackageFormat></Package></PISI>"#;
-        let files = br#"<Files><File><Path>usr/bin/demo</Path><Type>executable</Type><Size>5</Size><Uid>0</Uid><Gid>0</Gid><Mode>0755</Mode><Hash>aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d</Hash></File></Files>"#;
-        let output = tempfile::NamedTempFile::new().unwrap();
-        {
-            let mut archive = zip::ZipWriter::new(output.reopen().unwrap());
-            for (name, bytes) in [
-                ("metadata.xml", metadata.as_slice()),
-                ("files.xml", files.as_slice()),
-                ("install.tar.xz", compressed.as_slice()),
-            ] {
-                archive
-                    .start_file(name, SimpleFileOptions::default())
-                    .unwrap();
-                archive.write_all(bytes).unwrap();
-            }
-            archive.finish().unwrap();
-        }
-        output
-    }
 
     #[test]
     fn remi_parses_eopkg_through_the_exact_solus_profile() {

--- a/apps/remi/src/server/conversion/persistence.rs
+++ b/apps/remi/src/server/conversion/persistence.rs
@@ -15,7 +15,7 @@ pub(super) struct PersistConversionInput {
     pub(super) source_profile: String,
     pub(super) metadata: ForeignConversionInput,
     pub(super) format: &'static str,
-    pub(super) original_checksum: String,
+    pub(super) source_checksum: String,
     pub(super) conversion_result: ConversionResult,
     pub(super) repo_pkg: RepositoryPackage,
     pub(super) repository_provides_digest: String,
@@ -39,7 +39,7 @@ impl ConversionService {
         conn: &Connection,
         source_profile: &str,
         repo_pkg: &RepositoryPackage,
-        original_checksum: &str,
+        source_checksum: &str,
         repository_provides_digest: &str,
     ) -> Result<CacheInspection> {
         let repository_package_id = repo_pkg
@@ -52,7 +52,7 @@ impl ConversionService {
             "repository package identity changed during conversion cache lookup"
         );
         let Some(existing) =
-            ConvertedPackage::find_repository_by_checksum(conn, source_profile, original_checksum)?
+            ConvertedPackage::find_repository_by_checksum(conn, source_profile, source_checksum)?
         else {
             return Ok(CacheInspection::Missing);
         };
@@ -90,13 +90,13 @@ impl ConversionService {
         &self,
         source_profile: &str,
         repo_pkg: &RepositoryPackage,
-        original_checksum: &str,
+        source_checksum: &str,
         repository_provides_digest: &str,
     ) -> Result<Option<ServerConversionResult>> {
         let service = self.clone();
         let source_profile = source_profile.to_string();
         let repo_pkg = repo_pkg.clone();
-        let original_checksum = original_checksum.to_string();
+        let source_checksum = source_checksum.to_string();
         let repository_provides_digest = repository_provides_digest.to_string();
 
         tokio::task::spawn_blocking(move || {
@@ -106,13 +106,13 @@ impl ConversionService {
                 &tx,
                 &source_profile,
                 &repo_pkg,
-                &original_checksum,
+                &source_checksum,
                 &repository_provides_digest,
             )?;
             tx.commit()?;
             match inspection {
                 CacheInspection::Current(result) => {
-                    info!("Package already converted (checksum: {})", original_checksum);
+                    info!("Package already converted (checksum: {})", source_checksum);
                     return Ok(Some(*result));
                 }
                 CacheInspection::Missing => return Ok(None),
@@ -127,7 +127,7 @@ impl ConversionService {
                     &tx,
                     &source_profile,
                     &repo_pkg,
-                    &original_checksum,
+                    &source_checksum,
                     &repository_provides_digest,
                 )?;
                 let result = match inspection {
@@ -140,7 +140,7 @@ impl ConversionService {
                         ConvertedPackage::delete_repository_by_checksum(
                             &tx,
                             &source_profile,
-                            &original_checksum,
+                            &source_checksum,
                         )?;
                         None
                     }
@@ -161,7 +161,7 @@ impl ConversionService {
             source_profile,
             metadata,
             format,
-            original_checksum,
+            source_checksum,
             conversion_result,
             repo_pkg,
             repository_provides_digest,
@@ -198,7 +198,7 @@ impl ConversionService {
             metadata.version().to_string(),
             package_architecture.clone(),
             format.to_string(),
-            original_checksum.clone(),
+            source_checksum.clone(),
             &chunk_hashes,
             persisted_total_size,
             content_hash_text.clone(),
@@ -215,7 +215,7 @@ impl ConversionService {
                 &tx,
                 &source_profile,
                 &repo_pkg,
-                &original_checksum,
+                &source_checksum,
                 converted.repository_artifact()?.repository_provides_digest,
             )? {
                 CacheInspection::Current(result) => {
@@ -226,7 +226,7 @@ impl ConversionService {
                     ConvertedPackage::delete_repository_by_checksum(
                         &tx,
                         &source_profile,
-                        &original_checksum,
+                        &source_checksum,
                     )?;
                 }
                 CacheInspection::Missing => {}
@@ -307,7 +307,7 @@ impl ConversionService {
 
 #[cfg(test)]
 mod tests {
-    use super::super::test_support::{create_test_db, insert_package, insert_repo};
+    use super::super::test_support::{create_test_db, insert_repo};
     use super::*;
     use conary_core::db::models::RepositoryProvide;
     use conary_core::repository::versioning::VersionScheme;
@@ -322,9 +322,52 @@ mod tests {
         String,
         String,
     ) {
+        cache_fixture_for_source(
+            bind_current_digest,
+            "fedora-base",
+            "fedora",
+            "rpm",
+            VersionScheme::Rpm,
+            "sha256:systemd-udev-259.5-1.fc44",
+        )
+    }
+
+    fn cache_fixture_for_source(
+        bind_current_digest: bool,
+        repository_name: &str,
+        profile: &str,
+        format: &str,
+        version_scheme: VersionScheme,
+        source_checksum: &str,
+    ) -> (
+        tempfile::NamedTempFile,
+        tempfile::TempDir,
+        ConversionService,
+        RepositoryPackage,
+        String,
+        String,
+    ) {
         let (database, conn) = create_test_db();
-        let repository_id = insert_repo(&conn, "fedora-base", "fedora");
-        insert_package(&conn, repository_id, "systemd-udev", "259.5-1.fc44", 42);
+        let repository_id = insert_repo(&conn, repository_name, profile);
+        let exact_profile =
+            conary_core::repository::supported_profiles::profile_by_public_id(profile)
+                .or_else(|| {
+                    conary_core::repository::supported_profiles::profile_for_remi_route(profile)
+                })
+                .unwrap()
+                .id();
+        let mut package = RepositoryPackage::new(
+            repository_id,
+            "systemd-udev".to_string(),
+            "259.5-1.fc44".to_string(),
+            version_scheme,
+            source_checksum.to_string(),
+            42,
+            "https://example.com/systemd-udev.pkg".to_string(),
+        );
+        package.architecture = Some("x86_64".to_string());
+        package.source_profile = Some(exact_profile.to_string());
+        package.insert(&conn).unwrap();
         let package = RepositoryPackage::find_by_name(&conn, "systemd-udev")
             .unwrap()
             .pop()
@@ -337,7 +380,7 @@ mod tests {
             None,
             "file".to_string(),
             Some("/usr/bin/kernel-install".to_string()),
-            VersionScheme::Rpm,
+            version_scheme,
         );
         provide.insert(&conn).unwrap();
         let current_digest =
@@ -354,11 +397,11 @@ mod tests {
             conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string()
         };
         let mut converted = ConvertedPackage::new_repository(
-            "fedora-44".to_string(),
+            exact_profile.to_string(),
             "systemd-udev".to_string(),
             "259.5-1.fc44".to_string(),
             "x86_64".to_string(),
-            "rpm".to_string(),
+            format.to_string(),
             source_checksum.clone(),
             &[],
             8,
@@ -471,6 +514,30 @@ mod tests {
 
         assert_eq!(result.cache_state, "hot");
         assert_eq!(result.name, "systemd-udev");
+    }
+
+    #[tokio::test]
+    async fn cache_hit_preserves_eopkg_sha1_source_authority() {
+        let source_checksum = "sha1:1826421aded2a344b7864ffff2fae2430778b1f0";
+        let (_database, _storage, service, package, persisted_checksum, current_digest) =
+            cache_fixture_for_source(
+                true,
+                "solus-polaris",
+                "solus",
+                "eopkg",
+                VersionScheme::Eopkg,
+                source_checksum,
+            );
+
+        let result = service
+            .cached_conversion_result_async("solus", &package, &persisted_checksum, &current_digest)
+            .await
+            .unwrap()
+            .expect("exact SHA-1 conversion cache hit");
+
+        assert_eq!(persisted_checksum, source_checksum);
+        assert_eq!(result.source_profile.as_deref(), Some("solus"));
+        assert_eq!(result.cache_state, "hot");
     }
 
     #[tokio::test]

--- a/apps/remi/src/server/conversion/test_support.rs
+++ b/apps/remi/src/server/conversion/test_support.rs
@@ -5,9 +5,11 @@ use conary_core::ccs::convert::{ConversionResult, ScriptletBundleSummary};
 use conary_core::db::models::{ConvertedPackage, Repository, RepositoryPackage, RepositoryProvide};
 use conary_core::db::schema;
 use std::fs;
+use std::io::{Cursor, Read, Write};
 use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 use walkdir::WalkDir;
+use zip::write::SimpleFileOptions;
 
 pub(super) fn create_test_db() -> (NamedTempFile, rusqlite::Connection) {
     let temp_file = NamedTempFile::new().unwrap();
@@ -46,6 +48,44 @@ pub(super) fn insert_package(
     );
     pkg.architecture = Some("x86_64".to_string());
     pkg.insert(conn).unwrap();
+}
+
+pub(super) fn eopkg_fixture() -> tempfile::NamedTempFile {
+    let mut tar = tar::Builder::new(Vec::new());
+    let mut header = tar::Header::new_gnu();
+    header.set_path("usr/bin/demo").unwrap();
+    header.set_size(5);
+    header.set_mode(0o755);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_cksum();
+    tar.append(&header, Cursor::new(b"hello")).unwrap();
+    let tar = tar.into_inner().unwrap();
+    let stream =
+        liblzma::stream::Stream::new_easy_encoder(6, liblzma::stream::Check::Crc64).unwrap();
+    let mut encoder = liblzma::read::XzEncoder::new_stream(tar.as_slice(), stream);
+    let mut compressed = Vec::new();
+    encoder.read_to_end(&mut compressed).unwrap();
+
+    let metadata = br#"<PISI><Package><Name>demo</Name><Summary>demo</Summary><History><Update release="2"><Version>1.0</Version></Update></History><Distribution>Solus</Distribution><DistributionRelease>1</DistributionRelease><Architecture>x86_64</Architecture><PackageFormat>1.2</PackageFormat></Package></PISI>"#;
+    let files = br#"<Files><File><Path>usr/bin/demo</Path><Type>executable</Type><Size>5</Size><Uid>0</Uid><Gid>0</Gid><Mode>0755</Mode><Hash>aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d</Hash></File></Files>"#;
+    let output = tempfile::NamedTempFile::new().unwrap();
+    {
+        let mut archive = zip::ZipWriter::new(output.reopen().unwrap());
+        for (name, bytes) in [
+            ("metadata.xml", metadata.as_slice()),
+            ("files.xml", files.as_slice()),
+            ("install.tar.xz", compressed.as_slice()),
+        ] {
+            archive
+                .start_file(name, SimpleFileOptions::default())
+                .unwrap();
+            archive.write_all(bytes).unwrap();
+        }
+        archive.finish().unwrap();
+    }
+    output
 }
 
 /// Seed the exact repository source row that makes a converted fixture current,

--- a/apps/remi/src/server/conversion/workflow.rs
+++ b/apps/remi/src/server/conversion/workflow.rs
@@ -21,7 +21,7 @@ use tracing::info;
 struct ParsedConversion {
     metadata: ForeignConversionInput,
     format: &'static str,
-    original_checksum: String,
+    source_checksum: String,
     conversion_result: ConversionResult,
     repo_pkg: RepositoryPackage,
     repository_provides_digest: String,
@@ -121,12 +121,12 @@ impl ConversionService {
 
         let checksum_path = pkg_path.clone();
         let started = Instant::now();
-        let original_checksum =
+        let artifact_sha256 =
             tokio::task::spawn_blocking(move || Self::calculate_sha256(&checksum_path))
                 .await
                 .map_err(|e| anyhow!("checksum task panicked: {e}"))??;
         timing.record(ConversionPhase::Checksum, started.elapsed());
-        let original_checksum_text = original_checksum.to_prefixed_string();
+        let source_checksum = repo_pkg.checksum.clone();
 
         let started = Instant::now();
         let repository_metadata = self
@@ -136,7 +136,7 @@ impl ConversionService {
             .cached_conversion_result_async(
                 source_feed.id(),
                 &repo_pkg,
-                &original_checksum_text,
+                &source_checksum,
                 &repository_metadata.digest,
             )
             .await?
@@ -157,7 +157,7 @@ impl ConversionService {
                 repository_metadata,
                 pkg_path,
                 output_dir,
-                original_checksum,
+                artifact_sha256,
             )
         })
         .await
@@ -188,7 +188,7 @@ impl ConversionService {
                 source_profile: source_profile_owned,
                 metadata: parsed.metadata,
                 format: parsed.format,
-                original_checksum: parsed.original_checksum,
+                source_checksum: parsed.source_checksum,
                 conversion_result: parsed.conversion_result,
                 repo_pkg: parsed.repo_pkg,
                 repository_provides_digest: parsed.repository_provides_digest,
@@ -237,7 +237,7 @@ impl ConversionService {
         repository_metadata: RepositoryConversionMetadata,
         pkg_path: PathBuf,
         output_dir: PathBuf,
-        original_checksum: conary_core::hash::Hash,
+        artifact_sha256: conary_core::hash::Hash,
     ) -> Result<ParsedConversion> {
         let mut phase_timings = Vec::new();
         let mut skipped_phases = Vec::new();
@@ -284,7 +284,7 @@ impl ConversionService {
 
         let started = Instant::now();
         let conversion_result = converter
-            .convert_payload(&metadata, files.files(), format, &original_checksum)
+            .convert_payload(&metadata, files.files(), format, &artifact_sha256)
             .map_err(|e| anyhow!("Conversion failed: {}", e))?;
         phase_timings.push(ConversionPhaseTiming {
             phase: ConversionPhase::CcsEmission,
@@ -299,7 +299,7 @@ impl ConversionService {
         Ok(ParsedConversion {
             metadata,
             format,
-            original_checksum: original_checksum.to_prefixed_string(),
+            source_checksum: repo_pkg.checksum.clone(),
             conversion_result,
             repo_pkg,
             repository_provides_digest: repository_metadata.digest,
@@ -311,8 +311,13 @@ impl ConversionService {
 
 #[cfg(test)]
 mod tests {
-    use super::super::test_support::production_rust_sources;
-    use super::ConversionService;
+    use super::super::test_support::{eopkg_fixture, production_rust_sources};
+    use super::{ConversionService, RepositoryConversionMetadata};
+    use conary_core::ccs::SigningKeyPair;
+    use conary_core::db::models::RepositoryPackage;
+    use conary_core::repository::versioning::VersionScheme;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
 
     #[test]
     fn remi_server_conversion_paths_do_not_block_on_async_work() {
@@ -330,5 +335,65 @@ mod tests {
         let feed =
             ConversionService::public_feed_for_route("fedora").expect("fedora repository feed");
         assert_eq!(feed.id(), "fedora-44");
+    }
+
+    #[test]
+    fn eopkg_conversion_separates_source_checksum_from_ccs_sha256() {
+        let fixture = eopkg_fixture();
+        let root = tempfile::tempdir().unwrap();
+        let keys_root = root.path().join("keys");
+        let profile_dir = keys_root.join("solus");
+        fs::create_dir_all(&profile_dir).unwrap();
+        fs::set_permissions(&keys_root, fs::Permissions::from_mode(0o700)).unwrap();
+        fs::set_permissions(&profile_dir, fs::Permissions::from_mode(0o700)).unwrap();
+        let private = profile_dir.join("targets.private");
+        let public = profile_dir.join("targets.public");
+        SigningKeyPair::generate()
+            .with_key_id("targets")
+            .save_to_files(&private, &public)
+            .unwrap();
+        fs::set_permissions(&private, fs::Permissions::from_mode(0o600)).unwrap();
+        fs::set_permissions(&public, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let service = ConversionService::new(
+            root.path().join("chunks"),
+            root.path().join("cache"),
+            root.path().join("remi.db"),
+            None,
+        )
+        .with_repository_keys_dir(Some(keys_root));
+        let source_checksum = "sha1:1826421aded2a344b7864ffff2fae2430778b1f0";
+        let mut package = RepositoryPackage::new(
+            1,
+            "demo".to_string(),
+            "1.0-2".to_string(),
+            VersionScheme::Eopkg,
+            source_checksum.to_string(),
+            fixture.as_file().metadata().unwrap().len() as i64,
+            "https://example.invalid/demo.eopkg".to_string(),
+        );
+        package.architecture = Some("x86_64".to_string());
+        package.source_profile = Some("solus".to_string());
+        let artifact_sha256 = ConversionService::calculate_sha256(fixture.path()).unwrap();
+        let artifact_sha256_text = artifact_sha256.to_prefixed_string();
+
+        let parsed = service
+            .parse_and_convert_package(
+                "solus",
+                package,
+                RepositoryConversionMetadata {
+                    digest: conary_core::db::models::EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
+                },
+                fixture.path().to_path_buf(),
+                root.path().join("output"),
+                artifact_sha256,
+            )
+            .unwrap();
+
+        assert_eq!(parsed.source_checksum, source_checksum);
+        assert_eq!(
+            parsed.conversion_result.original_checksum,
+            artifact_sha256_text
+        );
     }
 }

--- a/crates/conary-core/src/db/models/converted.rs
+++ b/crates/conary-core/src/db/models/converted.rs
@@ -15,7 +15,7 @@ use std::collections::BTreeSet;
 use strum_macros::{AsRefStr, Display, EnumString};
 
 mod validation;
-use validation::{bare_sha256, default_scriptlet_summary_json, validate_current_scriptlet_summary};
+use validation::{default_scriptlet_summary_json, validate_current_scriptlet_summary};
 
 /// Current conversion algorithm version
 /// Bump this when making changes that require re-conversion of existing packages.
@@ -63,7 +63,8 @@ pub struct ConvertedPackage {
     pub trove_id: Option<i64>,
     /// Original package format (rpm, deb, arch)
     pub original_format: String,
-    /// Checksum of original package file (skip if already converted)
+    /// Exact repository checksum identity for repository artifacts, or the
+    /// verified native artifact checksum for installed conversions.
     pub original_checksum: String,
     /// Digest of the exact repository-provide cache projection. It invalidates
     /// stale conversions but never mutates source artifact authority.
@@ -367,14 +368,13 @@ impl ConvertedPackage {
             artifact.package_architecture,
         )?
         .into_iter()
-        .map(|(checksum, digest)| (bare_sha256(&checksum).to_string(), digest))
         .collect::<BTreeSet<_>>();
         if current_inputs.len() > 1 {
             return Ok(false);
         }
 
         Ok(current_inputs.contains(&(
-            bare_sha256(&self.original_checksum).to_string(),
+            self.original_checksum.clone(),
             artifact.repository_provides_digest.to_string(),
         )))
     }

--- a/crates/conary-core/src/db/models/converted/tests.rs
+++ b/crates/conary-core/src/db/models/converted/tests.rs
@@ -184,6 +184,55 @@ fn repository_provide_change_invalidates_and_reconciles_conversion() {
 }
 
 #[test]
+fn sha1_repository_checksum_is_current_and_algorithm_change_invalidates_it() {
+    let (_temp, conn) = create_test_db();
+    let source_checksum = "sha1:1826421aded2a344b7864ffff2fae2430778b1f0";
+    conn.execute(
+        "INSERT INTO repositories (name, url, source_profile)
+         VALUES ('solus-source', 'https://example.test', 'solus')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO repository_packages
+         (repository_id, name, version, architecture, checksum, size, download_url, version_scheme)
+         VALUES (1, 'fixture', '1.0-1', 'x86_64', ?1, 42,
+                 'https://example.test/fixture.eopkg', 'eopkg')",
+        [source_checksum],
+    )
+    .unwrap();
+    let mut converted = ConvertedPackage::new_repository(
+        "solus".to_string(),
+        "fixture".to_string(),
+        "1.0-1".to_string(),
+        "x86_64".to_string(),
+        "eopkg".to_string(),
+        source_checksum.to_string(),
+        &["sha256:chunk".to_string()],
+        42,
+        "sha256:content".to_string(),
+        "/tmp/fixture.ccs".to_string(),
+        EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
+    );
+    converted.insert(&conn).unwrap();
+
+    assert!(converted.repository_metadata_is_current(&conn).unwrap());
+    assert_eq!(
+        ConvertedPackage::find_current_conversions(&conn, "solus", Some("fixture"))
+            .unwrap()
+            .len(),
+        1
+    );
+
+    conn.execute(
+        "UPDATE repository_packages SET checksum = ?1 WHERE id = 1",
+        ["sha256:1826421aded2a344b7864ffff2fae2430778b1f0"],
+    )
+    .unwrap();
+    assert!(!converted.repository_metadata_is_current(&conn).unwrap());
+}
+
+#[test]
 fn repository_artifact_exposes_only_complete_serving_state() {
     let converted = server_package("sha256:source", "sha256:chunk");
     let artifact = converted.repository_artifact().unwrap();
@@ -268,7 +317,7 @@ fn repository_artifact_rejects_corrupt_chunk_json() {
 #[test]
 fn chunk_conversion_state_uses_current_typed_rows() {
     let (_temp, conn) = create_test_db();
-    seed_server_package_source(&conn, "source");
+    seed_server_package_source(&conn, "sha256:source");
     let mut converted = server_package("sha256:source", "sha256:chunk");
     converted.insert(&conn).unwrap();
 
@@ -281,7 +330,7 @@ fn chunk_conversion_state_uses_current_typed_rows() {
 #[test]
 fn chunk_conversion_state_errors_on_malformed_current_summary() {
     let (_temp, conn) = create_test_db();
-    seed_server_package_source(&conn, "source");
+    seed_server_package_source(&conn, "sha256:source");
     let mut converted = server_package("sha256:source", "sha256:chunk");
     converted.insert(&conn).unwrap();
     conn.execute(

--- a/crates/conary-core/src/db/models/converted/validation.rs
+++ b/crates/conary-core/src/db/models/converted/validation.rs
@@ -3,10 +3,6 @@
 use crate::ccs::convert::ScriptletBundleSummary;
 use crate::error::Result;
 
-pub(super) fn bare_sha256(value: &str) -> &str {
-    value.strip_prefix("sha256:").unwrap_or(value)
-}
-
 pub(super) fn default_scriptlet_summary_json() -> String {
     serde_json::to_string(&ScriptletBundleSummary::default())
         .expect("default lifecycle summary must serialize")

--- a/crates/conary-core/src/repository/sync/native.rs
+++ b/crates/conary-core/src/repository/sync/native.rs
@@ -140,9 +140,13 @@ pub(in crate::repository) fn synced_package_row(
     let download_url = super::rebase_download_url(&pkg_meta.download_url, repo_url, content_url);
     let version_scheme = pkg_meta.version_scheme;
     let checksum = match pkg_meta.checksum_type {
-        crate::repository::parsers::ChecksumType::Sha1 => format!("sha1:{}", pkg_meta.checksum),
-        crate::repository::parsers::ChecksumType::Sha256
-        | crate::repository::parsers::ChecksumType::Sha512
+        crate::repository::parsers::ChecksumType::Sha1 => {
+            format!("sha1:{}", pkg_meta.checksum.trim_start_matches("sha1:"))
+        }
+        crate::repository::parsers::ChecksumType::Sha256 => {
+            format!("sha256:{}", pkg_meta.checksum.trim_start_matches("sha256:"))
+        }
+        crate::repository::parsers::ChecksumType::Sha512
         | crate::repository::parsers::ChecksumType::Md5 => pkg_meta.checksum,
     };
     let mut repo_pkg = RepositoryPackage::new(

--- a/crates/conary-core/src/repository/sync/tests/native.rs
+++ b/crates/conary-core/src/repository/sync/tests/native.rs
@@ -69,7 +69,7 @@ fn pin_refusal_leaves_native_rows_and_sync_state_untouched() {
     assert!(matches!(error, Error::TrustError(_)));
     let stored = RepositoryPackage::find_by_repository(&conn, repo_id).unwrap();
     assert_eq!(stored.len(), 1);
-    assert_eq!(stored[0].checksum, "old");
+    assert_eq!(stored[0].checksum, "sha256:old");
     let after = Repository::find_by_id(&conn, repo_id).unwrap().unwrap();
     assert_eq!(after.last_sync, before.last_sync);
     assert_eq!(after.authenticated_snapshot, before.authenticated_snapshot);

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -324,6 +324,11 @@ metadata refresh removes mismatched conversion rows in the same SQLite
 transaction. Cold conversion carries one immutable repository-metadata digest
 through cache lookup and persistence, then revalidates it under the database
 write transaction so a concurrent refresh cannot publish stale source input.
+Repository conversion cache identity is the exact algorithm-prefixed checksum
+from authenticated repository metadata. The downloader verifies bytes against
+that checksum before conversion. Remi separately computes SHA-256 over the
+downloaded artifact for CCS provenance and emission; that CCS digest never
+replaces the repository checksum used for cache and refresh authority.
 CCS identity and capabilities come solely from the downloaded artifact. CCS
 cache files use their emitted content hash as the local filename
 instead of a mutable package-name/version slot. Lifecycle program content,


### PR DESCRIPTION
## Problem

The exact merged Remi candidate deployment in run `31739401601` populated all six configured sources but timed out with `solus-polaris` at zero current conversions. Production traced the first eopkg failure to a checksum-authority mismatch: the repository row carried authenticated SHA-1, while Remi substituted its separately computed artifact SHA-256 into repository cache/persistence identity and then rejected the result as changed source metadata.

## Fix

- normalize native SHA-1 and SHA-256 repository checksums to algorithm-prefixed identities at sync;
- retain that exact repository checksum through conversion cache lookup and persistence;
- keep the independently computed artifact SHA-256 as CCS provenance/emission authority;
- compare current repository checksum identities exactly, so an algorithm change invalidates a conversion;
- add a signed eopkg conversion regression, a SHA-1 cache-hit regression, and an algorithm-change invalidation regression;
- document the split between repository source authority and CCS artifact integrity.

## Verification

- `cargo test -p remi` — 627 lib, 5 binary, and 3 CLI tests passed; 2 doctests ignored
- `cargo test -p conary-core db::models::converted` — 25 passed
- `cargo test -p conary-core repository::sync` — 49 passed
- `cargo test -p conary --test conversion_integration golden_conversion` — 4 passed
- `cargo test -p conary --test packaging_m4c` — 1 passed
- `bash scripts/test-remi-deploy-helper.sh` — passed
- `bash scripts/test-remi-health.sh` — passed
- `cargo clippy -p remi -p conary-core --all-targets -- -D warnings` — passed
- `bash scripts/check-doc-truth.sh` — passed
- `bash scripts/test-doc-truth.sh` — passed
- `bash scripts/test-agent-context.sh` — passed
- `cargo fmt --check` — passed
- `git diff --check` — passed

Closes #424
Refs #421
