### PR TITLE
perf(generation): add typed database snapshots

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ resolvo = { path = "third_party/resolvo-0.12.0-patched" }
 sequoia-openpgp = { version = "2", default-features = false, features = ["crypto-rust", "allow-experimental-crypto", "allow-variable-time-crypto"] }
 
 # Database
-rusqlite = { version = "0.40", features = ["bundled", "limits"] }
+rusqlite = { version = "0.40", features = ["backup", "bundled", "limits"] }
 liblzma = "0.4"
 zip = { version = "8.4.0", default-features = false, features = ["deflate-flate2-zlib-rs"] }
 

--- a/apps/conary/src/commands/generation/commands.rs
+++ b/apps/conary/src/commands/generation/commands.rs
@@ -511,22 +511,55 @@ pub fn cmd_generation_verify_db_backup(
     let current_root = current.then_some(runtime_root.root());
     let verification =
         conary_core::db::backup::verify_generation_db_backup(&gen_dir, current_root)?;
-    println!(
-        "Verified generation {} DB backup: {}",
-        verification.generation_number,
-        verification.backup_path.display()
+    crate::ui::status(
+        "Verified",
+        &format!(
+            "generation {} database backup",
+            verification.generation_number
+        ),
     );
-    println!(
-        "  schema={} integrity={} pages={}",
-        verification.db_schema_version,
-        verification.integrity_check,
-        verification
+    crate::ui::field("Backup", &verification.backup_path.display().to_string());
+    crate::ui::field(
+        "Manifest",
+        &verification.manifest_path.display().to_string(),
+    );
+    crate::ui::field("Schema", &verification.db_schema_version.to_string());
+    crate::ui::field("Integrity", &verification.integrity_check);
+    crate::ui::field(
+        "SQLite pages",
+        &verification
             .sqlite_page_count
             .map(|pages| pages.to_string())
-            .unwrap_or_else(|| "unknown".to_string())
+            .unwrap_or_else(|| "unknown".to_string()),
     );
-    println!("  manifest={}", verification.manifest_path.display());
-    println!("  sha256={}", verification.backup_sha256);
+    crate::ui::field(
+        "Transaction high-water mark",
+        &verification
+            .transaction_high_water_mark
+            .map(|changeset| changeset.to_string())
+            .unwrap_or_else(|| "none".to_string()),
+    );
+    crate::ui::field("Snapshot method", verification.snapshot.method.as_str());
+    crate::ui::field(
+        "Snapshot payload bytes written",
+        &verification.snapshot.payload_bytes_written.to_string(),
+    );
+    let fallbacks = verification
+        .snapshot
+        .fallbacks
+        .iter()
+        .map(|fallback| format!("{}:{}", fallback.method.as_str(), fallback.reason.as_str()))
+        .collect::<Vec<_>>()
+        .join(",");
+    crate::ui::field(
+        "Snapshot fallbacks",
+        if fallbacks.is_empty() {
+            "none"
+        } else {
+            &fallbacks
+        },
+    );
+    crate::ui::field("SHA-256", &verification.backup_sha256);
     Ok(())
 }
 

--- a/apps/conary/src/commands/generation/publication.rs
+++ b/apps/conary/src/commands/generation/publication.rs
@@ -284,6 +284,7 @@ fn replay_publication(
                 )?;
                 checkpoint(PublicationReplayCheckpoint::ActiveStateMarkedBeforeDatabaseBackup)?;
                 conary_core::db::backup::create_generation_db_backup(
+                    conn,
                     db_path,
                     runtime_root.generation_path(built.generation_number),
                     built.generation_number,
@@ -296,7 +297,7 @@ fn replay_publication(
                     GenerationPublicationPhase::DatabaseBackedUp,
                     Some(built),
                 )?;
-                phase = GenerationPublicationPhase::DatabaseBackedUp;
+                return Ok(*built);
             }
             GenerationPublicationPhase::DatabaseBackedUp => {
                 let built = required_publication_numbers(built.as_ref(), phase)?;

--- a/crates/conary-core/Cargo.toml
+++ b/crates/conary-core/Cargo.toml
@@ -167,3 +167,7 @@ required-features = ["composefs-rs"]
 [[bench]]
 name = "selected_root_delta"
 harness = false
+
+[[bench]]
+name = "generation_db_snapshot"
+harness = false

--- a/crates/conary-core/benches/generation_db_snapshot.rs
+++ b/crates/conary-core/benches/generation_db_snapshot.rs
@@ -1,0 +1,128 @@
+// conary-core/benches/generation_db_snapshot.rs
+
+//! Generation database snapshot scaling against accumulated SQLite history.
+
+use conary_core::db::generation_snapshot::GenerationDbSnapshotProvider;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use rusqlite::Connection;
+use sha2::{Digest, Sha256};
+use std::hint::black_box;
+use std::io::{BufReader, Read};
+use std::path::Path;
+use std::time::Duration;
+
+const HISTORY_ROWS: [usize; 3] = [0, 10_000, 100_000];
+
+fn history_database(rows: usize) -> (tempfile::TempDir, std::path::PathBuf, Connection) {
+    let temp = tempfile::tempdir().unwrap();
+    let db_path = temp.path().join("conary-history.sqlite");
+    let mut conn = Connection::open(&db_path).unwrap();
+    conn.execute_batch(
+        "PRAGMA journal_mode=WAL;
+         PRAGMA synchronous=NORMAL;
+         CREATE TABLE generation_history (
+             id INTEGER PRIMARY KEY,
+             generation_number INTEGER NOT NULL,
+             summary TEXT NOT NULL,
+             authority BLOB NOT NULL
+         );",
+    )
+    .unwrap();
+    let transaction = conn.transaction().unwrap();
+    {
+        let mut insert = transaction
+            .prepare(
+                "INSERT INTO generation_history (generation_number, summary, authority)
+                 VALUES (?1, ?2, ?3)",
+            )
+            .unwrap();
+        for row in 0..rows {
+            let summary = format!("generation history row {row:08}");
+            let authority = format!("{row:064x}{:064x}", rows.saturating_sub(row));
+            insert
+                .execute((row as i64, summary, authority.as_bytes()))
+                .unwrap();
+        }
+    }
+    transaction.commit().unwrap();
+    (temp, db_path, conn)
+}
+
+fn sha256_file(path: &Path) -> String {
+    let file = std::fs::File::open(path).unwrap();
+    let mut reader = BufReader::new(file);
+    let mut digest = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = reader.read(&mut buffer).unwrap();
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+    }
+    hex::encode(digest.finalize())
+}
+
+fn benchmark_snapshot_history_scaling(criterion: &mut Criterion) {
+    let mut provider_group = criterion.benchmark_group("generation_db_snapshot/provider");
+    provider_group.sample_size(20);
+    provider_group.warm_up_time(Duration::from_secs(2));
+    provider_group.measurement_time(Duration::from_secs(6));
+
+    for history_rows in HISTORY_ROWS {
+        let (_temp, db_path, conn) = history_database(history_rows);
+        let destination = db_path.with_file_name("provider-snapshot.sqlite");
+        let probe = GenerationDbSnapshotProvider::default()
+            .snapshot(&conn, &db_path, &destination)
+            .unwrap();
+        let method = probe.provenance.method.as_str().to_string();
+        std::fs::remove_file(&destination).unwrap();
+
+        provider_group.bench_with_input(
+            BenchmarkId::new(method, history_rows),
+            &history_rows,
+            |bencher, _| {
+                bencher.iter(|| {
+                    let snapshot = GenerationDbSnapshotProvider::default()
+                        .snapshot(black_box(&conn), black_box(&db_path), &destination)
+                        .unwrap();
+                    black_box(snapshot.provenance);
+                });
+            },
+        );
+    }
+    provider_group.finish();
+
+    let mut identity_group =
+        criterion.benchmark_group("generation_db_snapshot/provider_plus_sha256");
+    identity_group.sample_size(20);
+    identity_group.warm_up_time(Duration::from_secs(2));
+    identity_group.measurement_time(Duration::from_secs(6));
+
+    for history_rows in HISTORY_ROWS {
+        let (_temp, db_path, conn) = history_database(history_rows);
+        let destination = db_path.with_file_name("identified-snapshot.sqlite");
+        let probe = GenerationDbSnapshotProvider::default()
+            .snapshot(&conn, &db_path, &destination)
+            .unwrap();
+        let method = probe.provenance.method.as_str().to_string();
+        std::fs::remove_file(&destination).unwrap();
+
+        identity_group.bench_with_input(
+            BenchmarkId::new(method, history_rows),
+            &history_rows,
+            |bencher, _| {
+                bencher.iter(|| {
+                    let snapshot = GenerationDbSnapshotProvider::default()
+                        .snapshot(black_box(&conn), black_box(&db_path), &destination)
+                        .unwrap();
+                    black_box(sha256_file(&snapshot.path));
+                });
+            },
+        );
+    }
+    identity_group.finish();
+}
+
+criterion_group!(benches, benchmark_snapshot_history_scaling);
+criterion_main!(benches);

--- a/crates/conary-core/src/db/backup.rs
+++ b/crates/conary-core/src/db/backup.rs
@@ -2,6 +2,9 @@
 
 //! Durable SQLite checkpoint backups for Conary live-state recovery.
 
+use crate::db::generation_snapshot::{
+    GenerationDbSnapshotMetrics, GenerationDbSnapshotProvenance, GenerationDbSnapshotProvider,
+};
 use crate::db::schema;
 use crate::filesystem::durable::{sync_parent_directory, write_file_atomic, write_json_atomic};
 use crate::hash::sha256_reader_hex;
@@ -15,8 +18,9 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 
 const BACKUP_FORMAT: &str = "conary.db-checkpoint.v1";
-const GENERATION_BACKUP_FORMAT: &str = "conary.generation-db-backup.v1";
-const MANIFEST_VERSION: u32 = 1;
+const GENERATION_BACKUP_FORMAT: &str = "conary.generation-db-backup.v2";
+const CHECKPOINT_MANIFEST_VERSION: u32 = 1;
+const GENERATION_MANIFEST_VERSION: u32 = 2;
 const DEFAULT_RETAIN_COUNT: usize = 5;
 const DEFAULT_RETAIN_DAYS: i64 = 14;
 const GENERATION_BACKUP_FILE: &str = "conary.db.backup";
@@ -70,6 +74,7 @@ pub struct BackupVerification {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GenerationDbBackupManifest {
     pub format: String,
     pub manifest_version: u32,
@@ -81,6 +86,8 @@ pub struct GenerationDbBackupManifest {
     pub compression: Option<String>,
     pub backup_sha256: String,
     pub sqlite_page_count: Option<i64>,
+    pub transaction_high_water_mark: Option<i64>,
+    pub snapshot: GenerationDbSnapshotProvenance,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -89,6 +96,7 @@ pub struct GenerationDbBackupRecord {
     pub checksum_path: PathBuf,
     pub manifest_path: PathBuf,
     pub manifest: GenerationDbBackupManifest,
+    pub creation_metrics: Option<GenerationDbSnapshotMetrics>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -101,6 +109,8 @@ pub struct GenerationDbBackupVerification {
     pub integrity_check: String,
     pub backup_sha256: String,
     pub sqlite_page_count: Option<i64>,
+    pub transaction_high_water_mark: Option<i64>,
+    pub snapshot: GenerationDbSnapshotProvenance,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -189,7 +199,7 @@ pub fn create_checkpoint(
     let backup_sha256 = sha256_file(&backup_path)?;
     let manifest = DbBackupManifest {
         format: BACKUP_FORMAT.to_string(),
-        manifest_version: MANIFEST_VERSION,
+        manifest_version: CHECKPOINT_MANIFEST_VERSION,
         created_at: now.to_rfc3339(),
         source_db_path: db_path.to_path_buf(),
         backup_file: backup_path
@@ -266,7 +276,7 @@ pub fn verify_backup(record: &DbBackupRecord) -> Result<BackupVerification> {
             record.manifest.format
         )));
     }
-    if record.manifest.manifest_version != MANIFEST_VERSION {
+    if record.manifest.manifest_version != CHECKPOINT_MANIFEST_VERSION {
         return Err(Error::RecoveryFailed(format!(
             "unsupported DB backup manifest version: {}",
             record.manifest.manifest_version
@@ -372,6 +382,7 @@ pub fn recover_latest(
 }
 
 pub fn create_generation_db_backup(
+    source: &Connection,
     db_path: impl AsRef<Path>,
     generation_dir: impl AsRef<Path>,
     generation_number: i64,
@@ -391,10 +402,13 @@ pub fn create_generation_db_backup(
     let manifest_path = state_dir.join(GENERATION_BACKUP_MANIFEST_FILE);
 
     remove_if_exists(&tmp_backup_path)?;
-    let source = Connection::open(db_path)?;
-    let tmp_backup_string = tmp_backup_path.to_string_lossy().into_owned();
-    source.execute("VACUUM main INTO ?1", [tmp_backup_string.as_str()])?;
-    sync_file(&tmp_backup_path)?;
+    let transaction_high_water_mark =
+        crate::db::models::GenerationPublication::applied_high_water_changeset_id(source)?;
+    validate_generation_directory_number(generation_dir, generation_number)?;
+    verify_generation_artifact_identity(generation_dir, generation_number)?;
+
+    let snapshot =
+        GenerationDbSnapshotProvider::default().snapshot(source, db_path, &tmp_backup_path)?;
     std::fs::rename(&tmp_backup_path, &backup_path)?;
     sync_parent_directory(&backup_path)?;
 
@@ -406,10 +420,12 @@ pub fn create_generation_db_backup(
             schema::SCHEMA_VERSION
         )));
     }
+    verify_generation_publication_state_values(generation_number, state_number, &backup_path)?;
+    verify_transaction_high_water_mark(transaction_high_water_mark, &backup_path)?;
 
     let manifest = GenerationDbBackupManifest {
         format: GENERATION_BACKUP_FORMAT.to_string(),
-        manifest_version: MANIFEST_VERSION,
+        manifest_version: GENERATION_MANIFEST_VERSION,
         db_schema_version: verification.db_schema_version,
         generation_number,
         state_number,
@@ -418,6 +434,8 @@ pub fn create_generation_db_backup(
         compression: None,
         backup_sha256: verification.backup_sha256.clone(),
         sqlite_page_count: verification.sqlite_page_count,
+        transaction_high_water_mark,
+        snapshot: snapshot.provenance,
     };
 
     write_file_atomic(
@@ -431,8 +449,18 @@ pub fn create_generation_db_backup(
         checksum_path,
         manifest_path,
         manifest,
+        creation_metrics: Some(snapshot.metrics),
     };
-    verify_generation_db_backup_record(&record, None)?;
+    tracing::info!(
+        snapshot_method = record.manifest.snapshot.method.as_str(),
+        payload_bytes_written = record.manifest.snapshot.payload_bytes_written,
+        logical_size = record.manifest.snapshot.logical_size,
+        provider_elapsed_ns = record
+            .creation_metrics
+            .map(|metrics| metrics.provider_elapsed_ns)
+            .unwrap_or_default(),
+        "Created generation database snapshot"
+    );
     Ok(record)
 }
 
@@ -575,7 +603,16 @@ fn read_record_from_manifest(path: &Path) -> Result<DbBackupRecord> {
 }
 
 fn verify_sqlite_database(path: &Path) -> Result<BackupVerification> {
+    let conn = open_immutable_sqlite_snapshot(path)?;
+    verify_sqlite_connection(path, &conn)
+}
+
+fn verify_live_sqlite_database(path: &Path) -> Result<BackupVerification> {
     let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    verify_sqlite_connection(path, &conn)
+}
+
+fn verify_sqlite_connection(path: &Path, conn: &Connection) -> Result<BackupVerification> {
     let integrity_check: String = conn.query_row("PRAGMA integrity_check", [], |row| row.get(0))?;
     if integrity_check != "ok" {
         return Err(Error::RecoveryFailed(format!(
@@ -596,6 +633,24 @@ fn verify_sqlite_database(path: &Path) -> Result<BackupVerification> {
     })
 }
 
+fn open_immutable_sqlite_snapshot(path: &Path) -> Result<Connection> {
+    let canonical = path.canonicalize()?;
+    let mut uri = url::Url::from_file_path(&canonical).map_err(|_| {
+        Error::InvalidPath(format!(
+            "SQLite snapshot path cannot be represented as a file URI: {}",
+            canonical.display()
+        ))
+    })?;
+    uri.query_pairs_mut().append_pair("immutable", "1");
+    Connection::open_with_flags(
+        uri.as_str(),
+        OpenFlags::SQLITE_OPEN_READ_ONLY
+            | OpenFlags::SQLITE_OPEN_NO_MUTEX
+            | OpenFlags::SQLITE_OPEN_URI,
+    )
+    .map_err(Into::into)
+}
+
 fn generation_state_backup_dir(generation_dir: &Path) -> PathBuf {
     generation_dir.join("state")
 }
@@ -613,6 +668,7 @@ fn read_generation_record(generation_dir: &Path) -> Result<GenerationDbBackupRec
         checksum_path,
         manifest_path,
         manifest,
+        creation_metrics: None,
     })
 }
 
@@ -632,7 +688,7 @@ fn verify_generation_db_backup_record(
             record.manifest.format
         )));
     }
-    if record.manifest.manifest_version != MANIFEST_VERSION {
+    if record.manifest.manifest_version != GENERATION_MANIFEST_VERSION {
         return Err(Error::RecoveryFailed(format!(
             "unsupported generation DB backup manifest version: {}",
             record.manifest.manifest_version
@@ -644,6 +700,7 @@ fn verify_generation_db_backup_record(
                 .to_string(),
         ));
     }
+    record.manifest.snapshot.validate()?;
     if record.manifest.backup_file != GENERATION_BACKUP_FILE {
         return Err(Error::InvalidPath(format!(
             "generation DB backup file must be {GENERATION_BACKUP_FILE}, got {}",
@@ -652,14 +709,7 @@ fn verify_generation_db_backup_record(
     }
     validate_generation_directory_number(generation_dir, record.manifest.generation_number)?;
 
-    let artifact =
-        crate::generation::artifact::load_generation_artifact_for_activation(generation_dir)?;
-    if artifact.generation != record.manifest.generation_number {
-        return Err(Error::RecoveryFailed(format!(
-            "generation artifact mismatch: backup is for generation {}, artifact declares {}",
-            record.manifest.generation_number, artifact.generation
-        )));
-    }
+    verify_generation_artifact_identity(generation_dir, record.manifest.generation_number)?;
     if let Some(root) = current_root {
         let selected = crate::generation::mount::current_generation(root)?;
         if selected != Some(record.manifest.generation_number) {
@@ -700,6 +750,10 @@ fn verify_generation_db_backup_record(
         )));
     }
     verify_generation_publication_state(&record.manifest, &record.backup_path)?;
+    verify_transaction_high_water_mark(
+        record.manifest.transaction_high_water_mark,
+        &record.backup_path,
+    )?;
 
     Ok(GenerationDbBackupVerification {
         backup_path: record.backup_path.clone(),
@@ -710,7 +764,24 @@ fn verify_generation_db_backup_record(
         integrity_check: verification.integrity_check,
         backup_sha256: record.manifest.backup_sha256.clone(),
         sqlite_page_count: verification.sqlite_page_count,
+        transaction_high_water_mark: record.manifest.transaction_high_water_mark,
+        snapshot: record.manifest.snapshot.clone(),
     })
+}
+
+fn verify_generation_artifact_identity(
+    generation_dir: &Path,
+    generation_number: i64,
+) -> Result<()> {
+    let artifact =
+        crate::generation::artifact::load_generation_artifact_for_activation(generation_dir)?;
+    if artifact.generation != generation_number {
+        return Err(Error::RecoveryFailed(format!(
+            "generation artifact mismatch: backup is for generation {generation_number}, artifact declares {}",
+            artifact.generation
+        )));
+    }
+    Ok(())
 }
 
 fn validate_generation_backup_file_name(file_name: &str) -> Result<&Path> {
@@ -765,20 +836,32 @@ fn verify_generation_publication_state(
     manifest: &GenerationDbBackupManifest,
     backup_path: &Path,
 ) -> Result<()> {
-    let conn = Connection::open_with_flags(backup_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    verify_generation_publication_state_values(
+        manifest.generation_number,
+        manifest.state_number,
+        backup_path,
+    )
+}
+
+fn verify_generation_publication_state_values(
+    generation_number: i64,
+    expected_state_number: i64,
+    backup_path: &Path,
+) -> Result<()> {
+    let conn = open_immutable_sqlite_snapshot(backup_path)?;
     let mut stmt = conn.prepare(
         "SELECT phase, status, recoverable, state_number
          FROM generation_publications
          WHERE generation_number = ?1
          ORDER BY id DESC",
     )?;
-    let mut rows = stmt.query([manifest.generation_number])?;
+    let mut rows = stmt.query([generation_number])?;
     while let Some(row) = rows.next()? {
         let phase: String = row.get(0)?;
         let status: String = row.get(1)?;
         let recoverable: i64 = row.get(2)?;
         let state_number: Option<i64> = row.get(3)?;
-        if state_number != Some(manifest.state_number) {
+        if state_number != Some(expected_state_number) {
             continue;
         }
         let complete = phase == "database_backed_up" && status == "complete" && recoverable == 0;
@@ -790,8 +873,23 @@ fn verify_generation_publication_state(
 
     Err(Error::RecoveryFailed(format!(
         "generation DB backup has no complete or active_marked/running publication state for generation {} state {}",
-        manifest.generation_number, manifest.state_number
+        generation_number, expected_state_number
     )))
+}
+
+fn verify_transaction_high_water_mark(expected: Option<i64>, backup_path: &Path) -> Result<()> {
+    let conn = open_immutable_sqlite_snapshot(backup_path)?;
+    let actual: Option<i64> = conn.query_row(
+        "SELECT MAX(id) FROM changesets WHERE status = 'applied'",
+        [],
+        |row| row.get(0),
+    )?;
+    if actual != expected {
+        return Err(Error::RecoveryFailed(format!(
+            "generation DB backup transaction high-water mark changed: manifest={expected:?}, backup={actual:?}"
+        )));
+    }
+    Ok(())
 }
 
 fn verify_generation_backup_copy(
@@ -815,7 +913,7 @@ fn verify_generation_backup_copy(
 }
 
 fn live_db_is_healthy(path: &Path) -> bool {
-    verify_sqlite_database(path).is_ok()
+    verify_live_sqlite_database(path).is_ok()
 }
 
 fn sqlite_database_paths(db_path: &Path) -> [PathBuf; 3] {

--- a/crates/conary-core/src/db/backup.rs
+++ b/crates/conary-core/src/db/backup.rs
@@ -624,7 +624,7 @@ fn verify_sqlite_connection(path: &Path, conn: &Connection) -> Result<BackupVeri
 
     Ok(BackupVerification {
         backup_path: path.to_path_buf(),
-        db_schema_version: schema::get_schema_version(&conn)?,
+        db_schema_version: schema::get_schema_version(conn)?,
         integrity_check,
         backup_sha256: sha256_file(path)?,
         sqlite_page_count: conn

--- a/crates/conary-core/src/db/generation_snapshot.rs
+++ b/crates/conary-core/src/db/generation_snapshot.rs
@@ -662,4 +662,56 @@ mod tests {
         assert!(error.to_string().contains("source mismatch"));
         assert!(db_path.exists());
     }
+
+    #[test]
+    fn reflink_provider_is_byte_exact_when_the_filesystem_supports_it() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("source");
+        let destination = temp.path().join("destination");
+        std::fs::write(&source, b"reflink snapshot authority").unwrap();
+
+        match create_reflink(&source, &destination).unwrap() {
+            GenerationDbSnapshotProviderOutcome::Unsupported(reason) => assert!(matches!(
+                reason,
+                GenerationDbSnapshotFallbackReason::PlatformUnsupported
+                    | GenerationDbSnapshotFallbackReason::FilesystemUnsupported
+                    | GenerationDbSnapshotFallbackReason::CrossDevice
+            )),
+            GenerationDbSnapshotProviderOutcome::Created {
+                payload_bytes_written,
+            } => {
+                assert_eq!(payload_bytes_written, 0);
+                assert_eq!(
+                    std::fs::read(&destination).unwrap(),
+                    b"reflink snapshot authority"
+                );
+                std::fs::write(&destination, b"copy-on-write destination").unwrap();
+                assert_eq!(
+                    std::fs::read(&source).unwrap(),
+                    b"reflink snapshot authority"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn persisted_provenance_rejects_impossible_provider_order() {
+        let provenance = GenerationDbSnapshotProvenance {
+            method: GenerationDbSnapshotMethod::FullCopy,
+            fallbacks: vec![GenerationDbSnapshotFallback {
+                method: GenerationDbSnapshotMethod::Reflink,
+                reason: GenerationDbSnapshotFallbackReason::FilesystemUnsupported,
+            }],
+            wal_checkpoint: Some(GenerationDbWalCheckpoint {
+                journal_mode: "wal".to_string(),
+                log_frames: 0,
+                checkpointed_frames: 0,
+            }),
+            payload_bytes_written: 4096,
+            logical_size: 4096,
+        };
+
+        let error = provenance.validate().unwrap_err();
+        assert!(error.to_string().contains("provider order is invalid"));
+    }
 }

--- a/crates/conary-core/src/db/generation_snapshot.rs
+++ b/crates/conary-core/src/db/generation_snapshot.rs
@@ -1,0 +1,665 @@
+// conary-core/src/db/generation_snapshot.rs
+
+//! Typed, crash-retryable SQLite snapshots for generation publication.
+
+use crate::filesystem::durable::sync_parent_directory;
+use crate::{Error, Result};
+use rusqlite::{Connection, MAIN_DB};
+use serde::{Deserialize, Serialize};
+use std::fs::{File, OpenOptions};
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+/// Exact mechanism that created a generation database snapshot.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum GenerationDbSnapshotMethod {
+    Reflink,
+    SqliteOnlineBackup,
+    FullCopy,
+}
+
+impl GenerationDbSnapshotMethod {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Reflink => "reflink",
+            Self::SqliteOnlineBackup => "sqlite-online-backup",
+            Self::FullCopy => "full-copy",
+        }
+    }
+}
+
+/// Typed reason that a faster snapshot provider could not be selected.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum GenerationDbSnapshotFallbackReason {
+    WalCheckpointBusy,
+    PlatformUnsupported,
+    FilesystemUnsupported,
+    CrossDevice,
+    OnlineBackupUnavailable,
+}
+
+impl GenerationDbSnapshotFallbackReason {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::WalCheckpointBusy => "wal-checkpoint-busy",
+            Self::PlatformUnsupported => "platform-unsupported",
+            Self::FilesystemUnsupported => "filesystem-unsupported",
+            Self::CrossDevice => "cross-device",
+            Self::OnlineBackupUnavailable => "online-backup-unavailable",
+        }
+    }
+}
+
+/// One provider that was considered but could not create the snapshot.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GenerationDbSnapshotFallback {
+    pub method: GenerationDbSnapshotMethod,
+    pub reason: GenerationDbSnapshotFallbackReason,
+}
+
+/// Exact WAL state established before a raw main-database snapshot.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GenerationDbWalCheckpoint {
+    pub journal_mode: String,
+    pub log_frames: i64,
+    pub checkpointed_frames: i64,
+}
+
+/// Persisted provider provenance for a generation database snapshot.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GenerationDbSnapshotProvenance {
+    pub method: GenerationDbSnapshotMethod,
+    pub fallbacks: Vec<GenerationDbSnapshotFallback>,
+    pub wal_checkpoint: Option<GenerationDbWalCheckpoint>,
+    /// Logical SQLite payload bytes copied by the selected provider.
+    ///
+    /// Reflink shares existing extents and therefore records zero payload
+    /// bytes even though the destination has a non-zero logical length.
+    pub payload_bytes_written: u64,
+    pub logical_size: u64,
+}
+
+impl GenerationDbSnapshotProvenance {
+    pub fn validate(&self) -> Result<()> {
+        if self.logical_size == 0 {
+            return Err(Error::RecoveryFailed(
+                "generation DB snapshot has zero logical size".to_string(),
+            ));
+        }
+        if let Some(checkpoint) = &self.wal_checkpoint
+            && (checkpoint.log_frames < 0
+                || checkpoint.checkpointed_frames < 0
+                || checkpoint.log_frames != checkpoint.checkpointed_frames)
+        {
+            return Err(Error::RecoveryFailed(format!(
+                "generation DB snapshot records an incomplete WAL checkpoint: {checkpoint:?}"
+            )));
+        }
+
+        let expected_fallbacks: &[GenerationDbSnapshotMethod] = match self.method {
+            GenerationDbSnapshotMethod::Reflink => &[],
+            GenerationDbSnapshotMethod::SqliteOnlineBackup => {
+                &[GenerationDbSnapshotMethod::Reflink]
+            }
+            GenerationDbSnapshotMethod::FullCopy => &[
+                GenerationDbSnapshotMethod::Reflink,
+                GenerationDbSnapshotMethod::SqliteOnlineBackup,
+            ],
+        };
+        let actual_fallbacks = self
+            .fallbacks
+            .iter()
+            .map(|fallback| fallback.method)
+            .collect::<Vec<_>>();
+        if actual_fallbacks != expected_fallbacks {
+            return Err(Error::RecoveryFailed(format!(
+                "generation DB snapshot provider order is invalid: selected={:?} fallbacks={actual_fallbacks:?}",
+                self.method
+            )));
+        }
+
+        match self.method {
+            GenerationDbSnapshotMethod::Reflink => {
+                if self.wal_checkpoint.is_none() || self.payload_bytes_written != 0 {
+                    return Err(Error::RecoveryFailed(
+                        "reflink generation DB snapshot requires a WAL checkpoint and zero payload bytes written"
+                            .to_string(),
+                    ));
+                }
+            }
+            GenerationDbSnapshotMethod::SqliteOnlineBackup => {
+                if self.payload_bytes_written != self.logical_size {
+                    return Err(Error::RecoveryFailed(format!(
+                        "SQLite online backup payload byte count {} does not match logical size {}",
+                        self.payload_bytes_written, self.logical_size
+                    )));
+                }
+            }
+            GenerationDbSnapshotMethod::FullCopy => {
+                if self.wal_checkpoint.is_none() || self.payload_bytes_written != self.logical_size
+                {
+                    return Err(Error::RecoveryFailed(
+                        "full-copy generation DB snapshot requires a WAL checkpoint and complete payload copy"
+                            .to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Runtime measurements kept out of persisted generation authority.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GenerationDbSnapshotMetrics {
+    pub provider_elapsed_ns: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GenerationDbSnapshot {
+    pub path: PathBuf,
+    pub provenance: GenerationDbSnapshotProvenance,
+    pub metrics: GenerationDbSnapshotMetrics,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum GenerationDbSnapshotProviderOutcome {
+    Created { payload_bytes_written: u64 },
+    Unsupported(GenerationDbSnapshotFallbackReason),
+}
+
+/// One concrete snapshot mechanism behind the provider-selection boundary.
+trait SnapshotProvider {
+    fn method(&self) -> GenerationDbSnapshotMethod;
+
+    /// Whether this provider reads the SQLite main file directly and therefore
+    /// requires a complete, synchronized WAL checkpoint first.
+    fn requires_checkpointed_main(&self) -> bool;
+
+    fn create(
+        &self,
+        source: &Connection,
+        source_path: &Path,
+        destination: &Path,
+    ) -> Result<GenerationDbSnapshotProviderOutcome>;
+}
+
+#[derive(Debug, Default)]
+struct ReflinkSnapshot;
+
+impl SnapshotProvider for ReflinkSnapshot {
+    fn method(&self) -> GenerationDbSnapshotMethod {
+        GenerationDbSnapshotMethod::Reflink
+    }
+
+    fn requires_checkpointed_main(&self) -> bool {
+        true
+    }
+
+    fn create(
+        &self,
+        _source: &Connection,
+        source_path: &Path,
+        destination: &Path,
+    ) -> Result<GenerationDbSnapshotProviderOutcome> {
+        create_reflink(source_path, destination)
+    }
+}
+
+#[derive(Debug, Default)]
+struct SqliteBackupSnapshot;
+
+impl SnapshotProvider for SqliteBackupSnapshot {
+    fn method(&self) -> GenerationDbSnapshotMethod {
+        GenerationDbSnapshotMethod::SqliteOnlineBackup
+    }
+
+    fn requires_checkpointed_main(&self) -> bool {
+        false
+    }
+
+    fn create(
+        &self,
+        source: &Connection,
+        _source_path: &Path,
+        destination: &Path,
+    ) -> Result<GenerationDbSnapshotProviderOutcome> {
+        source.backup(MAIN_DB, destination, None)?;
+        let bytes = destination.metadata()?.len();
+        Ok(GenerationDbSnapshotProviderOutcome::Created {
+            payload_bytes_written: bytes,
+        })
+    }
+}
+
+#[derive(Debug, Default)]
+struct FullCopyFallback;
+
+impl SnapshotProvider for FullCopyFallback {
+    fn method(&self) -> GenerationDbSnapshotMethod {
+        GenerationDbSnapshotMethod::FullCopy
+    }
+
+    fn requires_checkpointed_main(&self) -> bool {
+        true
+    }
+
+    fn create(
+        &self,
+        _source: &Connection,
+        source_path: &Path,
+        destination: &Path,
+    ) -> Result<GenerationDbSnapshotProviderOutcome> {
+        let bytes = std::fs::copy(source_path, destination)?;
+        Ok(GenerationDbSnapshotProviderOutcome::Created {
+            payload_bytes_written: bytes,
+        })
+    }
+}
+
+/// Ordered provider selector used by normal generation publication.
+pub struct GenerationDbSnapshotProvider {
+    providers: Vec<Box<dyn SnapshotProvider>>,
+}
+
+impl Default for GenerationDbSnapshotProvider {
+    fn default() -> Self {
+        Self {
+            providers: vec![
+                Box::new(ReflinkSnapshot),
+                Box::new(SqliteBackupSnapshot),
+                Box::new(FullCopyFallback),
+            ],
+        }
+    }
+}
+
+impl GenerationDbSnapshotProvider {
+    /// Create one exact SQLite snapshot at `destination`.
+    ///
+    /// The caller owns mutation serialization for `source_path`. Providers
+    /// that clone or copy the main file are admitted only after a successful
+    /// truncate checkpoint and explicit synchronization. SQLite online backup
+    /// remains exact when that checkpoint is temporarily busy.
+    pub fn snapshot(
+        &self,
+        source: &Connection,
+        source_path: impl AsRef<Path>,
+        destination: impl AsRef<Path>,
+    ) -> Result<GenerationDbSnapshot> {
+        let source_path = source_path.as_ref();
+        let destination = destination.as_ref();
+        validate_source_connection_path(source, source_path)?;
+        let started = Instant::now();
+        let mut fallbacks = Vec::new();
+        let mut checkpoint: Option<GenerationDbWalCheckpoint> = None;
+        let mut checkpoint_busy = false;
+
+        for provider in &self.providers {
+            if provider.requires_checkpointed_main() && checkpoint.is_none() && !checkpoint_busy {
+                match checkpoint_and_sync(source, source_path)? {
+                    CheckpointOutcome::Complete(value) => checkpoint = Some(value),
+                    CheckpointOutcome::Busy => checkpoint_busy = true,
+                }
+            }
+            if provider.requires_checkpointed_main() && checkpoint.is_none() {
+                fallbacks.push(GenerationDbSnapshotFallback {
+                    method: provider.method(),
+                    reason: GenerationDbSnapshotFallbackReason::WalCheckpointBusy,
+                });
+                continue;
+            }
+
+            remove_partial(destination)?;
+            match provider.create(source, source_path, destination)? {
+                GenerationDbSnapshotProviderOutcome::Created {
+                    payload_bytes_written,
+                } => {
+                    let mut permissions = destination.metadata()?.permissions();
+                    permissions.set_mode(0o600);
+                    std::fs::set_permissions(destination, permissions)?;
+                    File::open(destination)?.sync_all()?;
+                    sync_parent_directory(destination)?;
+                    let logical_size = destination.metadata()?.len();
+                    let provider_elapsed_ns =
+                        started.elapsed().as_nanos().try_into().unwrap_or(u64::MAX);
+                    let provenance = GenerationDbSnapshotProvenance {
+                        method: provider.method(),
+                        fallbacks,
+                        wal_checkpoint: checkpoint,
+                        payload_bytes_written,
+                        logical_size,
+                    };
+                    provenance.validate()?;
+                    return Ok(GenerationDbSnapshot {
+                        path: destination.to_path_buf(),
+                        provenance,
+                        metrics: GenerationDbSnapshotMetrics {
+                            provider_elapsed_ns,
+                        },
+                    });
+                }
+                GenerationDbSnapshotProviderOutcome::Unsupported(reason) => {
+                    remove_partial(destination)?;
+                    fallbacks.push(GenerationDbSnapshotFallback {
+                        method: provider.method(),
+                        reason,
+                    });
+                }
+            }
+        }
+
+        Err(Error::RecoveryFailed(format!(
+            "no generation DB snapshot provider could create an exact snapshot: {fallbacks:?}"
+        )))
+    }
+
+    #[cfg(test)]
+    fn with_providers(providers: Vec<Box<dyn SnapshotProvider>>) -> Self {
+        Self { providers }
+    }
+}
+
+enum CheckpointOutcome {
+    Complete(GenerationDbWalCheckpoint),
+    Busy,
+}
+
+fn checkpoint_and_sync(source: &Connection, source_path: &Path) -> Result<CheckpointOutcome> {
+    let journal_mode: String = source.query_row("PRAGMA journal_mode", [], |row| row.get(0))?;
+    let (busy, log_frames, checkpointed_frames): (i64, i64, i64) =
+        source.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+        })?;
+    if busy != 0 || log_frames != checkpointed_frames {
+        return Ok(CheckpointOutcome::Busy);
+    }
+
+    File::open(source_path)?.sync_all()?;
+    let wal_path = sqlite_sidecar_path(source_path, "-wal");
+    if wal_path.exists() {
+        File::open(&wal_path)?.sync_all()?;
+    }
+    sync_parent_directory(source_path)?;
+
+    Ok(CheckpointOutcome::Complete(GenerationDbWalCheckpoint {
+        journal_mode,
+        log_frames,
+        checkpointed_frames,
+    }))
+}
+
+fn validate_source_connection_path(source: &Connection, source_path: &Path) -> Result<()> {
+    let connected_path: String = source.query_row(
+        "SELECT file FROM pragma_database_list WHERE name = 'main'",
+        [],
+        |row| row.get(0),
+    )?;
+    let connected = Path::new(&connected_path).canonicalize()?;
+    let requested = source_path.canonicalize()?;
+    if connected != requested {
+        return Err(Error::RecoveryFailed(format!(
+            "generation DB snapshot source mismatch: connection={} requested={}",
+            connected.display(),
+            requested.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn create_reflink(
+    source_path: &Path,
+    destination: &Path,
+) -> Result<GenerationDbSnapshotProviderOutcome> {
+    let source = File::open(source_path)?;
+    let destination_file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .mode(0o600)
+        .open(destination)?;
+    // SAFETY: both descriptors remain open for the ioctl; the destination was
+    // created empty and exclusively for this snapshot attempt.
+    let result = unsafe {
+        libc::ioctl(
+            destination_file.as_raw_fd(),
+            libc::FICLONE,
+            source.as_raw_fd(),
+        )
+    };
+    if result == 0 {
+        return Ok(GenerationDbSnapshotProviderOutcome::Created {
+            payload_bytes_written: 0,
+        });
+    }
+
+    let error = std::io::Error::last_os_error();
+    let reason = match error.raw_os_error() {
+        Some(libc::EXDEV) => Some(GenerationDbSnapshotFallbackReason::CrossDevice),
+        Some(libc::EOPNOTSUPP) | Some(libc::ENOTTY) | Some(libc::EINVAL) | Some(libc::ENOSYS) => {
+            Some(GenerationDbSnapshotFallbackReason::FilesystemUnsupported)
+        }
+        _ => None,
+    };
+    match reason {
+        Some(reason) => Ok(GenerationDbSnapshotProviderOutcome::Unsupported(reason)),
+        None => Err(Error::Io(error)),
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn create_reflink(
+    _source_path: &Path,
+    _destination: &Path,
+) -> Result<GenerationDbSnapshotProviderOutcome> {
+    Ok(GenerationDbSnapshotProviderOutcome::Unsupported(
+        GenerationDbSnapshotFallbackReason::PlatformUnsupported,
+    ))
+}
+
+fn sqlite_sidecar_path(db_path: &Path, suffix: &str) -> PathBuf {
+    let mut path = db_path.as_os_str().to_os_string();
+    path.push(suffix);
+    PathBuf::from(path)
+}
+
+fn remove_partial(path: &Path) -> Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct UnsupportedProvider {
+        method: GenerationDbSnapshotMethod,
+        checkpointed: bool,
+        reason: GenerationDbSnapshotFallbackReason,
+    }
+
+    impl SnapshotProvider for UnsupportedProvider {
+        fn method(&self) -> GenerationDbSnapshotMethod {
+            self.method
+        }
+
+        fn requires_checkpointed_main(&self) -> bool {
+            self.checkpointed
+        }
+
+        fn create(
+            &self,
+            _source: &Connection,
+            _source_path: &Path,
+            _destination: &Path,
+        ) -> Result<GenerationDbSnapshotProviderOutcome> {
+            Ok(GenerationDbSnapshotProviderOutcome::Unsupported(
+                self.reason,
+            ))
+        }
+    }
+
+    fn fixture() -> (tempfile::TempDir, PathBuf, Connection) {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("source.sqlite");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             PRAGMA synchronous=NORMAL;
+             CREATE TABLE authority (id INTEGER PRIMARY KEY, value TEXT NOT NULL);
+             INSERT INTO authority (value) VALUES ('committed through WAL');",
+        )
+        .unwrap();
+        (temp, db_path, conn)
+    }
+
+    #[test]
+    fn default_chain_snapshots_exact_committed_wal_state() {
+        let (temp, db_path, conn) = fixture();
+        let destination = temp.path().join("snapshot.sqlite");
+
+        let snapshot = GenerationDbSnapshotProvider::default()
+            .snapshot(&conn, &db_path, &destination)
+            .unwrap();
+
+        let copied =
+            Connection::open_with_flags(&snapshot.path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+                .unwrap();
+        let value: String = copied
+            .query_row("SELECT value FROM authority", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(value, "committed through WAL");
+        assert_eq!(
+            snapshot.provenance.logical_size,
+            destination.metadata().unwrap().len()
+        );
+        assert!(snapshot.provenance.wal_checkpoint.is_some());
+    }
+
+    #[test]
+    fn unsupported_reflink_falls_back_to_sqlite_online_backup() {
+        let (temp, db_path, conn) = fixture();
+        let destination = temp.path().join("snapshot.sqlite");
+        let providers = GenerationDbSnapshotProvider::with_providers(vec![
+            Box::new(UnsupportedProvider {
+                method: GenerationDbSnapshotMethod::Reflink,
+                checkpointed: true,
+                reason: GenerationDbSnapshotFallbackReason::FilesystemUnsupported,
+            }),
+            Box::new(SqliteBackupSnapshot),
+            Box::new(FullCopyFallback),
+        ]);
+
+        let snapshot = providers.snapshot(&conn, &db_path, &destination).unwrap();
+
+        assert_eq!(
+            snapshot.provenance.method,
+            GenerationDbSnapshotMethod::SqliteOnlineBackup
+        );
+        assert_eq!(
+            snapshot.provenance.fallbacks,
+            vec![GenerationDbSnapshotFallback {
+                method: GenerationDbSnapshotMethod::Reflink,
+                reason: GenerationDbSnapshotFallbackReason::FilesystemUnsupported,
+            }]
+        );
+        assert_eq!(
+            snapshot.provenance.payload_bytes_written,
+            destination.metadata().unwrap().len()
+        );
+    }
+
+    #[test]
+    fn busy_wal_checkpoint_uses_online_backup_without_losing_committed_frames() {
+        let (temp, db_path, conn) = fixture();
+        let reader = Connection::open(&db_path).unwrap();
+        reader.execute_batch("BEGIN").unwrap();
+        let _: i64 = reader
+            .query_row("SELECT COUNT(*) FROM authority", [], |row| row.get(0))
+            .unwrap();
+        conn.execute(
+            "INSERT INTO authority (value) VALUES ('committed after reader snapshot')",
+            [],
+        )
+        .unwrap();
+        let destination = temp.path().join("snapshot.sqlite");
+
+        let snapshot = GenerationDbSnapshotProvider::default()
+            .snapshot(&conn, &db_path, &destination)
+            .unwrap();
+
+        assert_eq!(
+            snapshot.provenance.method,
+            GenerationDbSnapshotMethod::SqliteOnlineBackup
+        );
+        assert_eq!(
+            snapshot.provenance.fallbacks,
+            vec![GenerationDbSnapshotFallback {
+                method: GenerationDbSnapshotMethod::Reflink,
+                reason: GenerationDbSnapshotFallbackReason::WalCheckpointBusy,
+            }]
+        );
+        let copied =
+            Connection::open_with_flags(&destination, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+                .unwrap();
+        let count: i64 = copied
+            .query_row("SELECT COUNT(*) FROM authority", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn full_copy_is_used_only_after_both_faster_providers_are_unavailable() {
+        let (temp, db_path, conn) = fixture();
+        let destination = temp.path().join("snapshot.sqlite");
+        let providers = GenerationDbSnapshotProvider::with_providers(vec![
+            Box::new(UnsupportedProvider {
+                method: GenerationDbSnapshotMethod::Reflink,
+                checkpointed: true,
+                reason: GenerationDbSnapshotFallbackReason::FilesystemUnsupported,
+            }),
+            Box::new(UnsupportedProvider {
+                method: GenerationDbSnapshotMethod::SqliteOnlineBackup,
+                checkpointed: false,
+                reason: GenerationDbSnapshotFallbackReason::OnlineBackupUnavailable,
+            }),
+            Box::new(FullCopyFallback),
+        ]);
+
+        let snapshot = providers.snapshot(&conn, &db_path, &destination).unwrap();
+
+        assert_eq!(
+            snapshot.provenance.method,
+            GenerationDbSnapshotMethod::FullCopy
+        );
+        assert_eq!(snapshot.provenance.fallbacks.len(), 2);
+        assert_eq!(
+            snapshot.provenance.payload_bytes_written,
+            destination.metadata().unwrap().len()
+        );
+    }
+
+    #[test]
+    fn source_connection_must_name_the_exact_database_path() {
+        let (temp, db_path, conn) = fixture();
+        let other_path = temp.path().join("other.sqlite");
+        Connection::open(&other_path).unwrap();
+
+        let error = GenerationDbSnapshotProvider::default()
+            .snapshot(&conn, &other_path, temp.path().join("snapshot.sqlite"))
+            .unwrap_err();
+
+        assert!(error.to_string().contains("source mismatch"));
+        assert!(db_path.exists());
+    }
+}

--- a/crates/conary-core/src/db/mod.rs
+++ b/crates/conary-core/src/db/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod backup;
 pub mod current_schema;
+pub mod generation_snapshot;
 pub mod models;
 pub mod paths;
 pub mod rebuild;

--- a/crates/conary-core/tests/db_backup.rs
+++ b/crates/conary-core/tests/db_backup.rs
@@ -148,15 +148,23 @@ fn recovery_apply_quarantines_corrupt_db_and_sidecars() {
 fn generation_backup_writes_manifest_and_verifies_artifact_and_publication_state() {
     let fixture = GenerationBackupFixture::new(3);
 
-    let record =
-        create_generation_db_backup(&fixture.db_path, &fixture.generation_dir, 3, 3).unwrap();
+    let record = create_generation_db_backup(
+        &fixture.connection(),
+        &fixture.db_path,
+        &fixture.generation_dir,
+        3,
+        3,
+    )
+    .unwrap();
 
-    assert_eq!(record.manifest.format, "conary.generation-db-backup.v1");
-    assert_eq!(record.manifest.manifest_version, 1);
+    assert_eq!(record.manifest.format, "conary.generation-db-backup.v2");
+    assert_eq!(record.manifest.manifest_version, 2);
     assert_eq!(record.manifest.generation_number, 3);
     assert_eq!(record.manifest.state_number, 3);
     assert_eq!(record.manifest.db_schema_version, SCHEMA_VERSION);
     assert_eq!(record.manifest.backup_file, "conary.db.backup");
+    assert_eq!(record.manifest.transaction_high_water_mark, None);
+    assert!(record.creation_metrics.is_some());
     assert!(record.backup_path.ends_with("state/conary.db.backup"));
     assert!(
         record
@@ -179,8 +187,14 @@ fn generation_backup_writes_manifest_and_verifies_artifact_and_publication_state
 #[test]
 fn generation_backup_verification_rejects_tampered_backup_file() {
     let fixture = GenerationBackupFixture::new(4);
-    let record =
-        create_generation_db_backup(&fixture.db_path, &fixture.generation_dir, 4, 4).unwrap();
+    let record = create_generation_db_backup(
+        &fixture.connection(),
+        &fixture.db_path,
+        &fixture.generation_dir,
+        4,
+        4,
+    )
+    .unwrap();
 
     std::fs::write(&record.backup_path, b"not the original backup").unwrap();
 
@@ -191,7 +205,14 @@ fn generation_backup_verification_rejects_tampered_backup_file() {
 #[test]
 fn generation_backup_dry_run_recovery_verifies_copy_without_live_db() {
     let fixture = GenerationBackupFixture::new(5);
-    create_generation_db_backup(&fixture.db_path, &fixture.generation_dir, 5, 5).unwrap();
+    create_generation_db_backup(
+        &fixture.connection(),
+        &fixture.db_path,
+        &fixture.generation_dir,
+        5,
+        5,
+    )
+    .unwrap();
     std::fs::remove_file(&fixture.db_path).unwrap();
 
     let outcome = recover_generation_db_backup(
@@ -215,7 +236,14 @@ fn generation_backup_dry_run_recovery_verifies_copy_without_live_db() {
 #[test]
 fn generation_backup_apply_quarantines_corrupt_db_and_sidecars() {
     let fixture = GenerationBackupFixture::new(6);
-    create_generation_db_backup(&fixture.db_path, &fixture.generation_dir, 6, 6).unwrap();
+    create_generation_db_backup(
+        &fixture.connection(),
+        &fixture.db_path,
+        &fixture.generation_dir,
+        6,
+        6,
+    )
+    .unwrap();
 
     let wal_path = fixture.db_path.with_file_name("conary.db-wal");
     let shm_path = fixture.db_path.with_file_name("conary.db-shm");
@@ -245,7 +273,14 @@ fn generation_backup_apply_quarantines_corrupt_db_and_sidecars() {
 #[test]
 fn generation_backup_apply_refuses_healthy_live_db_without_debug_override() {
     let fixture = GenerationBackupFixture::new(7);
-    create_generation_db_backup(&fixture.db_path, &fixture.generation_dir, 7, 7).unwrap();
+    create_generation_db_backup(
+        &fixture.connection(),
+        &fixture.db_path,
+        &fixture.generation_dir,
+        7,
+        7,
+    )
+    .unwrap();
 
     let error = recover_generation_db_backup(
         &fixture.db_path,
@@ -260,6 +295,61 @@ fn generation_backup_apply_refuses_healthy_live_db_without_debug_override() {
     .unwrap_err();
 
     assert!(error.to_string().contains("refusing to replace"));
+}
+
+#[test]
+fn generation_backup_retry_replaces_partial_snapshot_and_metadata() {
+    let fixture = GenerationBackupFixture::new(8);
+    let conn = fixture.connection();
+    let first = create_generation_db_backup(&conn, &fixture.db_path, &fixture.generation_dir, 8, 8)
+        .unwrap();
+    let state_dir = fixture.generation_dir.join("state");
+    std::fs::write(
+        state_dir.join(".conary.db.backup.tmp"),
+        b"interrupted snapshot",
+    )
+    .unwrap();
+    std::fs::write(&first.backup_path, b"interrupted published snapshot").unwrap();
+    std::fs::write(&first.checksum_path, b"interrupted checksum").unwrap();
+    std::fs::write(&first.manifest_path, b"{\"interrupted\":true}").unwrap();
+
+    let retried =
+        create_generation_db_backup(&conn, &fixture.db_path, &fixture.generation_dir, 8, 8)
+            .unwrap();
+
+    assert!(!state_dir.join(".conary.db.backup.tmp").exists());
+    assert_eq!(retried.manifest.generation_number, 8);
+    verify_generation_db_backup(&fixture.generation_dir, None).unwrap();
+}
+
+#[test]
+fn generation_backup_binds_and_verifies_transaction_high_water_mark() {
+    let fixture = GenerationBackupFixture::new(9);
+    let conn = fixture.connection();
+    conn.execute(
+        "INSERT INTO changesets (description, status) VALUES ('history boundary', 'applied')",
+        [],
+    )
+    .unwrap();
+    let high_water = conn.last_insert_rowid();
+    let record =
+        create_generation_db_backup(&conn, &fixture.db_path, &fixture.generation_dir, 9, 9)
+            .unwrap();
+    assert_eq!(
+        record.manifest.transaction_high_water_mark,
+        Some(high_water)
+    );
+
+    let mut tampered = record.manifest;
+    tampered.transaction_high_water_mark = None;
+    std::fs::write(
+        &record.manifest_path,
+        serde_json::to_vec_pretty(&tampered).unwrap(),
+    )
+    .unwrap();
+
+    let error = verify_generation_db_backup(&fixture.generation_dir, None).unwrap_err();
+    assert!(error.to_string().contains("high-water mark changed"));
 }
 
 struct GenerationBackupFixture {
@@ -287,6 +377,10 @@ impl GenerationBackupFixture {
             db_path,
             generation_dir,
         }
+    }
+
+    fn connection(&self) -> rusqlite::Connection {
+        db::open(&self.db_path).unwrap()
     }
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-08-13
-revision: 49
-summary: Describe workspace and release boundaries, exact native source authority, package transactions, lifecycle execution, typed carrier security, generation GC, and service boundaries
+last_updated: 2026-08-14
+revision: 50
+summary: Describe workspace and release boundaries, exact native source authority, package transactions, typed generation database snapshots, lifecycle execution, carrier security, generation GC, and service boundaries
 ---
 
 # Conary Architecture
@@ -703,7 +703,18 @@ database is the single source of truth, queryable with standard SQL tools.
 Conary writes SQLite-native checkpoint backups around first-wave
 adoption/unadoption mutations and writes a generation-bound SQLite backup under
 `/conary/generations/<n>/state/` when a generation publication reaches the
-selected-generation boundary.
+selected-generation boundary. Generation publication does not compact the
+complete database with `VACUUM INTO`. It holds mutation authority, establishes
+and synchronizes an exact WAL checkpoint, and selects a typed snapshot provider:
+reflink first, SQLite online backup as the portable fallback, and a full copy
+only when both faster providers are unavailable. The v2 generation-backup
+manifest records the selected method, typed fallback reasons, schema epoch,
+transaction high-water mark, page count, logical size, payload bytes written,
+and SHA-256 identity. Creation performs one full integrity/digest pass; explicit
+verification and recovery repeat the full check, while an uninterrupted
+publication does not immediately verify the same snapshot a second time.
+Recovery opens checkpointed snapshots through SQLite's immutable read-only
+mode so verification cannot create or consume WAL sidecars.
 
 **Composefs-native transactions**: Every package mutation follows one linear
 pipeline: resolve -> fetch -> materialize an isolated selected root -> run typed

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-08-13
-revision: 69
-summary: Route workspace and release boundaries, typed database rebuilds, exact native source identity and adopted-artifact conversion, lossless source authority and trust-import planning, exact Remi signing, selected-root mutation, rollback lineage, canonical-map authority, carrier security, generation GC, and subsystem proof through current feature owners.
+last_updated: 2026-08-14
+revision: 70
+summary: Route workspace and release boundaries, typed database rebuilds and generation snapshots, exact native source identity and adopted-artifact conversion, lossless source authority and trust-import planning, exact Remi signing, selected-root mutation, rollback lineage, canonical-map authority, carrier security, generation GC, and subsystem proof through current feature owners.
 ---
 
 # Assistant Subsystem Map
@@ -156,6 +156,9 @@ commands.
   `db/models/canonical.rs` for typed persistence authority.
 - Generation, bootstrap, and QEMU proof:
   `docs/modules/feature-ownership.md` slugs `generation` and `bootstrap`, plus
+  `crates/conary-core/src/db/backup.rs`,
+  `crates/conary-core/src/db/generation_snapshot.rs`,
+  `crates/conary-core/benches/generation_db_snapshot.rs`,
   `crates/conary-core/src/generation/root_manifest.rs`,
   `crates/conary-core/src/generation/root_manifest/authority.rs`,
   `crates/conary-core/src/generation/root_manifest/overlay/indexed.rs`,

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-08-13
-revision: 71
-summary: Route feature ownership through typed database rebuilds, exact native source identity and adopted-artifact conversion, native declaration and trust-import planning, exact Remi signing, streaming package payloads, serialized selected-root mutation, typed rollback lineage, exact lifecycle, canonical-map authority, carrier security, generation GC, exact release authority, and current canonical docs
+last_updated: 2026-08-14
+revision: 72
+summary: Route feature ownership through typed database rebuilds and generation snapshots, exact native source identity and adopted-artifact conversion, native declaration and trust-import planning, exact Remi signing, streaming package payloads, serialized selected-root mutation, typed rollback lineage, exact lifecycle, canonical-map authority, carrier security, generation GC, exact release authority, and current canonical docs
 ---
 
 # Feature Ownership And Interaction Gates
@@ -549,6 +549,8 @@ next boot, recover publication debt, collect generations and local CAS objects,
 and export raw/qcow2/ISO carriers.
 
 **Start here:** `crates/conary-core/src/generation/builder.rs`;
+`crates/conary-core/src/db/backup.rs`;
+`crates/conary-core/src/db/generation_snapshot.rs`;
 `crates/conary-core/src/generation/root_manifest.rs`;
 `crates/conary-core/src/generation/root_manifest/delta.rs`;
 `crates/conary-core/src/generation/root_manifest/scan.rs`;
@@ -602,6 +604,9 @@ SELinux/AppArmor provider interfaces, transaction commit, SQLite generation
 state, image building, bootstrap validation, conaryd route history.
 
 **Paths:** `crates/conary-core/src/generation/*`;
+`crates/conary-core/src/db/backup.rs`;
+`crates/conary-core/src/db/generation_snapshot.rs`;
+`crates/conary-core/benches/generation_db_snapshot.rs`;
 `crates/conary-core/src/ccs/hooks/capabilities.rs`;
 `crates/conary-core/src/ccs/hooks/capabilities/*`;
 `crates/conary-core/src/boot_runtime.rs`;
@@ -636,6 +641,7 @@ state, image building, bootstrap validation, conaryd route history.
 `cargo test -p conary --lib commands::generation::activation_intents`;
 `cargo test -p conary --lib commands::generation::gc`;
 `cargo test -p conary-core --test db_backup`;
+`cargo bench -p conary-core --bench generation_db_snapshot`;
 `cargo test -p conary-core --test generation_composefs_runtime_contract`;
 `cargo test -p conary --test packaged_onboarding`.
 


### PR DESCRIPTION
## Primary Issue

Refs #402

Design / Plan / Roadmap: #402; performance measurement and regression ownership remains #121.

## Problem And Outcome

Generation publication rebuilt the complete SQLite database with `VACUUM INTO`, then repeated full integrity and digest work. This draft introduces the typed stage-1 snapshot boundary so publication selects the cheapest exact provider while preserving recovery identity and explicit fallback evidence.

## Changes

- add `GenerationDbSnapshotProvider` with ordered reflink, SQLite online-backup, and full-copy providers
- checkpoint and synchronize WAL/main authority before raw-file reflink/copy providers
- hard-cut generation DB backup manifests to v2 with provider provenance, schema epoch, transaction high-water mark, page count, byte counters, and SHA-256 identity
- remove routine `VACUUM INTO` and the immediate duplicate full verification from generation publication
- retain full integrity/digest verification for explicit verify, recovery, and replay after interruption
- add checkpoint-busy, fallback, source-binding, high-water tamper, partial-publication retry, corruption, GC, and recovery tests
- add history-depth Criterion coverage and route the new owner files through the generation feature card
- report snapshot method, fallbacks, and payload bytes through `generation verify-db-backup`

## Scope

- In scope: generation-bound database snapshots and recovery proof.
- Out of scope: adoption/unadoption checkpoint backups, retired-schema rebuild snapshots, SQLite session changesets/base-delta recovery, export/boot carrier behavior.
- Local `proopt.md` remains untracked and is not part of this PR.

## Ownership / Boundary

- Owning subsystem: generation publication and SQLite recovery authority.
- Boundary changed or preserved: provider selection moved to `db/generation_snapshot.rs`; `db/backup.rs` owns the v2 manifest and recovery binding; publication retains the canonical runtime mutation lock.
- Persisted state or public surface impact: pre-alpha hard cut from `conary.generation-db-backup.v1` to v2; verification output adds typed provider evidence.
- [x] Checked `docs/modules/feature-ownership.md` when this changes a user-visible capability

## Verification

- [x] Listed the exact verification commands run below
- [x] Added or updated tests when behavior changed
- [x] Updated subsystem docs and the feature owner when the look-here-first path changed
- [x] Ran the non-QEMU interaction proof for publication, recovery, and GC
- [x] Recorded remaining acceptance evidence on #402
- [ ] Export/boot QEMU gate (not run: this PR does not change export or boot-carrier behavior)

```text
- cargo check -p conary-core -p conary --all-targets
- cargo test -p conary-core --lib db::generation_snapshot -- --nocapture
  7 passed
- cargo test -p conary-core --test db_backup -- --nocapture
  13 passed
- cargo test -p conary --lib commands::generation::publication -- --nocapture
  5 passed
- cargo test -p conary-core --lib db::models::generation_publication -- --nocapture
  7 passed
- cargo test -p conary-core generation::gc -- --nocapture
  6 passed
- cargo test -p conary --lib commands::generation::gc -- --nocapture
  7 passed
- cargo test -p conary-core --test generation_composefs_runtime_contract -- --nocapture
  18 passed
- bash scripts/check-doc-truth.sh
- bash scripts/test-doc-truth.sh
- bash scripts/test-agent-context.sh
- bash scripts/agent-context.sh --validate
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- git diff --check
- taskset -c 2 cargo bench -p conary-core --bench generation_db_snapshot -- --noplot
  ext4 selected sqlite-online-backup
  provider: 0 rows 98.816-99.130 us; 10k 1.5149-1.5469 ms; 100k 13.318-13.336 ms
  provider+sha256: 0 rows 137.54-142.08 us; 10k 7.5152-7.5829 ms; 100k 78.594-78.906 ms
- TMPDIR=/dev/shm taskset -c 2 cargo bench -p conary-core --bench generation_db_snapshot -- --test
  tmpfs selected sqlite-online-backup for all six benchmark cases
```

## Review And Merge Notes

- Exact head: `e1f87de085460708167cdb6fbd8cb56dc1c9720b`
- Review focus: exact WAL/main consistency, provider fallback classification, v2 authority validation, and crash-retry ordering.
- User or developer impact: generation backup provenance is inspectable; normal publication no longer runs `VACUUM INTO` or immediately repeats a full verification.
- Required-check bypass: not used.
- Remaining before ready: obtain reflink-capable filesystem proof and reconcile #402's publication-latency criterion with the necessarily linear whole-file SHA-256 pass. The ext4/tmpfs fallback results are portable-path evidence, not reflink acceptance.
