### PR TITLE
perf(generation): benchmark selected-root delta scaling

### DIFF
--- a/crates/conary-core/Cargo.toml
+++ b/crates/conary-core/Cargo.toml
@@ -163,3 +163,7 @@ criterion.workspace = true
 name = "erofs_build"
 harness = false
 required-features = ["composefs-rs"]
+
+[[bench]]
+name = "selected_root_delta"
+harness = false

--- a/crates/conary-core/benches/selected_root_delta.rs
+++ b/crates/conary-core/benches/selected_root_delta.rs
@@ -1,0 +1,126 @@
+// conary-core/benches/selected_root_delta.rs
+
+//! Installed-path scaling for the selected-root transaction commit boundary.
+
+use std::collections::BTreeMap;
+use std::hint::black_box;
+use std::time::Duration;
+
+use conary_core::generation::root_manifest::{
+    CapturedSelectedRoot, GENERATION_ROOT_MANIFEST_VERSION, GenerationRootEntry,
+    GenerationRootManifest, MutableStateManifest, SELECTED_ROOT_MANIFEST_DELTA_VERSION,
+    SelectedRootManifestDelta,
+};
+use conary_core::payload::{
+    PayloadContentAuthority, PayloadIdentity, PayloadNode, PayloadNodeKind, PayloadTimestamp,
+    ResolvedPayloadNode,
+};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+
+const INSTALLED_FILE_COUNTS: [usize; 3] = [1_000, 10_000, 100_000];
+
+fn node(kind: PayloadNodeKind, permissions: u32) -> ResolvedPayloadNode {
+    let mode_type = match kind {
+        PayloadNodeKind::Regular { .. } | PayloadNodeKind::Hardlink { .. } => libc::S_IFREG,
+        PayloadNodeKind::Directory => libc::S_IFDIR,
+        PayloadNodeKind::Symlink { .. } => libc::S_IFLNK,
+        PayloadNodeKind::BlockDevice { .. } => libc::S_IFBLK,
+        PayloadNodeKind::CharacterDevice { .. } => libc::S_IFCHR,
+        PayloadNodeKind::Fifo => libc::S_IFIFO,
+        PayloadNodeKind::Socket => libc::S_IFSOCK,
+    };
+    ResolvedPayloadNode {
+        source: PayloadNode {
+            kind,
+            mode: mode_type | permissions,
+            user: PayloadIdentity::Numeric { id: 0 },
+            group: PayloadIdentity::Numeric { id: 0 },
+            mtime: PayloadTimestamp::UNIX_EPOCH,
+            xattrs: BTreeMap::new(),
+        },
+        uid: 0,
+        gid: 0,
+    }
+}
+
+fn directory_entry(path: &str) -> GenerationRootEntry {
+    GenerationRootEntry {
+        path: path.to_string(),
+        node: node(PayloadNodeKind::Directory, 0o755),
+        content: None,
+    }
+}
+
+fn regular_entry(path: String, content_identity: usize) -> GenerationRootEntry {
+    GenerationRootEntry {
+        path,
+        node: node(
+            PayloadNodeKind::Regular {
+                hardlink_identity: None,
+            },
+            0o644,
+        ),
+        content: Some(PayloadContentAuthority {
+            sha256: format!("{content_identity:064x}"),
+            size: 4096,
+        }),
+    }
+}
+
+fn prior_with_installed_files(installed_files: usize) -> CapturedSelectedRoot {
+    let mut entries = vec![directory_entry("/usr"), directory_entry("/usr/lib")];
+    entries.extend(
+        (0..installed_files)
+            .map(|index| regular_entry(format!("/usr/lib/lib{index:06}.so"), index)),
+    );
+    let prior = CapturedSelectedRoot {
+        generation: GenerationRootManifest {
+            version: GENERATION_ROOT_MANIFEST_VERSION,
+            root: node(PayloadNodeKind::Directory, 0o755),
+            entries,
+        },
+        state: MutableStateManifest::empty(),
+    };
+    prior.generation.validate().unwrap();
+    prior.state.validate().unwrap();
+    prior
+}
+
+fn fixed_one_path_upsert() -> SelectedRootManifestDelta {
+    SelectedRootManifestDelta {
+        version: SELECTED_ROOT_MANIFEST_DELTA_VERSION,
+        root: None,
+        removals: Vec::new(),
+        opaque_directories: Vec::new(),
+        upserts: vec![regular_entry(
+            "/usr/lib/lib000000.so".to_string(),
+            usize::MAX,
+        )],
+    }
+}
+
+fn benchmark_installed_path_scaling(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("selected_root_delta/fixed_one_path_upsert");
+    group.sample_size(20);
+    group.warm_up_time(Duration::from_secs(2));
+    group.measurement_time(Duration::from_secs(8));
+
+    for installed_files in INSTALLED_FILE_COUNTS {
+        let prior = prior_with_installed_files(installed_files);
+        let delta = fixed_one_path_upsert();
+        delta.validate().unwrap();
+        delta.apply(&prior).unwrap();
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(installed_files),
+            &installed_files,
+            |bencher, _| {
+                bencher.iter(|| black_box(delta.apply(black_box(&prior)).unwrap()));
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_installed_path_scaling);
+criterion_main!(benches);


### PR DESCRIPTION
## Problem

#403 had completed its filesystem-level selected-root hard cut but still lacked the required installed-path scaling measurement. Without a pinned series, the remaining commit-boundary cost could not be distinguished from the eliminated full-root scan.

## Summary

- add a dedicated Criterion benchmark for `SelectedRootManifestDelta::apply`
- hold the transaction change set at exactly one immutable-file upsert
- scale valid prior authority across 1,000, 10,000, and 100,000 installed files
- construct and validate fixtures outside the timed region while retaining actual delta validation, prior validation, authority reconstruction, and result validation inside it
- change no runtime behavior, correctness rule, persisted format, or public API

## Measured result

Command:

```text
CARGO_TERM_COLOR=never taskset -c 2 cargo bench -p conary-core --bench selected_root_delta -- --noplot
```

Conditions: commit `845275a84b0fbc6f6755421875ac1f8151f349cc`; Intel Core i7-8700; one pinned logical CPU; 62 GiB RAM; Linux 7.1.6-arch1-1; rustc 1.97.1; `intel_pstate` with the `powersave` governor; pre-run load 0.78/1.51/0.95 and post-run load 0.88/1.45/0.95; 20 Criterion samples after a two-second warmup for each input.

| Prior installed files | One-path apply latency |
| ---: | ---: |
| 1,000 | 1.0150–1.0208 ms |
| 10,000 | 12.862–13.070 ms |
| 100,000 | 122.79–123.48 ms |

The fixed change took about 12.72x longer from 1k to 10k and 9.52x longer from 10k to 100k; the 100x path increase produced about 121x latency. The benchmark therefore exposed residual complete-manifest reconstruction and validation. That architectural finding is filed separately as #433, as required by #121; this PR does not optimize it opportunistically.

## Verification

- `git diff --check`
- `cargo fmt --check`
- `cargo clippy -p conary-core --bench selected_root_delta -- -D warnings`
- `cargo test -p conary-core root_manifest::delta` — 6 passed
- `cargo bench -p conary-core --bench selected_root_delta --no-run`
- measured command above — all three series completed

Refs #403
Refs #121
Refs #433
