### PR TITLE
fix(release): stop discarded debug packages

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -266,9 +266,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: rpm-package
-          path: |
-            packaging/rpm/output/*.rpm
-            !packaging/rpm/output/*debug*
+          path: packaging/rpm/output/*.rpm
           if-no-files-found: error
           retention-days: 5
 
@@ -383,9 +381,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: arch-package
-          path: |
-            packaging/arch/output/*.pkg.tar.zst
-            !packaging/arch/output/*debug*
+          path: packaging/arch/output/*.pkg.tar.zst
           if-no-files-found: error
           retention-days: 5
 
@@ -408,7 +404,6 @@ jobs:
           mkdir -p release-packages
           find release-artifacts -type f \
             \( -name '*.ccs' -o -name '*.rpm' -o -name '*.deb' -o -name '*.pkg.tar.zst' \) \
-            ! -name '*debuginfo*' ! -name '*debugsource*' \
             -exec cp {} release-packages/ \;
           cp release-artifacts/release-metadata/metadata.json release-packages/metadata.json
 

--- a/apps/conary/tests/packaged_onboarding.rs
+++ b/apps/conary/tests/packaged_onboarding.rs
@@ -133,6 +133,24 @@ fn native_release_packages_disable_unpublished_debug_subpackages() {
         spec.contains("no separate debug artifact") && spec.contains("discarded subpackages"),
         "RPM spec must explain why automatic debug subpackages are disabled"
     );
+    assert!(
+        spec.lines()
+            .any(|line| line.trim() == "%undefine _auto_set_build_flags"),
+        "RPM spec must stop Fedora's automatic debug-oriented Rust flag injection"
+    );
+    assert!(
+        spec.lines().any(|line| {
+            line.trim()
+                == "RUSTFLAGS=\"-Cforce-frame-pointers=yes -Clink-arg=%{_package_note_flags}\""
+        }) && spec.lines().any(|line| line.trim() == "%set_build_flags"),
+        "RPM spec must retain Fedora frame-pointer, package-note, and native build flags"
+    );
+    assert!(
+        !spec.contains("-Cdebuginfo")
+            && !spec.contains("-Cstrip=none")
+            && !spec.contains("%{build_rustflags}"),
+        "RPM spec must leave release debuginfo and stripping authority in Cargo.toml"
+    );
 
     let pkgbuild = read_packaging_file("packaging/arch/PKGBUILD");
     let options = pkgbuild

--- a/apps/conary/tests/packaged_onboarding.rs
+++ b/apps/conary/tests/packaged_onboarding.rs
@@ -145,6 +145,11 @@ fn native_release_packages_disable_unpublished_debug_subpackages() {
         }) && spec.lines().any(|line| line.trim() == "%set_build_flags"),
         "RPM spec must retain Fedora frame-pointer, package-note, and native build flags"
     );
+    assert_eq!(
+        spec.matches("%set_build_flags").count(),
+        1,
+        "RPM macros expand inside comments; the build-flag macro must appear only as its command"
+    );
     assert!(
         !spec.contains("-Cdebuginfo")
             && !spec.contains("-Cstrip=none")

--- a/apps/conary/tests/packaged_onboarding.rs
+++ b/apps/conary/tests/packaged_onboarding.rs
@@ -120,3 +120,31 @@ fn fedora_package_declares_and_preflights_systemd_macro_authority() {
         "release RPM build must install systemd-rpm-macros"
     );
 }
+
+#[test]
+fn native_release_packages_disable_unpublished_debug_subpackages() {
+    let spec = read_packaging_file("packaging/rpm/conary.spec");
+    assert!(
+        spec.lines()
+            .any(|line| line.trim() == "%global debug_package %{nil}"),
+        "RPM spec must disable automatic debuginfo and debugsource subpackages"
+    );
+    assert!(
+        spec.contains("no separate debug artifact") && spec.contains("discarded subpackages"),
+        "RPM spec must explain why automatic debug subpackages are disabled"
+    );
+
+    let pkgbuild = read_packaging_file("packaging/arch/PKGBUILD");
+    let options = pkgbuild
+        .lines()
+        .find_map(|line| {
+            line.trim()
+                .strip_prefix("options=(")
+                .and_then(|value| value.strip_suffix(')'))
+        })
+        .expect("Arch PKGBUILD options");
+    assert!(
+        options.split_whitespace().any(|option| option == "!debug"),
+        "Arch PKGBUILD must disable automatic debug split packages"
+    );
+}

--- a/docs/operations/infrastructure.md
+++ b/docs/operations/infrastructure.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-13
-revision: 24
+revision: 25
 summary: Non-secret infrastructure, agent-operations transport, release, Remi deploy, TLS renewal, remote development, and retired Forge staging guidance for Conary contributors and coding assistants
 ---
 
@@ -282,7 +282,10 @@ old process. That can fail with `Text file busy`.
 - Native builders explicitly disable distro-default debug split packages
   because the suite defines no debug artifact product. Upload and bundle steps
   do not filter unexpected native outputs; an extra package fails exact asset
-  validation.
+  validation. The RPM spec also opts out of Fedora's automatic debug-oriented
+  Rust flags, manually reapplies the distro's frame-pointer, package-note, and
+  native dependency flags, and leaves release codegen and stripping to the
+  workspace Cargo profile.
 - Exact-main `deploy-remi-candidate` remains available between suite releases
   for bounded hard cuts. It creates no tag or release and does not change suite
   version authority.

--- a/docs/operations/infrastructure.md
+++ b/docs/operations/infrastructure.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-13
-revision: 23
+revision: 24
 summary: Non-secret infrastructure, agent-operations transport, release, Remi deploy, TLS renewal, remote development, and retired Forge staging guidance for Conary contributors and coding assistants
 ---
 
@@ -279,6 +279,10 @@ old process. That can fail with `Text file busy`.
   follows the terminal workflow result.
 - conaryd and conary-test are first-class suite artifacts with explicit
   `deploy_mode=none`; no runtime deployment job may start for either product.
+- Native builders explicitly disable distro-default debug split packages
+  because the suite defines no debug artifact product. Upload and bundle steps
+  do not filter unexpected native outputs; an extra package fails exact asset
+  validation.
 - Exact-main `deploy-remi-candidate` remains available between suite releases
   for bounded hard cuts. It creates no tag or release and does not change suite
   version authority.

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -12,7 +12,8 @@ url='https://github.com/ConaryLabs/Conary'
 license=('MIT')
 depends=('openssl' 'xz' 'libseccomp')
 makedepends=('cargo' 'pkg-config' 'cmake' 'perl')
-options=(!lto)
+# Suite releases publish one installable package and no discarded debug split package.
+options=(!debug !lto)
 install=conary.install
 source=("$pkgname-$pkgver.tar.gz"
         "vendor.tar.gz")

--- a/packaging/arch/build.sh
+++ b/packaging/arch/build.sh
@@ -107,8 +107,13 @@ else
 fi
 
 EXPECTED_PACKAGE="$OUTPUT/${NAME}-${VERSION}-1-x86_64.pkg.tar.zst"
-if [[ ! -s "$EXPECTED_PACKAGE" || -L "$EXPECTED_PACKAGE" ]]; then
-    echo "Expected Arch package not found: $EXPECTED_PACKAGE" >&2
+shopt -s nullglob
+package_outputs=("$OUTPUT"/*.pkg.tar.zst)
+if [[ ${#package_outputs[@]} -ne 1 ||
+      "${package_outputs[0]:-}" != "$EXPECTED_PACKAGE" ||
+      ! -s "$EXPECTED_PACKAGE" ||
+      -L "$EXPECTED_PACKAGE" ]]; then
+    echo "Expected exactly one Arch package at $EXPECTED_PACKAGE, found ${#package_outputs[@]}" >&2
     exit 1
 fi
 

--- a/packaging/rpm/build.sh
+++ b/packaging/rpm/build.sh
@@ -124,8 +124,13 @@ else
 fi
 
 shopt -s nullglob
-rpm_outputs=("$OUTPUT/$NAME-$VERSION-"*.x86_64.rpm)
-if [[ ${#rpm_outputs[@]} -ne 1 || ! -s "${rpm_outputs[0]:-}" || -L "${rpm_outputs[0]:-}" ]]; then
+rpm_outputs=("$OUTPUT"/*.rpm)
+versioned_rpm_outputs=("$OUTPUT/$NAME-$VERSION-"*.x86_64.rpm)
+if [[ ${#rpm_outputs[@]} -ne 1 ||
+      ${#versioned_rpm_outputs[@]} -ne 1 ||
+      "${rpm_outputs[0]:-}" != "${versioned_rpm_outputs[0]:-}" ||
+      ! -s "${rpm_outputs[0]:-}" ||
+      -L "${rpm_outputs[0]:-}" ]]; then
     echo "Expected exactly one $NAME $VERSION x86_64 RPM, found ${#rpm_outputs[@]}" >&2
     exit 1
 fi

--- a/packaging/rpm/conary.spec
+++ b/packaging/rpm/conary.spec
@@ -1,3 +1,6 @@
+# Suite releases publish one installable RPM and no separate debug artifact;
+# the workspace release profile owns stripping, so do not generate discarded subpackages.
+%global debug_package %{nil}
 %global crate conary
 
 Name:           conary

--- a/packaging/rpm/conary.spec
+++ b/packaging/rpm/conary.spec
@@ -53,7 +53,7 @@ EOF
 %build
 # Cargo.toml owns release optimization, LTO, codegen units, and stripping.
 # Retain Fedora's x86_64 frame pointers and embedded RPM package note, while
-# %set_build_flags continues to populate the native dependency toolchain flags.
+# the manual distro macro below populates native dependency toolchain flags.
 RUSTFLAGS="-Cforce-frame-pointers=yes -Clink-arg=%{_package_note_flags}"
 export RUSTFLAGS
 %set_build_flags

--- a/packaging/rpm/conary.spec
+++ b/packaging/rpm/conary.spec
@@ -1,6 +1,11 @@
 # Suite releases publish one installable RPM and no separate debug artifact;
 # the workspace release profile owns stripping, so do not generate discarded subpackages.
 %global debug_package %{nil}
+
+# Fedora's phase prelude otherwise exports Rust flags whose debug and strip
+# settings exist to feed split debuginfo. Reapply the distro build flags below
+# after selecting only the Rust additions that remain part of this package.
+%undefine _auto_set_build_flags
 %global crate conary
 
 Name:           conary
@@ -46,6 +51,13 @@ directory = "vendor"
 EOF
 
 %build
+# Cargo.toml owns release optimization, LTO, codegen units, and stripping.
+# Retain Fedora's x86_64 frame pointers and embedded RPM package note, while
+# %set_build_flags continues to populate the native dependency toolchain flags.
+RUSTFLAGS="-Cforce-frame-pointers=yes -Clink-arg=%{_package_note_flags}"
+export RUSTFLAGS
+%set_build_flags
+echo "Conary effective RUSTFLAGS: $RUSTFLAGS"
 cargo build --release --locked -p conary
 
 %install

--- a/scripts/check-release-matrix.sh
+++ b/scripts/check-release-matrix.sh
@@ -41,7 +41,7 @@ require_match() {
     local pattern="$2"
     local description="$3"
 
-    rg -q --multiline "$pattern" "$file" || fail "$description missing in $file"
+    rg -q --multiline -- "$pattern" "$file" || fail "$description missing in $file"
 }
 
 forbid_match() {
@@ -49,7 +49,7 @@ forbid_match() {
     local pattern="$2"
     local description="$3"
 
-    if rg -q --multiline "$pattern" "$file"; then
+    if rg -q --multiline -- "$pattern" "$file"; then
         fail "$description unexpectedly present in $file"
     fi
 }
@@ -80,7 +80,7 @@ require_job_match() {
 
     block="$(extract_job_block "$file" "$job")"
     [[ -n "$block" ]] || fail "$job job missing in $file"
-    printf '%s\n' "$block" | rg -q --multiline "$pattern" ||
+    printf '%s\n' "$block" | rg -q --multiline -- "$pattern" ||
         fail "$description missing in $file job $job"
 }
 
@@ -199,6 +199,8 @@ require_match "$rpm_spec" '^BuildRequires:[[:space:]]+systemd-rpm-macros$' 'RPM 
 require_job_match "$release_build" build-rpm 'dnf install -y[\s\S]*systemd-rpm-macros' 'release-build RPM systemd macro dependency'
 require_match "$rpm_containerfile" 'systemd-rpm-macros[\s\S]*rpm --eval '\''%\{_unitdir\}'\''[\s\S]*/usr/lib/systemd/system' 'RPM Containerfile systemd macro dependency and expansion proof'
 require_match "$rpm_spec" '# Suite releases publish one installable RPM and no separate debug artifact;[\s\S]*^%global debug_package %\{nil\}$' 'RPM spec must explain and disable debug subpackage generation'
