### PR TITLE
fix(test): stabilize Artix repository authority

### DIFF
--- a/apps/conary-test/src/container/image.rs
+++ b/apps/conary-test/src/container/image.rs
@@ -763,6 +763,33 @@ printf 'fixture\n' > "$output/$file"
     }
 
     #[test]
+    fn artix_container_uses_core_mirrors_before_package_sync() {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let containerfile =
+            manifest_dir.join("../conary/tests/integration/remi/containers/Containerfile.artix");
+        let contents = fs::read_to_string(containerfile).expect("read Artix containerfile");
+
+        let mirror1 = contents
+            .find("Server = https://mirror1.artixlinux.org/repos/$repo/os/$arch")
+            .expect("Artix container must select the first official core mirror");
+        let cvut = contents
+            .find("Server = https://ftp.sh.cvut.cz/artix-linux/$repo/os/$arch")
+            .expect("Artix container must select the second official core mirror");
+        let sync = contents
+            .find("pacman -Syyu --noconfirm")
+            .expect("Artix container must force-refresh package databases before upgrading");
+
+        assert!(
+            mirror1 < sync && cvut < sync,
+            "Artix core mirrors must be configured before package synchronization"
+        );
+        assert!(
+            !contents.contains("--overwrite"),
+            "the image must resolve repository coherence instead of masking file conflicts"
+        );
+    }
+
+    #[test]
     fn package_mode_containerfiles_install_exact_canonical_artifacts() {
         let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
         let containers = manifest_dir.join("../conary/tests/integration/remi/containers");

--- a/apps/conary/tests/integration/remi/containers/Containerfile.artix
+++ b/apps/conary/tests/integration/remi/containers/Containerfile.artix
@@ -11,7 +11,14 @@ FROM docker.io/artixlinux/artixlinux:base-openrc@sha256:56c8369263d83ef9b0ba4d95
 
 ARG INSTALL_MODE=binary
 
-RUN pacman -Syu --noconfirm \
+# Normal Artix mirrors can lag the OCI image during a repository publication.
+# Prefer the two official core mirrors, which sync directly from the build
+# server, so package synchronization cannot select an older repository view.
+RUN printf '%s\n' \
+        'Server = https://mirror1.artixlinux.org/repos/$repo/os/$arch' \
+        'Server = https://ftp.sh.cvut.cz/artix-linux/$repo/os/$arch' \
+        > /etc/pacman.d/mirrorlist \
+    && pacman -Syyu --noconfirm \
         ca-certificates \
         curl \
         diffutils \

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -586,6 +586,12 @@ matrix job; there is no manifest skip fallback. A stable
 `native-cross-source-lifecycle` aggregator fails unless every distro matrix job
 succeeds.
 
+The Artix lane keeps both sides of its rolling package view deliberate: the OCI
+base is digest-pinned, and the container selects Artix's two official core
+mirrors before forcing a package-database refresh. Normal mirrors sync from
+those core mirrors and can briefly advertise packages older than the pinned
+image during publication, so they are not image-build authority for this lane.
+
 The two Debian-derivative jobs also run `debian-derivative-acceptance`. Their
 shared Containerfile starts from one digest-pinned Ubuntu transport root, then
 installs exact release-owned identity and keyring packages and restores the

--- a/docs/modules/test-fixtures.md
+++ b/docs/modules/test-fixtures.md
@@ -451,6 +451,9 @@ Each fixture family should record:
   artifact identities, signing fingerprints, and preflight stages; configuration
   alone is not acceptance evidence. Artifact digest provenance remains typed as
   pinned release authority, pinned build input, or running-target bytes.
+  The rolling Artix image is digest-pinned and configures the two official core
+  mirrors before package synchronization; normal-mirror lag must not determine
+  whether its required lifecycle lane can start.
 
 ### supported-host-generation-export
 


### PR DESCRIPTION
## Problem

The digest-pinned Artix image can be newer than a normal mirror during repository publication. That made the required lifecycle lane attempt an OpenRC downgrade and fail before Conary executed.

## Fix

- Configure both official Artix core mirrors before package synchronization.
- Force-refresh package databases before the rolling upgrade.
- Add a contract test for mirror ordering and rejection of conflict-masking flags.
- Record the image/repository coherence rule in the owning integration docs.

## Verification

- `cargo test -p conary-test artix_container_uses_core_mirrors_before_package_sync`
- `cargo test -p conary-test suite_inventory`
- `cargo test -p conary-test distro_config_requires_a_typed_build_context`
- `cargo test -p conary-test focused_native_cross_source_manifest_runs_the_shared_lifecycle_contract`
- `cargo test -p conary-test native_cross_source_`
- `cargo run -p conary-test -- list`
- `cargo clippy -p conary-test --all-targets -- -D warnings`
- `bash scripts/check-doc-truth.sh`
- `bash scripts/test-doc-truth.sh`
- `bash scripts/test-agent-context.sh`
- `cargo fmt --check`
- `git diff --check`

Hosted proof required: the exact-head `native-cross-source-lifecycle (artix)` job must build the pinned image and pass the lifecycle contract.

Closes #426
Refs #425