### PR TITLE
perf(generation): add bounded database recovery deltas

### DIFF
--- a/.github/actions/test-generation-db-reflink/action.yml
+++ b/.github/actions/test-generation-db-reflink/action.yml
@@ -1,0 +1,30 @@
+name: Test generation DB reflink provider
+description: Mount a Btrfs loop filesystem and require zero-copy generation DB snapshots.
+runs:
+  using: composite
+  steps:
+    - name: Create a reflink-capable Btrfs proof filesystem
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y btrfs-progs
+        truncate -s 2G /tmp/conary-reflink.btrfs
+        sudo mkfs.btrfs -f /tmp/conary-reflink.btrfs
+        sudo mkdir -p /mnt/conary-reflink
+        sudo mount -o loop /tmp/conary-reflink.btrfs /mnt/conary-reflink
+        sudo chown "$(id -u):$(id -g)" /mnt/conary-reflink
+    - name: Require the reflink snapshot provider
+      shell: bash
+      env:
+        CONARY_TEST_REFLINK_DIR: /mnt/conary-reflink
+      run: >-
+        cargo test -p conary-core --lib
+        db::generation_snapshot::tests::required_reflink_filesystem_selects_zero_copy_provider
+        -- --ignored --exact --nocapture
+    - name: Unmount the proof filesystem
+      if: ${{ always() }}
+      shell: bash
+      run: |
+        if mountpoint -q /mnt/conary-reflink; then
+          sudo umount /mnt/conary-reflink
+        fi

--- a/.github/workflows/merge-validation.yml
+++ b/.github/workflows/merge-validation.yml
@@ -138,6 +138,15 @@ jobs:
       - name: Run workspace tests
         run: cargo test --workspace --exclude conary-test --verbose
 
+  generation-db-reflink:
+    name: generation-db-reflink
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-rust-workspace
+      - uses: ./.github/actions/test-generation-db-reflink
+
   conary-test-crate:
     name: conary-test-crate
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -132,6 +132,15 @@ jobs:
       - name: Run workspace tests
         run: cargo test --workspace --exclude conary-test --verbose
 