+require_match "$rpm_spec" '^%undefine _auto_set_build_flags$[\s\S]*^%build$[\s\S]*^RUSTFLAGS="-Cforce-frame-pointers=yes -Clink-arg=%\{_package_note_flags\}"$[\s\S]*^export RUSTFLAGS$[\s\S]*^%set_build_flags$[\s\S]*^cargo build --release --locked -p conary$' 'RPM spec must preserve non-debug Fedora Rust flags without overriding the workspace release profile'
+forbid_match "$rpm_spec" '-Cdebuginfo(=|[[:space:]])|-Cstrip=none|%\{build_rustflags\}' 'RPM spec debug-oriented Rust flag override'
 require_match "$arch_pkgbuild" '# Suite releases publish one installable package and no discarded debug split package\.[\s\S]*^options=\(!debug !lto\)$' 'Arch package must explicitly disable debug split-package generation'
 forbid_match "$release_build" '\*debug(source|info)?\*' 'native debug artifact filtering'
 

--- a/scripts/check-release-matrix.sh
+++ b/scripts/check-release-matrix.sh
@@ -19,6 +19,7 @@ rpm_containerfile="packaging/rpm/Containerfile.build"
 rpm_spec="packaging/rpm/conary.spec"
 deb_containerfile="packaging/deb/Containerfile.build"
 arch_containerfile="packaging/arch/Containerfile.build"
