### PR TITLE
docs(release): record v0.15.0 closeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Merge validation](https://github.com/ConaryLabs/Conary/actions/workflows/merge-validation.yml/badge.svg?branch=main)](https://github.com/ConaryLabs/Conary/actions/workflows/merge-validation.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Release: v0.14.0](https://img.shields.io/badge/release-v0.14.0-blue.svg)](https://github.com/ConaryLabs/Conary/releases/tag/v0.14.0)
+[![Release: v0.15.0](https://img.shields.io/badge/release-v0.15.0-blue.svg)](https://github.com/ConaryLabs/Conary/releases/tag/v0.15.0)
 
 **Website:** [conary.io](https://conary.io) | **Packages:** [remi.conary.io](https://remi.conary.io) | **Discussions:** [GitHub Discussions](https://github.com/ConaryLabs/Conary/discussions)
 
@@ -54,15 +54,15 @@ attach only a reviewed support bundle.
 
 ## Try It
 
-Release `v0.14.0` is published and artifact-verified, but it predates fixes
-discovered while completing the supported-host generation export/boot proof.
-It is therefore not current tester-authoritative. The
-[release artifact matrix](docs/operations/release-artifact-matrix.md) records
-the exact release proof and this limitation. If you inspect the released
-artifact, install it only on a VM or non-critical host; do not treat its result
-as validation of the unreleased fixes.
+Release `v0.15.0` is the current immutable, artifact-verified synchronized
+suite. The [release artifact matrix](docs/operations/release-artifact-matrix.md)
+records its exact tag, complete asset set, deployments, and three-distro
+released-package proof. Broad external testing remains paused until #110's
+ordinary-package corpus gate passes, so the release is not yet the pinned
+tester authority. If you inspect it now, install it only on a VM or
+non-critical host and do not treat the result as an outreach completion.
 
-After a later release is pinned and the tester guide is resumed, choose a
+After an exact release is pinned and the tester guide is resumed, choose a
 source whose package format differs from the host and run the complete bounded
 loop:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,16 +18,11 @@ maintainer pivot may close the milestone instead only when a reproducible
 systemic blocker is documented with the affected attempts and chosen next
 action.
 
-The enabling sequence is:
-
-1. W0 Neutral Planning Migration
-2. W1 Integrated Release-Green Baseline
-3. W2 Preview Release and Remi Readiness
-4. W3 First External Tester Loop
-
-W3 is active, but outreach has not started. Its W3a public-readiness gate must
-publish and verify the current onboarding release before the manual tester
-posts begin.
+The synchronized `v0.15.0` suite and its released-package proof are complete.
+The active workstream is W6 Authority Audit Closure; W7 then owns the
+ordinary-package corpus gate in #110. Outreach remains at 0/10 and moves only
+after that engineering gate plus the separate cached-history and venue checks
+close. Release publication alone does not assign tester authority.
 
 Detailed maturity, workstream status, proof, blockers, and longer horizons live
 in the [development roadmap](docs/roadmaps/development-roadmap.md).

--- a/docs/guides/agent-assisted-tester-loop.md
+++ b/docs/guides/agent-assisted-tester-loop.md
@@ -1,8 +1,8 @@
 ---
-last_updated: 2026-07-31
-revision: 14
+last_updated: 2026-08-13
+revision: 15
 status: paused
-summary: Preserve the v0.14.0 tester-loop shape while execution waits for a release containing the supported-host fixes
+summary: Preserve the v0.15.0 tester-loop shape while execution waits for the ordinary-package corpus gate
 ---
 
 # Agent-Assisted Tester Loop
@@ -16,16 +16,19 @@ Use a disposable VM, a snapshot, or a non-critical host. Do not run this loop
 first on an irreplaceable daily driver.
 
 **Do not run this guide while its frontmatter status is `paused`.** Its
-`v0.14.0` commands are retained so the next release can be re-pinned without
-losing the reviewed flow, but that immutable release predates fixes discovered
-during supported-host generation bring-up and is not current tester authority.
-Resume only after this guide names a later release and the
+`v0.15.0` commands match the current immutable, independently verified suite,
+but release proof does not satisfy #110's ordinary-package corpus gate and the
+suite is not yet pinned tester authority. Resume only after that separate gate
+passes, this guide names an exact tester release, and the
 [current release artifact matrix](https://github.com/ConaryLabs/Conary/blob/main/docs/operations/release-artifact-matrix.md)
-records that exact tag as published and independently verified.
+still records that tag as published and independently verified.
 
 ## Copy-Paste Agent Prompt
 
-Paste this into the agent running inside the VM or snapshot:
+The retained prompt below is inactive while this guide is paused. It assumes
+the frontmatter has been changed to active and the displayed release has been
+assigned as tester authority. Only then paste it into the agent running inside
+the VM or snapshot:
 
 ```text
 First read the guide frontmatter. If its status is paused, stop without
@@ -35,19 +38,19 @@ release exists.
 I want you to help me run the Conary first external tester loop on this host.
 
 Read this guide first:
-https://github.com/ConaryLabs/Conary/blob/v0.14.0/docs/guides/agent-assisted-tester-loop.md
+https://github.com/ConaryLabs/Conary/blob/v0.15.0/docs/guides/agent-assisted-tester-loop.md
 
 Goal: install, inspect, update-preview, and remove a package whose source
 format differs from this host's native package format with pinned Conary
-v0.14.0, then draft a pre-alpha tester feedback issue. You are testing the user-facing
+v0.15.0, then draft a pre-alpha tester feedback issue. You are testing the user-facing
 cross-distro package-manager flow, not developing Conary itself.
 
 Safety rules:
 - Stop immediately if this is not a VM, snapshot, or explicitly non-critical
   host.
 - Confirm distro, architecture, kernel, and sudo before installing anything.
-- Use only the pinned v0.14.0 release from
-  https://github.com/ConaryLabs/Conary/releases/tag/v0.14.0 and confirm its
+- Use only the pinned v0.15.0 release from
+  https://github.com/ConaryLabs/Conary/releases/tag/v0.15.0 and confirm its
   release page provides the package for this host plus SHA256SUMS.
 - Verify SHA256SUMS for every downloaded artifact before installation.
 - Run dry-run commands before live commands when the loop provides both.
@@ -73,7 +76,7 @@ Stop and do not install Conary if any of these are true:
 - the host is not Fedora 44, Ubuntu 26.04 LTS, or Arch Linux;
 - the host is not `x86_64`;
 - `sudo -v` fails;
-- the pinned `v0.14.0` release page does not provide the package for this host
+- the pinned `v0.15.0` release page does not provide the package for this host
   plus `SHA256SUMS`;
 - downloaded artifact checksums do not match `SHA256SUMS`;
 - the agent or human cannot explain what a live mutation command is about to
@@ -109,45 +112,45 @@ support. Those only matter for generation-model features outside this test.
 Create a clean work directory:
 
 ```bash
-mkdir -p "$HOME/conary-preview-v0.14.0"
-cd "$HOME/conary-preview-v0.14.0"
+mkdir -p "$HOME/conary-preview-v0.15.0"
+cd "$HOME/conary-preview-v0.15.0"
 ```
 
 Download `SHA256SUMS` and the package for the current distro from:
 
 ```text
-https://github.com/ConaryLabs/Conary/releases/tag/v0.14.0
+https://github.com/ConaryLabs/Conary/releases/tag/v0.15.0
 ```
 
 Use exactly one package. Fedora 44:
 
 ```bash
-base="https://github.com/ConaryLabs/Conary/releases/download/v0.14.0"
+base="https://github.com/ConaryLabs/Conary/releases/download/v0.15.0"
 curl -fLO "$base/SHA256SUMS"
-curl -fLO "$base/conary-0.14.0-1.fc44.x86_64.rpm"
+curl -fLO "$base/conary-0.15.0-1.fc44.x86_64.rpm"
 ```
 
 Ubuntu 26.04 LTS:
 
 ```bash
-base="https://github.com/ConaryLabs/Conary/releases/download/v0.14.0"
+base="https://github.com/ConaryLabs/Conary/releases/download/v0.15.0"
 curl -fLO "$base/SHA256SUMS"
-curl -fLO "$base/conary_0.14.0-1_amd64.deb"
+curl -fLO "$base/conary_0.15.0-1_amd64.deb"
 ```
 
 Arch Linux:
 
 ```bash
-base="https://github.com/ConaryLabs/Conary/releases/download/v0.14.0"
+base="https://github.com/ConaryLabs/Conary/releases/download/v0.15.0"
 curl -fLO "$base/SHA256SUMS"
-curl -fLO "$base/conary-0.14.0-1-x86_64.pkg.tar.zst"
+curl -fLO "$base/conary-0.15.0-1-x86_64.pkg.tar.zst"
 ```
 
 Downloaded package names:
 
-- Fedora 44: `conary-0.14.0-1.fc44.x86_64.rpm`
-- Ubuntu 26.04 LTS: `conary_0.14.0-1_amd64.deb`
-- Arch Linux: `conary-0.14.0-1-x86_64.pkg.tar.zst`
+- Fedora 44: `conary-0.15.0-1.fc44.x86_64.rpm`
+- Ubuntu 26.04 LTS: `conary_0.15.0-1_amd64.deb`
+- Arch Linux: `conary-0.15.0-1-x86_64.pkg.tar.zst`
 
 Verify the downloaded package against `SHA256SUMS`:
 
@@ -164,19 +167,19 @@ Ask the human before running the matching install command.
 Fedora 44:
 
 ```bash
-sudo dnf install ./conary-0.14.0-1.fc44.x86_64.rpm
+sudo dnf install ./conary-0.15.0-1.fc44.x86_64.rpm
 ```
 
 Ubuntu 26.04 LTS:
 
 ```bash
-sudo apt install ./conary_0.14.0-1_amd64.deb
+sudo apt install ./conary_0.15.0-1_amd64.deb
 ```
 
 Arch Linux:
 
 ```bash
-sudo pacman -U ./conary-0.14.0-1-x86_64.pkg.tar.zst
+sudo pacman -U ./conary-0.15.0-1-x86_64.pkg.tar.zst
 ```
 
 Then record:

--- a/docs/operations/external-tester-outreach.md
+++ b/docs/operations/external-tester-outreach.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-31
-revision: 7
+last_updated: 2026-08-13
+revision: 8
 status: postponed
 target_release: unassigned
 summary: Postponed multi-venue launch packet for the first cross-distro tester loop
@@ -11,17 +11,16 @@ summary: Postponed multi-venue launch packet for the first cross-distro tester l
 > **POSTPONED; NO NEW DATE IS ASSIGNED:** the current qualifying milestone is
 > 0/10. The two earlier supported-host reports remain useful adoption and
 > onboarding evidence, but neither installed a source package whose format
-> differed from the host's native format. Release `v0.14.0` is published and
-> artifact-verified, but supported-host bring-up subsequently exposed defects
-> whose fixes remain unreleased. It is not current tester authority. Do not
-> publish the copy below until a later immutable release is named here and the
-> W7, external cached-history, and venue-eligibility gates are closed.
+> differed from the host's native format. Release `v0.15.0` is published and
+> artifact-verified, but release proof does not satisfy #110's ordinary-package
+> corpus gate. No tester release is assigned. Do not publish the copy below
+> until W7, external cached-history, and venue-eligibility gates are closed.
 
-The venue copy below retains its `v0.14.0` wording as an unpublishable draft
-until a replacement release exists; replacing the version without exact
-release evidence would create false authority. The maintainer re-pins and
-assigns fresh dates only after every remaining gate closes, then posts manually
-and remains available to answer comments.
+The venue copy below references the current `v0.15.0` release as an
+unpublishable draft, not as assigned tester authority. The maintainer re-pins
+the exact current release if necessary and assigns fresh dates only after every
+remaining gate closes, then posts manually and remains available to answer
+comments.
 
 ## Show HN Submission
 
@@ -71,10 +70,10 @@ the executor enforcement contract automatically. Unsupported requirements fail
 before mutation; there is no capability-approval bypass.
 
 Agent-assisted walkthrough, including download and checksum verification:
-https://github.com/ConaryLabs/Conary/blob/v0.14.0/docs/guides/agent-assisted-tester-loop.md
+https://github.com/ConaryLabs/Conary/blob/v0.15.0/docs/guides/agent-assisted-tester-loop.md
 
 Pinned release:
-https://github.com/ConaryLabs/Conary/releases/tag/v0.14.0
+https://github.com/ConaryLabs/Conary/releases/tag/v0.15.0
 
 Privacy-safe feedback form:
 https://github.com/ConaryLabs/Conary/issues/new?template=pre_alpha_feedback.md
@@ -113,13 +112,13 @@ The pinned guide asks an agent to preflight a disposable supported VM, verify
 the release checksum, select a source format different from the host format,
 explain the complete dry-run, ask before live mutations, keep a private
 transcript, and draft privacy-safe feedback:
-https://github.com/ConaryLabs/Conary/blob/v0.14.0/docs/guides/agent-assisted-tester-loop.md
+https://github.com/ConaryLabs/Conary/blob/v0.15.0/docs/guides/agent-assisted-tester-loop.md
 
 Repository:
 https://github.com/ConaryLabs/Conary
 
 Pinned release:
-https://github.com/ConaryLabs/Conary/releases/tag/v0.14.0
+https://github.com/ConaryLabs/Conary/releases/tag/v0.15.0
 
 I'm interested both in product defects and in whether repo-owned instructions
 make Codex useful as a supervised systems-test operator. Exact failures,
@@ -151,11 +150,11 @@ contracts while owning the transaction and rollback on the target.
 The guide tells Claude Code to confirm a disposable supported VM, verify the
 pinned release checksum, inspect the complete dry-run, ask before every live
 mutation, keep a private transcript, and draft privacy-safe feedback:
-https://github.com/ConaryLabs/Conary/blob/v0.14.0/docs/guides/agent-assisted-tester-loop.md
+https://github.com/ConaryLabs/Conary/blob/v0.15.0/docs/guides/agent-assisted-tester-loop.md
 
 Repository and pinned release:
 https://github.com/ConaryLabs/Conary
-https://github.com/ConaryLabs/Conary/releases/tag/v0.14.0
+https://github.com/ConaryLabs/Conary/releases/tag/v0.15.0
 
 The useful feedback is where a source-native contract fails, whether Conary
 explains it precisely, whether install/update/remove behave consistently, and
@@ -186,7 +185,7 @@ failed attempts are useful evidence.
   reports as non-qualifying historical evidence.
 - [x] Rewrite the venue copy around the cross-distro package loop.
 - [x] Retire the passed 2026-07-20 through 2026-07-22 dates.
-- [x] Publish immutable `v0.14.0` with RPM, DEB, Arch, CCS, checksums, and the
+- [x] Publish immutable `v0.15.0` with RPM, DEB, Arch, CCS, checksums, and the
   required signature and installed-binary evidence.
 - [x] Record exact cross-distro install/query/update-preview/remove proof for
   the released binary on supported hosts.
@@ -194,9 +193,11 @@ failed attempts are useful evidence.
   body claims.
 - [x] Update the release artifact matrix and milestone tracker with exact
   release, deployment, and Remi population evidence.
-- [ ] Publish and independently verify a later immutable Conary release that
-  contains the supported-host fixes discovered after `v0.14.0`, then replace
-  every pinned version and URL in this draft.
+- [x] Publish and independently verify the synchronized `v0.15.0` suite that
+  contains the supported-host fixes, then replace every release version and
+  URL in this draft.
+- [ ] Pass #110's ordinary-package corpus gate and assign the exact tester
+  release without treating release proof as corpus proof.
 - [ ] Obtain GitHub Support confirmation that cached pre-rewrite pull-request
   and commit views have been dereferenced.
 - [ ] Re-check each venue's current rules and account eligibility immediately

--- a/docs/operations/infrastructure.md
+++ b/docs/operations/infrastructure.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-13
-revision: 22
+revision: 23
 summary: Non-secret infrastructure, agent-operations transport, release, Remi deploy, TLS renewal, remote development, and retired Forge staging guidance for Conary contributors and coding assistants
 ---
 
@@ -242,7 +242,7 @@ old process. That can fail with `Text file busy`.
   GitHub release. All members inherit `publish = false`; there is no parallel
   crates.io release track.
 - Run `./scripts/release.sh suite --dry-run` to inspect the next version, or
-  pass an exact decision such as `--target 0.15.0`. The target must be an
+  pass an exact decision as `--target MAJOR.MINOR.PATCH`. The target must be an
   increasing `MAJOR.MINOR.PATCH` version for the complete suite.
 - Run `./scripts/release.sh suite --prepare-only --target VERSION` on the
   issue-linked release branch. Preparation updates the root version, inherited

--- a/docs/operations/release-artifact-matrix.md
+++ b/docs/operations/release-artifact-matrix.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-13
-revision: 22
-summary: Define the synchronized suite release contract while preserving exact historical release and current Remi deployment evidence
+revision: 23
+summary: Record the immutable synchronized v0.15.0 suite, deployment, and released-artifact evidence
 ---
 
 # Release Artifact Matrix
@@ -18,7 +18,7 @@ date, distro, suite, and pass counts.
 
 ## Current Release Suite
 
-Issue [#428](https://github.com/ConaryLabs/Conary/issues/428) establishes the
+Issue [#428](https://github.com/ConaryLabs/Conary/issues/428) established the
 current hard-cut topology: all eight Cargo packages inherit one root workspace
 version; four artifact products are built from one reviewed suite commit; and
 one annotated `vMAJOR.MINOR.PATCH` tag publishes one GitHub release. Conary and
@@ -33,38 +33,105 @@ independent closeout proof. The `Protect suite tags` ruleset separately permits
 new `v*` tags while rejecting updates and deletions from the moment each tag is
 created.
 
-Version `0.15.0` is prepared by that issue but is not yet immutable release
-authority. It becomes authority only after the preparation PR is reviewed and
-merged, `v0.15.0` is created at that exact merge commit, all four products are
-published together, deployment and released-package workflows finish, and the
-independent evidence is recorded in a closeout PR. Historical product-prefixed
-tags and releases remain immutable evidence for their own trees, but they are
-not current release inputs.
+Version `0.15.0` is the current immutable release authority. Annotated tag
+object `83ef2d8a264cb49c5deb9e79e2a84a20e6883dab` peels to reviewed merge commit
+`642750878d5a59a9aa27976347cafc6f9dd86cfd`; all four products were published
+together, routed through their declared deployment modes, and independently
+verified. Historical product-prefixed tags and releases remain immutable
+evidence for their own trees, but they are not current release inputs.
 
-The current production Remi is a merged exact-main candidate at
-`c5b13097ef8818ab2df050afdf93d8343994cca9`, deployed by successful protected
-run `31751375620`. It reports `remi 0.12.1` with binary SHA-256
-`e6c6b826b1df6c12e33391dcbf5abc88e2719ab2b63c46750188d40675a80ef3`.
-That candidate is deployment authority, not an independent release baseline.
-The latest immutable historical Remi release is `remi-v0.12.1`; its lightweight
-tag points directly to commit `ad8537f93ed94da417ecb4b53dc12c978d985bf9`.
+Production Remi runs the exact tagged `remi 0.15.0` binary with SHA-256
+`5638e4715a7d6f6b2aa75105b337b77b49953ab6b04e84cf809daaa439563cc4`.
+The self-update endpoint serves the exact released `conary-0.15.0.ccs` at
+SHA-256 `8c5348be89d2c92b094498443d23782c88ff5d4deed888290939b4d73d39cc8f`.
+Broad external outreach remains separately postponed at 0/10 qualifying
+completions until #110's ordinary-package corpus gate passes; release proof is
+not tester authority.
 
-Conary `v0.14.0` remains immutable evidence for its exact tree, but it is not
-current tester authority. Broad external outreach remains separately postponed
-at 0/10 qualifying completions.
-
-| Artifact product | Artifact classes | Current construction authority | Suite deploy mode | Authority before the 0.15.0 closeout | Local build |
+| Artifact product | Artifact classes | Current construction authority | Suite deploy mode | Current immutable authority | Local build |
 | --- | --- | --- | --- | --- | --- |
-| `conary` | binary, `.ccs`, `.rpm`, `.deb`, `.pkg.tar.zst` | `.github/workflows/release-build.yml`, `scripts/release.sh suite`, `scripts/release-matrix.sh` | protected release assets, static sites, and released-package proof | immutable `v0.14.0` evidence at annotated tag object `c36c767c7169ff519a96dfdc7bedfa757211f334`, reviewed commit `fe23a604b64ea6f7cc87fce8298911e2245e027f`; not current tester authority | `cargo build -p conary` |
-| `remi` | binary and tarball | `.github/workflows/release-build.yml`, `scripts/release.sh suite`, `scripts/release-matrix.sh` | protected Remi deployment and repopulation proof, serialized before Conary deployment | current deployed exact-main candidate `c5b13097ef8818ab2df050afdf93d8343994cca9`; latest immutable historical release [remi-v0.12.1](https://github.com/ConaryLabs/Conary/releases/tag/remi-v0.12.1) | `cargo build -p remi` |
-| `conaryd` | binary and tarball | `.github/workflows/release-build.yml`, `scripts/release.sh suite`, `scripts/release-matrix.sh` | `none` | immutable historical `conaryd-v0.7.0` at tag object `381ee55cd051234dd78647ef5d7a8c3250c6b9df`, commit `a231276a900bbe8a8ccb6a0942f104cba2ab86b4`; no deployment | `cargo build -p conaryd` |
-| `conary-test` | binary and tarball | `.github/workflows/release-build.yml`, `scripts/release.sh suite`, `scripts/release-matrix.sh` | `none` | immutable historical `conary-test-v0.9.0` at tag object `6c4a8cb4bb2c6e89f359a8ceb89ac40a5ce06890`, commit `a231276a900bbe8a8ccb6a0942f104cba2ab86b4`; no deployment | `cargo build -p conary-test` |
+| `conary` | binary, `.ccs`, `.rpm`, `.deb`, `.pkg.tar.zst` | `.github/workflows/release-build.yml`, `scripts/release.sh suite`, `scripts/release-matrix.sh` | protected release assets, static sites, and released-package proof | synchronized suite `v0.15.0`; detached signature for the CCS artifact | `cargo build -p conary` |
+| `remi` | binary and tarball | `.github/workflows/release-build.yml`, `scripts/release.sh suite`, `scripts/release-matrix.sh` | protected Remi deployment and repopulation proof, serialized before Conary deployment | synchronized suite `v0.15.0`; exact released binary deployed | `cargo build -p remi` |
+| `conaryd` | binary and tarball | `.github/workflows/release-build.yml`, `scripts/release.sh suite`, `scripts/release-matrix.sh` | `none` | synchronized suite `v0.15.0`; build-only route | `cargo build -p conaryd` |
+| `conary-test` | binary and tarball | `.github/workflows/release-build.yml`, `scripts/release.sh suite`, `scripts/release-matrix.sh` | `none` | synchronized suite `v0.15.0`; build-only route | `cargo build -p conary-test` |
 
 ## Recorded Evidence
 
-### Current exact-main Remi candidate
+### Conary 0.15.0 synchronized suite
 
-- Protected candidate-deployment run `31751375620` completed successfully on
+- Preparation PR [#429](https://github.com/ConaryLabs/Conary/pull/429) passed
+  exact-head gate `31762562819` and exact-head rehearsal `31763203456` at
+  `9361d2af4bdcc83b190de2fc6bf95234d92ac86c`, then merged as reviewed commit
+  `642750878d5a59a9aa27976347cafc6f9dd86cfd`. Post-merge validation
+  `31766458093` passed at that exact commit.
+- Protected annotated tag `v0.15.0` has tag object
+  `83ef2d8a264cb49c5deb9e79e2a84a20e6883dab` and peels to that merge commit.
+  The commit is reachable from `main`; active ruleset `Protect suite tags`
+  (`20825313`) rejects updates and deletions of `v*` tags with no bypass.
+- Exact-tag release-build run
+  [31766900566](https://github.com/ConaryLabs/Conary/actions/runs/31766900566)
+  passed all 11 jobs. It published the immutable 13-asset release
+  [v0.15.0](https://github.com/ConaryLabs/Conary/releases/tag/v0.15.0) at
+  `2026-08-14T04:23:49Z`:
+  - `SHA256SUMS`:
+    `f160f65291b7d4f8a8e8357f6bf7783526fe17885165a09419f6c8652bf4024d`
+  - `metadata.json`:
+    `6c4615e8e9faa101674d5f168261f7b47621dad8f8f6cd5a474917b743f59033`
+  - `conary-0.15.0.ccs`:
+    `8c5348be89d2c92b094498443d23782c88ff5d4deed888290939b4d73d39cc8f`
+  - `conary-0.15.0.ccs.sig`:
+    `1730816e0cf92f219692f80e0575a4ef13f536d1bbe200ef45103a789a421c86`
+  - `conary-0.15.0-1.fc44.x86_64.rpm`:
+    `3297e0e1e625a3d0eb51c68f6bbe715443f2a69fb27216e61ab21529c76fe060`
+  - `conary_0.15.0-1_amd64.deb`:
+    `61f6c6691c0997f42abb2d2c6b37ed1a699a5cedca6721729d36be43a165cf94`
+  - `conary-0.15.0-1-x86_64.pkg.tar.zst`:
+    `ae28c6562e82dbb17bbdddf783b916c3ac37a02d5720fbb6101629cfa5e5078d`
+  - `remi-0.15.0-linux-x64`:
+    `5638e4715a7d6f6b2aa75105b337b77b49953ab6b04e84cf809daaa439563cc4`
+  - `remi-0.15.0-linux-x64.tar.gz`:
+    `d9fc6efde106e2e4d4f253eeeca929fa144b94737dfe22da9779122b3e99f0d0`
+  - `conaryd-0.15.0-linux-x64`:
+    `1ab85520d0c870bcd6e7f5c5df687b3487db2d268ab13324ab15e422aa34c770`
+  - `conaryd-0.15.0-linux-x64.tar.gz`:
+    `be1d6a23e094d7ca14d1bc5faee1899cab6b8105c740114833936f9f2dbb62dd`
+  - `conary-test-0.15.0-linux-x64`:
+    `7a135284ddc16901317c2ea1c66566cb6857f7bd67800d44c39d3f63235421a7`
+  - `conary-test-0.15.0-linux-x64.tar.gz`:
+    `3bc8fa88d80df3cbf03fbbe125dbcf5f924add3a9412d399842ac232cfe25ce1`
+- Independent download proof passed `sha256sum -c SHA256SUMS` for all 12
+  non-checksum assets and matched every one of the 13 local SHA-256 values to
+  the release API digest. `gh release verify v0.15.0` and
+  `gh release verify-asset` for every asset passed against GitHub's immutable
+  release attestation.
+- Schema-v1 metadata names release `suite`, tag `v0.15.0`, version `0.15.0`,
+  bundle `suite-bundle`, typed `dry_run=false`, and exactly four product routes:
+  protected Conary and Remi deployment plus `deploy_mode=none` for conaryd and
+  conary-test. All 11 artifact patterns were present.
+- Downloaded Remi, conaryd, and conary-test binaries report `0.15.0`; each raw
+  binary is byte-identical to the copy in its tarball. The Arch package reports
+  `conary 0.15.0-1` for `x86_64`, and the released-package workflow confirmed
+  the installed Conary version for all three native package formats.
+- Protected deployment run
+  [31769739765](https://github.com/ConaryLabs/Conary/actions/runs/31769739765)
+  passed exact metadata routing, build-only-route proof, Remi deployment,
+  Conary release/static-site deployment, and terminal native-package lifecycle
+  proof on Fedora 44, Ubuntu 26.04 LTS, and Arch at the tagged commit.
+- Independent Remi proof passed `scripts/remi-health.sh --full` at 10/10 and
+  `inspect-remi --require-repopulated` at schema revision 37, 6/6 populated
+  sources, four exact signing profiles, 110,220 repository packages, and 1,798
+  conversions. The installed `remi 0.15.0` binary hash exactly matches the
+  release asset. The public self-update endpoint serves version `0.15.0` and
+  the exact released CCS hash.
+- The detached `.ccs.sig` is the product-owned signature. Native packages,
+  executable bundles, and metadata have GitHub's release attestation and
+  checksum coverage but no separate detached signature, SBOM, or additional
+  provenance sidecar.
+
+### Superseded exact-main Remi candidate
+
+- Before the synchronized release, protected candidate-deployment run
+  `31751375620` completed successfully on
   2026-08-13 at exact merged commit
   `c5b13097ef8818ab2df050afdf93d8343994cca9`.
 - Independent host proof found the active `/usr/local/bin/remi` reporting
@@ -76,7 +143,7 @@ at 0/10 qualifying completions.
   packages and one validated conversion.
 - `scripts/remi-health.sh --full` independently passed 10/10, and public Solus
   package conversion for `0ad` returned HTTP 200.
-- This evidence proves the current deployment. It does not create a tag,
+- This evidence proves that superseded deployment. It did not create a tag,
   GitHub release, or separate Remi version authority.
 
 ### Remi 0.12.1

--- a/docs/roadmaps/development-roadmap.md
+++ b/docs/roadmaps/development-roadmap.md
@@ -1,8 +1,8 @@
 ---
 last_updated: 2026-08-13
-revision: 19
+revision: 20
 summary: Track Conary's cross-distro package milestone, authenticated derivative execution, and the issue-decomposed W10 takeover horizon
-proof_baseline: "immutable v0.14.0 at fe23a604b64ea6f7cc87fce8298911e2245e027f; current exact-main Remi candidate c5b13097ef8818ab2df050afdf93d8343994cca9; synchronized v0.15.0 suite prepared under #428 but not yet release authority"
+proof_baseline: "immutable synchronized v0.15.0 suite at 642750878d5a59a9aa27976347cafc6f9dd86cfd; exact tagged Remi deployed; external tester result remains 0/10 behind #110"
 current_milestone: first external tester loop
 active_workstream: W6 Authority Audit Closure
 next_workstream: W7 Just-Works Corpus Gate
@@ -121,16 +121,16 @@ the stated scope, not whether a workstream happens to be active.
 | CLI and core package operations | solid | Scope is the limited preview; external use and fresh combined proof matter more than new surface area. |
 | Adoption, unadoption, and native handoff | solid | Proof covers the current three-distro scope; the released Arch package initializes only its exact native profile and synchronizes Remi. |
 | Database, CAS, native parsing, and resolution | solid | Some advanced repository-policy abstractions and integration edges remain incomplete. |
-| Packaging, static repositories, trust, and self-update | solid | Immutable `v0.14.0` has exact tag, hashes, detached signature, self-update endpoint, deployment, native RPM/DEB/Arch installed-binary proof, and a released Fedora sparse sync. Issue #428 prepares one synchronized `v0.15.0` suite release across four artifacts, but preparation is not immutable authority. No current artifact publishes an SBOM or provenance sidecar. |
+| Packaging, static repositories, trust, and self-update | solid | Immutable synchronized `v0.15.0` has an exact annotated tag, 13 checksum/digest-verified assets across four products, GitHub release attestation, detached CCS signature, self-update endpoint, deployments, and native RPM/DEB/Arch lifecycle proof. No current artifact publishes an SBOM or additional provenance sidecar. |
 | CCS conversion and native lifecycle authority | active hard switch | The exact RPM, Debian, and ALPM lifecycle contract is released and deployed; current source-backed format defects are explicit work in #98, #99, and #102 through #105 rather than manual-review authority. These share one root cause: the shared package model normalizes source facts at parse time instead of at each consumer's boundary. W5 owns the structural correction. |
 | Generation build and export | limited | Bootable-image export (raw/qcow2/ISO plus a UEFI QEMU boot proof) is retained and proven from a supported-host fixture rather than from bootstrap; the re-based Group O/P suites passed locally on 2026-07-31. Proven paths are x86_64; non-x86 assets, signed boot authority, and persistent-effect rollback remain later work. |
 | Model, source selection, and replatforming | limited | Some resolution deltas and builder inputs are not wired end to end. |
 | Bootstrap and self-hosting | limited | Rootful, chroot, fixture, and QEMU dependencies need repeatable current proof. |
-| Remi core and publication | solid | Exact-main candidate `c5b13097ef8818ab2df050afdf93d8343994cca9` is deployed at schema revision 37 with 6/6 populated sources, four exact signing profiles, 110,220 repository packages, 1,645 conversions, public Solus conversion, and full health 10/10. It is deployment authority, not a separate release baseline. Distribution and a wider stranger-operated path remain limited. |
+| Remi core and publication | solid | Exact tagged `remi 0.15.0` is deployed at schema revision 37 with 6/6 populated sources, four exact signing profiles, 110,220 repository packages, 1,798 conversions, and full health 10/10. Its binary hash matches the immutable release asset. Distribution and a wider stranger-operated path remain limited. |
 | conaryd package and query service | limited | Authorization is exact root/daemon/configured-group authority; restart semantics, resolver-backed dry-run proof, and deployment remain incomplete. |
 | Federation | experimental | Only `/v1/federation/directory` is routed and no federation call exists in chunk serving, so the router is a library nothing invokes on a local miss. TLS fingerprint pinning is enforced in code; the documented disagreement is a docs defect. See the federation horizon for measured state and slice ordering. |
 | Advanced derivation, lock, and reproducibility flows | unfinished | Several interfaces exist without complete persisted inputs or update-path integration. |
-| External product readiness | unfinished | The `v0.14.0` released-package matrix is complete, while synchronized `v0.15.0` remains a prepared target until exact publication and closeout proof. The revised cross-distro milestone remains 0/10. Outreach is separately gated on W7/#110 corpus proof, cached-history clearance, and venue eligibility. |
+| External product readiness | unfinished | The synchronized `v0.15.0` released-package matrix is complete. The revised cross-distro milestone remains 0/10, and outreach is separately gated on W7/#110 corpus proof, cached-history clearance, and venue eligibility. Release proof is not tester readiness. |
 
 ## Workstreams
 
@@ -175,42 +175,30 @@ the stated scope, not whether a workstream happens to be active.
   behind the W4 through W7 engineering gate, because the release proof covers
   a curated lifecycle rather than ordinary repository packages. Outreach state,
   venue eligibility, and the 0/10 tracker are now W8's.
-- **Current truth:** the latest immutable Conary release is `v0.14.0`. The
-  released RPM, DEB, and Arch packages passed the Cartesian
-  source-format lifecycle on Fedora 44, Ubuntu 26.04 LTS, and Arch. The
-  release predates fixes found during supported-host generation bring-up, so
-  it remains exact evidence for its own tree but is not current tester
-  authority. Remi now runs exact merged candidate
-  `c5b13097ef8818ab2df050afdf93d8343994cca9`. Issue #428 prepares the first
-  synchronized suite release, `v0.15.0`, but no prepared version is immutable
-  authority before exact tag, publication, deployment, and closeout proof. W7
-  owns the ordinary-package corpus.
+- **Current truth:** the latest immutable release is synchronized suite
+  `v0.15.0`. Its released RPM, DEB, and Arch packages passed the Cartesian
+  source-format lifecycle on Fedora 44, Ubuntu 26.04 LTS, and Arch. Remi runs
+  the exact tagged suite binary; conaryd and conary-test are checksum-verified
+  build-only artifacts. This is current release authority, not pinned tester
+  authority. W7/#110 owns the ordinary-package corpus gate.
 - **Execution status:** complete for the release, deployment, and
   published-package proof it owns.
 - **Dependencies:** none remaining.
-- **Proof:** immutable `v0.14.0` published on 2026-07-29; annotated tag
-  `c36c767c7169ff519a96dfdc7bedfa757211f334` peels to
-  `fe23a604b64ea6f7cc87fce8298911e2245e027f`. Exact-tag release-build
-  `30409720307` and protected deploy-and-verify `30412130145` passed.
-  Independent downloads matched the seven-asset checksum/digest inventory and
-  detached CCS signature. The released Fedora RPM reports `conary 0.14.0` and
-  synchronized 76,354 live Fedora packages in a 2,048 MiB guest in 194,288 ms.
-  Historical `remi-v0.9.5` tag object
-  `f2bf17f0086a7f8ea4be3e032336551c4e6089c1` peels to
-  `101dba655257f1ff3d1bee689d9c5ac8b2b68cbd`; release-build `30583793501`
-  and protected deployment `30585462182` passed. Independent production proof
-  reports installed `remi 0.9.5`, schema revision 23, 83,885 packages, 1,783
-  conversions, three distributions, and full health 11/11. conaryd 0.7.0 and
-  conary-test 0.9.0 remain immutable build-only products. Exact hashes and
-  complete per-product evidence live in the release matrix. No current product
-  publishes an SBOM or provenance sidecar.
-- **Current deployment evidence:** protected exact-main candidate run
-  `31751375620` passed at
-  `c5b13097ef8818ab2df050afdf93d8343994cca9`. Independent proof reports
-  installed `remi 0.12.1`, schema revision 37, 6/6 populated sources, four
-  signing profiles, 110,220 repository packages, 1,645 conversions, full
-  health 10/10, and a public Solus conversion. This advances current service
-  truth without revising W3's historical release result.
+- **Proof:** annotated tag object
+  `83ef2d8a264cb49c5deb9e79e2a84a20e6883dab` peels to reviewed merge commit
+  `642750878d5a59a9aa27976347cafc6f9dd86cfd`. Exact-tag release-build
+  `31766900566` published the immutable 13-asset release on 2026-08-13 PDT;
+  every asset passed checksum, GitHub digest, and immutable-attestation
+  verification. Protected deployment `31769739765` passed both deployment
+  routes, both build-only routes, and all three native-package lifecycle lanes.
+  Exact hashes and complete per-product evidence live in the release matrix.
+  The CCS has a detached signature; no product publishes an SBOM or additional
+  provenance sidecar.
+- **Current deployment evidence:** independent proof reports installed
+  `remi 0.15.0` with the exact release hash, schema revision 37, 6/6 populated
+  sources, four signing profiles, 110,220 repository packages, 1,798
+  conversions, and full health 10/10. The self-update endpoint serves the exact
+  released `conary-0.15.0.ccs`.
 - **Limitations:** the release proof does not establish that ordinary
   repository packages convert. W4 through W7 own that claim.
 
@@ -700,10 +688,10 @@ installed-binary self-update, compatible prewarmed Remi, rollback, and
 clean-host proof. W3's release proof gate was reopened for the supported `htop`
 SONAME repair and again for issue #41's path-safety and support-bundle defects,
 then superseded by the post-hard-cut package authority suite. The latest exact
-immutable Conary release evidence is `v0.14.0`; current Remi deployment
-authority is exact merged candidate
-`c5b13097ef8818ab2df050afdf93d8343994cca9`. Issue #428 prepares synchronized
-suite `v0.15.0`, but the prepared version is not release or tester authority.
+immutable release evidence is synchronized `v0.15.0` at
+`642750878d5a59a9aa27976347cafc6f9dd86cfd`; current Remi deployment authority
+is the exact tagged `remi 0.15.0` binary. This release authority remains
+separate from the unassigned tester pin and 0/10 external milestone.
 
 W3 was subsequently split. Its release gate is complete, and its external
 tester outreach moved to W8 behind an engineering gate, because a bounded

--- a/docs/roadmaps/external-tester-milestone.md
+++ b/docs/roadmaps/external-tester-milestone.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-13
-revision: 8
+revision: 9
 status: active
 current_result: 0/10
 summary: Outcome tracker for Conary's first cross-distro external tester milestone
@@ -35,29 +35,22 @@ but does not count as a completion.
 
 ## Release Gate
 
-The historical publication gate for `v0.14.0` is complete: the
-`docs/operations/release-artifact-matrix.md` records its annotated tag,
-immutable seven-asset release, checksums and GitHub digests, detached CCS
-signature, deployment, self-update endpoint, and three-distro
-released-package proof. It remains exact evidence for its own tree, not the
-pinned tester release.
+The publication gate for synchronized suite `v0.15.0` is complete. The
+`docs/operations/release-artifact-matrix.md` records its exact reviewed commit,
+annotated tag, immutable 13-asset release across four products, checksums and
+GitHub digests, release attestation, detached CCS signature, deployments,
+self-update endpoint, build-only routes, and three-distro released-package
+proof. Production Remi runs the exact tagged binary.
 
-Issue #428 is preparing synchronized suite version `0.15.0` across all eight
-workspace packages and four artifact products. Preparation is not publication:
-the matrix must record the exact reviewed tag, complete suite assets,
-deployments, released-package proof, and independent checks before `v0.15.0`
-becomes immutable release authority. The currently deployed Remi is an
-exact-main candidate at `c5b13097ef8818ab2df050afdf93d8343994cca9`; that
-deployment creates no release or tester pin.
-
-Even a complete `v0.15.0` release closeout does not by itself open outreach.
-The ordinary-package corpus gate owned by #110/W7 must also pass before this
+That complete release closeout does not by itself open outreach. The
+ordinary-package corpus gate owned by #110/W7 must also pass before this
 tracker names a pinned tester version. No tester version is assigned in
-advance.
+advance, and `v0.15.0` must not be presented as one merely because it is the
+current release authority.
 
 Release proof is not an external-user completion. The result therefore remains
-0/10, and broad outreach remains postponed by the release-closeout gate, the
-W7 corpus gate, and the separate cached-history and venue-eligibility gates.
+0/10, and broad outreach remains postponed by the W7 corpus gate plus the
+separate cached-history and venue-eligibility gates.
 
 Supported tester hosts are x86_64 Fedora 44, Ubuntu 26.04 LTS, and Arch Linux.
 Use a disposable VM, snapshot, spare system, or other non-critical host.

--- a/site/scripts/verify-build.mjs
+++ b/site/scripts/verify-build.mjs
@@ -19,7 +19,7 @@ const pages = [
 		file: 'install/index.html',
 		title: 'Conary tester release status — Conary',
 		canonical: 'https://conary.io/install/',
-		marker: 'Wait for the next verified tester release.'
+		marker: 'The release is verified; the tester runbook remains paused.'
 	},
 	{
 		file: 'compare/index.html',

--- a/site/src/lib/preview-release.ts
+++ b/site/src/lib/preview-release.ts
@@ -6,8 +6,8 @@ export type PreviewTarget = {
 	installCommand: string;
 };
 
-const version = '0.14.0';
-const tag = 'v0.14.0';
+const version = '0.15.0';
+const tag = 'v0.15.0';
 const releaseUrl = `https://github.com/ConaryLabs/Conary/releases/tag/${tag}`;
 const downloadBaseUrl = `https://github.com/ConaryLabs/Conary/releases/download/${tag}`;
 const matrixUrl =
@@ -21,7 +21,7 @@ export const previewRelease = {
 	matrixUrl,
 	testerAuthority: 'paused',
 	testerAuthorityReason:
-		'v0.14.0 is published and artifact-verified, but it predates supported-host fixes that remain unreleased.',
+		'v0.15.0 is published and artifact-verified, but the external tester pin remains paused until the #110 ordinary-package corpus gate passes.',
 	testerGuideUrl:
 		'https://github.com/ConaryLabs/Conary/blob/main/docs/guides/agent-assisted-tester-loop.md',
 	feedbackUrl: 'https://github.com/ConaryLabs/Conary/issues/new?template=pre_alpha_feedback.md',
@@ -31,22 +31,22 @@ export const previewRelease = {
 			id: 'fedora',
 			name: 'Fedora 44',
 			profile: 'fedora-44',
-			asset: 'conary-0.14.0-1.fc44.x86_64.rpm',
-			installCommand: 'sudo dnf install ./conary-0.14.0-1.fc44.x86_64.rpm'
+			asset: 'conary-0.15.0-1.fc44.x86_64.rpm',
+			installCommand: 'sudo dnf install ./conary-0.15.0-1.fc44.x86_64.rpm'
 		},
 		{
 			id: 'ubuntu',
 			name: 'Ubuntu 26.04 LTS',
 			profile: 'ubuntu-26.04',
-			asset: 'conary_0.14.0-1_amd64.deb',
-			installCommand: 'sudo apt install ./conary_0.14.0-1_amd64.deb'
+			asset: 'conary_0.15.0-1_amd64.deb',
+			installCommand: 'sudo apt install ./conary_0.15.0-1_amd64.deb'
 		},
 		{
 			id: 'arch',
 			name: 'Arch Linux',
 			profile: 'arch',
-			asset: 'conary-0.14.0-1-x86_64.pkg.tar.zst',
-			installCommand: 'sudo pacman -U ./conary-0.14.0-1-x86_64.pkg.tar.zst'
+			asset: 'conary-0.15.0-1-x86_64.pkg.tar.zst',
+			installCommand: 'sudo pacman -U ./conary-0.15.0-1-x86_64.pkg.tar.zst'
 		}
 	] satisfies PreviewTarget[]
 } as const;

--- a/site/src/routes/install/+page.svelte
+++ b/site/src/routes/install/+page.svelte
@@ -7,13 +7,13 @@
 
 <PageMeta
 	title="Conary tester release status — Conary"
-	description={`Conary ${previewRelease.tag} is published but not current tester authority; the packaged tester loop is paused until a release contains the supported-host fixes.`}
+	description={`Conary ${previewRelease.tag} is published and verified; the packaged tester loop remains paused until the ordinary-package corpus gate passes.`}
 	path="/install/"
 />
 
 <PageIntro
 	eyebrow="Tester loop paused"
-	title="Wait for the next verified tester release."
+	title="The release is verified; the tester runbook remains paused."
 	description={previewRelease.testerAuthorityReason}
 />
 
@@ -41,9 +41,9 @@
 				<h2 id="authority-pause-title">The package runbook is not open.</h2>
 				<p>
 					{previewRelease.testerAuthorityReason} The exact {previewRelease.tag}
-					artifacts remain available for inspecting that immutable release, but their
-					results do not validate the fixes now under review. This page will reopen
-					only after a later immutable release passes the artifact matrix.
+					artifacts are the current immutable release, but release proof is not the
+					ordinary-package corpus proof required before outreach. This page will reopen
+					only after that separate gate closes and a tester pin is assigned.
 				</p>
 				<div class="button-row">
 					<a href={previewRelease.matrixUrl} class="btn btn-primary">
@@ -56,7 +56,7 @@
 			</section>
 
 			<details class="retained-runbook">
-				<summary>Retained {previewRelease.tag} commands — historical reference, do not run</summary>
+				<summary>Retained {previewRelease.tag} commands — paused, do not run</summary>
 				<section class="install-step" id="preflight">
 				<div class="step-heading">
 					<span class="step-number">01</span>


### PR DESCRIPTION
## Problem

The synchronized v0.15.0 suite is immutable, deployed, and independently verified, but public and canonical repository truth still describes v0.14.0 as current and says supported-host fixes remain unreleased.

## Summary

- record the exact v0.15.0 tag, commit, 13-asset hashes, attestation checks, product routes, deployment run, three native lifecycle lanes, and independent Remi/self-update proof
- advance README, roadmap, milestone, tester-guide, and site release statements to v0.15.0
- keep the tester runbook paused behind #110's ordinary-package corpus gate; release proof is not tester authority
- update the site's prerendered-body assertion for the new accurate pause wording

## Verification

- `git diff --check`
- `cargo fmt --check`
- `bash scripts/check-doc-truth.sh`
- `bash scripts/test-doc-truth.sh`
- `bash scripts/check-release-matrix.sh`
- `bash scripts/test-release-matrix.sh`
- `npm --prefix site run check`
- `npm --prefix site run build`
- `bash scripts/test-deploy-sites.sh`

## Live evidence recorded

- release-build `31766900566`: success at `642750878d5a59a9aa27976347cafc6f9dd86cfd`
- deploy-and-verify `31769739765`: success, including Fedora 44, Ubuntu 26.04, and Arch released-package lifecycle
- immutable release and every asset verified; every local digest matched `SHA256SUMS` and the GitHub asset digest
- independent Remi health 10/10 and repopulated inspection passed; installed binary and self-update CCS match the release hashes

Refs #428