+  generation-db-reflink:
+    name: generation-db-reflink
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-rust-workspace
+      - uses: ./.github/actions/test-generation-db-reflink
+
   conary-test-crate:
     name: conary-test-crate
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3508,6 +3508,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76001fb4daed01e5f2b518aac0b4dc592e7c734da63dbffcf0c64fa612a8d0c"
 dependencies = [
+ "bindgen",
  "cc",
  "pkg-config",
  "vcpkg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ resolvo = { path = "third_party/resolvo-0.12.0-patched" }
 sequoia-openpgp = { version = "2", default-features = false, features = ["crypto-rust", "allow-experimental-crypto", "allow-variable-time-crypto"] }
 
 # Database
-rusqlite = { version = "0.40", features = ["backup", "bundled", "limits"] }
+rusqlite = { version = "0.40", features = ["backup", "bundled", "limits", "session"] }
 liblzma = "0.4"
 zip = { version = "8.4.0", default-features = false, features = ["deflate-flate2-zlib-rs"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ resolvo = { path = "third_party/resolvo-0.12.0-patched" }
 sequoia-openpgp = { version = "2", default-features = false, features = ["crypto-rust", "allow-experimental-crypto", "allow-variable-time-crypto"] }
 
 # Database
-rusqlite = { version = "0.40", features = ["backup", "bundled", "limits", "session"] }
+rusqlite = { version = "0.40", features = ["backup", "bundled", "functions", "limits", "session"] }
 liblzma = "0.4"
 zip = { version = "8.4.0", default-features = false, features = ["deflate-flate2-zlib-rs"] }
 

--- a/apps/conary/src/commands/generation/commands.rs
+++ b/apps/conary/src/commands/generation/commands.rs
@@ -518,15 +518,11 @@ pub fn cmd_generation_verify_db_backup(
             verification.generation_number
         ),
     );
-    crate::ui::field("Backup", &verification.backup_path.display().to_string());
-    crate::ui::field(
-        "Manifest",
-        &verification.manifest_path.display().to_string(),
-    );
+    crate::ui::field("Authority", &verification.backup_path.display().to_string());
     crate::ui::field("Schema", &verification.db_schema_version.to_string());
     crate::ui::field("Integrity", &verification.integrity_check);
     crate::ui::field(
-        "SQLite pages",
+        "Base SQLite pages",
         &verification
             .sqlite_page_count
             .map(|pages| pages.to_string())
@@ -539,11 +535,15 @@ pub fn cmd_generation_verify_db_backup(
             .map(|changeset| changeset.to_string())
             .unwrap_or_else(|| "none".to_string()),
     );
-    crate::ui::field("Snapshot method", verification.snapshot.method.as_str());
     crate::ui::field(
-        "Snapshot payload bytes written",
+        "Base snapshot method",
+        verification.snapshot.method.as_str(),
+    );
+    crate::ui::field(
+        "Base snapshot payload bytes",
         &verification.snapshot.payload_bytes_written.to_string(),
     );
+    crate::ui::field("Deltas", &verification.delta_count.to_string());
     let fallbacks = verification
         .snapshot
         .fallbacks
@@ -552,14 +552,14 @@ pub fn cmd_generation_verify_db_backup(
         .collect::<Vec<_>>()
         .join(",");
     crate::ui::field(
-        "Snapshot fallbacks",
+        "Base snapshot fallbacks",
         if fallbacks.is_empty() {
             "none"
         } else {
             &fallbacks
         },
     );
-    crate::ui::field("SHA-256", &verification.backup_sha256);
+    crate::ui::field("Chain SHA-256", &verification.backup_sha256);
     Ok(())
 }
 

--- a/apps/conary/src/commands/generation/publication.rs
+++ b/apps/conary/src/commands/generation/publication.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{Result, anyhow};
 use conary_core::config_transaction::GenerationConfigTransaction;
+use conary_core::db::generation_delta::{GenerationDbDeltaCapture, GenerationDbDeltaRecorder};
 use conary_core::db::models::{
     GenerationPublication, GenerationPublicationPhase, GenerationPublicationStatus,
 };
@@ -78,8 +79,9 @@ pub(crate) fn publish_recorded_selected_root(
     db_path: &str,
     summary: &str,
     debt: GenerationPublication,
+    delta_recorder: Option<&mut GenerationDbDeltaRecorder<'_>>,
 ) -> Result<PublicationOutcome> {
-    publish_pending_debt(conn, db_path, summary, debt)
+    publish_pending_debt(conn, db_path, summary, debt, delta_recorder)
 }
 
 pub(crate) fn retry_pending_publication(
@@ -91,7 +93,7 @@ pub(crate) fn retry_pending_publication(
         .into_iter()
         .last()
         .ok_or_else(|| anyhow!("no pending generation publication debt"))?;
-    publish_pending_debt(conn, db_path, summary, debt)
+    publish_pending_debt(conn, db_path, summary, debt, None)
 }
 
 fn publish_pending_debt(
@@ -99,8 +101,9 @@ fn publish_pending_debt(
     db_path: &str,
     summary: &str,
     debt: GenerationPublication,
+    delta_recorder: Option<&mut GenerationDbDeltaRecorder<'_>>,
 ) -> Result<PublicationOutcome> {
-    publish_pending_debt_with_hook(conn, db_path, summary, debt, |_| Ok(()))
+    publish_pending_debt_with_hook(conn, db_path, summary, debt, delta_recorder, |_| Ok(()))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -115,6 +118,7 @@ fn publish_pending_debt_with_hook(
     db_path: &str,
     summary: &str,
     debt: GenerationPublication,
+    mut delta_recorder: Option<&mut GenerationDbDeltaRecorder<'_>>,
     mut checkpoint: impl FnMut(PublicationReplayCheckpoint) -> Result<()>,
 ) -> Result<PublicationOutcome> {
     let runtime_root = ConaryRuntimeRoot::from_db_path(db_path);
@@ -127,11 +131,14 @@ fn publish_pending_debt_with_hook(
 
     let publish_result = replay_publication(
         conn,
-        db_path,
-        summary,
-        &runtime_root,
-        &debt,
-        &config_transactions,
+        PublicationReplayRequest {
+            db_path,
+            summary,
+            runtime_root: &runtime_root,
+            debt: &debt,
+            config_transactions: &config_transactions,
+        },
+        delta_recorder.as_deref_mut(),
         &mut checkpoint,
     )
     .and_then(|built| {
@@ -142,6 +149,9 @@ fn publish_pending_debt_with_hook(
             built.state_number,
             built.generation_number,
         )?;
+        if let Some(recorder) = delta_recorder {
+            write_generation_db_backup(conn, db_path, &runtime_root, &built, Some(recorder))?;
+        }
         Ok((built, completed))
     });
 
@@ -169,15 +179,27 @@ fn publish_pending_debt_with_hook(
     }
 }
 
+struct PublicationReplayRequest<'a> {
+    db_path: &'a str,
+    summary: &'a str,
+    runtime_root: &'a ConaryRuntimeRoot,
+    debt: &'a GenerationPublication,
+    config_transactions: &'a [GenerationConfigTransaction],
+}
+
 fn replay_publication(
     conn: &Connection,
-    db_path: &str,
-    summary: &str,
-    runtime_root: &ConaryRuntimeRoot,
-    debt: &GenerationPublication,
-    config_transactions: &[GenerationConfigTransaction],
+    request: PublicationReplayRequest<'_>,
+    mut delta_recorder: Option<&mut GenerationDbDeltaRecorder<'_>>,
     checkpoint: &mut impl FnMut(PublicationReplayCheckpoint) -> Result<()>,
 ) -> Result<BuiltForPublication> {
+    let PublicationReplayRequest {
+        db_path,
+        summary,
+        runtime_root,
+        debt,
+        config_transactions,
+    } = request;
     let mut phase = debt.phase;
     let mut built = recorded_publication_numbers(debt)?;
 
@@ -283,12 +305,12 @@ fn replay_publication(
                     Some(built),
                 )?;
                 checkpoint(PublicationReplayCheckpoint::ActiveStateMarkedBeforeDatabaseBackup)?;
-                conary_core::db::backup::create_generation_db_backup(
+                write_generation_db_backup(
                     conn,
                     db_path,
-                    runtime_root.generation_path(built.generation_number),
-                    built.generation_number,
-                    built.state_number,
+                    runtime_root,
+                    built,
+                    delta_recorder.as_deref_mut(),
                 )
                 .map_err(|error| anyhow!("failed to write generation DB backup: {error}"))?;
                 set_replay_phase(
@@ -320,6 +342,54 @@ fn replay_publication(
             }
         }
     }
+}
+
+fn write_generation_db_backup(
+    conn: &Connection,
+    db_path: &str,
+    runtime_root: &ConaryRuntimeRoot,
+    built: &BuiltForPublication,
+    delta_recorder: Option<&mut GenerationDbDeltaRecorder<'_>>,
+) -> Result<()> {
+    let generation_dir = runtime_root.generation_path(built.generation_number);
+    if let Some(recorder) = delta_recorder {
+        match recorder.capture()? {
+            GenerationDbDeltaCapture::Captured(delta) => {
+                let prior =
+                    conary_core::db::generation_backup_chain::find_generation_db_chain_by_baseline(
+                        runtime_root.generations_dir(),
+                        built.generation_number,
+                        delta.source_baseline(),
+                    )?;
+                if let Some(prior_generation_dir) = prior {
+                    conary_core::db::backup::create_generation_db_backup_from_delta(
+                        conn,
+                        db_path,
+                        prior_generation_dir,
+                        &generation_dir,
+                        built.generation_number,
+                        built.state_number,
+                        &delta,
+                    )?;
+                    return Ok(());
+                }
+            }
+            GenerationDbDeltaCapture::Fallback(reason) => {
+                tracing::info!(
+                    fallback_reason = reason.as_str(),
+                    "Generation database delta capture requires a new full base"
+                );
+            }
+        }
+    }
+    conary_core::db::backup::create_generation_db_backup(
+        conn,
+        db_path,
+        generation_dir,
+        built.generation_number,
+        built.state_number,
+    )?;
+    Ok(())
 }
 
 fn set_replay_phase(
@@ -460,6 +530,7 @@ mod tests {
             &fixture.db_path,
             "link-before-projection crash",
             fixture.debt.clone(),
+            None,
             |checkpoint| {
                 if checkpoint == PublicationReplayCheckpoint::CurrentLinkSwappedBeforePhase
                     && !interrupted
@@ -518,6 +589,7 @@ mod tests {
             &fixture.db_path,
             "active-before-backup crash",
             fixture.debt.clone(),
+            None,
             |checkpoint| {
                 if checkpoint == PublicationReplayCheckpoint::ActiveStateMarkedBeforeDatabaseBackup
                     && !interrupted
@@ -567,6 +639,7 @@ mod tests {
             &fixture.db_path,
             "database-backup crash",
             fixture.debt.clone(),
+            None,
             |checkpoint| {
                 if checkpoint == PublicationReplayCheckpoint::DatabaseBackedUpBeforeTerminalState
                     && !interrupted
@@ -605,6 +678,71 @@ mod tests {
             fixture.reload_debt()
         );
         fixture.assert_terminal_publication();
+    }
+
+    #[test]
+    fn normal_publication_finalizes_one_self_contained_terminal_delta() {
+        let fixture = PublicationCrashFixture::new();
+        fixture
+            .conn
+            .execute(
+                "INSERT INTO generation_publications (
+                     db_path, runtime_root, phase, status, state_number,
+                     generation_number, summary, recoverable, completed_at
+                 ) VALUES (?1, ?2, 'database_backed_up', 'complete', 1, 1,
+                           'prior generation', 0, CURRENT_TIMESTAMP)",
+                rusqlite::params![
+                    &fixture.db_path,
+                    fixture.runtime_root.root().display().to_string()
+                ],
+            )
+            .unwrap();
+        conary_core::db::backup::create_generation_db_backup(
+            &fixture.conn,
+            &fixture.db_path,
+            fixture.runtime_root.generation_path(1),
+            1,
+            1,
+        )
+        .unwrap();
+        let mut recorder =
+            GenerationDbDeltaRecorder::begin(&fixture.conn, &fixture.db_path).unwrap();
+
+        let outcome = publish_pending_debt_with_hook(
+            &fixture.conn,
+            &fixture.db_path,
+            "delta publication",
+            fixture.debt.clone(),
+            Some(&mut recorder),
+            |_| Ok(()),
+        )
+        .unwrap();
+
+        assert!(!outcome.needs_publication, "{outcome:?}");
+        let generation = outcome.generation_number.unwrap();
+        let manifest = conary_core::db::generation_backup_chain::read_generation_db_chain(
+            fixture
+                .runtime_root
+                .generation_path(generation)
+                .join("state"),
+        )
+        .unwrap();
+        assert_eq!(manifest.deltas.len(), 1);
+        assert_eq!(
+            manifest.final_baseline,
+            conary_core::db::generation_delta::read_baseline_token(&fixture.conn).unwrap()
+        );
+        let state_dir = fixture
+            .runtime_root
+            .generation_path(generation)
+            .join("state");
+        let delta_artifact_count = std::fs::read_dir(state_dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .filter(|name| name.to_string_lossy().starts_with("conary.db.delta-"))
+            .count();
+        assert_eq!(delta_artifact_count, 1);
+        assert!(fixture.generation_backup_exists(&fixture.reload_debt()));
     }
 
     struct PublicationCrashFixture {

--- a/apps/conary/src/commands/install/batch/execution.rs
+++ b/apps/conary/src/commands/install/batch/execution.rs
@@ -60,6 +60,11 @@ impl BatchInstaller<'_> {
             std::path::PathBuf::from(self.db_path),
         );
         let selected_root = selected.selected_root().to_path_buf();
+        let mut generation_db_delta =
+            conary_core::db::generation_delta::GenerationDbDeltaRecorder::begin(
+                conn,
+                self.db_path,
+            )?;
         let tx = conn.unchecked_transaction()?;
         let execution = (|| -> Result<_> {
             let BatchDbRows {
@@ -162,6 +167,7 @@ impl BatchInstaller<'_> {
             self.db_path,
             summary,
             publication_debt,
+            Some(&mut generation_db_delta),
         )?;
         if outcome.needs_publication {
             crate::commands::append_deferred_follow_up_metadata(

--- a/apps/conary/src/commands/install/restore/transaction.rs
+++ b/apps/conary/src/commands/install/restore/transaction.rs
@@ -228,6 +228,8 @@ fn execute_locked_restore(
         .map(|prepared| inner::store_install_files_in_cas(cas, &prepared.extraction))
         .collect::<Result<Vec<_>>>()?;
     let selected_path = selected_root.selected_root().to_path_buf();
+    let mut generation_db_delta =
+        conary_core::db::generation_delta::GenerationDbDeltaRecorder::begin(conn, db_path)?;
     let tx = conn.unchecked_transaction()?;
     let execution = (|| -> Result<_> {
         let mut changeset = Changeset::new(description.to_string());
@@ -340,6 +342,7 @@ fn execute_locked_restore(
         db_path,
         description,
         publication_debt,
+        Some(&mut generation_db_delta),
     )?;
     if outcome.needs_publication {
         crate::commands::append_deferred_follow_up_metadata(

--- a/apps/conary/src/commands/install/transaction/selected_root.rs
+++ b/apps/conary/src/commands/install/transaction/selected_root.rs
@@ -170,6 +170,13 @@ where
     );
     let selected_path = selected_root.selected_root().to_path_buf();
     let mut changeset = Changeset::new(tx_description.clone());
+    let mut generation_db_delta = if ctx.defer_generation {
+        None
+    } else {
+        Some(
+            conary_core::db::generation_delta::GenerationDbDeltaRecorder::begin(conn, ctx.db_path)?,
+        )
+    };
     let tx = conn.unchecked_transaction()?;
     let changeset_id = changeset.insert(&tx)?;
     let materialized_directories =
@@ -263,6 +270,7 @@ where
             ctx.db_path,
             &tx_description,
             publication_debt,
+            generation_db_delta.as_mut(),
         )?;
         if outcome.needs_publication {
             crate::commands::append_deferred_follow_up_metadata(

--- a/apps/conary/src/commands/model/apply.rs
+++ b/apps/conary/src/commands/model/apply.rs
@@ -225,7 +225,7 @@ pub(super) async fn apply_replatform_changes(
     root: &str,
     actions: &[&DiffAction],
 ) -> Result<(usize, Vec<String>)> {
-    let conn = rusqlite::Connection::open(db_path)?;
+    let conn = conary_core::db::open(db_path)?;
     let owned_actions = actions
         .iter()
         .map(|action| (*action).clone())
@@ -271,7 +271,7 @@ pub(super) async fn apply_replatform_changes(
         };
 
         let current_source = {
-            let conn = rusqlite::Connection::open(db_path)?;
+            let conn = conary_core::db::open(db_path)?;
             find_current_replatform_source(&conn, &transaction)?
                 .or_else(|| transaction.current_source_identity.clone())
                 .unwrap_or_else(|| "unknown source".to_string())
@@ -285,7 +285,7 @@ pub(super) async fn apply_replatform_changes(
             let repository_package_id = transaction
                 .install_repository_package_id
                 .context("executable replatform plan has no exact repository package id")?;
-            let conn = rusqlite::Connection::open(db_path)?;
+            let conn = conary_core::db::open(db_path)?;
             let package = RepositoryPackage::find_by_id(&conn, repository_package_id)?
                 .context("exact replatform repository package row disappeared")?;
             if package.name != transaction.package
@@ -321,7 +321,7 @@ pub(super) async fn apply_replatform_changes(
         .await
         {
             Ok(()) => {
-                let conn = rusqlite::Connection::open(db_path)?;
+                let conn = conary_core::db::open(db_path)?;
                 match finalize_replatform_provenance(&conn, &transaction, &selection_reason) {
                     Ok(()) => {
                         println!(

--- a/apps/conary/src/commands/model/apply/dry_run_tests.rs
+++ b/apps/conary/src/commands/model/apply/dry_run_tests.rs
@@ -115,7 +115,7 @@ async fn model_apply_dry_run_rejects_the_same_invalid_package_transaction_as_app
     );
     let (package_url, _server) = serve_test_file_n(package_path.clone(), 2);
 
-    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let conn = conary_core::db::open(&db_path).unwrap();
     let repository_id = insert_test_static_ccs_repository(
         &conn,
         "fedora",

--- a/apps/conary/src/commands/model/apply/tests.rs
+++ b/apps/conary/src/commands/model/apply/tests.rs
@@ -193,7 +193,7 @@ async fn test_model_apply_installs_explicit_roots_in_one_lifecycle_transaction()
     let (consumer_url, _consumer_server) = serve_test_file(consumer_path.clone());
     let (provider_url, _provider_server) = serve_test_file(provider_path.clone());
 
-    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let conn = conary_core::db::open(&db_path).unwrap();
     let repository_id = insert_test_static_ccs_repository(
         &conn,
         "fedora",
@@ -283,7 +283,7 @@ install = ["a-model-consumer", "z-model-provider"]
     let _mount_skip = crate::commands::composefs_ops::test_mount_skip_guard();
     result.await.unwrap();
 
-    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let conn = conary_core::db::open(&db_path).unwrap();
     let mut changeset_ids = Vec::new();
     for name in [consumer_name, provider_name] {
         let installed = Trove::find_by_name(&conn, name).unwrap();
@@ -329,7 +329,7 @@ async fn test_replatform_executor_replaces_package_when_route_is_executable() {
     let package_checksum = conary_core::hash::sha256(&std::fs::read(&package_path).unwrap());
     let (package_url, _server_handle) = serve_test_file(package_path.clone());
 
-    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let conn = conary_core::db::open(&db_path).unwrap();
     let mut fedora_repo = Repository::new(
         "fedora".to_string(),
         "https://example.test/fedora".to_string(),
@@ -403,7 +403,7 @@ async fn test_replatform_executor_replaces_package_when_route_is_executable() {
         "unexpected replatform errors: {errors:?}"
     );
 
-    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let conn = conary_core::db::open(&db_path).unwrap();
     let installed_troves = Trove::find_by_name(&conn, "vim").unwrap();
     assert_eq!(installed_troves.len(), 1);
     let installed = &installed_troves[0];
@@ -447,7 +447,7 @@ async fn test_model_apply_replatform_executes_typed_rpm_lifecycle() {
     let package_checksum = conary_core::hash::sha256(&std::fs::read(&package_path).unwrap());
     let (package_url, _server_handle) = serve_test_file(package_path.clone());
 
-    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let conn = conary_core::db::open(&db_path).unwrap();
     let mut arch_repo =
         Repository::new("arch".to_string(), "https://example.test/arch".to_string());
     arch_repo.source_profile = Some("arch".to_string());
@@ -534,7 +534,7 @@ async fn test_model_apply_replatform_executes_typed_rpm_lifecycle() {
         "unexpected replatform errors: {errors:?}"
     );
 
-    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let conn = conary_core::db::open(&db_path).unwrap();
     let installed_troves = Trove::find_by_name(&conn, "vim").unwrap();
     assert_eq!(installed_troves.len(), 1);
     let installed = &installed_troves[0];
@@ -583,7 +583,7 @@ async fn test_model_apply_rolls_back_or_reports_partial_failure_during_replatfor
     let package_checksum = conary_core::hash::sha256(&std::fs::read(&package_path).unwrap());
     let (package_url, _server_handle) = serve_test_file(package_path.clone());
 
-    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let conn = conary_core::db::open(&db_path).unwrap();
 
     let mut fedora_repo = Repository::new(
         "fedora".to_string(),
@@ -670,7 +670,7 @@ async fn test_model_apply_rolls_back_or_reports_partial_failure_during_replatfor
         errors[0]
     );
 
-    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let conn = conary_core::db::open(&db_path).unwrap();
     let installed_troves = Trove::find_by_name(&conn, "vim").unwrap();
     assert_eq!(installed_troves.len(), 1);
     let installed = &installed_troves[0];

--- a/apps/conary/src/commands/model/remote_diff.rs
+++ b/apps/conary/src/commands/model/remote_diff.rs
@@ -214,7 +214,7 @@ mod tests {
     async fn test_remote_diff_detects_missing() {
         // Create test DB and populate cache
         let (_temp_file, db_path) = create_test_db();
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = conary_core::db::open(&db_path).unwrap();
 
         // Create a cached remote collection with members
         let mut signed_data = CollectionData {

--- a/apps/conary/src/commands/remove/native_graph.rs
+++ b/apps/conary/src/commands/remove/native_graph.rs
@@ -88,6 +88,8 @@ fn execute_selected_root_graph(
         .to_string();
     let summary = format!("Remove {package_name}");
     let mut changeset = Changeset::new(format!("Remove {}-{}", trove.name, trove.version));
+    let mut generation_db_delta =
+        conary_core::db::generation_delta::GenerationDbDeltaRecorder::begin(conn, db_path)?;
     let tx = conn.unchecked_transaction()?;
     let changeset_id = changeset.insert(&tx)?;
     let mut output: Option<(RemoveInnerResult, crate::commands::LiveRootStats)> = None;
@@ -220,6 +222,7 @@ fn execute_selected_root_graph(
         db_path,
         &summary,
         publication_debt,
+        Some(&mut generation_db_delta),
     )?;
     if outcome.needs_publication {
         crate::commands::append_deferred_follow_up_metadata(

--- a/apps/conary/src/commands/system/rollback_command.rs
+++ b/apps/conary/src/commands/system/rollback_command.rs
@@ -59,8 +59,10 @@ where
     }
 
     require_active_generation(changeset_id, &runtime_root)?;
-    let mut conn = crate::commands::open_db(db_path)?;
-    let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let conn = crate::commands::open_db(db_path)?;
+    let mut generation_db_delta =
+        conary_core::db::generation_delta::GenerationDbDeltaRecorder::begin(&conn, db_path)?;
+    let tx = rusqlite::Transaction::new_unchecked(&conn, TransactionBehavior::Immediate)?;
     let execution = (|| -> Result<CommittedRollback> {
         let changeset = require_effective_rollback_target(&tx, changeset_id)?;
         let authority = exact_rollback_authority(&tx, &changeset)?;
@@ -168,6 +170,7 @@ where
         db_path,
         &committed.summary,
         committed.publication_debt,
+        Some(&mut generation_db_delta),
     )?;
     if publication.needs_publication {
         crate::commands::append_deferred_follow_up_metadata(

--- a/apps/conary/src/commands/update/collection.rs
+++ b/apps/conary/src/commands/update/collection.rs
@@ -247,12 +247,11 @@ mod tests {
     use conary_core::db::models::{
         CollectionMember, InstallSource, Repository, RepositoryPackage, Trove, TroveType,
     };
-    use rusqlite::Connection;
 
     #[tokio::test]
     async fn collection_update_preserves_member_variant_selector() {
         let (_temp, db_path) = create_test_db();
-        let conn = Connection::open(&db_path).unwrap();
+        let conn = conary_core::db::open(&db_path).unwrap();
 
         let mut repo = Repository::new(
             "variant-repo".to_string(),

--- a/apps/conary/src/commands/update/package/tests.rs
+++ b/apps/conary/src/commands/update/package/tests.rs
@@ -613,7 +613,7 @@ fn delta_result_uses_verified_cas_retrieval() {
 #[test]
 fn mark_pending_changeset_rolled_back_updates_pending_rows() {
     let (_temp, db_path) = create_test_db();
-    let mut conn = rusqlite::Connection::open(&db_path).unwrap();
+    let mut conn = conary_core::db::open(&db_path).unwrap();
     let changeset_id = conary_core::db::transaction(&mut conn, |tx| {
         let mut changeset = conary_core::db::models::Changeset::new("test update".to_string());
         changeset.insert(tx)
@@ -634,7 +634,7 @@ fn mark_pending_changeset_rolled_back_updates_pending_rows() {
 #[test]
 fn mark_pending_changeset_rolled_back_leaves_applied_rows_alone() {
     let (_temp, db_path) = create_test_db();
-    let mut conn = rusqlite::Connection::open(&db_path).unwrap();
+    let mut conn = conary_core::db::open(&db_path).unwrap();
     let changeset_id = conary_core::db::transaction(&mut conn, |tx| {
         let mut changeset = conary_core::db::models::Changeset::new("applied update".to_string());
         let id = changeset.insert(tx)?;

--- a/apps/conary/src/commands/update/selection.rs
+++ b/apps/conary/src/commands/update/selection.rs
@@ -487,7 +487,7 @@ mod tests {
     #[test]
     fn selects_debian_update_from_generic_metadata_driven_repo() {
         let (_temp, db_path) = create_test_db();
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = conary_core::db::open(&db_path).unwrap();
         let mut repo = Repository::new(
             "slice-d-local-update".to_string(),
             "http://127.0.0.1:18087".to_string(),
@@ -536,7 +536,7 @@ mod tests {
     #[test]
     fn repology_latest_signal_cannot_switch_update_source() {
         let (_temp, db_path) = create_test_db();
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = conary_core::db::open(&db_path).unwrap();
         let trove = seed_cross_source_update_fixture(&conn);
         let policy = ResolutionPolicy::new().with_mixing(DependencyMixingPolicy::Permissive);
 
@@ -551,7 +551,7 @@ mod tests {
     #[test]
     fn security_update_refuses_unknown_source_metadata_before_mutation() {
         let (_temp, db_path) = create_test_db();
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = conary_core::db::open(&db_path).unwrap();
         let trove = seed_security_update_fixture(&conn, SecurityAdvisorySupport::Unknown, false);
         let policy = ResolutionPolicy::new();
 
@@ -566,7 +566,7 @@ mod tests {
     #[test]
     fn security_update_refuses_unsupported_source_metadata_before_mutation() {
         let (_temp, db_path) = create_test_db();
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = conary_core::db::open(&db_path).unwrap();
         let trove =
             seed_security_update_fixture(&conn, SecurityAdvisorySupport::Unsupported, false);
         let policy = ResolutionPolicy::new();
@@ -582,7 +582,7 @@ mod tests {
     #[test]
     fn security_update_selects_supported_security_candidate() {
         let (_temp, db_path) = create_test_db();
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = conary_core::db::open(&db_path).unwrap();
         let trove = seed_security_update_fixture(&conn, SecurityAdvisorySupport::Supported, true);
         let policy = ResolutionPolicy::new();
 
@@ -629,7 +629,7 @@ mod tests {
     #[test]
     fn security_update_ignores_supported_non_security_candidate() {
         let (_temp, db_path) = create_test_db();
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = conary_core::db::open(&db_path).unwrap();
         let trove = seed_security_update_fixture(&conn, SecurityAdvisorySupport::Supported, false);
         let policy = ResolutionPolicy::new();
 
@@ -641,7 +641,7 @@ mod tests {
     #[test]
     fn strict_mixing_update_stays_on_current_source() {
         let (_temp, db_path) = create_test_db();
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = conary_core::db::open(&db_path).unwrap();
         let trove = seed_cross_source_update_fixture(&conn);
         let policy = ResolutionPolicy::new().with_mixing(DependencyMixingPolicy::Strict);
 

--- a/apps/remi/src/server/conversion/storage.rs
+++ b/apps/remi/src/server/conversion/storage.rs
@@ -359,8 +359,7 @@ mod tests {
 
     fn initialized_db(temp_dir: &tempfile::TempDir) -> PathBuf {
         let db_path = temp_dir.path().join("remi.db");
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
-        conary_core::db::schema::ensure_current(&conn).unwrap();
+        conary_core::db::init(&db_path).unwrap();
         db_path
     }
 
@@ -505,7 +504,7 @@ mod tests {
         // Age every row past any plausible grace period, then convert the same
         // artifact again: every chunk is already in the CAS, so this second run
         // stores nothing new and only takes references.
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = crate::server::open_runtime_db(&db_path).unwrap();
         conn.execute("UPDATE chunk_access SET last_accessed = ?1", [ANCIENT])
             .unwrap();
         drop(conn);
@@ -696,7 +695,7 @@ mod tests {
 
         // What a GC run does: unlink the chunk, then drop its tracking rows.
         harness.delete_chunk(&missing);
-        rusqlite::Connection::open(&harness.db_path)
+        crate::server::open_runtime_db(&harness.db_path)
             .unwrap()
             .execute("DELETE FROM chunk_access", [])
             .unwrap();

--- a/apps/remi/src/server/handlers/admin/chunk_gc.rs
+++ b/apps/remi/src/server/handlers/admin/chunk_gc.rs
@@ -86,7 +86,7 @@ mod tests {
         let reader_token = "chunk-gc-reader-token-67890";
         let hash = crate::server::auth::hash_token(reader_token);
         {
-            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            let conn = crate::server::open_runtime_db(&db_path).unwrap();
             conary_core::db::models::admin_token::create(
                 &conn,
                 "chunk-gc-reader",

--- a/apps/remi/src/server/handlers/admin/mod.rs
+++ b/apps/remi/src/server/handlers/admin/mod.rs
@@ -117,13 +117,8 @@ pub(crate) mod test_helpers {
         let tmp = tempfile::tempdir().unwrap();
         let db_path = tmp.path().join("test.db");
 
-        // Initialize DB with full schema
-        {
-            let conn = rusqlite::Connection::open(&db_path).unwrap();
-            conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
-                .unwrap();
-            conary_core::db::schema::ensure_current(&conn).unwrap();
-        }
+        // Initialize DB with the same connection contract as the server.
+        conary_core::db::init(&db_path).unwrap();
 
         let config = crate::server::ServerConfig {
             db_path: db_path.clone(),
@@ -154,7 +149,7 @@ pub(crate) mod test_helpers {
         let test_token = "test-admin-token-12345";
         let hash = crate::server::auth::hash_token(test_token);
         {
-            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            let conn = crate::server::open_runtime_db(&db_path).unwrap();
             conary_core::db::models::admin_token::create(&conn, "test-admin", &hash, "admin")
                 .unwrap();
         }

--- a/apps/remi/src/server/handlers/admin/repos.rs
+++ b/apps/remi/src/server/handlers/admin/repos.rs
@@ -726,7 +726,7 @@ mod tests {
         let repo_reader_token = "repo-read-only-token-67890";
         let hash = crate::server::auth::hash_token(repo_reader_token);
         {
-            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            let conn = crate::server::open_runtime_db(&db_path).unwrap();
             conary_core::db::models::admin_token::create(&conn, "repo-reader", &hash, "repos:read")
                 .unwrap();
         }

--- a/apps/remi/src/server/handlers/chunks/tests.rs
+++ b/apps/remi/src/server/handlers/chunks/tests.rs
@@ -228,7 +228,7 @@ async fn get_chunk_hides_unreferenced_protected_local_cache_hash() {
     let (state, _temp) = chunk_state_with_db(TEST_HASH, Vec::new()).await;
     {
         let state_guard = state.read().await;
-        let conn = rusqlite::Connection::open(&state_guard.config.db_path).unwrap();
+        let conn = crate::server::open_runtime_db(&state_guard.config.db_path).unwrap();
         let mut chunk = ChunkAccess::new(TEST_HASH.to_string(), 11);
         chunk.protected = true;
         chunk.upsert(&conn).unwrap();

--- a/apps/remi/src/server/handlers/models.rs
+++ b/apps/remi/src/server/handlers/models.rs
@@ -16,13 +16,15 @@ use conary_core::db::models::{CollectionMember, Trove, TroveType};
 use conary_core::model::remote::{
     CollectionData, CollectionSignature, PublishedCollectionEnvelope,
 };
-use rusqlite::{Connection, OptionalExtension};
+use rusqlite::OptionalExtension;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
 #[cfg(test)]
 use conary_core::model::remote::CollectionMemberData;
+#[cfg(test)]
+use rusqlite::Connection;
 #[cfg(test)]
 use std::collections::BTreeMap;
 
@@ -154,7 +156,7 @@ fn query_signature(
     use base64::Engine;
     use base64::engine::general_purpose::STANDARD as BASE64;
 
-    let conn = Connection::open(db_path)?;
+    let conn = super::open_handler_db(db_path)?;
 
     let result: Option<(Vec<u8>, String)> = conn
         .query_row(
@@ -372,7 +374,8 @@ fn store_collection(
         });
     }
 
-    let mut conn = Connection::open(db_path).map_err(|e| StoreError::Database(e.to_string()))?;
+    let mut conn =
+        super::open_handler_db(db_path).map_err(|e| StoreError::Database(e.to_string()))?;
     let transaction = conn
         .transaction()
         .map_err(|error| StoreError::Database(error.to_string()))?;
@@ -481,7 +484,7 @@ fn build_collection_data(
     db_path: &std::path::Path,
     name: &str,
 ) -> Result<Option<CollectionData>, anyhow::Error> {
-    let conn = Connection::open(db_path)?;
+    let conn = super::open_handler_db(db_path)?;
 
     let stored: Option<String> = conn
         .query_row(
@@ -514,7 +517,7 @@ fn insert_invalid_stored_collection(conn: &Connection, name: &str) {
 
 /// Build a listing of all collections with member counts in a single query
 fn build_collection_list(db_path: &std::path::Path) -> Result<Vec<CollectionEntry>, anyhow::Error> {
-    let conn = Connection::open(db_path)?;
+    let conn = super::open_handler_db(db_path)?;
 
     let mut stmt = conn.prepare(
         "SELECT t.name, t.version, t.description, COUNT(cm.id) AS member_count

--- a/apps/remi/src/server/release_publish.rs
+++ b/apps/remi/src/server/release_publish.rs
@@ -261,7 +261,6 @@ mod tests {
         FileAuthorityV3, LifecycleAuthorityV3, PackageDataV3, PackageIdentityV3, PackageKindTagV3,
         PackageKindV3, PackagePolicyV3, ProvenanceAuthorityV3,
     };
-    use conary_core::db::schema;
     use conary_core::payload::{PayloadContentAuthority, PayloadNode};
     use conary_core::recipe::hermetic::{
         BuildInputIdentity, BuilderEnvironmentIdentity, BuilderEnvironmentKind, DependencyLock,
@@ -302,11 +301,7 @@ mod tests {
             std::fs::create_dir_all(&cache_dir).unwrap();
             write_tuf_role_keys(&keys_dir, TEST_PROFILE, tuf_roles);
 
-            let conn = rusqlite::Connection::open(&db_path).unwrap();
-            conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
-                .unwrap();
-            schema::ensure_current(&conn).unwrap();
-            drop(conn);
+            conary_core::db::init(&db_path).unwrap();
 
             let release_publish = crate::server::config::ReleasePublishSection {
                 repository_keys_dir: Some(keys_dir.clone()),
@@ -354,7 +349,7 @@ mod tests {
         }
 
         fn converted_package_row_exists(&self, package: &str) -> bool {
-            let conn = rusqlite::Connection::open(&self.db_path).unwrap();
+            let conn = crate::server::open_runtime_db(&self.db_path).unwrap();
             let count: i64 = conn
                 .query_row(
                     "SELECT COUNT(*) FROM converted_packages
@@ -367,7 +362,7 @@ mod tests {
         }
 
         fn native_publication_row_exists(&self, package: &str, package_release: &str) -> bool {
-            let conn = rusqlite::Connection::open(&self.db_path).unwrap();
+            let conn = crate::server::open_runtime_db(&self.db_path).unwrap();
             let count: i64 = conn
                 .query_row(
                     "SELECT COUNT(*) FROM native_package_publications
@@ -381,7 +376,7 @@ mod tests {
         }
 
         fn native_status_count(&self, package: &str, status: &str) -> i64 {
-            let conn = rusqlite::Connection::open(&self.db_path).unwrap();
+            let conn = crate::server::open_runtime_db(&self.db_path).unwrap();
             conn.query_row(
                 "SELECT COUNT(*) FROM native_package_publications
                  WHERE source_profile = ?1 AND name = ?2 AND status = ?3",
@@ -392,7 +387,7 @@ mod tests {
         }
 
         fn public_package_detail_exists(&self, package: &str) -> bool {
-            let conn = rusqlite::Connection::open(&self.db_path).unwrap();
+            let conn = crate::server::open_runtime_db(&self.db_path).unwrap();
             let count: i64 = conn
                 .query_row(
                     "SELECT COUNT(*) FROM repository_packages rp
@@ -410,7 +405,7 @@ mod tests {
         }
 
         fn tuf_target_exists(&self, package: &str) -> bool {
-            let conn = rusqlite::Connection::open(&self.db_path).unwrap();
+            let conn = crate::server::open_runtime_db(&self.db_path).unwrap();
             let count: i64 = conn
                 .query_row(
                     "SELECT COUNT(*) FROM tuf_targets
@@ -423,7 +418,7 @@ mod tests {
         }
 
         fn tuf_target_hash_exists(&self, content_hash: &str) -> bool {
-            let conn = rusqlite::Connection::open(&self.db_path).unwrap();
+            let conn = crate::server::open_runtime_db(&self.db_path).unwrap();
             let count: i64 = conn
                 .query_row(
                     "SELECT COUNT(*) FROM tuf_targets
@@ -677,7 +672,7 @@ mod tests {
     fn seed_admin_token(db_path: &Path) {
         let token = "test-admin-token-12345";
         let hash = crate::server::auth::hash_token(token);
-        let conn = rusqlite::Connection::open(db_path).unwrap();
+        let conn = crate::server::open_runtime_db(db_path).unwrap();
         conary_core::db::models::admin_token::create(&conn, "test-admin", &hash, "admin").unwrap();
     }
 

--- a/apps/remi/src/server/routes.rs
+++ b/apps/remi/src/server/routes.rs
@@ -677,7 +677,7 @@ mod tests {
         let (_app, db_path) = crate::server::handlers::admin::test_helpers::test_app().await;
         let token = "test-repo-reader-token-54321";
         let hash = crate::server::auth::hash_token(token);
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = crate::server::open_runtime_db(&db_path).unwrap();
         conary_core::db::models::admin_token::create(
             &conn,
             "test-repo-reader",

--- a/apps/remi/src/server/search.rs
+++ b/apps/remi/src/server/search.rs
@@ -852,7 +852,7 @@ mod tests {
     #[test]
     fn search_rebuild_marks_stale_rows_unconverted() {
         let (db_file, _) = create_test_db();
-        let conn = rusqlite::Connection::open(db_file.path()).unwrap();
+        let conn = crate::server::open_runtime_db(db_file.path()).unwrap();
         insert_repo_package(&conn, "fedora", "gtk3", "3.24.0");
         insert_stale_conversion(&conn, "fedora", "gtk3", "3.24.0");
         drop(conn);

--- a/crates/conary-core/benches/generation_db_snapshot.rs
+++ b/crates/conary-core/benches/generation_db_snapshot.rs
@@ -2,6 +2,11 @@
 
 //! Generation database snapshot scaling against accumulated SQLite history.
 
+use conary_core::db::generation_backup_chain::{
+    GenerationDbBackupIdentity, GenerationDbChainAppend, append_generation_db_chain_delta,
+    create_generation_db_chain_base,
+};
+use conary_core::db::generation_delta::{GenerationDbDeltaCapture, GenerationDbDeltaRecorder};
 use conary_core::db::generation_snapshot::GenerationDbSnapshotProvider;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use rusqlite::Connection;
@@ -13,39 +18,34 @@ use std::time::Duration;
 
 const HISTORY_ROWS: [usize; 3] = [0, 10_000, 100_000];
 
-fn history_database(rows: usize) -> (tempfile::TempDir, std::path::PathBuf, Connection) {
+fn history_database(rows: usize) -> (tempfile::TempDir, std::path::PathBuf, Connection, i64) {
     let temp = tempfile::tempdir().unwrap();
     let db_path = temp.path().join("conary-history.sqlite");
-    let mut conn = Connection::open(&db_path).unwrap();
-    conn.execute_batch(
-        "PRAGMA journal_mode=WAL;
-         PRAGMA synchronous=NORMAL;
-         CREATE TABLE generation_history (
-             id INTEGER PRIMARY KEY,
-             generation_number INTEGER NOT NULL,
-             summary TEXT NOT NULL,
-             authority BLOB NOT NULL
-         );",
-    )
-    .unwrap();
+    conary_core::db::init(&db_path).unwrap();
+    let mut conn = conary_core::db::open(&db_path).unwrap();
     let transaction = conn.transaction().unwrap();
     {
         let mut insert = transaction
             .prepare(
-                "INSERT INTO generation_history (generation_number, summary, authority)
-                 VALUES (?1, ?2, ?3)",
+                "INSERT INTO changesets (description, status, metadata)
+                 VALUES (?1, 'applied', ?2)",
             )
             .unwrap();
         for row in 0..rows {
             let summary = format!("generation history row {row:08}");
             let authority = format!("{row:064x}{:064x}", rows.saturating_sub(row));
-            insert
-                .execute((row as i64, summary, authority.as_bytes()))
-                .unwrap();
+            insert.execute((summary, authority)).unwrap();
         }
     }
     transaction.commit().unwrap();
-    (temp, db_path, conn)
+    conn.execute(
+        "INSERT INTO changesets (description, status)
+         VALUES ('fixed delta benchmark row a', 'applied')",
+        [],
+    )
+    .unwrap();
+    let benchmark_row = conn.last_insert_rowid();
+    (temp, db_path, conn, benchmark_row)
 }
 
 fn sha256_file(path: &Path) -> String {
@@ -70,7 +70,7 @@ fn benchmark_snapshot_history_scaling(criterion: &mut Criterion) {
     provider_group.measurement_time(Duration::from_secs(6));
 
     for history_rows in HISTORY_ROWS {
-        let (_temp, db_path, conn) = history_database(history_rows);
+        let (_temp, db_path, conn, _) = history_database(history_rows);
         let destination = db_path.with_file_name("provider-snapshot.sqlite");
         let probe = GenerationDbSnapshotProvider::default()
             .snapshot(&conn, &db_path, &destination)
@@ -100,7 +100,7 @@ fn benchmark_snapshot_history_scaling(criterion: &mut Criterion) {
     identity_group.measurement_time(Duration::from_secs(6));
 
     for history_rows in HISTORY_ROWS {
-        let (_temp, db_path, conn) = history_database(history_rows);
+        let (_temp, db_path, conn, _) = history_database(history_rows);
         let destination = db_path.with_file_name("identified-snapshot.sqlite");
         let probe = GenerationDbSnapshotProvider::default()
             .snapshot(&conn, &db_path, &destination)
@@ -122,6 +122,111 @@ fn benchmark_snapshot_history_scaling(criterion: &mut Criterion) {
         );
     }
     identity_group.finish();
+
+    let mut delta_group = criterion.benchmark_group("generation_db_delta/fixed_update_capture");
+    delta_group.sample_size(20);
+    delta_group.warm_up_time(Duration::from_secs(2));
+    delta_group.measurement_time(Duration::from_secs(6));
+
+    for history_rows in HISTORY_ROWS {
+        let (_temp, db_path, conn, benchmark_row) = history_database(history_rows);
+        let mut use_a = true;
+        delta_group.bench_with_input(
+            BenchmarkId::new("sqlite-session", history_rows),
+            &history_rows,
+            |bencher, _| {
+                bencher.iter(|| {
+                    let recorder =
+                        GenerationDbDeltaRecorder::begin(black_box(&conn), black_box(&db_path))
+                            .unwrap();
+                    use_a = !use_a;
+                    let description = if use_a {
+                        "fixed delta benchmark row a"
+                    } else {
+                        "fixed delta benchmark row b"
+                    };
+                    conn.execute(
+                        "UPDATE changesets SET description = ?1 WHERE id = ?2",
+                        (description, benchmark_row),
+                    )
+                    .unwrap();
+                    let GenerationDbDeltaCapture::Captured(delta) = recorder.finish().unwrap()
+                    else {
+                        panic!("single-connection benchmark unexpectedly required a full base");
+                    };
+                    black_box((delta.payload_bytes(), delta.sha256()));
+                });
+            },
+        );
+    }
+    delta_group.finish();
+
+    let mut append_group =
+        criterion.benchmark_group("generation_db_delta/fixed_append_persistence");
+    append_group.sample_size(20);
+    append_group.warm_up_time(Duration::from_secs(2));
+    append_group.measurement_time(Duration::from_secs(6));
+
+    for history_rows in HISTORY_ROWS {
+        let (temp, db_path, conn, benchmark_row) = history_database(history_rows);
+        let base_state = temp.path().join("base-state");
+        create_generation_db_chain_base(
+            &conn,
+            &db_path,
+            &base_state,
+            conary_core::db::schema::SCHEMA_EPOCH,
+            conary_core::db::schema::SCHEMA_VERSION,
+            GenerationDbBackupIdentity {
+                generation_number: 1,
+                state_number: 1,
+                transaction_high_water_mark: None,
+            },
+        )
+        .unwrap();
+        let recorder = GenerationDbDeltaRecorder::begin(&conn, &db_path).unwrap();
+        conn.execute(
+            "UPDATE changesets SET description = 'fixed delta benchmark row b' WHERE id = ?1",
+            [benchmark_row],
+        )
+        .unwrap();
+        let GenerationDbDeltaCapture::Captured(delta) = recorder.finish().unwrap() else {
+            panic!("single-connection benchmark unexpectedly required a full base");
+        };
+        let mut next_generation = 2_i64;
+        append_group.bench_with_input(
+            BenchmarkId::new("sqlite-session", history_rows),
+            &history_rows,
+            |bencher, _| {
+                bencher.iter(|| {
+                    let generation_number = next_generation;
+                    next_generation += 1;
+                    let state_dir = temp
+                        .path()
+                        .join(format!("append-state-{generation_number}"));
+                    let GenerationDbChainAppend::Appended(record) =
+                        append_generation_db_chain_delta(
+                            black_box(&base_state),
+                            black_box(&state_dir),
+                            black_box(&delta),
+                            conary_core::db::schema::SCHEMA_EPOCH,
+                            conary_core::db::schema::SCHEMA_VERSION,
+                            GenerationDbBackupIdentity {
+                                generation_number,
+                                state_number: generation_number,
+                                transaction_high_water_mark: None,
+                            },
+                        )
+                        .unwrap()
+                    else {
+                        panic!("exact single-delta append unexpectedly required a full base");
+                    };
+                    assert_eq!(record.metrics.payload_bytes_written, delta.payload_bytes());
+                    black_box(record.metrics);
+                });
+            },
+        );
+    }
+    append_group.finish();
 }
 
 criterion_group!(benches, benchmark_snapshot_history_scaling);

--- a/crates/conary-core/src/db/backup.rs
+++ b/crates/conary-core/src/db/backup.rs
@@ -2,9 +2,14 @@
 
 //! Durable SQLite checkpoint backups for Conary live-state recovery.
 
-use crate::db::generation_snapshot::{
-    GenerationDbSnapshotMetrics, GenerationDbSnapshotProvenance, GenerationDbSnapshotProvider,
+use crate::db::generation_backup_chain::{
+    GENERATION_DB_CHAIN_MANIFEST_FILE, GenerationDbBackupIdentity, GenerationDbChainAppend,
+    GenerationDbChainManifest, GenerationDbChainMetrics, GenerationDbChainRecord,
+    append_generation_db_chain_delta, create_generation_db_chain_base,
+    materialize_and_verify_generation_db_chain, read_generation_db_chain,
 };
+use crate::db::generation_delta::GenerationDbDelta;
+use crate::db::generation_snapshot::GenerationDbSnapshotProvenance;
 use crate::db::schema;
 use crate::filesystem::durable::{sync_parent_directory, write_file_atomic, write_json_atomic};
 use crate::hash::sha256_reader_hex;
@@ -18,14 +23,9 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 
 const BACKUP_FORMAT: &str = "conary.db-checkpoint.v1";
-const GENERATION_BACKUP_FORMAT: &str = "conary.generation-db-backup.v2";
 const CHECKPOINT_MANIFEST_VERSION: u32 = 1;
-const GENERATION_MANIFEST_VERSION: u32 = 2;
 const DEFAULT_RETAIN_COUNT: usize = 5;
 const DEFAULT_RETAIN_DAYS: i64 = 14;
-const GENERATION_BACKUP_FILE: &str = "conary.db.backup";
-const GENERATION_BACKUP_CHECKSUM_FILE: &str = "conary.db.backup.sha256";
-const GENERATION_BACKUP_MANIFEST_FILE: &str = "conary-db-backup.json";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -73,30 +73,20 @@ pub struct BackupVerification {
     pub sqlite_page_count: Option<i64>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct GenerationDbBackupManifest {
-    pub format: String,
-    pub manifest_version: u32,
-    pub db_schema_version: i32,
-    pub generation_number: i64,
-    pub state_number: i64,
-    pub created_at: String,
-    pub backup_file: String,
-    pub compression: Option<String>,
-    pub backup_sha256: String,
-    pub sqlite_page_count: Option<i64>,
-    pub transaction_high_water_mark: Option<i64>,
-    pub snapshot: GenerationDbSnapshotProvenance,
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct MaterializedSqliteInspection {
+    db_schema_version: i32,
+    sqlite_page_count: Option<i64>,
 }
+
+pub type GenerationDbBackupManifest = GenerationDbChainManifest;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GenerationDbBackupRecord {
     pub backup_path: PathBuf,
-    pub checksum_path: PathBuf,
     pub manifest_path: PathBuf,
     pub manifest: GenerationDbBackupManifest,
-    pub creation_metrics: Option<GenerationDbSnapshotMetrics>,
+    pub creation_metrics: Option<GenerationDbChainMetrics>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -111,6 +101,7 @@ pub struct GenerationDbBackupVerification {
     pub sqlite_page_count: Option<i64>,
     pub transaction_high_water_mark: Option<i64>,
     pub snapshot: GenerationDbSnapshotProvenance,
+    pub delta_count: usize,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -394,74 +385,104 @@ pub fn create_generation_db_backup(
         return Err(Error::DatabaseNotFound(db_path.display().to_string()));
     }
 
-    let state_dir = generation_state_backup_dir(generation_dir);
-    std::fs::create_dir_all(&state_dir)?;
-    let tmp_backup_path = state_dir.join(".conary.db.backup.tmp");
-    let backup_path = state_dir.join(GENERATION_BACKUP_FILE);
-    let checksum_path = state_dir.join(GENERATION_BACKUP_CHECKSUM_FILE);
-    let manifest_path = state_dir.join(GENERATION_BACKUP_MANIFEST_FILE);
-
-    remove_if_exists(&tmp_backup_path)?;
     let transaction_high_water_mark =
         crate::db::models::GenerationPublication::applied_high_water_changeset_id(source)?;
     validate_generation_directory_number(generation_dir, generation_number)?;
     verify_generation_artifact_identity(generation_dir, generation_number)?;
-
-    let snapshot =
-        GenerationDbSnapshotProvider::default().snapshot(source, db_path, &tmp_backup_path)?;
-    std::fs::rename(&tmp_backup_path, &backup_path)?;
-    sync_parent_directory(&backup_path)?;
-
-    let verification = verify_sqlite_database(&backup_path)?;
-    if verification.db_schema_version != schema::SCHEMA_VERSION {
-        return Err(Error::RecoveryFailed(format!(
-            "refusing to write generation DB backup with schema version {}; supported schema is {}",
-            verification.db_schema_version,
-            schema::SCHEMA_VERSION
-        )));
-    }
-    verify_generation_publication_state_values(generation_number, state_number, &backup_path)?;
-    verify_transaction_high_water_mark(transaction_high_water_mark, &backup_path)?;
-
-    let manifest = GenerationDbBackupManifest {
-        format: GENERATION_BACKUP_FORMAT.to_string(),
-        manifest_version: GENERATION_MANIFEST_VERSION,
-        db_schema_version: verification.db_schema_version,
-        generation_number,
-        state_number,
-        created_at: Utc::now().to_rfc3339(),
-        backup_file: GENERATION_BACKUP_FILE.to_string(),
-        compression: None,
-        backup_sha256: verification.backup_sha256.clone(),
-        sqlite_page_count: verification.sqlite_page_count,
-        transaction_high_water_mark,
-        snapshot: snapshot.provenance,
-    };
-
-    write_file_atomic(
-        &checksum_path,
-        format!("{}  {}\n", manifest.backup_sha256, manifest.backup_file).as_bytes(),
+    verify_generation_publication_state_connection(source, generation_number, state_number)?;
+    verify_transaction_high_water_mark_connection(source, transaction_high_water_mark)?;
+    let state_dir = generation_state_backup_dir(generation_dir);
+    let chain = create_generation_db_chain_base(
+        source,
+        db_path,
+        &state_dir,
+        schema::SCHEMA_EPOCH,
+        schema::SCHEMA_VERSION,
+        GenerationDbBackupIdentity {
+            generation_number,
+            state_number,
+            transaction_high_water_mark,
+        },
     )?;
-    write_json_atomic(&manifest_path, &manifest)?;
-
-    let record = GenerationDbBackupRecord {
-        backup_path,
-        checksum_path,
-        manifest_path,
-        manifest,
-        creation_metrics: Some(snapshot.metrics),
-    };
+    let record = generation_record_from_chain(chain);
     tracing::info!(
-        snapshot_method = record.manifest.snapshot.method.as_str(),
-        payload_bytes_written = record.manifest.snapshot.payload_bytes_written,
-        logical_size = record.manifest.snapshot.logical_size,
+        snapshot_method = record.manifest.base.snapshot.method.as_str(),
+        payload_bytes_written = record
+            .creation_metrics
+            .map(|metrics| metrics.payload_bytes_written)
+            .unwrap_or_default(),
+        logical_size = record.manifest.base.logical_size,
+        delta_count = record.manifest.deltas.len(),
         provider_elapsed_ns = record
             .creation_metrics
-            .map(|metrics| metrics.provider_elapsed_ns)
+            .and_then(|metrics| metrics.provider_elapsed_ns)
             .unwrap_or_default(),
-        "Created generation database snapshot"
+        "Created generation database recovery chain"
     );
     Ok(record)
+}
+
+pub fn create_generation_db_backup_from_delta(
+    source: &Connection,
+    db_path: impl AsRef<Path>,
+    prior_generation_dir: impl AsRef<Path>,
+    generation_dir: impl AsRef<Path>,
+    generation_number: i64,
+    state_number: i64,
+    delta: &GenerationDbDelta,
+) -> Result<GenerationDbBackupRecord> {
+    let db_path = db_path.as_ref();
+    let generation_dir = generation_dir.as_ref();
+    let transaction_high_water_mark =
+        crate::db::models::GenerationPublication::applied_high_water_changeset_id(source)?;
+    validate_generation_directory_number(generation_dir, generation_number)?;
+    verify_generation_artifact_identity(generation_dir, generation_number)?;
+    verify_generation_publication_state_connection(source, generation_number, state_number)?;
+    verify_transaction_high_water_mark_connection(source, transaction_high_water_mark)?;
+    let identity = GenerationDbBackupIdentity {
+        generation_number,
+        state_number,
+        transaction_high_water_mark,
+    };
+    let state_dir = generation_state_backup_dir(generation_dir);
+    match append_generation_db_chain_delta(
+        generation_state_backup_dir(prior_generation_dir.as_ref()),
+        &state_dir,
+        delta,
+        schema::SCHEMA_EPOCH,
+        schema::SCHEMA_VERSION,
+        identity,
+    )? {
+        GenerationDbChainAppend::Appended(chain) => {
+            let record = generation_record_from_chain(*chain);
+            tracing::info!(
+                payload_bytes_written = record
+                    .creation_metrics
+                    .map(|metrics| metrics.payload_bytes_written)
+                    .unwrap_or_default(),
+                linked_artifacts = record
+                    .creation_metrics
+                    .map(|metrics| metrics.linked_artifacts)
+                    .unwrap_or_default(),
+                delta_count = record.manifest.deltas.len(),
+                "Created generation database recovery delta"
+            );
+            Ok(record)
+        }
+        GenerationDbChainAppend::NeedsBase(reason) => {
+            tracing::info!(
+                fallback_reason = ?reason,
+                "Generation database delta requires a new full base"
+            );
+            create_generation_db_backup(
+                source,
+                db_path,
+                generation_dir,
+                generation_number,
+                state_number,
+            )
+        }
+    }
 }
 
 pub fn verify_generation_db_backup(
@@ -482,7 +503,10 @@ pub fn recover_generation_db_backup(
     verify_generation_db_backup_record(&record, None)?;
 
     if options.dry_run {
-        let verified_temp_path = verify_generation_backup_copy(&record.backup_path, options)?;
+        let verified_temp_path = verify_generation_backup_copy(
+            &generation_state_backup_dir(generation_dir.as_ref()),
+            options,
+        )?;
         return Ok(GenerationDbRecoveryOutcome {
             backup_path: record.backup_path,
             manifest_path: record.manifest_path,
@@ -523,8 +547,10 @@ pub fn recover_generation_db_backup(
 
     let restore_tmp = restore_temp_path(db_path);
     remove_if_exists(&restore_tmp)?;
-    std::fs::copy(&record.backup_path, &restore_tmp)?;
-    sync_file(&restore_tmp)?;
+    materialize_and_verify_generation_db_chain(
+        generation_state_backup_dir(generation_dir.as_ref()),
+        &restore_tmp,
+    )?;
     verify_sqlite_database(&restore_tmp)?;
     std::fs::rename(&restore_tmp, db_path)?;
     sync_parent_directory(db_path)?;
@@ -607,6 +633,16 @@ fn verify_sqlite_database(path: &Path) -> Result<BackupVerification> {
     verify_sqlite_connection(path, &conn)
 }
 
+fn inspect_materialized_sqlite(path: &Path) -> Result<MaterializedSqliteInspection> {
+    let conn = open_immutable_sqlite_snapshot(path)?;
+    Ok(MaterializedSqliteInspection {
+        db_schema_version: schema::get_schema_version(&conn)?,
+        sqlite_page_count: conn
+            .query_row("PRAGMA page_count", [], |row| row.get(0))
+            .ok(),
+    })
+}
+
 fn verify_live_sqlite_database(path: &Path) -> Result<BackupVerification> {
     let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
     verify_sqlite_connection(path, &conn)
@@ -655,17 +691,21 @@ fn generation_state_backup_dir(generation_dir: &Path) -> PathBuf {
     generation_dir.join("state")
 }
 
+fn generation_record_from_chain(chain: GenerationDbChainRecord) -> GenerationDbBackupRecord {
+    GenerationDbBackupRecord {
+        backup_path: chain.manifest_path.clone(),
+        manifest_path: chain.manifest_path,
+        manifest: chain.manifest,
+        creation_metrics: Some(chain.metrics),
+    }
+}
+
 fn read_generation_record(generation_dir: &Path) -> Result<GenerationDbBackupRecord> {
     let state_dir = generation_state_backup_dir(generation_dir);
-    let manifest_path = state_dir.join(GENERATION_BACKUP_MANIFEST_FILE);
-    let raw = std::fs::read(&manifest_path)?;
-    let manifest: GenerationDbBackupManifest = serde_json::from_slice(&raw)?;
-    let backup_rel = validate_generation_backup_file_name(&manifest.backup_file)?;
-    let backup_path = state_dir.join(backup_rel);
-    let checksum_path = state_dir.join(GENERATION_BACKUP_CHECKSUM_FILE);
+    let manifest_path = state_dir.join(GENERATION_DB_CHAIN_MANIFEST_FILE);
+    let manifest = read_generation_db_chain(&state_dir)?;
     Ok(GenerationDbBackupRecord {
-        backup_path,
-        checksum_path,
+        backup_path: manifest_path.clone(),
         manifest_path,
         manifest,
         creation_metrics: None,
@@ -682,31 +722,14 @@ fn verify_generation_db_backup_record(
         .and_then(Path::parent)
         .ok_or_else(|| Error::InvalidPath(record.manifest_path.display().to_string()))?;
 
-    if record.manifest.format != GENERATION_BACKUP_FORMAT {
+    if record.manifest.schema_epoch != schema::SCHEMA_EPOCH {
         return Err(Error::RecoveryFailed(format!(
-            "unsupported generation DB backup manifest format: {}",
-            record.manifest.format
+            "generation DB backup schema epoch {} is not supported by this Conary binary (expected {})",
+            record.manifest.schema_epoch,
+            schema::SCHEMA_EPOCH
         )));
     }
-    if record.manifest.manifest_version != GENERATION_MANIFEST_VERSION {
-        return Err(Error::RecoveryFailed(format!(
-            "unsupported generation DB backup manifest version: {}",
-            record.manifest.manifest_version
-        )));
-    }
-    if record.manifest.compression.is_some() {
-        return Err(Error::RecoveryFailed(
-            "compressed generation DB backups are not supported by this recovery path yet"
-                .to_string(),
-        ));
-    }
-    record.manifest.snapshot.validate()?;
-    if record.manifest.backup_file != GENERATION_BACKUP_FILE {
-        return Err(Error::InvalidPath(format!(
-            "generation DB backup file must be {GENERATION_BACKUP_FILE}, got {}",
-            record.manifest.backup_file
-        )));
-    }
+
     validate_generation_directory_number(generation_dir, record.manifest.generation_number)?;
 
     verify_generation_artifact_identity(generation_dir, record.manifest.generation_number)?;
@@ -720,52 +743,51 @@ fn verify_generation_db_backup_record(
         }
     }
 
-    let actual_hash = sha256_file(&record.backup_path)?;
-    if actual_hash != record.manifest.backup_sha256 {
-        return Err(Error::ChecksumMismatch {
-            expected: record.manifest.backup_sha256.clone(),
-            actual: actual_hash,
-        });
-    }
-    verify_checksum_sidecar(record)?;
-
-    let verification = verify_sqlite_database(&record.backup_path)?;
-    if verification.db_schema_version != schema::SCHEMA_VERSION {
-        return Err(Error::RecoveryFailed(format!(
-            "generation DB backup schema version {} is not supported by this Conary binary (expected {})",
-            verification.db_schema_version,
-            schema::SCHEMA_VERSION
-        )));
-    }
-    if verification.db_schema_version != record.manifest.db_schema_version {
-        return Err(Error::RecoveryFailed(format!(
-            "generation DB backup schema version changed since manifest creation: manifest={}, backup={}",
-            record.manifest.db_schema_version, verification.db_schema_version
-        )));
-    }
-    if verification.sqlite_page_count != record.manifest.sqlite_page_count {
-        return Err(Error::RecoveryFailed(format!(
-            "generation DB backup page count changed since manifest creation: manifest={:?}, backup={:?}",
-            record.manifest.sqlite_page_count, verification.sqlite_page_count
-        )));
-    }
-    verify_generation_publication_state(&record.manifest, &record.backup_path)?;
-    verify_transaction_high_water_mark(
-        record.manifest.transaction_high_water_mark,
-        &record.backup_path,
-    )?;
+    let state_dir = generation_state_backup_dir(generation_dir);
+    let temp_path = generation_backup_temp_path();
+    let inspection = (|| -> Result<MaterializedSqliteInspection> {
+        materialize_and_verify_generation_db_chain(&state_dir, &temp_path)?;
+        let inspection = inspect_materialized_sqlite(&temp_path).map_err(|error| {
+            Error::RecoveryFailed(format!(
+                "materialized generation DB verification failed: {error}"
+            ))
+        })?;
+        if inspection.db_schema_version != schema::SCHEMA_VERSION {
+            return Err(Error::RecoveryFailed(format!(
+                "generation DB backup schema version {} is not supported by this Conary binary (expected {})",
+                inspection.db_schema_version,
+                schema::SCHEMA_VERSION
+            )));
+        }
+        if inspection.db_schema_version != record.manifest.db_schema_version {
+            return Err(Error::RecoveryFailed(format!(
+                "generation DB backup schema version changed since manifest creation: manifest={}, backup={}",
+                record.manifest.db_schema_version, inspection.db_schema_version
+            )));
+        }
+        verify_generation_publication_state(&record.manifest, &temp_path)?;
+        verify_transaction_high_water_mark(
+            record.manifest.transaction_high_water_mark,
+            &temp_path,
+        )?;
+        Ok(inspection)
+    })();
+    let cleanup = remove_if_exists(&temp_path);
+    let inspection = inspection?;
+    cleanup?;
 
     Ok(GenerationDbBackupVerification {
-        backup_path: record.backup_path.clone(),
+        backup_path: record.manifest_path.clone(),
         manifest_path: record.manifest_path.clone(),
         generation_number: record.manifest.generation_number,
         state_number: record.manifest.state_number,
-        db_schema_version: verification.db_schema_version,
-        integrity_check: verification.integrity_check,
-        backup_sha256: record.manifest.backup_sha256.clone(),
-        sqlite_page_count: verification.sqlite_page_count,
+        db_schema_version: inspection.db_schema_version,
+        integrity_check: "ok".to_string(),
+        backup_sha256: record.manifest.chain_sha256.clone(),
+        sqlite_page_count: inspection.sqlite_page_count,
         transaction_high_water_mark: record.manifest.transaction_high_water_mark,
-        snapshot: record.manifest.snapshot.clone(),
+        snapshot: record.manifest.base.snapshot.clone(),
+        delta_count: record.manifest.deltas.len(),
     })
 }
 
@@ -784,20 +806,6 @@ fn verify_generation_artifact_identity(
     Ok(())
 }
 
-fn validate_generation_backup_file_name(file_name: &str) -> Result<&Path> {
-    let path = Path::new(file_name);
-    if path.is_absolute()
-        || path
-            .components()
-            .any(|component| !matches!(component, std::path::Component::Normal(_)))
-    {
-        return Err(Error::InvalidPath(format!(
-            "generation DB backup file must be a plain relative filename: {file_name}"
-        )));
-    }
-    Ok(path)
-}
-
 fn validate_generation_directory_number(generation_dir: &Path, expected: i64) -> Result<()> {
     let actual = generation_dir
         .file_name()
@@ -812,21 +820,6 @@ fn validate_generation_directory_number(generation_dir: &Path, expected: i64) ->
     if actual != expected {
         return Err(Error::RecoveryFailed(format!(
             "generation directory mismatch: directory is {actual}, backup manifest says {expected}"
-        )));
-    }
-    Ok(())
-}
-
-fn verify_checksum_sidecar(record: &GenerationDbBackupRecord) -> Result<()> {
-    let raw = std::fs::read_to_string(&record.checksum_path)?;
-    let expected = format!(
-        "{}  {}\n",
-        record.manifest.backup_sha256, record.manifest.backup_file
-    );
-    if raw != expected {
-        return Err(Error::RecoveryFailed(format!(
-            "generation DB backup checksum sidecar mismatch at {}",
-            record.checksum_path.display()
         )));
     }
     Ok(())
@@ -849,6 +842,14 @@ fn verify_generation_publication_state_values(
     backup_path: &Path,
 ) -> Result<()> {
     let conn = open_immutable_sqlite_snapshot(backup_path)?;
+    verify_generation_publication_state_connection(&conn, generation_number, expected_state_number)
+}
+
+fn verify_generation_publication_state_connection(
+    conn: &Connection,
+    generation_number: i64,
+    expected_state_number: i64,
+) -> Result<()> {
     let mut stmt = conn.prepare(
         "SELECT phase, status, recoverable, state_number
          FROM generation_publications
@@ -879,6 +880,13 @@ fn verify_generation_publication_state_values(
 
 fn verify_transaction_high_water_mark(expected: Option<i64>, backup_path: &Path) -> Result<()> {
     let conn = open_immutable_sqlite_snapshot(backup_path)?;
+    verify_transaction_high_water_mark_connection(&conn, expected)
+}
+
+fn verify_transaction_high_water_mark_connection(
+    conn: &Connection,
+    expected: Option<i64>,
+) -> Result<()> {
     let actual: Option<i64> = conn.query_row(
         "SELECT MAX(id) FROM changesets WHERE status = 'applied'",
         [],
@@ -892,8 +900,15 @@ fn verify_transaction_high_water_mark(expected: Option<i64>, backup_path: &Path)
     Ok(())
 }
 
+fn generation_backup_temp_path() -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "conary-generation-db-verify-{}.sqlite",
+        uuid::Uuid::new_v4()
+    ))
+}
+
 fn verify_generation_backup_copy(
-    backup_path: &Path,
+    state_dir: &Path,
     options: GenerationDbRecoveryOptions,
 ) -> Result<Option<PathBuf>> {
     let stamp = Utc::now()
@@ -901,9 +916,7 @@ fn verify_generation_backup_copy(
         .unwrap_or_else(|| Utc::now().timestamp_micros() * 1_000);
     let temp_path =
         std::env::temp_dir().join(format!("conary-generation-db-recover-{stamp}.sqlite"));
-    std::fs::copy(backup_path, &temp_path)?;
-    sync_file(&temp_path)?;
-    verify_sqlite_database(&temp_path)?;
+    materialize_and_verify_generation_db_chain(state_dir, &temp_path)?;
     if options.keep_temp {
         Ok(Some(temp_path))
     } else {

--- a/crates/conary-core/src/db/current_schema/definition.rs
+++ b/crates/conary-core/src/db/current_schema/definition.rs
@@ -17,5 +17,6 @@ pub fn create_current_schema(conn: &Connection) -> Result<()> {
     ] {
         conn.execute_batch(schema)?;
     }
+    crate::db::generation_delta::create_mutation_epoch_triggers(conn)?;
     Ok(())
 }

--- a/crates/conary-core/src/db/current_schema/sql/package_manager.sql
+++ b/crates/conary-core/src/db/current_schema/sql/package_manager.sql
@@ -10,6 +10,12 @@ CREATE TABLE schema_identity (
     revision INTEGER NOT NULL,
     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+CREATE TABLE generation_db_mutation_epoch (
+    singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+    token TEXT NOT NULL CHECK(length(token) = 36)
+);
+INSERT INTO generation_db_mutation_epoch (singleton, token)
+VALUES (1, '00000000-0000-0000-0000-000000000000');
 CREATE TABLE troves (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             name TEXT NOT NULL,

--- a/crates/conary-core/src/db/generation_backup_chain.rs
+++ b/crates/conary-core/src/db/generation_backup_chain.rs
@@ -11,17 +11,26 @@ use crate::filesystem::durable::{
 };
 use crate::hash::sha256_reader_hex;
 use crate::{Error, Result};
-use rusqlite::Connection;
+use chrono::Utc;
 use rusqlite::session::ConflictAction;
+use rusqlite::{Connection, OpenFlags};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 use std::fs::File;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
-pub const GENERATION_DB_CHAIN_FORMAT: &str = "conary.generation-db-chain.v1";
-pub const GENERATION_DB_CHAIN_MANIFEST_VERSION: u32 = 1;
+pub const GENERATION_DB_CHAIN_FORMAT: &str = "conary.generation-db-backup.v3";
+pub const GENERATION_DB_CHAIN_MANIFEST_VERSION: u32 = 3;
 pub const MAX_GENERATION_DB_DELTAS: usize = 32;
-pub const GENERATION_DB_CHAIN_MANIFEST_FILE: &str = "conary-db-chain.json";
+pub const GENERATION_DB_CHAIN_MANIFEST_FILE: &str = "conary-db-backup.json";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GenerationDbBackupIdentity {
+    pub generation_number: i64,
+    pub state_number: i64,
+    pub transaction_high_water_mark: Option<i64>,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -31,6 +40,7 @@ pub struct GenerationDbBaseArtifact {
     pub sqlite_page_count: i64,
     pub logical_size: u64,
     pub snapshot: GenerationDbSnapshotProvenance,
+    pub result_baseline: GenerationDbBaselineToken,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -39,6 +49,7 @@ pub struct GenerationDbDeltaArtifact {
     pub file: String,
     pub sha256: String,
     pub payload_bytes: u64,
+    pub source_baseline: GenerationDbBaselineToken,
     pub result_baseline: GenerationDbBaselineToken,
 }
 
@@ -49,6 +60,10 @@ pub struct GenerationDbChainManifest {
     pub manifest_version: u32,
     pub schema_epoch: String,
     pub db_schema_version: i32,
+    pub generation_number: i64,
+    pub state_number: i64,
+    pub created_at: String,
+    pub transaction_high_water_mark: Option<i64>,
     pub base: GenerationDbBaseArtifact,
     pub deltas: Vec<GenerationDbDeltaArtifact>,
     pub final_baseline: GenerationDbBaselineToken,
@@ -72,6 +87,7 @@ pub struct GenerationDbChainRecord {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum GenerationDbChainFallbackReason {
     ChainLimitReached,
+    EmptyDelta,
     SourceBaselineChanged,
     SchemaChanged,
 }
@@ -88,19 +104,32 @@ pub fn create_generation_db_chain_base(
     state_dir: impl AsRef<Path>,
     schema_epoch: &str,
     db_schema_version: i32,
+    identity: GenerationDbBackupIdentity,
 ) -> Result<GenerationDbChainRecord> {
     let state_dir = state_dir.as_ref();
     std::fs::create_dir_all(state_dir)?;
     let temp = state_dir.join(".conary.db.base.tmp");
     remove_if_exists(&temp)?;
     let snapshot = GenerationDbSnapshotProvider::default().snapshot(source, source_path, &temp)?;
+    let snapshot_connection = Connection::open_with_flags(
+        &temp,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    let observed_schema_version = crate::db::schema::get_schema_version(&snapshot_connection)?;
+    if observed_schema_version != db_schema_version {
+        return Err(Error::RecoveryFailed(format!(
+            "generation DB base schema version changed during snapshot: expected={db_schema_version} observed={observed_schema_version}"
+        )));
+    }
+    let sqlite_page_count =
+        snapshot_connection.query_row("PRAGMA page_count", [], |row| row.get(0))?;
+    let final_baseline = crate::db::generation_delta::read_baseline_token(&snapshot_connection)?;
+    drop(snapshot_connection);
     let sha256 = sha256_file(&temp)?;
     let file = format!("conary.db.base-{sha256}.sqlite");
     let base_path = state_dir.join(&file);
     std::fs::rename(&temp, &base_path)?;
     sync_parent_directory(&base_path)?;
-    let sqlite_page_count = source.query_row("PRAGMA page_count", [], |row| row.get(0))?;
-    let final_baseline = crate::db::generation_delta::read_baseline_token(source)?;
     let payload_bytes_written = snapshot.provenance.payload_bytes_written;
     let provider_elapsed_ns = snapshot.metrics.provider_elapsed_ns;
     let base = GenerationDbBaseArtifact {
@@ -109,19 +138,25 @@ pub fn create_generation_db_chain_base(
         sqlite_page_count,
         logical_size: snapshot.provenance.logical_size,
         snapshot: snapshot.provenance,
+        result_baseline: final_baseline.clone(),
     };
-    let chain_sha256 = calculate_chain_sha256(&base.sha256, &[]);
+    let chain_sha256 = calculate_chain_sha256(&base, &[]);
     let manifest = GenerationDbChainManifest {
         format: GENERATION_DB_CHAIN_FORMAT.to_string(),
         manifest_version: GENERATION_DB_CHAIN_MANIFEST_VERSION,
         schema_epoch: schema_epoch.to_string(),
         db_schema_version,
+        generation_number: identity.generation_number,
+        state_number: identity.state_number,
+        created_at: Utc::now().to_rfc3339(),
+        transaction_high_water_mark: identity.transaction_high_water_mark,
         base,
         deltas: Vec::new(),
         final_baseline,
         chain_sha256,
     };
     persist_manifest(state_dir, &manifest)?;
+    prune_unreferenced_artifacts(state_dir, &manifest)?;
     Ok(GenerationDbChainRecord {
         manifest_path: state_dir.join(GENERATION_DB_CHAIN_MANIFEST_FILE),
         manifest,
@@ -139,6 +174,7 @@ pub fn append_generation_db_chain_delta(
     delta: &GenerationDbDelta,
     schema_epoch: &str,
     db_schema_version: i32,
+    identity: GenerationDbBackupIdentity,
 ) -> Result<GenerationDbChainAppend> {
     let prior_state_dir = prior_state_dir.as_ref();
     let state_dir = state_dir.as_ref();
@@ -157,6 +193,11 @@ pub fn append_generation_db_chain_delta(
     if prior.deltas.len() >= MAX_GENERATION_DB_DELTAS {
         return Ok(GenerationDbChainAppend::NeedsBase(
             GenerationDbChainFallbackReason::ChainLimitReached,
+        ));
+    }
+    if delta.payload_bytes() == 0 || delta.source_baseline() == delta.result_baseline() {
+        return Ok(GenerationDbChainAppend::NeedsBase(
+            GenerationDbChainFallbackReason::EmptyDelta,
         ));
     }
 
@@ -179,22 +220,28 @@ pub fn append_generation_db_chain_delta(
         file,
         sha256: delta.sha256().to_string(),
         payload_bytes: delta.payload_bytes(),
+        source_baseline: delta.source_baseline().clone(),
         result_baseline: delta.result_baseline().clone(),
     };
     let mut deltas = prior.deltas;
     deltas.push(artifact);
-    let chain_sha256 = calculate_chain_sha256(&prior.base.sha256, &deltas);
+    let chain_sha256 = calculate_chain_sha256(&prior.base, &deltas);
     let manifest = GenerationDbChainManifest {
         format: GENERATION_DB_CHAIN_FORMAT.to_string(),
         manifest_version: GENERATION_DB_CHAIN_MANIFEST_VERSION,
         schema_epoch: schema_epoch.to_string(),
         db_schema_version,
+        generation_number: identity.generation_number,
+        state_number: identity.state_number,
+        created_at: Utc::now().to_rfc3339(),
+        transaction_high_water_mark: identity.transaction_high_water_mark,
         base: prior.base,
         deltas,
         final_baseline: delta.result_baseline().clone(),
         chain_sha256,
     };
     persist_manifest(state_dir, &manifest)?;
+    prune_unreferenced_artifacts(state_dir, &manifest)?;
     Ok(GenerationDbChainAppend::Appended(Box::new(
         GenerationDbChainRecord {
             manifest_path: state_dir.join(GENERATION_DB_CHAIN_MANIFEST_FILE),
@@ -212,6 +259,45 @@ pub fn read_generation_db_chain(state_dir: impl AsRef<Path>) -> Result<Generatio
     let path = state_dir.as_ref().join(GENERATION_DB_CHAIN_MANIFEST_FILE);
     let bytes = std::fs::read(&path)?;
     serde_json::from_slice(&bytes).map_err(Into::into)
+}
+
+pub fn find_generation_db_chain_by_baseline(
+    generations_dir: impl AsRef<Path>,
+    before_generation: i64,
+    baseline: &GenerationDbBaselineToken,
+) -> Result<Option<PathBuf>> {
+    let generations_dir = generations_dir.as_ref();
+    if !generations_dir.exists() {
+        return Ok(None);
+    }
+    let mut candidates = Vec::new();
+    for entry in std::fs::read_dir(generations_dir)? {
+        let entry = entry?;
+        let Some(number) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.parse::<i64>().ok())
+        else {
+            continue;
+        };
+        if number < before_generation {
+            candidates.push((number, entry.path()));
+        }
+    }
+    candidates.sort_by_key(|candidate| std::cmp::Reverse(candidate.0));
+    for (_, generation_dir) in candidates {
+        let state_dir = generation_dir.join("state");
+        let manifest_path = state_dir.join(GENERATION_DB_CHAIN_MANIFEST_FILE);
+        if !manifest_path.exists() {
+            continue;
+        }
+        let manifest = read_generation_db_chain(&state_dir)?;
+        validate_manifest_structure(&manifest)?;
+        if manifest.final_baseline == *baseline {
+            return Ok(Some(generation_dir));
+        }
+    }
+    Ok(None)
 }
 
 pub fn materialize_and_verify_generation_db_chain(
@@ -280,6 +366,30 @@ fn persist_manifest(state_dir: &Path, manifest: &GenerationDbChainManifest) -> R
     )
 }
 
+fn prune_unreferenced_artifacts(
+    state_dir: &Path,
+    manifest: &GenerationDbChainManifest,
+) -> Result<()> {
+    let retained = std::iter::once(manifest.base.file.as_str())
+        .chain(manifest.deltas.iter().map(|delta| delta.file.as_str()))
+        .collect::<BTreeSet<_>>();
+    for entry in std::fs::read_dir(state_dir)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        let unreferenced_v3 = (name.starts_with("conary.db.base-")
+            || name.starts_with("conary.db.delta-"))
+            && !retained.contains(name);
+        let retired_v2 = matches!(name, "conary.db.backup" | "conary.db.backup.sha256");
+        if unreferenced_v3 || retired_v2 {
+            remove_if_exists(&entry.path())?;
+        }
+    }
+    Ok(())
+}
+
 fn validate_manifest_structure(manifest: &GenerationDbChainManifest) -> Result<()> {
     if manifest.format != GENERATION_DB_CHAIN_FORMAT
         || manifest.manifest_version != GENERATION_DB_CHAIN_MANIFEST_VERSION
@@ -296,34 +406,80 @@ fn validate_manifest_structure(manifest: &GenerationDbChainManifest) -> Result<(
             manifest.deltas.len()
         )));
     }
+    if manifest.generation_number < 0
+        || manifest.state_number < 0
+        || manifest.generation_number != manifest.state_number
+    {
+        return Err(Error::RecoveryFailed(format!(
+            "generation DB chain has invalid generation/state identity: generation={} state={}",
+            manifest.generation_number, manifest.state_number
+        )));
+    }
     validate_artifact_name(&manifest.base.file, "conary.db.base-")?;
     validate_sha256(&manifest.base.sha256)?;
+    let expected_base_file = format!("conary.db.base-{}.sqlite", manifest.base.sha256);
+    if manifest.base.file != expected_base_file {
+        return Err(Error::RecoveryFailed(format!(
+            "generation DB base filename does not bind its digest: {}",
+            manifest.base.file
+        )));
+    }
     if manifest.base.logical_size == 0 || manifest.base.sqlite_page_count <= 0 {
         return Err(Error::RecoveryFailed(
             "generation DB base has invalid SQLite size metadata".to_string(),
         ));
     }
     manifest.base.snapshot.validate()?;
+    if manifest.base.snapshot.logical_size != manifest.base.logical_size {
+        return Err(Error::RecoveryFailed(
+            "generation DB base logical size disagrees with snapshot provenance".to_string(),
+        ));
+    }
+    validate_baseline_token(&manifest.base.result_baseline)?;
+    let mut expected_source = &manifest.base.result_baseline;
     for (index, artifact) in manifest.deltas.iter().enumerate() {
         validate_artifact_name(&artifact.file, "conary.db.delta-")?;
         validate_sha256(&artifact.sha256)?;
+        let expected_file = format!(
+            "conary.db.delta-{:03}-{}.changeset",
+            index + 1,
+            artifact.sha256
+        );
+        if artifact.file != expected_file {
+            return Err(Error::RecoveryFailed(format!(
+                "generation DB delta filename does not bind order and digest: {}",
+                artifact.file
+            )));
+        }
         if artifact.payload_bytes == 0 {
             return Err(Error::RecoveryFailed(format!(
                 "generation DB delta {} has zero payload bytes",
                 index + 1
             )));
         }
+        validate_baseline_token(&artifact.source_baseline)?;
+        validate_baseline_token(&artifact.result_baseline)?;
+        if artifact.source_baseline != *expected_source {
+            return Err(Error::RecoveryFailed(format!(
+                "generation DB delta {} does not continue the prior baseline",
+                index + 1
+            )));
+        }
+        if artifact.result_baseline == artifact.source_baseline {
+            return Err(Error::RecoveryFailed(format!(
+                "generation DB delta {} does not advance the baseline",
+                index + 1
+            )));
+        }
+        expected_source = &artifact.result_baseline;
     }
-    if manifest
-        .deltas
-        .last()
-        .is_some_and(|last| last.result_baseline != manifest.final_baseline)
-    {
+    validate_baseline_token(&manifest.final_baseline)?;
+    if *expected_source != manifest.final_baseline {
         return Err(Error::RecoveryFailed(
-            "generation DB chain final baseline does not match its last delta".to_string(),
+            "generation DB chain final baseline does not match its payload sequence".to_string(),
         ));
     }
-    let expected_chain = calculate_chain_sha256(&manifest.base.sha256, &manifest.deltas);
+    let expected_chain = calculate_chain_sha256(&manifest.base, &manifest.deltas);
     if expected_chain != manifest.chain_sha256 {
         return Err(Error::RecoveryFailed(format!(
             "generation DB chain identity mismatch: manifest={} calculated={expected_chain}",
@@ -370,11 +526,20 @@ fn verify_artifact(path: &Path, expected_sha256: &str, expected_size: Option<u64
     Ok(())
 }
 
-fn calculate_chain_sha256(base_sha256: &str, deltas: &[GenerationDbDeltaArtifact]) -> String {
-    let mut identity = format!("{GENERATION_DB_CHAIN_FORMAT}\0{base_sha256}").into_bytes();
+fn calculate_chain_sha256(
+    base: &GenerationDbBaseArtifact,
+    deltas: &[GenerationDbDeltaArtifact],
+) -> String {
+    let mut identity = format!(
+        "{GENERATION_DB_CHAIN_FORMAT}\0{}\0{}",
+        base.sha256, base.result_baseline.mutation_token
+    )
+    .into_bytes();
     for delta in deltas {
         identity.push(0);
         identity.extend_from_slice(delta.sha256.as_bytes());
+        identity.push(0);
+        identity.extend_from_slice(delta.source_baseline.mutation_token.as_bytes());
         identity.push(0);
         identity.extend_from_slice(delta.result_baseline.mutation_token.as_bytes());
     }
@@ -399,11 +564,25 @@ fn validate_artifact_name(file: &str, prefix: &str) -> Result<()> {
 }
 
 fn validate_sha256(value: &str) -> Result<()> {
-    if value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
         return Err(Error::RecoveryFailed(format!(
             "invalid generation DB SHA-256 identity: {value}"
         )));
     }
+    Ok(())
+}
+
+fn validate_baseline_token(token: &GenerationDbBaselineToken) -> Result<()> {
+    uuid::Uuid::parse_str(&token.mutation_token).map_err(|_| {
+        Error::RecoveryFailed(format!(
+            "invalid generation DB mutation token: {}",
+            token.mutation_token
+        ))
+    })?;
     Ok(())
 }
 
@@ -472,6 +651,36 @@ mod tests {
         connection
     }
 
+    fn identity(number: i64) -> GenerationDbBackupIdentity {
+        GenerationDbBackupIdentity {
+            generation_number: number,
+            state_number: number,
+            transaction_high_water_mark: None,
+        }
+    }
+
+    #[test]
+    fn first_generation_zero_is_a_valid_chain_identity() {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("live.sqlite");
+        let state_dir = temp.path().join("generation-0-state");
+        let source = fixture(&db_path);
+
+        let record = create_generation_db_chain_base(
+            &source,
+            &db_path,
+            &state_dir,
+            "fixture-v1",
+            39,
+            identity(0),
+        )
+        .unwrap();
+
+        assert_eq!(record.manifest.generation_number, 0);
+        assert_eq!(record.manifest.state_number, 0);
+        validate_manifest_structure(&record.manifest).unwrap();
+    }
+
     #[test]
     fn delta_generation_is_self_contained_and_reconstructs_exact_rows() {
         let temp = tempfile::tempdir().unwrap();
@@ -480,9 +689,15 @@ mod tests {
         let delta_state = temp.path().join("generation-2-state");
         let recovered = temp.path().join("recovered.sqlite");
         let source = fixture(&db_path);
-        let base =
-            create_generation_db_chain_base(&source, &db_path, &base_state, "fixture-v1", 39)
-                .unwrap();
+        let base = create_generation_db_chain_base(
+            &source,
+            &db_path,
+            &base_state,
+            "fixture-v1",
+            39,
+            identity(1),
+        )
+        .unwrap();
         let mut recorder = GenerationDbDeltaRecorder::begin_against(
             &source,
             &db_path,
@@ -498,10 +713,15 @@ mod tests {
         let GenerationDbDeltaCapture::Captured(delta) = recorder.capture().unwrap() else {
             panic!("exact base unexpectedly required a full snapshot");
         };
-        let GenerationDbChainAppend::Appended(appended) =
-            append_generation_db_chain_delta(&base_state, &delta_state, &delta, "fixture-v1", 39)
-                .unwrap()
-        else {
+        let GenerationDbChainAppend::Appended(appended) = append_generation_db_chain_delta(
+            &base_state,
+            &delta_state,
+            &delta,
+            "fixture-v1",
+            39,
+            identity(2),
+        )
+        .unwrap() else {
             panic!("short exact chain unexpectedly required a new base");
         };
         assert_eq!(
@@ -540,9 +760,15 @@ mod tests {
         let base_state = temp.path().join("generation-1-state");
         let delta_state = temp.path().join("generation-2-state");
         let source = fixture(&db_path);
-        let base =
-            create_generation_db_chain_base(&source, &db_path, &base_state, "fixture-v1", 39)
-                .unwrap();
+        let base = create_generation_db_chain_base(
+            &source,
+            &db_path,
+            &base_state,
+            "fixture-v1",
+            39,
+            identity(1),
+        )
+        .unwrap();
         let recorder = GenerationDbDeltaRecorder::begin_against(
             &source,
             &db_path,
@@ -555,10 +781,15 @@ mod tests {
         let GenerationDbDeltaCapture::Captured(delta) = recorder.finish().unwrap() else {
             panic!("exact base unexpectedly required a full snapshot");
         };
-        let GenerationDbChainAppend::Appended(record) =
-            append_generation_db_chain_delta(&base_state, &delta_state, &delta, "fixture-v1", 39)
-                .unwrap()
-        else {
+        let GenerationDbChainAppend::Appended(record) = append_generation_db_chain_delta(
+            &base_state,
+            &delta_state,
+            &delta,
+            "fixture-v1",
+            39,
+            identity(2),
+        )
+        .unwrap() else {
             panic!("short exact chain unexpectedly required a new base");
         };
         std::fs::write(
@@ -576,6 +807,55 @@ mod tests {
     }
 
     #[test]
+    fn manifest_rejects_a_delta_baseline_gap_even_with_a_matching_chain_digest() {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("live.sqlite");
+        let base_state = temp.path().join("generation-1-state");
+        let delta_state = temp.path().join("generation-2-state");
+        let source = fixture(&db_path);
+        let base = create_generation_db_chain_base(
+            &source,
+            &db_path,
+            &base_state,
+            "fixture-v1",
+            39,
+            identity(1),
+        )
+        .unwrap();
+        let recorder = GenerationDbDeltaRecorder::begin_against(
+            &source,
+            &db_path,
+            base.manifest.final_baseline,
+        )
+        .unwrap();
+        source
+            .execute("INSERT INTO authority (id, value) VALUES (2, 'delta')", [])
+            .unwrap();
+        let GenerationDbDeltaCapture::Captured(delta) = recorder.finish().unwrap() else {
+            panic!("exact base unexpectedly required a full snapshot");
+        };
+        let GenerationDbChainAppend::Appended(record) = append_generation_db_chain_delta(
+            &base_state,
+            &delta_state,
+            &delta,
+            "fixture-v1",
+            39,
+            identity(2),
+        )
+        .unwrap() else {
+            panic!("short exact chain unexpectedly required a new base");
+        };
+        let mut manifest = record.manifest;
+        manifest.deltas[0].source_baseline = GenerationDbBaselineToken {
+            mutation_token: uuid::Uuid::new_v4().to_string(),
+        };
+        manifest.chain_sha256 = calculate_chain_sha256(&manifest.base, &manifest.deltas);
+
+        let error = validate_manifest_structure(&manifest).unwrap_err();
+        assert!(error.to_string().contains("does not continue"));
+    }
+
+    #[test]
     fn current_schema_triggers_admit_exact_chain_replay() {
         let temp = tempfile::tempdir().unwrap();
         let (database, source) = crate::db::testing::create_test_db();
@@ -588,6 +868,7 @@ mod tests {
             &base_state,
             crate::db::schema::SCHEMA_EPOCH,
             crate::db::schema::SCHEMA_VERSION,
+            identity(1),
         )
         .unwrap();
         let recorder = GenerationDbDeltaRecorder::begin_against(
@@ -611,6 +892,7 @@ mod tests {
             &delta,
             crate::db::schema::SCHEMA_EPOCH,
             crate::db::schema::SCHEMA_VERSION,
+            identity(2),
         )
         .unwrap() else {
             panic!("current-schema chain unexpectedly required a new base");
@@ -626,5 +908,64 @@ mod tests {
                 .unwrap(),
             "chain-replay-fixture"
         );
+    }
+
+    #[test]
+    fn thirty_third_delta_forces_a_new_base_before_any_link_work() {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("live.sqlite");
+        let base_state = temp.path().join("generation-1-state");
+        let next_state = temp.path().join("generation-34-state");
+        let source = fixture(&db_path);
+        let mut manifest = create_generation_db_chain_base(
+            &source,
+            &db_path,
+            &base_state,
+            "fixture-v1",
+            39,
+            identity(1),
+        )
+        .unwrap()
+        .manifest;
+        let mut source_baseline = manifest.base.result_baseline.clone();
+        for index in 0..MAX_GENERATION_DB_DELTAS {
+            let result_baseline = GenerationDbBaselineToken {
+                mutation_token: uuid::Uuid::new_v4().to_string(),
+            };
+            let bytes = format!("delta-{index}").into_bytes();
+            let sha256 = crate::hash::sha256(&bytes);
+            manifest.deltas.push(GenerationDbDeltaArtifact {
+                file: format!("conary.db.delta-{:03}-{sha256}.changeset", index + 1),
+                sha256,
+                payload_bytes: bytes.len() as u64,
+                source_baseline,
+                result_baseline: result_baseline.clone(),
+            });
+            source_baseline = result_baseline;
+        }
+        manifest.final_baseline = source_baseline.clone();
+        manifest.chain_sha256 = calculate_chain_sha256(&manifest.base, &manifest.deltas);
+        persist_manifest(&base_state, &manifest).unwrap();
+        let next = GenerationDbDelta::from_bytes(
+            b"next-delta".to_vec(),
+            source_baseline,
+            GenerationDbBaselineToken {
+                mutation_token: uuid::Uuid::new_v4().to_string(),
+            },
+        );
+
+        assert_eq!(
+            append_generation_db_chain_delta(
+                &base_state,
+                &next_state,
+                &next,
+                "fixture-v1",
+                39,
+                identity(34),
+            )
+            .unwrap(),
+            GenerationDbChainAppend::NeedsBase(GenerationDbChainFallbackReason::ChainLimitReached)
+        );
+        assert!(!next_state.exists());
     }
 }

--- a/crates/conary-core/src/db/generation_backup_chain.rs
+++ b/crates/conary-core/src/db/generation_backup_chain.rs
@@ -1,0 +1,630 @@
+// conary-core/src/db/generation_backup_chain.rs
+
+//! Self-contained, bounded SQLite base-plus-changeset recovery authority.
+
+use crate::db::generation_delta::{GenerationDbBaselineToken, GenerationDbDelta};
+use crate::db::generation_snapshot::{
+    GenerationDbSnapshotProvenance, GenerationDbSnapshotProvider,
+};
+use crate::filesystem::durable::{
+    sync_parent_directory, write_file_atomic_with_mode, write_json_atomic_with_mode,
+};
+use crate::hash::sha256_reader_hex;
+use crate::{Error, Result};
+use rusqlite::Connection;
+use rusqlite::session::ConflictAction;
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+
+pub const GENERATION_DB_CHAIN_FORMAT: &str = "conary.generation-db-chain.v1";
+pub const GENERATION_DB_CHAIN_MANIFEST_VERSION: u32 = 1;
+pub const MAX_GENERATION_DB_DELTAS: usize = 32;
+pub const GENERATION_DB_CHAIN_MANIFEST_FILE: &str = "conary-db-chain.json";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GenerationDbBaseArtifact {
+    pub file: String,
+    pub sha256: String,
+    pub sqlite_page_count: i64,
+    pub logical_size: u64,
+    pub snapshot: GenerationDbSnapshotProvenance,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GenerationDbDeltaArtifact {
+    pub file: String,
+    pub sha256: String,
+    pub payload_bytes: u64,
+    pub result_baseline: GenerationDbBaselineToken,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GenerationDbChainManifest {
+    pub format: String,
+    pub manifest_version: u32,
+    pub schema_epoch: String,
+    pub db_schema_version: i32,
+    pub base: GenerationDbBaseArtifact,
+    pub deltas: Vec<GenerationDbDeltaArtifact>,
+    pub final_baseline: GenerationDbBaselineToken,
+    pub chain_sha256: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GenerationDbChainMetrics {
+    pub payload_bytes_written: u64,
+    pub linked_artifacts: usize,
+    pub provider_elapsed_ns: Option<u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GenerationDbChainRecord {
+    pub manifest_path: PathBuf,
+    pub manifest: GenerationDbChainManifest,
+    pub metrics: GenerationDbChainMetrics,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GenerationDbChainFallbackReason {
+    ChainLimitReached,
+    SourceBaselineChanged,
+    SchemaChanged,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum GenerationDbChainAppend {
+    Appended(Box<GenerationDbChainRecord>),
+    NeedsBase(GenerationDbChainFallbackReason),
+}
+
+pub fn create_generation_db_chain_base(
+    source: &Connection,
+    source_path: impl AsRef<Path>,
+    state_dir: impl AsRef<Path>,
+    schema_epoch: &str,
+    db_schema_version: i32,
+) -> Result<GenerationDbChainRecord> {
+    let state_dir = state_dir.as_ref();
+    std::fs::create_dir_all(state_dir)?;
+    let temp = state_dir.join(".conary.db.base.tmp");
+    remove_if_exists(&temp)?;
+    let snapshot = GenerationDbSnapshotProvider::default().snapshot(source, source_path, &temp)?;
+    let sha256 = sha256_file(&temp)?;
+    let file = format!("conary.db.base-{sha256}.sqlite");
+    let base_path = state_dir.join(&file);
+    std::fs::rename(&temp, &base_path)?;
+    sync_parent_directory(&base_path)?;
+    let sqlite_page_count = source.query_row("PRAGMA page_count", [], |row| row.get(0))?;
+    let final_baseline = crate::db::generation_delta::read_baseline_token(source)?;
+    let payload_bytes_written = snapshot.provenance.payload_bytes_written;
+    let provider_elapsed_ns = snapshot.metrics.provider_elapsed_ns;
+    let base = GenerationDbBaseArtifact {
+        file,
+        sha256,
+        sqlite_page_count,
+        logical_size: snapshot.provenance.logical_size,
+        snapshot: snapshot.provenance,
+    };
+    let chain_sha256 = calculate_chain_sha256(&base.sha256, &[]);
+    let manifest = GenerationDbChainManifest {
+        format: GENERATION_DB_CHAIN_FORMAT.to_string(),
+        manifest_version: GENERATION_DB_CHAIN_MANIFEST_VERSION,
+        schema_epoch: schema_epoch.to_string(),
+        db_schema_version,
+        base,
+        deltas: Vec::new(),
+        final_baseline,
+        chain_sha256,
+    };
+    persist_manifest(state_dir, &manifest)?;
+    Ok(GenerationDbChainRecord {
+        manifest_path: state_dir.join(GENERATION_DB_CHAIN_MANIFEST_FILE),
+        manifest,
+        metrics: GenerationDbChainMetrics {
+            payload_bytes_written,
+            linked_artifacts: 0,
+            provider_elapsed_ns: Some(provider_elapsed_ns),
+        },
+    })
+}
+
+pub fn append_generation_db_chain_delta(
+    prior_state_dir: impl AsRef<Path>,
+    state_dir: impl AsRef<Path>,
+    delta: &GenerationDbDelta,
+    schema_epoch: &str,
+    db_schema_version: i32,
+) -> Result<GenerationDbChainAppend> {
+    let prior_state_dir = prior_state_dir.as_ref();
+    let state_dir = state_dir.as_ref();
+    let prior = read_generation_db_chain(prior_state_dir)?;
+    validate_manifest_structure(&prior)?;
+    if prior.schema_epoch != schema_epoch || prior.db_schema_version != db_schema_version {
+        return Ok(GenerationDbChainAppend::NeedsBase(
+            GenerationDbChainFallbackReason::SchemaChanged,
+        ));
+    }
+    if prior.final_baseline != *delta.source_baseline() {
+        return Ok(GenerationDbChainAppend::NeedsBase(
+            GenerationDbChainFallbackReason::SourceBaselineChanged,
+        ));
+    }
+    if prior.deltas.len() >= MAX_GENERATION_DB_DELTAS {
+        return Ok(GenerationDbChainAppend::NeedsBase(
+            GenerationDbChainFallbackReason::ChainLimitReached,
+        ));
+    }
+
+    std::fs::create_dir_all(state_dir)?;
+    let mut linked_artifacts = 0;
+    link_artifact(prior_state_dir, state_dir, &prior.base.file)?;
+    linked_artifacts += 1;
+    for artifact in &prior.deltas {
+        link_artifact(prior_state_dir, state_dir, &artifact.file)?;
+        linked_artifacts += 1;
+    }
+
+    let file = format!(
+        "conary.db.delta-{:03}-{}.changeset",
+        prior.deltas.len() + 1,
+        delta.sha256()
+    );
+    write_file_atomic_with_mode(&state_dir.join(&file), delta.bytes(), 0o600)?;
+    let artifact = GenerationDbDeltaArtifact {
+        file,
+        sha256: delta.sha256().to_string(),
+        payload_bytes: delta.payload_bytes(),
+        result_baseline: delta.result_baseline().clone(),
+    };
+    let mut deltas = prior.deltas;
+    deltas.push(artifact);
+    let chain_sha256 = calculate_chain_sha256(&prior.base.sha256, &deltas);
+    let manifest = GenerationDbChainManifest {
+        format: GENERATION_DB_CHAIN_FORMAT.to_string(),
+        manifest_version: GENERATION_DB_CHAIN_MANIFEST_VERSION,
+        schema_epoch: schema_epoch.to_string(),
+        db_schema_version,
+        base: prior.base,
+        deltas,
+        final_baseline: delta.result_baseline().clone(),
+        chain_sha256,
+    };
+    persist_manifest(state_dir, &manifest)?;
+    Ok(GenerationDbChainAppend::Appended(Box::new(
+        GenerationDbChainRecord {
+            manifest_path: state_dir.join(GENERATION_DB_CHAIN_MANIFEST_FILE),
+            manifest,
+            metrics: GenerationDbChainMetrics {
+                payload_bytes_written: delta.payload_bytes(),
+                linked_artifacts,
+                provider_elapsed_ns: None,
+            },
+        },
+    )))
+}
+
+pub fn read_generation_db_chain(state_dir: impl AsRef<Path>) -> Result<GenerationDbChainManifest> {
+    let path = state_dir.as_ref().join(GENERATION_DB_CHAIN_MANIFEST_FILE);
+    let bytes = std::fs::read(&path)?;
+    serde_json::from_slice(&bytes).map_err(Into::into)
+}
+
+pub fn materialize_and_verify_generation_db_chain(
+    state_dir: impl AsRef<Path>,
+    destination: impl AsRef<Path>,
+) -> Result<GenerationDbChainManifest> {
+    let state_dir = state_dir.as_ref();
+    let destination = destination.as_ref();
+    let manifest = read_generation_db_chain(state_dir)?;
+    verify_manifest_payloads(state_dir, &manifest)?;
+    remove_if_exists(destination)?;
+    std::fs::copy(state_dir.join(&manifest.base.file), destination)?;
+    File::open(destination)?.sync_all()?;
+    let connection = Connection::open(destination)?;
+    crate::db::generation_delta::configure_mutation_epoch(&connection)?;
+    connection.execute_batch(
+        "PRAGMA journal_mode = DELETE;
+         PRAGMA synchronous = FULL;
+         PRAGMA foreign_keys = OFF;",
+    )?;
+    for artifact in &manifest.deltas {
+        let bytes = std::fs::read(state_dir.join(&artifact.file))?;
+        let mut input = bytes.as_slice();
+        connection.apply_strm(&mut input, None::<fn(&str) -> bool>, |_conflict, _item| {
+            ConflictAction::SQLITE_CHANGESET_ABORT
+        })?;
+        connection.execute(
+            "UPDATE generation_db_mutation_epoch SET token = ?1 WHERE singleton = 1",
+            [&artifact.result_baseline.mutation_token],
+        )?;
+    }
+    let observed = crate::db::generation_delta::read_baseline_token(&connection)?;
+    if observed != manifest.final_baseline {
+        return Err(Error::RecoveryFailed(format!(
+            "materialized generation DB baseline mismatch: manifest={:?} database={observed:?}",
+            manifest.final_baseline
+        )));
+    }
+    let integrity: String = connection.query_row("PRAGMA integrity_check", [], |row| row.get(0))?;
+    if integrity != "ok" {
+        return Err(Error::RecoveryFailed(format!(
+            "materialized generation DB integrity check failed: {integrity}"
+        )));
+    }
+    let foreign_key_errors: i64 =
+        connection.query_row("SELECT COUNT(*) FROM pragma_foreign_key_check", [], |row| {
+            row.get(0)
+        })?;
+    if foreign_key_errors != 0 {
+        return Err(Error::RecoveryFailed(format!(
+            "materialized generation DB has {foreign_key_errors} foreign-key violations"
+        )));
+    }
+    drop(connection);
+    File::open(destination)?.sync_all()?;
+    sync_parent_directory(destination)?;
+    Ok(manifest)
+}
+
+fn persist_manifest(state_dir: &Path, manifest: &GenerationDbChainManifest) -> Result<()> {
+    validate_manifest_structure(manifest)?;
+    write_json_atomic_with_mode(
+        &state_dir.join(GENERATION_DB_CHAIN_MANIFEST_FILE),
+        manifest,
+        0o600,
+    )
+}
+
+fn validate_manifest_structure(manifest: &GenerationDbChainManifest) -> Result<()> {
+    if manifest.format != GENERATION_DB_CHAIN_FORMAT
+        || manifest.manifest_version != GENERATION_DB_CHAIN_MANIFEST_VERSION
+    {
+        return Err(Error::RecoveryFailed(format!(
+            "unsupported generation DB chain format/version: {}/{}",
+            manifest.format, manifest.manifest_version
+        )));
+    }
+    if manifest.deltas.len() > MAX_GENERATION_DB_DELTAS {
+        return Err(Error::RecoveryFailed(format!(
+            "generation DB delta chain exceeds limit {}: {}",
+            MAX_GENERATION_DB_DELTAS,
+            manifest.deltas.len()
+        )));
+    }
+    validate_artifact_name(&manifest.base.file, "conary.db.base-")?;
+    validate_sha256(&manifest.base.sha256)?;
+    if manifest.base.logical_size == 0 || manifest.base.sqlite_page_count <= 0 {
+        return Err(Error::RecoveryFailed(
+            "generation DB base has invalid SQLite size metadata".to_string(),
+        ));
+    }
+    manifest.base.snapshot.validate()?;
+    for (index, artifact) in manifest.deltas.iter().enumerate() {
+        validate_artifact_name(&artifact.file, "conary.db.delta-")?;
+        validate_sha256(&artifact.sha256)?;
+        if artifact.payload_bytes == 0 {
+            return Err(Error::RecoveryFailed(format!(
+                "generation DB delta {} has zero payload bytes",
+                index + 1
+            )));
+        }
+    }
+    if manifest
+        .deltas
+        .last()
+        .is_some_and(|last| last.result_baseline != manifest.final_baseline)
+    {
+        return Err(Error::RecoveryFailed(
+            "generation DB chain final baseline does not match its last delta".to_string(),
+        ));
+    }
+    let expected_chain = calculate_chain_sha256(&manifest.base.sha256, &manifest.deltas);
+    if expected_chain != manifest.chain_sha256 {
+        return Err(Error::RecoveryFailed(format!(
+            "generation DB chain identity mismatch: manifest={} calculated={expected_chain}",
+            manifest.chain_sha256
+        )));
+    }
+    Ok(())
+}
+
+fn verify_manifest_payloads(state_dir: &Path, manifest: &GenerationDbChainManifest) -> Result<()> {
+    validate_manifest_structure(manifest)?;
+    verify_artifact(
+        &state_dir.join(&manifest.base.file),
+        &manifest.base.sha256,
+        Some(manifest.base.logical_size),
+    )?;
+    for artifact in &manifest.deltas {
+        verify_artifact(
+            &state_dir.join(&artifact.file),
+            &artifact.sha256,
+            Some(artifact.payload_bytes),
+        )?;
+    }
+    Ok(())
+}
+
+fn verify_artifact(path: &Path, expected_sha256: &str, expected_size: Option<u64>) -> Result<()> {
+    if let Some(expected) = expected_size {
+        let actual = path.metadata()?.len();
+        if actual != expected {
+            return Err(Error::RecoveryFailed(format!(
+                "generation DB chain artifact size mismatch at {}: expected={expected} actual={actual}",
+                path.display()
+            )));
+        }
+    }
+    let actual = sha256_file(path)?;
+    if actual != expected_sha256 {
+        return Err(Error::ChecksumMismatch {
+            expected: expected_sha256.to_string(),
+            actual,
+        });
+    }
+    Ok(())
+}
+
+fn calculate_chain_sha256(base_sha256: &str, deltas: &[GenerationDbDeltaArtifact]) -> String {
+    let mut identity = format!("{GENERATION_DB_CHAIN_FORMAT}\0{base_sha256}").into_bytes();
+    for delta in deltas {
+        identity.push(0);
+        identity.extend_from_slice(delta.sha256.as_bytes());
+        identity.push(0);
+        identity.extend_from_slice(delta.result_baseline.mutation_token.as_bytes());
+    }
+    crate::hash::sha256(&identity)
+}
+
+fn validate_artifact_name(file: &str, prefix: &str) -> Result<()> {
+    let path = Path::new(file);
+    if !file.starts_with(prefix)
+        || path.is_absolute()
+        || path.components().count() != 1
+        || !matches!(
+            path.components().next(),
+            Some(std::path::Component::Normal(_))
+        )
+    {
+        return Err(Error::InvalidPath(format!(
+            "generation DB chain artifact must be a plain {prefix} filename: {file}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_sha256(value: &str) -> Result<()> {
+    if value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(Error::RecoveryFailed(format!(
+            "invalid generation DB SHA-256 identity: {value}"
+        )));
+    }
+    Ok(())
+}
+
+fn link_artifact(source_dir: &Path, destination_dir: &Path, file: &str) -> Result<()> {
+    let source = source_dir.join(file);
+    let destination = destination_dir.join(file);
+    if destination.exists() {
+        let source_metadata = source.metadata()?;
+        let destination_metadata = destination.metadata()?;
+        if source_metadata.dev() == destination_metadata.dev()
+            && source_metadata.ino() == destination_metadata.ino()
+        {
+            return Ok(());
+        }
+        return Err(Error::RecoveryFailed(format!(
+            "generation DB chain artifact already exists with different identity: {}",
+            destination.display()
+        )));
+    }
+    std::fs::hard_link(&source, &destination)?;
+    sync_parent_directory(&destination)
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let mut file = File::open(path)?;
+    sha256_reader_hex(&mut file).map_err(Error::Io)
+}
+
+fn remove_if_exists(path: &Path) -> Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => sync_parent_directory(path),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(Error::Io(error)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::generation_delta::{
+        GenerationDbDeltaCapture, GenerationDbDeltaRecorder, create_mutation_epoch_triggers,
+        read_baseline_token,
+    };
+
+    fn fixture(path: &Path) -> Connection {
+        let connection = Connection::open(path).unwrap();
+        crate::db::generation_delta::configure_mutation_epoch(&connection).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE generation_db_mutation_epoch (
+                     singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+                     token TEXT NOT NULL CHECK(length(token) = 36)
+                 );
+                 INSERT INTO generation_db_mutation_epoch (singleton, token)
+                 VALUES (1, '00000000-0000-0000-0000-000000000000');
+                 CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+                 INSERT INTO schema_version (version) VALUES (39);
+                 CREATE TABLE authority (
+                     id INTEGER PRIMARY KEY,
+                     value TEXT NOT NULL
+                 );
+                 INSERT INTO authority (id, value) VALUES (1, 'base');",
+            )
+            .unwrap();
+        create_mutation_epoch_triggers(&connection).unwrap();
+        connection
+    }
+
+    #[test]
+    fn delta_generation_is_self_contained_and_reconstructs_exact_rows() {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("live.sqlite");
+        let base_state = temp.path().join("generation-1-state");
+        let delta_state = temp.path().join("generation-2-state");
+        let recovered = temp.path().join("recovered.sqlite");
+        let source = fixture(&db_path);
+        let base =
+            create_generation_db_chain_base(&source, &db_path, &base_state, "fixture-v1", 39)
+                .unwrap();
+        let mut recorder = GenerationDbDeltaRecorder::begin_against(
+            &source,
+            &db_path,
+            base.manifest.final_baseline.clone(),
+        )
+        .unwrap();
+        source
+            .execute_batch(
+                "UPDATE authority SET value = 'updated' WHERE id = 1;
+                 INSERT INTO authority (id, value) VALUES (2, 'inserted');",
+            )
+            .unwrap();
+        let GenerationDbDeltaCapture::Captured(delta) = recorder.capture().unwrap() else {
+            panic!("exact base unexpectedly required a full snapshot");
+        };
+        let GenerationDbChainAppend::Appended(appended) =
+            append_generation_db_chain_delta(&base_state, &delta_state, &delta, "fixture-v1", 39)
+                .unwrap()
+        else {
+            panic!("short exact chain unexpectedly required a new base");
+        };
+        assert_eq!(
+            appended.metrics.payload_bytes_written,
+            delta.payload_bytes()
+        );
+        assert_eq!(appended.metrics.linked_artifacts, 1);
+        assert_eq!(appended.manifest.deltas.len(), 1);
+
+        std::fs::remove_dir_all(&base_state).unwrap();
+        materialize_and_verify_generation_db_chain(&delta_state, &recovered).unwrap();
+        let recovered = Connection::open(recovered).unwrap();
+        let rows = recovered
+            .prepare("SELECT id, value FROM authority ORDER BY id")
+            .unwrap()
+            .query_map([], |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+            })
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![(1, "updated".to_string()), (2, "inserted".to_string())]
+        );
+        assert_eq!(
+            read_baseline_token(&recovered).unwrap(),
+            appended.manifest.final_baseline
+        );
+    }
+
+    #[test]
+    fn manifest_and_delta_tampering_fail_before_replay() {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("live.sqlite");
+        let base_state = temp.path().join("generation-1-state");
+        let delta_state = temp.path().join("generation-2-state");
+        let source = fixture(&db_path);
+        let base =
+            create_generation_db_chain_base(&source, &db_path, &base_state, "fixture-v1", 39)
+                .unwrap();
+        let recorder = GenerationDbDeltaRecorder::begin_against(
+            &source,
+            &db_path,
+            base.manifest.final_baseline,
+        )
+        .unwrap();
+        source
+            .execute("INSERT INTO authority (id, value) VALUES (2, 'delta')", [])
+            .unwrap();
+        let GenerationDbDeltaCapture::Captured(delta) = recorder.finish().unwrap() else {
+            panic!("exact base unexpectedly required a full snapshot");
+        };
+        let GenerationDbChainAppend::Appended(record) =
+            append_generation_db_chain_delta(&base_state, &delta_state, &delta, "fixture-v1", 39)
+                .unwrap()
+        else {
+            panic!("short exact chain unexpectedly required a new base");
+        };
+        std::fs::write(
+            delta_state.join(&record.manifest.deltas[0].file),
+            b"tampered",
+        )
+        .unwrap();
+
+        let error = materialize_and_verify_generation_db_chain(
+            &delta_state,
+            temp.path().join("recovered.sqlite"),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("size mismatch"));
+    }
+
+    #[test]
+    fn current_schema_triggers_admit_exact_chain_replay() {
+        let temp = tempfile::tempdir().unwrap();
+        let (database, source) = crate::db::testing::create_test_db();
+        let base_state = temp.path().join("generation-1-state");
+        let delta_state = temp.path().join("generation-2-state");
+        let recovered_path = temp.path().join("recovered.sqlite");
+        let base = create_generation_db_chain_base(
+            &source,
+            database.path(),
+            &base_state,
+            crate::db::schema::SCHEMA_EPOCH,
+            crate::db::schema::SCHEMA_VERSION,
+        )
+        .unwrap();
+        let recorder = GenerationDbDeltaRecorder::begin_against(
+            &source,
+            database.path(),
+            base.manifest.final_baseline,
+        )
+        .unwrap();
+        source
+            .execute(
+                "UPDATE schema_identity SET created_at = 'chain-replay-fixture'",
+                [],
+            )
+            .unwrap();
+        let GenerationDbDeltaCapture::Captured(delta) = recorder.finish().unwrap() else {
+            panic!("current-schema mutation unexpectedly required a full snapshot");
+        };
+        let GenerationDbChainAppend::Appended(_) = append_generation_db_chain_delta(
+            &base_state,
+            &delta_state,
+            &delta,
+            crate::db::schema::SCHEMA_EPOCH,
+            crate::db::schema::SCHEMA_VERSION,
+        )
+        .unwrap() else {
+            panic!("current-schema chain unexpectedly required a new base");
+        };
+
+        materialize_and_verify_generation_db_chain(&delta_state, &recovered_path).unwrap();
+        let recovered = Connection::open(recovered_path).unwrap();
+        assert_eq!(
+            recovered
+                .query_row("SELECT created_at FROM schema_identity", [], |row| {
+                    row.get::<_, String>(0)
+                })
+                .unwrap(),
+            "chain-replay-fixture"
+        );
+    }
+}

--- a/crates/conary-core/src/db/generation_delta.rs
+++ b/crates/conary-core/src/db/generation_delta.rs
@@ -4,23 +4,42 @@
 
 use crate::{Error, Result};
 use rusqlite::Connection;
+use rusqlite::functions::FunctionFlags;
 use rusqlite::session::Session;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+const MUTATION_TOKEN_FUNCTION: &str = "conary_generation_mutation_token";
+const MUTATION_EPOCH_TABLE: &str = "generation_db_mutation_epoch";
 
 /// Why a transaction-local changeset cannot be complete generation authority.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum GenerationDbDeltaFallbackReason {
     ConcurrentConnectionWrite,
+    SourceBaselineChanged,
 }
 
 impl GenerationDbDeltaFallbackReason {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::ConcurrentConnectionWrite => "concurrent-connection-write",
+            Self::SourceBaselineChanged => "source-baseline-changed",
         }
     }
+}
+
+/// Cheap persisted SQLite identity used only to admit an incremental delta.
+///
+/// The cryptographic recovery identity remains the base digest plus ordered
+/// changeset digests. This token proves that the checkpointed source file has
+/// not moved away from the exact prior generation baseline before recording
+/// begins.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GenerationDbBaselineToken {
+    pub mutation_token: String,
 }
 
 /// Exact bytes and identity emitted by SQLite's session extension.
@@ -67,6 +86,7 @@ pub struct GenerationDbDeltaRecorder<'connection> {
     source: &'connection Connection,
     source_path: PathBuf,
     starting_data_version: i64,
+    baseline_fallback: Option<GenerationDbDeltaFallbackReason>,
 }
 
 impl<'connection> GenerationDbDeltaRecorder<'connection> {
@@ -81,13 +101,33 @@ impl<'connection> GenerationDbDeltaRecorder<'connection> {
             source,
             source_path: source_path.to_path_buf(),
             starting_data_version,
+            baseline_fallback: None,
         })
+    }
+
+    pub fn begin_against(
+        source: &'connection Connection,
+        source_path: impl AsRef<Path>,
+        expected: GenerationDbBaselineToken,
+    ) -> Result<Self> {
+        let source_path = source_path.as_ref();
+        let observed = read_baseline_token(source)?;
+        let mut recorder = Self::begin(source, source_path)?;
+        recorder.baseline_fallback = if observed == expected {
+            None
+        } else {
+            Some(GenerationDbDeltaFallbackReason::SourceBaselineChanged)
+        };
+        Ok(recorder)
     }
 
     pub fn finish(mut self) -> Result<GenerationDbDeltaCapture> {
         let mut bytes = Vec::new();
         self.session.changeset_strm(&mut bytes)?;
         let ending_data_version = data_version(self.source)?;
+        if let Some(reason) = self.baseline_fallback {
+            return Ok(GenerationDbDeltaCapture::Fallback(reason));
+        }
         if ending_data_version != self.starting_data_version {
             return Ok(GenerationDbDeltaCapture::Fallback(
                 GenerationDbDeltaFallbackReason::ConcurrentConnectionWrite,
@@ -102,6 +142,88 @@ impl<'connection> GenerationDbDeltaRecorder<'connection> {
     pub fn source_path(&self) -> &Path {
         &self.source_path
     }
+}
+
+pub fn read_baseline_token(source: &Connection) -> Result<GenerationDbBaselineToken> {
+    let mutation_token = source.query_row(
+        "SELECT token FROM generation_db_mutation_epoch WHERE singleton = 1",
+        [],
+        |row| row.get(0),
+    )?;
+    Ok(GenerationDbBaselineToken { mutation_token })
+}
+
+pub(crate) fn configure_mutation_epoch(source: &Connection) -> Result<()> {
+    let transaction_token = Arc::new(Mutex::new(None::<String>));
+    let function_token = Arc::clone(&transaction_token);
+    source.create_scalar_function(
+        MUTATION_TOKEN_FUNCTION,
+        0,
+        FunctionFlags::SQLITE_UTF8,
+        move |_| {
+            let mut token = function_token.lock().map_err(|_| {
+                rusqlite::Error::UserFunctionError(Box::new(std::io::Error::other(
+                    "generation DB mutation token lock is poisoned",
+                )))
+            })?;
+            Ok(token
+                .get_or_insert_with(|| uuid::Uuid::new_v4().to_string())
+                .clone())
+        },
+    )?;
+    let committed_token = Arc::clone(&transaction_token);
+    source.commit_hook(Some(move || {
+        committed_token.lock().map_or(true, |mut token| {
+            *token = None;
+            false
+        })
+    }))?;
+    source.rollback_hook(Some(move || {
+        if let Ok(mut token) = transaction_token.lock() {
+            *token = None;
+        }
+    }))?;
+    Ok(())
+}
+
+pub(crate) fn create_mutation_epoch_triggers(source: &Connection) -> Result<()> {
+    let mut statement = source.prepare(
+        "SELECT name
+         FROM sqlite_schema
+         WHERE type = 'table'
+           AND name NOT LIKE 'sqlite_%'
+           AND name != ?1
+         ORDER BY name",
+    )?;
+    let tables = statement
+        .query_map([MUTATION_EPOCH_TABLE], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    drop(statement);
+
+    for (index, table) in tables.iter().enumerate() {
+        let table = quote_identifier(table);
+        for (operation, suffix) in [("INSERT", "ai"), ("UPDATE", "au"), ("DELETE", "ad")] {
+            let trigger = quote_identifier(&format!(
+                "conary_generation_mutation_epoch_{index:03}_{suffix}"
+            ));
+            source.execute_batch(&format!(
+                "CREATE TRIGGER {trigger}
+                 AFTER {operation} ON {table}
+                 WHEN (SELECT token FROM {MUTATION_EPOCH_TABLE} WHERE singleton = 1)
+                      != {MUTATION_TOKEN_FUNCTION}()
+                 BEGIN
+                     UPDATE {MUTATION_EPOCH_TABLE}
+                     SET token = {MUTATION_TOKEN_FUNCTION}()
+                     WHERE singleton = 1;
+                 END;"
+            ))?;
+        }
+    }
+    Ok(())
+}
+
+fn quote_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
 }
 
 fn data_version(source: &Connection) -> Result<i64> {
@@ -144,6 +266,28 @@ mod tests {
                  INSERT INTO authority (id, value) VALUES (1, 'base');",
             )
             .unwrap();
+        connection
+    }
+
+    fn create_epoch_fixture(path: &Path) -> Connection {
+        let connection = Connection::open(path).unwrap();
+        configure_mutation_epoch(&connection).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE generation_db_mutation_epoch (
+                     singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+                     token TEXT NOT NULL CHECK(length(token) = 36)
+                 );
+                 INSERT INTO generation_db_mutation_epoch (singleton, token)
+                 VALUES (1, '00000000-0000-0000-0000-000000000000');
+                 CREATE TABLE authority (
+                     id INTEGER PRIMARY KEY,
+                     value TEXT NOT NULL
+                 );
+                 INSERT INTO authority (id, value) VALUES (1, 'base');",
+            )
+            .unwrap();
+        create_mutation_epoch_triggers(&connection).unwrap();
         connection
     }
 
@@ -215,6 +359,108 @@ mod tests {
     }
 
     #[test]
+    fn mutation_token_admits_only_the_exact_prior_source_state() {
+        let temp = tempfile::tempdir().unwrap();
+        let source_path = temp.path().join("source.sqlite");
+        let source = create_epoch_fixture(&source_path);
+        let baseline = read_baseline_token(&source).unwrap();
+        let recorder =
+            GenerationDbDeltaRecorder::begin_against(&source, &source_path, baseline.clone())
+                .unwrap();
+        source
+            .execute(
+                "INSERT INTO authority (id, value) VALUES (2, 'same connection')",
+                [],
+            )
+            .unwrap();
+
+        assert!(matches!(
+            recorder.finish().unwrap(),
+            GenerationDbDeltaCapture::Captured(_)
+        ));
+        assert_ne!(read_baseline_token(&source).unwrap(), baseline);
+    }
+
+    #[test]
+    fn committed_source_change_rejects_the_prior_baseline_token() {
+        let temp = tempfile::tempdir().unwrap();
+        let source_path = temp.path().join("source.sqlite");
+        let source = create_epoch_fixture(&source_path);
+        let baseline = read_baseline_token(&source).unwrap();
+        source
+            .execute(
+                "INSERT INTO authority (id, value) VALUES (2, 'committed divergence')",
+                [],
+            )
+            .unwrap();
+        let recorder =
+            GenerationDbDeltaRecorder::begin_against(&source, &source_path, baseline).unwrap();
+
+        assert_eq!(
+            recorder.finish().unwrap(),
+            GenerationDbDeltaCapture::Fallback(
+                GenerationDbDeltaFallbackReason::SourceBaselineChanged
+            )
+        );
+    }
+
+    #[test]
+    fn one_transaction_uses_one_mutation_token_for_many_rows() {
+        let temp = tempfile::tempdir().unwrap();
+        let source_path = temp.path().join("source.sqlite");
+        let source = create_epoch_fixture(&source_path);
+        let before = read_baseline_token(&source).unwrap();
+        let tx = source.unchecked_transaction().unwrap();
+        tx.execute("INSERT INTO authority (id, value) VALUES (2, 'first')", [])
+            .unwrap();
+        let after_first = read_baseline_token(&tx).unwrap();
+        tx.execute("INSERT INTO authority (id, value) VALUES (3, 'second')", [])
+            .unwrap();
+        let after_second = read_baseline_token(&tx).unwrap();
+        tx.commit().unwrap();
+
+        assert_ne!(after_first, before);
+        assert_eq!(after_second, after_first);
+        assert_eq!(read_baseline_token(&source).unwrap(), after_first);
+    }
+
+    #[test]
+    fn another_configured_connection_advances_the_persisted_token() {
+        let temp = tempfile::tempdir().unwrap();
+        let source_path = temp.path().join("source.sqlite");
+        let source = create_epoch_fixture(&source_path);
+        let before = read_baseline_token(&source).unwrap();
+        let writer = Connection::open(&source_path).unwrap();
+        configure_mutation_epoch(&writer).unwrap();
+
+        writer
+            .execute(
+                "INSERT INTO authority (id, value) VALUES (2, 'other connection')",
+                [],
+            )
+            .unwrap();
+
+        assert_ne!(read_baseline_token(&source).unwrap(), before);
+    }
+
+    #[test]
+    fn unconfigured_writer_cannot_bypass_the_mutation_epoch() {
+        let temp = tempfile::tempdir().unwrap();
+        let source_path = temp.path().join("source.sqlite");
+        let _source = create_epoch_fixture(&source_path);
+        let writer = Connection::open(&source_path).unwrap();
+
+        let error = writer
+            .execute(
+                "INSERT INTO authority (id, value) VALUES (2, 'untracked write')",
+                [],
+            )
+            .unwrap_err();
+
+        assert!(error.to_string().contains(MUTATION_TOKEN_FUNCTION));
+    }
+
+    #[test]
     fn source_connection_must_name_the_exact_database_path() {
         let temp = tempfile::tempdir().unwrap();
         let source_path = temp.path().join("source.sqlite");
@@ -254,5 +500,28 @@ mod tests {
             tables.is_empty(),
             "SQLite session changesets require a declared primary key: {tables:?}"
         );
+
+        let table_count: i64 = connection
+            .query_row(
+                "SELECT COUNT(*)
+                 FROM sqlite_schema
+                 WHERE type = 'table'
+                   AND name NOT LIKE 'sqlite_%'
+                   AND name != ?1",
+                [MUTATION_EPOCH_TABLE],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let trigger_count: i64 = connection
+            .query_row(
+                "SELECT COUNT(*)
+                 FROM sqlite_schema
+                 WHERE type = 'trigger'
+                   AND name LIKE 'conary_generation_mutation_epoch_%'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(trigger_count, table_count * 3);
     }
 }

--- a/crates/conary-core/src/db/generation_delta.rs
+++ b/crates/conary-core/src/db/generation_delta.rs
@@ -1,0 +1,258 @@
+// conary-core/src/db/generation_delta.rs
+
+//! Typed SQLite session changesets for generation recovery deltas.
+
+use crate::{Error, Result};
+use rusqlite::Connection;
+use rusqlite::session::Session;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Why a transaction-local changeset cannot be complete generation authority.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum GenerationDbDeltaFallbackReason {
+    ConcurrentConnectionWrite,
+}
+
+impl GenerationDbDeltaFallbackReason {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ConcurrentConnectionWrite => "concurrent-connection-write",
+        }
+    }
+}
+
+/// Exact bytes and identity emitted by SQLite's session extension.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GenerationDbDelta {
+    bytes: Vec<u8>,
+    sha256: String,
+}
+
+impl GenerationDbDelta {
+    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+        let sha256 = crate::hash::sha256(&bytes);
+        Self { bytes, sha256 }
+    }
+
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    pub fn sha256(&self) -> &str {
+        &self.sha256
+    }
+
+    pub fn payload_bytes(&self) -> u64 {
+        self.bytes.len().try_into().unwrap_or(u64::MAX)
+    }
+}
+
+/// Result of trying to turn one connection's writes into a recovery delta.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum GenerationDbDeltaCapture {
+    Captured(GenerationDbDelta),
+    Fallback(GenerationDbDeltaFallbackReason),
+}
+
+/// Records every session-compatible table mutation made through one connection.
+///
+/// SQLite increments `PRAGMA data_version` on this connection when another
+/// connection commits. A changed value therefore rejects the candidate. The
+/// eventual publication owner must additionally prove the candidate's base
+/// identity and hold write serialization through durable publication.
+pub struct GenerationDbDeltaRecorder<'connection> {
+    session: Session<'connection>,
+    source: &'connection Connection,
+    source_path: PathBuf,
+    starting_data_version: i64,
+}
+
+impl<'connection> GenerationDbDeltaRecorder<'connection> {
+    pub fn begin(source: &'connection Connection, source_path: impl AsRef<Path>) -> Result<Self> {
+        let source_path = source_path.as_ref();
+        validate_source_connection_path(source, source_path)?;
+        let starting_data_version = data_version(source)?;
+        let mut session = Session::new(source)?;
+        session.attach::<&str>(None)?;
+        Ok(Self {
+            session,
+            source,
+            source_path: source_path.to_path_buf(),
+            starting_data_version,
+        })
+    }
+
+    pub fn finish(mut self) -> Result<GenerationDbDeltaCapture> {
+        let mut bytes = Vec::new();
+        self.session.changeset_strm(&mut bytes)?;
+        let ending_data_version = data_version(self.source)?;
+        if ending_data_version != self.starting_data_version {
+            return Ok(GenerationDbDeltaCapture::Fallback(
+                GenerationDbDeltaFallbackReason::ConcurrentConnectionWrite,
+            ));
+        }
+
+        Ok(GenerationDbDeltaCapture::Captured(
+            GenerationDbDelta::from_bytes(bytes),
+        ))
+    }
+
+    pub fn source_path(&self) -> &Path {
+        &self.source_path
+    }
+}
+
+fn data_version(source: &Connection) -> Result<i64> {
+    source
+        .query_row("PRAGMA data_version", [], |row| row.get(0))
+        .map_err(Into::into)
+}
+
+fn validate_source_connection_path(source: &Connection, source_path: &Path) -> Result<()> {
+    let connected_path: String = source.query_row(
+        "SELECT file FROM pragma_database_list WHERE name = 'main'",
+        [],
+        |row| row.get(0),
+    )?;
+    let connected = Path::new(&connected_path).canonicalize()?;
+    let requested = source_path.canonicalize()?;
+    if connected != requested {
+        return Err(Error::RecoveryFailed(format!(
+            "generation DB delta source mismatch: connection={} requested={}",
+            connected.display(),
+            requested.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::session::ConflictAction;
+
+    fn create_fixture(path: &Path) -> Connection {
+        let connection = Connection::open(path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE authority (
+                     id INTEGER PRIMARY KEY,
+                     value TEXT NOT NULL
+                 );
+                 INSERT INTO authority (id, value) VALUES (1, 'base');",
+            )
+            .unwrap();
+        connection
+    }
+
+    #[test]
+    fn session_delta_replays_exact_insert_update_and_delete() {
+        let temp = tempfile::tempdir().unwrap();
+        let source_path = temp.path().join("source.sqlite");
+        let base_path = temp.path().join("base.sqlite");
+        let source = create_fixture(&source_path);
+        let base = create_fixture(&base_path);
+        let recorder = GenerationDbDeltaRecorder::begin(&source, &source_path).unwrap();
+
+        source
+            .execute_batch(
+                "UPDATE authority SET value = 'updated' WHERE id = 1;
+                 INSERT INTO authority (id, value) VALUES (2, 'inserted');
+                 INSERT INTO authority (id, value) VALUES (3, 'deleted');
+                 DELETE FROM authority WHERE id = 3;",
+            )
+            .unwrap();
+
+        let GenerationDbDeltaCapture::Captured(delta) = recorder.finish().unwrap() else {
+            panic!("same-connection mutations unexpectedly required a full snapshot");
+        };
+        assert!(!delta.bytes().is_empty());
+        assert_eq!(delta.sha256(), crate::hash::sha256(delta.bytes()));
+
+        let mut input = delta.bytes();
+        base.apply_strm(&mut input, None::<fn(&str) -> bool>, |_conflict, _item| {
+            ConflictAction::SQLITE_CHANGESET_ABORT
+        })
+        .unwrap();
+        let rows = base
+            .prepare("SELECT id, value FROM authority ORDER BY id")
+            .unwrap()
+            .query_map([], |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+            })
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![(1, "updated".to_string()), (2, "inserted".to_string())]
+        );
+    }
+
+    #[test]
+    fn another_connection_commit_forces_typed_full_snapshot_fallback() {
+        let temp = tempfile::tempdir().unwrap();
+        let source_path = temp.path().join("source.sqlite");
+        let source = create_fixture(&source_path);
+        let writer = Connection::open(&source_path).unwrap();
+        let recorder = GenerationDbDeltaRecorder::begin(&source, &source_path).unwrap();
+
+        writer
+            .execute(
+                "INSERT INTO authority (id, value) VALUES (2, 'other connection')",
+                [],
+            )
+            .unwrap();
+
+        assert_eq!(
+            recorder.finish().unwrap(),
+            GenerationDbDeltaCapture::Fallback(
+                GenerationDbDeltaFallbackReason::ConcurrentConnectionWrite
+            )
+        );
+    }
+
+    #[test]
+    fn source_connection_must_name_the_exact_database_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let source_path = temp.path().join("source.sqlite");
+        let other_path = temp.path().join("other.sqlite");
+        let source = create_fixture(&source_path);
+        create_fixture(&other_path);
+
+        let error = match GenerationDbDeltaRecorder::begin(&source, &other_path) {
+            Ok(_) => panic!("mismatched source path unexpectedly admitted"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("delta source mismatch"));
+    }
+
+    #[test]
+    fn every_current_schema_table_is_session_compatible() {
+        let (_database, connection) = crate::db::testing::create_test_db();
+        let mut statement = connection
+            .prepare(
+                "SELECT m.name
+                 FROM sqlite_schema AS m
+                 WHERE m.type = 'table'
+                   AND m.name NOT LIKE 'sqlite_%'
+                   AND NOT EXISTS (
+                       SELECT 1 FROM pragma_table_info(m.name) WHERE pk > 0
+                   )
+                 ORDER BY m.name",
+            )
+            .unwrap();
+        let tables = statement
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert!(
+            tables.is_empty(),
+            "SQLite session changesets require a declared primary key: {tables:?}"
+        );
+    }
+}

--- a/crates/conary-core/src/db/generation_delta.rs
+++ b/crates/conary-core/src/db/generation_delta.rs
@@ -111,20 +111,32 @@ pub struct GenerationDbDeltaRecorder<'connection> {
 
 impl<'connection> GenerationDbDeltaRecorder<'connection> {
     pub fn begin(source: &'connection Connection, source_path: impl AsRef<Path>) -> Result<Self> {
+        Self::begin_with_arm_hook(source, source_path, || Ok(()))
+    }
+
+    fn begin_with_arm_hook(
+        source: &'connection Connection,
+        source_path: impl AsRef<Path>,
+        arm_hook: impl FnOnce() -> Result<()>,
+    ) -> Result<Self> {
         let source_path = source_path.as_ref();
         validate_source_connection_path(source, source_path)?;
+        let before_data_version = data_version(source)?;
         let source_baseline = read_baseline_token(source)?;
-        let starting_data_version = data_version(source)?;
+        arm_hook()?;
         let mut session = Session::new(source)?;
         session.table_filter(Some(|table: &str| table != MUTATION_EPOCH_TABLE));
         session.attach::<&str>(None)?;
+        let starting_data_version = data_version(source)?;
+        let baseline_fallback = (starting_data_version != before_data_version)
+            .then_some(GenerationDbDeltaFallbackReason::ConcurrentConnectionWrite);
         Ok(Self {
             session,
             source,
             source_path: source_path.to_path_buf(),
             source_baseline,
             starting_data_version,
-            baseline_fallback: None,
+            baseline_fallback,
         })
     }
 
@@ -133,14 +145,11 @@ impl<'connection> GenerationDbDeltaRecorder<'connection> {
         source_path: impl AsRef<Path>,
         expected: GenerationDbBaselineToken,
     ) -> Result<Self> {
-        let source_path = source_path.as_ref();
-        let observed = read_baseline_token(source)?;
         let mut recorder = Self::begin(source, source_path)?;
-        recorder.baseline_fallback = if observed == expected {
-            None
-        } else {
-            Some(GenerationDbDeltaFallbackReason::SourceBaselineChanged)
-        };
+        if recorder.source_baseline != expected && recorder.baseline_fallback.is_none() {
+            recorder.baseline_fallback =
+                Some(GenerationDbDeltaFallbackReason::SourceBaselineChanged);
+        }
         Ok(recorder)
     }
 
@@ -389,6 +398,31 @@ mod tests {
                 "INSERT INTO authority (id, value) VALUES (2, 'other connection')",
                 [],
             )
+            .unwrap();
+
+        assert_eq!(
+            recorder.finish().unwrap(),
+            GenerationDbDeltaCapture::Fallback(
+                GenerationDbDeltaFallbackReason::ConcurrentConnectionWrite
+            )
+        );
+    }
+
+    #[test]
+    fn commit_while_the_recorder_is_arming_forces_full_snapshot_fallback() {
+        let temp = tempfile::tempdir().unwrap();
+        let source_path = temp.path().join("source.sqlite");
+        let source = create_epoch_fixture(&source_path);
+        let writer = Connection::open(&source_path).unwrap();
+        configure_mutation_epoch(&writer).unwrap();
+        let recorder =
+            GenerationDbDeltaRecorder::begin_with_arm_hook(&source, &source_path, || {
+                writer.execute(
+                    "INSERT INTO authority (id, value) VALUES (2, 'arming window')",
+                    [],
+                )?;
+                Ok(())
+            })
             .unwrap();
 
         assert_eq!(

--- a/crates/conary-core/src/db/generation_delta.rs
+++ b/crates/conary-core/src/db/generation_delta.rs
@@ -47,12 +47,23 @@ pub struct GenerationDbBaselineToken {
 pub struct GenerationDbDelta {
     bytes: Vec<u8>,
     sha256: String,
+    source_baseline: GenerationDbBaselineToken,
+    result_baseline: GenerationDbBaselineToken,
 }
 
 impl GenerationDbDelta {
-    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+    pub fn from_bytes(
+        bytes: Vec<u8>,
+        source_baseline: GenerationDbBaselineToken,
+        result_baseline: GenerationDbBaselineToken,
+    ) -> Self {
         let sha256 = crate::hash::sha256(&bytes);
-        Self { bytes, sha256 }
+        Self {
+            bytes,
+            sha256,
+            source_baseline,
+            result_baseline,
+        }
     }
 
     pub fn bytes(&self) -> &[u8] {
@@ -65,6 +76,14 @@ impl GenerationDbDelta {
 
     pub fn payload_bytes(&self) -> u64 {
         self.bytes.len().try_into().unwrap_or(u64::MAX)
+    }
+
+    pub fn result_baseline(&self) -> &GenerationDbBaselineToken {
+        &self.result_baseline
+    }
+
+    pub fn source_baseline(&self) -> &GenerationDbBaselineToken {
+        &self.source_baseline
     }
 }
 
@@ -85,6 +104,7 @@ pub struct GenerationDbDeltaRecorder<'connection> {
     session: Session<'connection>,
     source: &'connection Connection,
     source_path: PathBuf,
+    source_baseline: GenerationDbBaselineToken,
     starting_data_version: i64,
     baseline_fallback: Option<GenerationDbDeltaFallbackReason>,
 }
@@ -93,13 +113,16 @@ impl<'connection> GenerationDbDeltaRecorder<'connection> {
     pub fn begin(source: &'connection Connection, source_path: impl AsRef<Path>) -> Result<Self> {
         let source_path = source_path.as_ref();
         validate_source_connection_path(source, source_path)?;
+        let source_baseline = read_baseline_token(source)?;
         let starting_data_version = data_version(source)?;
         let mut session = Session::new(source)?;
+        session.table_filter(Some(|table: &str| table != MUTATION_EPOCH_TABLE));
         session.attach::<&str>(None)?;
         Ok(Self {
             session,
             source,
             source_path: source_path.to_path_buf(),
+            source_baseline,
             starting_data_version,
             baseline_fallback: None,
         })
@@ -121,7 +144,13 @@ impl<'connection> GenerationDbDeltaRecorder<'connection> {
         Ok(recorder)
     }
 
-    pub fn finish(mut self) -> Result<GenerationDbDeltaCapture> {
+    /// Capture the cumulative changes observed since this recorder began.
+    ///
+    /// Calling this more than once does not reset the session. Publication can
+    /// therefore persist a recoverable pre-terminal checkpoint and later
+    /// replace its manifest with the exact terminal delta without reopening a
+    /// gap in crash recovery.
+    pub fn capture(&mut self) -> Result<GenerationDbDeltaCapture> {
         let mut bytes = Vec::new();
         self.session.changeset_strm(&mut bytes)?;
         let ending_data_version = data_version(self.source)?;
@@ -134,9 +163,15 @@ impl<'connection> GenerationDbDeltaRecorder<'connection> {
             ));
         }
 
+        let result_baseline = read_baseline_token(self.source)?;
+
         Ok(GenerationDbDeltaCapture::Captured(
-            GenerationDbDelta::from_bytes(bytes),
+            GenerationDbDelta::from_bytes(bytes, self.source_baseline.clone(), result_baseline),
         ))
+    }
+
+    pub fn finish(mut self) -> Result<GenerationDbDeltaCapture> {
+        self.capture()
     }
 
     pub fn source_path(&self) -> &Path {
@@ -296,8 +331,8 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let source_path = temp.path().join("source.sqlite");
         let base_path = temp.path().join("base.sqlite");
-        let source = create_fixture(&source_path);
-        let base = create_fixture(&base_path);
+        let source = create_epoch_fixture(&source_path);
+        let base = create_epoch_fixture(&base_path);
         let recorder = GenerationDbDeltaRecorder::begin(&source, &source_path).unwrap();
 
         source
@@ -320,6 +355,11 @@ mod tests {
             ConflictAction::SQLITE_CHANGESET_ABORT
         })
         .unwrap();
+        base.execute(
+            "UPDATE generation_db_mutation_epoch SET token = ?1 WHERE singleton = 1",
+            [&delta.result_baseline().mutation_token],
+        )
+        .unwrap();
         let rows = base
             .prepare("SELECT id, value FROM authority ORDER BY id")
             .unwrap()
@@ -339,8 +379,9 @@ mod tests {
     fn another_connection_commit_forces_typed_full_snapshot_fallback() {
         let temp = tempfile::tempdir().unwrap();
         let source_path = temp.path().join("source.sqlite");
-        let source = create_fixture(&source_path);
+        let source = create_epoch_fixture(&source_path);
         let writer = Connection::open(&source_path).unwrap();
+        configure_mutation_epoch(&writer).unwrap();
         let recorder = GenerationDbDeltaRecorder::begin(&source, &source_path).unwrap();
 
         writer
@@ -374,11 +415,62 @@ mod tests {
             )
             .unwrap();
 
-        assert!(matches!(
-            recorder.finish().unwrap(),
-            GenerationDbDeltaCapture::Captured(_)
-        ));
-        assert_ne!(read_baseline_token(&source).unwrap(), baseline);
+        let GenerationDbDeltaCapture::Captured(delta) = recorder.finish().unwrap() else {
+            panic!("matching mutation token unexpectedly required a full snapshot");
+        };
+        assert_ne!(delta.result_baseline(), &baseline);
+        assert_eq!(
+            delta.result_baseline(),
+            &read_baseline_token(&source).unwrap()
+        );
+    }
+
+    #[test]
+    fn cumulative_capture_excludes_internal_epoch_and_tracks_latest_token() {
+        let temp = tempfile::tempdir().unwrap();
+        let source_path = temp.path().join("source.sqlite");
+        let base_path = temp.path().join("base.sqlite");
+        let source = create_epoch_fixture(&source_path);
+        let base = create_epoch_fixture(&base_path);
+        let baseline = read_baseline_token(&source).unwrap();
+        let mut recorder =
+            GenerationDbDeltaRecorder::begin_against(&source, &source_path, baseline).unwrap();
+
+        source
+            .execute("INSERT INTO authority (id, value) VALUES (2, 'first')", [])
+            .unwrap();
+        let GenerationDbDeltaCapture::Captured(first) = recorder.capture().unwrap() else {
+            panic!("first cumulative capture unexpectedly required a full snapshot");
+        };
+        source
+            .execute("INSERT INTO authority (id, value) VALUES (3, 'second')", [])
+            .unwrap();
+        let GenerationDbDeltaCapture::Captured(second) = recorder.capture().unwrap() else {
+            panic!("second cumulative capture unexpectedly required a full snapshot");
+        };
+
+        assert!(second.payload_bytes() > first.payload_bytes());
+        let mut input = second.bytes();
+        base.apply_strm(&mut input, None::<fn(&str) -> bool>, |_conflict, _item| {
+            ConflictAction::SQLITE_CHANGESET_ABORT
+        })
+        .unwrap();
+        base.execute(
+            "UPDATE generation_db_mutation_epoch SET token = ?1 WHERE singleton = 1",
+            [&second.result_baseline().mutation_token],
+        )
+        .unwrap();
+
+        assert_eq!(
+            base.query_row("SELECT COUNT(*) FROM authority", [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            3
+        );
+        assert_eq!(
+            read_baseline_token(&base).unwrap(),
+            *second.result_baseline()
+        );
     }
 
     #[test]

--- a/crates/conary-core/src/db/generation_snapshot.rs
+++ b/crates/conary-core/src/db/generation_snapshot.rs
@@ -374,6 +374,15 @@ enum CheckpointOutcome {
 
 fn checkpoint_and_sync(source: &Connection, source_path: &Path) -> Result<CheckpointOutcome> {
     let journal_mode: String = source.query_row("PRAGMA journal_mode", [], |row| row.get(0))?;
+    if !journal_mode.eq_ignore_ascii_case("wal") {
+        File::open(source_path)?.sync_all()?;
+        sync_parent_directory(source_path)?;
+        return Ok(CheckpointOutcome::Complete(GenerationDbWalCheckpoint {
+            journal_mode,
+            log_frames: 0,
+            checkpointed_frames: 0,
+        }));
+    }
     let (busy, log_frames, checkpointed_frames): (i64, i64, i64) =
         source.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| {
             Ok((row.get(0)?, row.get(1)?, row.get(2)?))
@@ -544,6 +553,36 @@ mod tests {
             destination.metadata().unwrap().len()
         );
         assert!(snapshot.provenance.wal_checkpoint.is_some());
+    }
+
+    #[test]
+    fn rollback_journal_source_records_synchronized_zero_wal_frames() {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("source.sqlite");
+        let destination = temp.path().join("snapshot.sqlite");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE authority (id INTEGER PRIMARY KEY, value TEXT NOT NULL);
+             INSERT INTO authority (value) VALUES ('committed');",
+        )
+        .unwrap();
+
+        let snapshot = GenerationDbSnapshotProvider::default()
+            .snapshot(&conn, &db_path, &destination)
+            .unwrap();
+        let checkpoint = snapshot.provenance.wal_checkpoint.unwrap();
+
+        assert_eq!(checkpoint.journal_mode, "delete");
+        assert_eq!(checkpoint.log_frames, 0);
+        assert_eq!(checkpoint.checkpointed_frames, 0);
+        assert_eq!(
+            Connection::open(destination)
+                .unwrap()
+                .query_row("SELECT value FROM authority", [], |row| row
+                    .get::<_, String>(0))
+                .unwrap(),
+            "committed"
+        );
     }
 
     #[test]

--- a/crates/conary-core/src/db/generation_snapshot.rs
+++ b/crates/conary-core/src/db/generation_snapshot.rs
@@ -586,6 +586,46 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "requires CONARY_TEST_REFLINK_DIR on a reflink-capable filesystem"]
+    fn required_reflink_filesystem_selects_zero_copy_provider() {
+        let root = std::env::var_os("CONARY_TEST_REFLINK_DIR")
+            .expect("CONARY_TEST_REFLINK_DIR must name the mounted proof filesystem");
+        let temp = tempfile::Builder::new()
+            .prefix("conary-reflink-proof-")
+            .tempdir_in(root)
+            .unwrap();
+        let db_path = temp.path().join("source.sqlite");
+        let destination = temp.path().join("snapshot.sqlite");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             PRAGMA synchronous=NORMAL;
+             CREATE TABLE authority (id INTEGER PRIMARY KEY, value TEXT NOT NULL);
+             INSERT INTO authority (value) VALUES ('reflink proof');",
+        )
+        .unwrap();
+
+        let snapshot = GenerationDbSnapshotProvider::default()
+            .snapshot(&conn, &db_path, &destination)
+            .unwrap();
+
+        assert_eq!(
+            snapshot.provenance.method,
+            GenerationDbSnapshotMethod::Reflink
+        );
+        assert_eq!(snapshot.provenance.payload_bytes_written, 0);
+        assert!(snapshot.provenance.fallbacks.is_empty());
+        assert_eq!(
+            Connection::open(destination)
+                .unwrap()
+                .query_row("SELECT value FROM authority", [], |row| row
+                    .get::<_, String>(0))
+                .unwrap(),
+            "reflink proof"
+        );
+    }
+
+    #[test]
     fn unsupported_reflink_falls_back_to_sqlite_online_backup() {
         let (temp, db_path, conn) = fixture();
         let destination = temp.path().join("snapshot.sqlite");

--- a/crates/conary-core/src/db/mod.rs
+++ b/crates/conary-core/src/db/mod.rs
@@ -46,6 +46,7 @@ const SQLITE_WAL_MAGIC_BE: [u32; 2] = [0x377f0682, 0x377f0683];
 
 /// Apply standard PRAGMAs to a connection
 fn configure(conn: &Connection) -> Result<()> {
+    generation_delta::configure_mutation_epoch(conn)?;
     conn.execute_batch(CONNECTION_PRAGMAS)?;
     Ok(())
 }

--- a/crates/conary-core/src/db/mod.rs
+++ b/crates/conary-core/src/db/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod backup;
 pub mod current_schema;
+pub mod generation_backup_chain;
 pub mod generation_delta;
 pub mod generation_snapshot;
 pub mod models;

--- a/crates/conary-core/src/db/mod.rs
+++ b/crates/conary-core/src/db/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod backup;
 pub mod current_schema;
+pub mod generation_delta;
 pub mod generation_snapshot;
 pub mod models;
 pub mod paths;

--- a/crates/conary-core/src/db/schema.rs
+++ b/crates/conary-core/src/db/schema.rs
@@ -12,12 +12,12 @@ use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 use std::path::Path;
 use tracing::info;
 
-/// Revision 38 of the current-only schema epoch.
+/// Revision 39 of the current-only schema epoch.
 ///
-/// Revision 38 hard-cuts selected-root transaction authority to indexed,
-/// append-only SQLite snapshots. Earlier pre-alpha databases must be rebuilt;
-/// no compatibility migration is provided.
-pub const SCHEMA_VERSION: i32 = 38;
+/// Revision 39 adds the transaction-scoped mutation token used to prove an
+/// exact generation database delta base. Earlier pre-alpha databases must be
+/// rebuilt; no compatibility migration is provided.
+pub const SCHEMA_VERSION: i32 = 39;
 /// Stable identity that distinguishes this epoch from retired schema revisions.
 pub const SCHEMA_EPOCH: &str = "conary-current-v1";
 
@@ -111,6 +111,7 @@ pub fn require_current(conn: &Connection) -> Result<()> {
 /// deliberate: carrying an untested compatibility chain would make old
 /// structure, queue normalization, and retired workflow state authoritative.
 pub fn ensure_current(conn: &Connection) -> Result<()> {
+    super::generation_delta::configure_mutation_epoch(conn)?;
     let current_version = get_schema_version(conn)?;
     match get_schema_identity(conn)? {
         Some((epoch, revision)) if epoch == SCHEMA_EPOCH && revision == SCHEMA_VERSION => {
@@ -239,7 +240,7 @@ mod tests {
     }
 
     #[test]
-    fn revision_37_requires_rebuild_for_revision_38() {
+    fn revision_38_requires_rebuild_for_revision_39() {
         let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(
             "CREATE TABLE schema_identity (
@@ -247,19 +248,19 @@ mod tests {
                 revision INTEGER NOT NULL
             );
             INSERT INTO schema_identity (epoch, revision)
-                VALUES ('conary-current-v1', 37);
+                VALUES ('conary-current-v1', 38);
             CREATE TABLE schema_version (
                 version INTEGER PRIMARY KEY,
                 applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             );
-            INSERT INTO schema_version (version) VALUES (37);",
+            INSERT INTO schema_version (version) VALUES (38);",
         )
         .unwrap();
 
         let error = ensure_current(&conn).unwrap_err();
         assert_eq!(
             error.to_string(),
-            "Database schema rebuild required: database uses schema epoch conary-current-v1 revision 37; this pre-alpha build supports only schema epoch conary-current-v1 revision 38"
+            "Database schema rebuild required: database uses schema epoch conary-current-v1 revision 38; this pre-alpha build supports only schema epoch conary-current-v1 revision 39"
         );
     }
 

--- a/crates/conary-core/tests/db_backup.rs
+++ b/crates/conary-core/tests/db_backup.rs
@@ -157,20 +157,16 @@ fn generation_backup_writes_manifest_and_verifies_artifact_and_publication_state
     )
     .unwrap();
 
-    assert_eq!(record.manifest.format, "conary.generation-db-backup.v2");
-    assert_eq!(record.manifest.manifest_version, 2);
+    assert_eq!(record.manifest.format, "conary.generation-db-backup.v3");
+    assert_eq!(record.manifest.manifest_version, 3);
     assert_eq!(record.manifest.generation_number, 3);
     assert_eq!(record.manifest.state_number, 3);
     assert_eq!(record.manifest.db_schema_version, SCHEMA_VERSION);
-    assert_eq!(record.manifest.backup_file, "conary.db.backup");
+    assert!(record.manifest.base.file.starts_with("conary.db.base-"));
+    assert!(record.manifest.deltas.is_empty());
     assert_eq!(record.manifest.transaction_high_water_mark, None);
     assert!(record.creation_metrics.is_some());
-    assert!(record.backup_path.ends_with("state/conary.db.backup"));
-    assert!(
-        record
-            .checksum_path
-            .ends_with("state/conary.db.backup.sha256")
-    );
+    assert!(record.backup_path.ends_with("state/conary-db-backup.json"));
     assert!(
         record
             .manifest_path
@@ -196,10 +192,39 @@ fn generation_backup_verification_rejects_tampered_backup_file() {
     )
     .unwrap();
 
-    std::fs::write(&record.backup_path, b"not the original backup").unwrap();
+    std::fs::write(
+        fixture
+            .generation_dir
+            .join("state")
+            .join(&record.manifest.base.file),
+        b"not the original backup",
+    )
+    .unwrap();
 
     let error = verify_generation_db_backup(&fixture.generation_dir, None).unwrap_err();
-    assert!(error.to_string().to_lowercase().contains("checksum"));
+    assert!(error.to_string().contains("size mismatch"));
+}
+
+#[test]
+fn generation_backup_verification_rejects_a_retired_schema_epoch() {
+    let fixture = GenerationBackupFixture::new(4);
+    let mut record = create_generation_db_backup(
+        &fixture.connection(),
+        &fixture.db_path,
+        &fixture.generation_dir,
+        4,
+        4,
+    )
+    .unwrap();
+    record.manifest.schema_epoch = "conary-retired-v0".to_string();
+    std::fs::write(
+        &record.manifest_path,
+        serde_json::to_vec_pretty(&record.manifest).unwrap(),
+    )
+    .unwrap();
+
+    let error = verify_generation_db_backup(&fixture.generation_dir, None).unwrap_err();
+    assert!(error.to_string().contains("schema epoch"));
 }
 
 #[test]
@@ -305,19 +330,22 @@ fn generation_backup_retry_replaces_partial_snapshot_and_metadata() {
         .unwrap();
     let state_dir = fixture.generation_dir.join("state");
     std::fs::write(
-        state_dir.join(".conary.db.backup.tmp"),
+        state_dir.join(".conary.db.base.tmp"),
         b"interrupted snapshot",
     )
     .unwrap();
-    std::fs::write(&first.backup_path, b"interrupted published snapshot").unwrap();
-    std::fs::write(&first.checksum_path, b"interrupted checksum").unwrap();
+    std::fs::write(
+        state_dir.join(&first.manifest.base.file),
+        b"interrupted published snapshot",
+    )
+    .unwrap();
     std::fs::write(&first.manifest_path, b"{\"interrupted\":true}").unwrap();
 
     let retried =
         create_generation_db_backup(&conn, &fixture.db_path, &fixture.generation_dir, 8, 8)
             .unwrap();
 
-    assert!(!state_dir.join(".conary.db.backup.tmp").exists());
+    assert!(!state_dir.join(".conary.db.base.tmp").exists());
     assert_eq!(retried.manifest.generation_number, 8);
     verify_generation_db_backup(&fixture.generation_dir, None).unwrap();
 }

--- a/crates/conary-core/tests/generation_composefs_runtime_contract.rs
+++ b/crates/conary-core/tests/generation_composefs_runtime_contract.rs
@@ -403,7 +403,7 @@ fn recovery_does_not_promote_generations_by_erofs_magic_only() {
 }
 
 #[test]
-fn publication_writes_generation_db_backup_before_marking_debt_complete() {
+fn publication_writes_recoverable_and_terminal_generation_db_authority() {
     let publication_rs = fs::read_to_string(app_source("commands/generation/publication.rs"))
         .expect("failed to read generation publication source");
     let replay_rs = publication_rs
@@ -415,8 +415,8 @@ fn publication_writes_generation_db_backup_before_marking_debt_complete() {
         .find("mark_generation_state_active")
         .expect("publication must mark the selected generation active");
     let backup = replay_rs
-        .find("create_generation_db_backup")
-        .expect("publication must write a generation-bound DB backup");
+        .find("write_generation_db_backup")
+        .expect("publication must write crash-valid generation DB authority");
     let backup_phase = replay_rs
         .find("GenerationPublicationPhase::DatabaseBackedUp")
         .expect("publication must persist generation DB backup completion");
@@ -428,6 +428,22 @@ fn publication_writes_generation_db_backup_before_marking_debt_complete() {
     assert!(
         publication_rs.contains("debt.mark_complete_through"),
         "publication must finalize covered debt through the backup-gated model API"
+    );
+
+    let completion = publication_rs
+        .split_once("fn publish_pending_debt_with_hook")
+        .and_then(|(_, body)| body.split_once("struct PublicationReplayRequest"))
+        .map(|(body, _)| body)
+        .expect("publication must expose the terminal completion owner");
+    let mark_complete = completion
+        .find("debt.mark_complete_through")
+        .expect("publication must mark covered debt terminal");
+    let terminal_backup = completion
+        .find("write_generation_db_backup")
+        .expect("normal publication must replace provisional authority after terminal state");
+    assert!(
+        mark_complete < terminal_backup,
+        "normal publication must recapture terminal database state after marking covered debt complete"
     );
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-14
-revision: 52
+revision: 53
 summary: Describe workspace and release boundaries, exact native source authority, package transactions, typed generation database snapshots, lifecycle execution, carrier security, generation GC, and service boundaries
 ---
 
@@ -514,9 +514,10 @@ not a fallback for normal mutation.
 
 Publication and rollback rows reference the same SQLite-selected-root snapshot
 lineage by foreign key. The retired filesystem candidate and complete
-`rollback_root` JSON copy have no current-schema reader. Revision 38 is a
+`rollback_root` JSON copy have no current-schema reader. Revision 39 is a
 pre-alpha hard cut: older databases must be rebuilt from authoritative package
-and repository inputs.
+and repository inputs. It retains revision 38's indexed selected-root authority
+and adds the generation database mutation epoch described below.
 
 1. **Select**: Use the latest cumulative selected-root snapshot as lower authority when publication debt is pending. Otherwise mount the current generation's verified composefs image directly beneath its typed mutable-state layer; only first-generation database authority still reconstructs the complete lower
 2. **Mutate**: Apply payload changes, typed native lifecycle, CCS hooks, triggers, and config decisions inside that isolated root
@@ -704,20 +705,12 @@ the owning package directly:
 lives in SQLite. No TOML/YAML/JSON config files drive runtime state. The live
 database is the single source of truth, queryable with standard SQL tools.
 Conary writes SQLite-native checkpoint backups around first-wave
-adoption/unadoption mutations and writes a generation-bound SQLite backup under
-`/conary/generations/<n>/state/` when a generation publication reaches the
-selected-generation boundary. Generation publication does not compact the
-complete database with `VACUUM INTO`. It holds mutation authority, establishes
-and synchronizes an exact WAL checkpoint, and selects a typed snapshot provider:
-reflink first, SQLite online backup as the portable fallback, and a full copy
-only when both faster providers are unavailable. The v2 generation-backup
-manifest records the selected method, typed fallback reasons, schema epoch,
-transaction high-water mark, page count, logical size, payload bytes written,
-and SHA-256 identity. Creation performs one full integrity/digest pass; explicit
-verification and recovery repeat the full check, while an uninterrupted
-publication does not immediately verify the same snapshot a second time.
-Recovery opens checkpointed snapshots through SQLite's immutable read-only
-mode so verification cannot create or consume WAL sidecars.
+adoption/unadoption mutations and writes generation-bound v3 recovery authority
+under `/conary/generations/<n>/state/`. A new base does not compact the database
+with `VACUUM INTO`: it selects reflink first, SQLite online backup as the
+portable fallback, and a full copy only when both faster providers are
+unavailable. Normal generation publication instead records a SQLite session
+changeset from before the package transaction through terminal publication.
 
 Schema revision 39 adds one generation-delta mutation epoch row plus generated
 triggers for every authoritative table. A connection-local SQLite function
@@ -730,17 +723,25 @@ registers the function before schema validation. An unconfigured writer fails
 closed at the trigger instead of changing authority without advancing the
 epoch. This is a pre-alpha hard cut: revision 38 databases must be rebuilt.
 
-`generation_backup_chain.rs` owns the staged replacement format: one
+`generation_backup_chain.rs` owns the active v3 format: one
 content-addressed SQLite base plus at most 32 ordered, content-addressed session
 changesets. Each generation hard-links the complete base/delta set into its own
 state directory, so generation GC never leaves a surviving manifest dependent
 on an ancestor directory. The recursive chain identity binds the base digest,
-every ordered delta digest, and each resulting mutation token. Normal append
-writes and hashes only the new changeset; full payload hashing, changeset replay,
-SQLite integrity checking, and foreign-key checking occur when verification or
-recovery materializes the database. A schema change, chain limit, or mismatched
-source baseline requires a new full base. Until publication and recovery are
-wired to this owner, the v2 full-snapshot manifest remains active authority.
+base token, every ordered delta digest, and every source/result token transition.
+Normal append writes and hashes only the new changeset; full payload hashing,
+changeset replay, SQLite integrity checking, and foreign-key checking occur
+when verification or recovery materializes the database. A schema change,
+32-delta chain limit, mismatched source baseline, concurrent-connection write,
+retry publication, or otherwise unprovable capture requires a new full base.
+
+Publication first persists a crash-valid `active_marked` chain, advances the
+SQLite publication row to terminal state, then atomically replaces the manifest
+with the recorder's cumulative terminal delta. A crash before replacement keeps
+the provisional chain recoverable; its token mismatch forces the next normal
+publication to create a new base. A successful terminal replacement removes
+unreferenced provisional artifacts. The retired v2 whole-file manifest and
+checksum sidecar have no compatibility reader.
 
 **Composefs-native transactions**: Every package mutation follows one linear
 pipeline: resolve -> fetch -> materialize an isolated selected root -> run typed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-14
-revision: 51
+revision: 52
 summary: Describe workspace and release boundaries, exact native source authority, package transactions, typed generation database snapshots, lifecycle execution, carrier security, generation GC, and service boundaries
 ---
 
@@ -125,6 +125,9 @@ crates/conary-core/      Core library crate
     +-- db/              Database layer
     |   +-- schema.rs    Current pre-alpha schema epoch initializer and rebuild gate
     |   +-- rebuild.rs   Explicit retired-schema snapshot and active-state replacement
+    |   +-- generation_snapshot.rs Typed full-snapshot provider selection
+    |   +-- generation_delta.rs Transaction-scoped SQLite session capture
+    |   +-- generation_backup_chain.rs Bounded self-contained base-plus-delta recovery authority
     |   +-- current_schema/ One schema split into package-manager, repository, and Remi ownership files
     |   +-- models/      ORM-style model structs
     |   |   +-- try_session.rs M1b package try session state
@@ -726,6 +729,18 @@ from another connection while capture is active. Every Conary write connection
 registers the function before schema validation. An unconfigured writer fails
 closed at the trigger instead of changing authority without advancing the
 epoch. This is a pre-alpha hard cut: revision 38 databases must be rebuilt.
+
+`generation_backup_chain.rs` owns the staged replacement format: one
+content-addressed SQLite base plus at most 32 ordered, content-addressed session
+changesets. Each generation hard-links the complete base/delta set into its own
+state directory, so generation GC never leaves a surviving manifest dependent
+on an ancestor directory. The recursive chain identity binds the base digest,
+every ordered delta digest, and each resulting mutation token. Normal append
+writes and hashes only the new changeset; full payload hashing, changeset replay,
+SQLite integrity checking, and foreign-key checking occur when verification or
+recovery materializes the database. A schema change, chain limit, or mismatched
+source baseline requires a new full base. Until publication and recovery are
+wired to this owner, the v2 full-snapshot manifest remains active authority.
 
 **Composefs-native transactions**: Every package mutation follows one linear
 pipeline: resolve -> fetch -> materialize an isolated selected root -> run typed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-14
-revision: 50
+revision: 51
 summary: Describe workspace and release boundaries, exact native source authority, package transactions, typed generation database snapshots, lifecycle execution, carrier security, generation GC, and service boundaries
 ---
 
@@ -715,6 +715,17 @@ verification and recovery repeat the full check, while an uninterrupted
 publication does not immediately verify the same snapshot a second time.
 Recovery opens checkpointed snapshots through SQLite's immutable read-only
 mode so verification cannot create or consume WAL sidecars.
+
+Schema revision 39 adds one generation-delta mutation epoch row plus generated
+triggers for every authoritative table. A connection-local SQLite function
+assigns one UUID to all writes in a transaction, and the triggers persist that
+UUID exactly once for the transaction. Generation publication can therefore
+admit a session changeset only when the live database still names the exact
+prior generation baseline; `PRAGMA data_version` separately rejects a commit
+from another connection while capture is active. Every Conary write connection
+registers the function before schema validation. An unconfigured writer fails
+closed at the trigger instead of changing authority without advancing the
+epoch. This is a pre-alpha hard cut: revision 38 databases must be rebuilt.
 
 **Composefs-native transactions**: Every package mutation follows one linear
 pipeline: resolve -> fetch -> materialize an isolated selected root -> run typed

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-14
-revision: 71
+revision: 72
 summary: Route workspace and release boundaries, typed database rebuilds, generation snapshots and recovery deltas, exact native source identity and adopted-artifact conversion, lossless source authority and trust-import planning, exact Remi signing, selected-root mutation, rollback lineage, canonical-map authority, carrier security, generation GC, and subsystem proof through current feature owners.
 ---
 
@@ -157,6 +157,7 @@ commands.
 - Generation, bootstrap, and QEMU proof:
   `docs/modules/feature-ownership.md` slugs `generation` and `bootstrap`, plus
   `crates/conary-core/src/db/backup.rs`,
+  `crates/conary-core/src/db/generation_backup_chain.rs`,
   `crates/conary-core/src/db/generation_delta.rs`,
   `crates/conary-core/src/db/generation_snapshot.rs`,
   `crates/conary-core/benches/generation_db_snapshot.rs`,

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-14
-revision: 70
-summary: Route workspace and release boundaries, typed database rebuilds and generation snapshots, exact native source identity and adopted-artifact conversion, lossless source authority and trust-import planning, exact Remi signing, selected-root mutation, rollback lineage, canonical-map authority, carrier security, generation GC, and subsystem proof through current feature owners.
+revision: 71
+summary: Route workspace and release boundaries, typed database rebuilds, generation snapshots and recovery deltas, exact native source identity and adopted-artifact conversion, lossless source authority and trust-import planning, exact Remi signing, selected-root mutation, rollback lineage, canonical-map authority, carrier security, generation GC, and subsystem proof through current feature owners.
 ---
 
 # Assistant Subsystem Map
@@ -157,6 +157,7 @@ commands.
 - Generation, bootstrap, and QEMU proof:
   `docs/modules/feature-ownership.md` slugs `generation` and `bootstrap`, plus
   `crates/conary-core/src/db/backup.rs`,
+  `crates/conary-core/src/db/generation_delta.rs`,
   `crates/conary-core/src/db/generation_snapshot.rs`,
   `crates/conary-core/benches/generation_db_snapshot.rs`,
   `crates/conary-core/src/generation/root_manifest.rs`,

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-14
-revision: 72
-summary: Route feature ownership through typed database rebuilds and generation snapshots, exact native source identity and adopted-artifact conversion, native declaration and trust-import planning, exact Remi signing, streaming package payloads, serialized selected-root mutation, typed rollback lineage, exact lifecycle, canonical-map authority, carrier security, generation GC, exact release authority, and current canonical docs
+revision: 73
+summary: Route feature ownership through typed database rebuilds, generation snapshots and recovery deltas, exact native source identity and adopted-artifact conversion, native declaration and trust-import planning, exact Remi signing, streaming package payloads, serialized selected-root mutation, typed rollback lineage, exact lifecycle, canonical-map authority, carrier security, generation GC, exact release authority, and current canonical docs
 ---
 
 # Feature Ownership And Interaction Gates
@@ -550,6 +550,7 @@ and export raw/qcow2/ISO carriers.
 
 **Start here:** `crates/conary-core/src/generation/builder.rs`;
 `crates/conary-core/src/db/backup.rs`;
+`crates/conary-core/src/db/generation_delta.rs`;
 `crates/conary-core/src/db/generation_snapshot.rs`;
 `crates/conary-core/src/generation/root_manifest.rs`;
 `crates/conary-core/src/generation/root_manifest/delta.rs`;
@@ -605,6 +606,7 @@ state, image building, bootstrap validation, conaryd route history.
 
 **Paths:** `crates/conary-core/src/generation/*`;
 `crates/conary-core/src/db/backup.rs`;
+`crates/conary-core/src/db/generation_delta.rs`;
 `crates/conary-core/src/db/generation_snapshot.rs`;
 `crates/conary-core/benches/generation_db_snapshot.rs`;
 `crates/conary-core/src/ccs/hooks/capabilities.rs`;
@@ -641,6 +643,7 @@ state, image building, bootstrap validation, conaryd route history.
 `cargo test -p conary --lib commands::generation::activation_intents`;
 `cargo test -p conary --lib commands::generation::gc`;
 `cargo test -p conary-core --test db_backup`;
+`cargo test -p conary-core --lib db::generation_delta`;
 `cargo bench -p conary-core --bench generation_db_snapshot`;
 `cargo test -p conary-core --test generation_composefs_runtime_contract`;
 `cargo test -p conary --test packaged_onboarding`.

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-14
-revision: 73
+revision: 74
 summary: Route feature ownership through typed database rebuilds, generation snapshots and recovery deltas, exact native source identity and adopted-artifact conversion, native declaration and trust-import planning, exact Remi signing, streaming package payloads, serialized selected-root mutation, typed rollback lineage, exact lifecycle, canonical-map authority, carrier security, generation GC, exact release authority, and current canonical docs
 ---
 
@@ -550,6 +550,7 @@ and export raw/qcow2/ISO carriers.
 
 **Start here:** `crates/conary-core/src/generation/builder.rs`;
 `crates/conary-core/src/db/backup.rs`;
+`crates/conary-core/src/db/generation_backup_chain.rs`;
 `crates/conary-core/src/db/generation_delta.rs`;
 `crates/conary-core/src/db/generation_snapshot.rs`;
 `crates/conary-core/src/generation/root_manifest.rs`;
@@ -606,6 +607,7 @@ state, image building, bootstrap validation, conaryd route history.
 
 **Paths:** `crates/conary-core/src/generation/*`;
 `crates/conary-core/src/db/backup.rs`;
+`crates/conary-core/src/db/generation_backup_chain.rs`;
 `crates/conary-core/src/db/generation_delta.rs`;
 `crates/conary-core/src/db/generation_snapshot.rs`;
 `crates/conary-core/benches/generation_db_snapshot.rs`;


### PR DESCRIPTION
## Primary issue

Refs #402

Performance measurement and regression detection remain paired with #121.

## Outcome

- activates the v3 generation recovery format: one content-addressed SQLite base plus at most 32 ordered SQLite session changesets
- records normal install, batch, restore, remove, and rollback mutations from before their transaction through terminal generation publication
- keeps each generation self-contained with hard-linked base/delta artifacts and replaces crash-valid provisional authority with the cumulative terminal delta
- falls back to a new full base when the exact prior baseline, connection history, schema epoch, or bounded-chain contract cannot be proven
- removes the retired v2 whole-file manifest/checksum authority and validates materialized recovery with digest, session replay, SQLite integrity, foreign keys, publication identity, and transaction high-water checks
- preserves reflink-first base creation, local SQLite online backup fallback, and typed full-copy fallback
- requires all writers, including Remi, to use Conary's configured SQLite opener so the persisted mutation epoch cannot be bypassed
- adds a required Btrfs loop-filesystem CI job that proves the reflink provider is selected with zero payload bytes written

## Scaling proof

Exact Criterion measurements on the same local host showed fixed-work behavior across 0, 10,000, and 100,000 historical rows:

```text
generation_db_delta/fixed_update_capture
0 rows:       76.023-76.450 us
10,000 rows:  75.663-76.601 us
100,000 rows: 74.084-74.215 us

generation_db_delta/fixed_append_persistence
0 rows:       61.301-61.620 us
10,000 rows:  61.471-61.741 us
100,000 rows: 60.863-61.009 us
```

Each append also asserts that reported payload bytes equal only the new changeset bytes. The benchmark temp directory is tmpfs, so these measurements prove history independence rather than production absolute latency. Hosted Btrfs zero-copy proof remains an exact-head CI requirement.

## Local verification

```text
cargo test --workspace --exclude conary-test --quiet
  complete workspace passed; notable suites include:
  conary: 1086 passed, 2 ignored
  conary-core: 3602 passed, 5 ignored
  remi: 627 passed

cargo test -p conaryd --lib daemon::package_ops::tests::package_executor_runs_remove_through_cli_contract -- --exact --nocapture
  1 passed
cargo test -p conary-core --lib db::generation_backup_chain::tests::first_generation_zero_is_a_valid_chain_identity -- --exact --nocapture
  1 passed
cargo clippy --workspace --all-targets -- -D warnings
cargo fmt --all -- --check
cargo bench -p conary-core --bench generation_db_snapshot --no-run
bash scripts/check-doc-truth.sh
bash scripts/agent-context.sh --validate
bash scripts/check-github-action-runtimes.sh
bash scripts/test-github-action-runtimes.sh
git diff --check
```

## Review notes

- Exact head: `e81ea0c8156d7890c67797d5b8bd219bb79c6ac2`
- Exact-head PR checks, including `generation-db-reflink`, are pending.
- Review focus: recorder arming/terminal completeness, crash-valid provisional replacement, self-contained bounded chains, configured-writer enforcement, and recovery validation.
- Local `proopt.md` remains untracked and is not part of this PR.