+arch_pkgbuild="packaging/arch/PKGBUILD"
 rpm_build_script="packaging/rpm/build.sh"
 deb_build_script="packaging/deb/build.sh"
 arch_build_script="packaging/arch/build.sh"
@@ -149,6 +150,7 @@ for required_file in \
     "$rpm_spec" \
     "$deb_containerfile" \
     "$arch_containerfile" \
+    "$arch_pkgbuild" \
     "$rpm_build_script" \
     "$deb_build_script" \
     "$arch_build_script" \
@@ -196,6 +198,9 @@ require_match "$arch_containerfile" "^FROM ${arch_release_image}$" 'Arch Contain
 require_match "$rpm_spec" '^BuildRequires:[[:space:]]+systemd-rpm-macros$' 'RPM spec systemd macro build dependency'
 require_job_match "$release_build" build-rpm 'dnf install -y[\s\S]*systemd-rpm-macros' 'release-build RPM systemd macro dependency'
 require_match "$rpm_containerfile" 'systemd-rpm-macros[\s\S]*rpm --eval '\''%\{_unitdir\}'\''[\s\S]*/usr/lib/systemd/system' 'RPM Containerfile systemd macro dependency and expansion proof'
+require_match "$rpm_spec" '# Suite releases publish one installable RPM and no separate debug artifact;[\s\S]*^%global debug_package %\{nil\}$' 'RPM spec must explain and disable debug subpackage generation'
+require_match "$arch_pkgbuild" '# Suite releases publish one installable package and no discarded debug split package\.[\s\S]*^options=\(!debug !lto\)$' 'Arch package must explicitly disable debug split-package generation'
+forbid_match "$release_build" '\*debug(source|info)?\*' 'native debug artifact filtering'
 
 rustup_flow_pattern="${rustup_init_url}[\\s\\S]*${rustup_init_sha256}  /tmp/rustup-init[\\s\\S]*sha256sum -c -[\\s\\S]*/tmp/rustup-init -y --default-toolchain 1\\.97\\.1 --profile minimal[\\s\\S]*rm -f /tmp/rustup-init"
 require_job_match "$release_build" build-rpm "$rustup_flow_pattern" 'release-build RPM builder checksum-pinned rustup-init flow'
@@ -266,6 +271,7 @@ forbid_match "$release_build" 'gh release create "\$TAG_NAME" (release|suite)-pa
 
 require_match "$rpm_build_script" 'find "\$OUTPUT".*\*\.rpm.*-delete' 'RPM build must clean stale package output'
 require_match "$rpm_build_script" 'VERSION="\$\(bash "\$REPO_ROOT/scripts/release-matrix\.sh" workspace-version\)"[\s\S]*assert-owned-version suite "\$VERSION"' 'RPM build must use and validate the root workspace version authority'
+require_match "$rpm_build_script" 'rpm_outputs=\("\$OUTPUT"/\*\.rpm\)[\s\S]*versioned_rpm_outputs=\("\$OUTPUT/\$NAME-\$VERSION-"\*\.x86_64\.rpm\)[\s\S]*\$\{#rpm_outputs\[@\]\} -ne 1[\s\S]*\$\{#versioned_rpm_outputs\[@\]\} -ne 1' 'RPM build must reject every extra package output'
 require_match "$rpm_build_script" 'Expected exactly one \$NAME \$VERSION x86_64 RPM' 'RPM build must fail without its expected package'
 require_match "$rpm_build_script" 'rpm --eval '\''%\{_unitdir\}'\''[\s\S]*systemd-rpm-macros build dependency' 'RPM build must fail fast without systemd macro authority'
 require_match "$deb_build_script" 'find "\$OUTPUT".*\*\.deb.*-delete' 'DEB build must clean stale package output'
@@ -273,7 +279,7 @@ require_match "$deb_build_script" 'VERSION="\$\(bash "\$REPO_ROOT/scripts/releas
 require_match "$deb_build_script" 'EXPECTED_DEB="\$OUTPUT/\$\{NAME\}_\$\{VERSION\}-1_amd64\.deb"[\s\S]*\[\[ ! -s "\$EXPECTED_DEB"' 'DEB build must require its expected package'
 require_match "$arch_build_script" 'find "\$OUTPUT".*\*\.pkg\.tar\.zst.*-delete' 'Arch build must clean stale package output'
 require_match "$arch_build_script" 'VERSION="\$\(bash "\$REPO_ROOT/scripts/release-matrix\.sh" workspace-version\)"[\s\S]*assert-owned-version suite "\$VERSION"' 'Arch build must use and validate the root workspace version authority'
-require_match "$arch_build_script" 'EXPECTED_PACKAGE="\$OUTPUT/\$\{NAME\}-\$\{VERSION\}-1-x86_64\.pkg\.tar\.zst"[\s\S]*\[\[ ! -s "\$EXPECTED_PACKAGE"' 'Arch build must require its expected package'
+require_match "$arch_build_script" 'EXPECTED_PACKAGE="\$OUTPUT/\$\{NAME\}-\$\{VERSION\}-1-x86_64\.pkg\.tar\.zst"[\s\S]*package_outputs=\("\$OUTPUT"/\*\.pkg\.tar\.zst\)[\s\S]*\$\{#package_outputs\[@\]\} -ne 1[\s\S]*"\$\{package_outputs\[0\]:-\}" != "\$EXPECTED_PACKAGE"' 'Arch build must reject every extra package output'
 require_match "$ccs_build_script" 'find "\$OUTPUT".*\*\.ccs.*-delete' 'CCS build must clean stale package output'
 require_match "$ccs_build_script" 'assert-owned-version suite "\$VERSION"' 'CCS build must validate the root workspace version authority'
 require_match "$ccs_build_script" 'SIGNING_KEY=""[\s\S]*--key\)[\s\S]*SIGNING_KEY="\$2"[\s\S]*CCS release signing key must be a regular, non-symlink file' 'CCS wrapper must require an explicit regular signing key'

--- a/scripts/check-release-matrix.sh
+++ b/scripts/check-release-matrix.sh
@@ -200,6 +200,7 @@ require_job_match "$release_build" build-rpm 'dnf install -y[\s\S]*systemd-rpm-m
 require_match "$rpm_containerfile" 'systemd-rpm-macros[\s\S]*rpm --eval '\''%\{_unitdir\}'\''[\s\S]*/usr/lib/systemd/system' 'RPM Containerfile systemd macro dependency and expansion proof'
 require_match "$rpm_spec" '# Suite releases publish one installable RPM and no separate debug artifact;[\s\S]*^%global debug_package %\{nil\}$' 'RPM spec must explain and disable debug subpackage generation'
 require_match "$rpm_spec" '^%undefine _auto_set_build_flags$[\s\S]*^%build$[\s\S]*^RUSTFLAGS="-Cforce-frame-pointers=yes -Clink-arg=%\{_package_note_flags\}"$[\s\S]*^export RUSTFLAGS$[\s\S]*^%set_build_flags$[\s\S]*^cargo build --release --locked -p conary$' 'RPM spec must preserve non-debug Fedora Rust flags without overriding the workspace release profile'
+require_literal_count "$rpm_spec" '%set_build_flags' 1 'RPM spec manual build-flag macro invocation'
 forbid_match "$rpm_spec" '-Cdebuginfo(=|[[:space:]])|-Cstrip=none|%\{build_rustflags\}' 'RPM spec debug-oriented Rust flag override'
 require_match "$arch_pkgbuild" '# Suite releases publish one installable package and no discarded debug split package\.[\s\S]*^options=\(!debug !lto\)$' 'Arch package must explicitly disable debug split-package generation'
 forbid_match "$release_build" '\*debug(source|info)?\*' 'native debug artifact filtering'

--- a/scripts/test-release-matrix.sh
+++ b/scripts/test-release-matrix.sh
@@ -808,6 +808,30 @@ test_check_release_matrix_rejects_rpm_debug_subpackage_generation() {
     assert_check_release_matrix_fails "$repo" "RPM spec must explain and disable debug subpackage generation"
 }
 
+test_check_release_matrix_rejects_automatic_rpm_rust_flags() {
+    local repo
+    repo="$(create_release_policy_fixture)"
+    replace_fixture_text_once \
+        "$repo/packaging/rpm/conary.spec" \
+        '%undefine _auto_set_build_flags' \
+        '%global _auto_set_build_flags 1'
+
+    assert_check_release_matrix_fails \
+        "$repo" \
+        "RPM spec must preserve non-debug Fedora Rust flags without overriding the workspace release profile"
+}
+
+test_check_release_matrix_rejects_rpm_debug_rust_flags() {
+    local repo
+    repo="$(create_release_policy_fixture)"
+    replace_fixture_text_once \
+        "$repo/packaging/rpm/conary.spec" \
+        'echo "Conary effective RUSTFLAGS: $RUSTFLAGS"' \
+        $'RUSTFLAGS="$RUSTFLAGS -Cdebuginfo=2"\necho "Conary effective RUSTFLAGS: $RUSTFLAGS"'
+
+    assert_check_release_matrix_fails "$repo" "RPM spec debug-oriented Rust flag override"
+}
+
 test_check_release_matrix_rejects_arch_debug_split_package_generation() {
     local repo
     repo="$(create_release_policy_fixture)"
@@ -1346,6 +1370,8 @@ main() {
         test_check_release_matrix_rejects_unpinned_deb_builder_image
         test_check_release_matrix_rejects_unpinned_arch_builder_image
         test_check_release_matrix_rejects_rpm_debug_subpackage_generation
+        test_check_release_matrix_rejects_automatic_rpm_rust_flags
+        test_check_release_matrix_rejects_rpm_debug_rust_flags
         test_check_release_matrix_rejects_arch_debug_split_package_generation
         test_check_release_matrix_rejects_hidden_native_debug_outputs
         test_check_release_matrix_rejects_unverified_rustup_init

--- a/scripts/test-release-matrix.sh
+++ b/scripts/test-release-matrix.sh
@@ -285,6 +285,7 @@ create_release_policy_fixture() {
     cp "$REPO_ROOT/packaging/rpm/conary.spec" "$repo/packaging/rpm/conary.spec"
     cp "$REPO_ROOT/packaging/deb/Containerfile.build" "$repo/packaging/deb/Containerfile.build"
     cp "$REPO_ROOT/packaging/arch/Containerfile.build" "$repo/packaging/arch/Containerfile.build"
+    cp "$REPO_ROOT/packaging/arch/PKGBUILD" "$repo/packaging/arch/PKGBUILD"
     cp "$REPO_ROOT/packaging/rpm/build.sh" "$repo/packaging/rpm/build.sh"
     cp "$REPO_ROOT/packaging/deb/build.sh" "$repo/packaging/deb/build.sh"
     cp "$REPO_ROOT/packaging/arch/build.sh" "$repo/packaging/arch/build.sh"
@@ -796,6 +797,39 @@ test_check_release_matrix_rejects_unpinned_arch_builder_image() {
     assert_check_release_matrix_fails "$repo" "release-build Arch builder must use the pinned Arch image"
 }
 
+test_check_release_matrix_rejects_rpm_debug_subpackage_generation() {
+    local repo
+    repo="$(create_release_policy_fixture)"
+    replace_fixture_text_once \
+        "$repo/packaging/rpm/conary.spec" \
+        '%global debug_package %{nil}' \
+        '%global debug_package 1'
+
+    assert_check_release_matrix_fails "$repo" "RPM spec must explain and disable debug subpackage generation"
+}
+
+test_check_release_matrix_rejects_arch_debug_split_package_generation() {
+    local repo
+    repo="$(create_release_policy_fixture)"
+    replace_fixture_text_once \
+        "$repo/packaging/arch/PKGBUILD" \
+        'options=(!debug !lto)' \
+        'options=(debug !lto)'
+
+    assert_check_release_matrix_fails "$repo" "Arch package must explicitly disable debug split-package generation"
+}
+
+test_check_release_matrix_rejects_hidden_native_debug_outputs() {
+    local repo
+    repo="$(create_release_policy_fixture)"
+    replace_fixture_text_once \
+        "$repo/.github/workflows/release-build.yml" \
+        '          path: packaging/rpm/output/*.rpm' \
+        $'          path: |\n            packaging/rpm/output/*.rpm\n            !packaging/rpm/output/*debug*'
+
+    assert_check_release_matrix_fails "$repo" "native debug artifact filtering"
+}
+
 test_check_release_matrix_rejects_unverified_rustup_init() {
     local repo
     repo="$(create_release_policy_fixture)"
@@ -1159,6 +1193,28 @@ test_check_release_matrix_rejects_stale_native_output_policy() {
     assert_check_release_matrix_fails "$repo" "RPM build must clean stale package output"
 }
 
+test_check_release_matrix_rejects_rpm_extra_output_blind_spot() {
+    local repo
+    repo="$(create_release_policy_fixture)"
+    replace_fixture_text_once \
+        "$repo/packaging/rpm/build.sh" \
+        'rpm_outputs=("$OUTPUT"/*.rpm)' \
+        'rpm_outputs=("$OUTPUT/$NAME-$VERSION-"*.x86_64.rpm)'
+
+    assert_check_release_matrix_fails "$repo" "RPM build must reject every extra package output"
+}
+
+test_check_release_matrix_rejects_arch_extra_output_blind_spot() {
+    local repo
+    repo="$(create_release_policy_fixture)"
+    replace_fixture_text_once \
+        "$repo/packaging/arch/build.sh" \
+        'package_outputs=("$OUTPUT"/*.pkg.tar.zst)' \
+        'package_outputs=("$EXPECTED_PACKAGE")'
+
+    assert_check_release_matrix_fails "$repo" "Arch build must reject every extra package output"
+}
+
 test_check_release_matrix_rejects_direct_release_publication() {
     local repo
     repo="$(create_release_policy_fixture)"
@@ -1289,6 +1345,9 @@ main() {
         test_check_release_matrix_rejects_unpinned_rpm_builder_image
         test_check_release_matrix_rejects_unpinned_deb_builder_image
         test_check_release_matrix_rejects_unpinned_arch_builder_image
+        test_check_release_matrix_rejects_rpm_debug_subpackage_generation
+        test_check_release_matrix_rejects_arch_debug_split_package_generation
+        test_check_release_matrix_rejects_hidden_native_debug_outputs
         test_check_release_matrix_rejects_unverified_rustup_init
         test_check_release_matrix_rejects_unpinned_ccs_toolchain
         test_check_release_matrix_rejects_unpinned_arch_toolchain
@@ -1318,6 +1377,8 @@ main() {
         test_check_release_matrix_rejects_unstable_ccs_release_name
         test_check_release_matrix_rejects_ambiguous_ccs_target_directory
         test_check_release_matrix_rejects_stale_native_output_policy
+        test_check_release_matrix_rejects_rpm_extra_output_blind_spot
+        test_check_release_matrix_rejects_arch_extra_output_blind_spot
         test_check_release_matrix_rejects_direct_release_publication
         test_check_release_matrix_rejects_moved_tag_publication
         test_check_release_matrix_rejects_mutable_publication_result

--- a/scripts/test-release-matrix.sh
+++ b/scripts/test-release-matrix.sh
@@ -832,6 +832,19 @@ test_check_release_matrix_rejects_rpm_debug_rust_flags() {
     assert_check_release_matrix_fails "$repo" "RPM spec debug-oriented Rust flag override"
 }
 
+test_check_release_matrix_rejects_rpm_macro_expansion_in_comment() {
+    local repo
+    repo="$(create_release_policy_fixture)"
+    replace_fixture_text_once \
+        "$repo/packaging/rpm/conary.spec" \
+        '# the manual distro macro below populates native dependency toolchain flags.' \
+        '# %set_build_flags populates native dependency toolchain flags.'
+
+    assert_check_release_matrix_fails \
+        "$repo" \
+        "RPM spec manual build-flag macro invocation expected 1 occurrences"
+}
+
 test_check_release_matrix_rejects_arch_debug_split_package_generation() {
     local repo
     repo="$(create_release_policy_fixture)"
@@ -1372,6 +1385,7 @@ main() {
         test_check_release_matrix_rejects_rpm_debug_subpackage_generation
         test_check_release_matrix_rejects_automatic_rpm_rust_flags
         test_check_release_matrix_rejects_rpm_debug_rust_flags
+        test_check_release_matrix_rejects_rpm_macro_expansion_in_comment
         test_check_release_matrix_rejects_arch_debug_split_package_generation
         test_check_release_matrix_rejects_hidden_native_debug_outputs
         test_check_release_matrix_rejects_unverified_rustup_init


### PR DESCRIPTION
## Problem

Fedora and Arch packaging defaults generated debug split packages that the suite immediately filtered out. On v0.15.0, RPM spent another 4m37s after writing the main package before the discarded debuginfo RPM finished; Fedora's injected debug flags also stretched the Cargo build itself.

## Summary

- explicitly disable Fedora debuginfo/debugsource generation with the documented RPM macro and an in-spec reason
- explicitly disable Arch's default debug split package
- opt out of Fedora's automatic debug-oriented Rust flags, retain its frame-pointer and RPM package-note flags, and leave release codegen/stripping to the workspace Cargo profile
- remove every workflow exclusion that hid debug outputs
- require each native build wrapper to see exactly one complete expected output
- add static policy, focused Rust coverage, and negative mutations for the hard cut and RPM macro placement

## Verification

- `git diff --check`
- `bash -n packaging/rpm/build.sh packaging/arch/build.sh scripts/check-release-matrix.sh scripts/test-release-matrix.sh`
- `bash scripts/check-release-matrix.sh`
- `bash scripts/test-release-matrix.sh`
- `cargo test -p conary --test packaged_onboarding` — 4 passed
- `cargo fmt --check`
- `bash scripts/check-doc-truth.sh`
- exact-head PR gate — 20/20 passed

## Exact integration proof

No-publication release rehearsal [31777222298](https://github.com/ConaryLabs/Conary/actions/runs/31777222298) completed 11/11 successfully on exact head `1bfeb71a45ce51b2c5f9a5ade22f35f83a60e736`.

RPM:

- effective Conary flags were exactly `-Cforce-frame-pointers=yes -Clink-arg=-specs=/usr/lib/rpm/redhat/redhat-package-notes`; neither `-Cdebuginfo=2` nor `-Cstrip=none` remained
- Cargo finished in 14m13s, down 17m46s (55.5%) from v0.15.0 and 18m12s (56.1%) from the first debug-disabled rehearsal
- the complete RPM package step finished in 15m08s, down 23m40s (61.0%) from v0.15.0 and 18m27s (54.9%) from the first rehearsal
- RPM processed and wrote exactly `conary-0.15.1-1.fc44.x86_64.rpm`; there was no debuginfo or debugsource processing/write
- downloaded artifact SHA-256: `f0e904185632b52bd5efa8f259e84e0acbf410c534806a80a87c3b6f24a3e3`
- the RPM contained 13 expected payload entries and zero debug-named entries; `/usr/bin/conary` was 48,278,288 bytes, 7,461,088 bytes (13.4%) smaller than the first rehearsal's debug-flagged binary

Arch:

- Cargo finished in 13m05s and the complete package step finished in 13m56s, down from 24m00s on v0.15.0
- makepkg created exactly `conary-0.15.1-1-x86_64.pkg.tar.zst`; `.PKGINFO` names only `pkgname = conary`, version `0.15.1-1`, architecture `x86_64`
- downloaded artifact SHA-256: `f9d512726daa2893d50a24913669f9836d5f043211cb63f01fa27d6bfad4ded6`

The rehearsal was typed as a dry run and could not publish or deploy.

Closes #431
