### PR TITLE
perf(adopt): consume one coherent native inventory

### DIFF
--- a/apps/conary/src/commands/adopt/cas_capture.rs
+++ b/apps/conary/src/commands/adopt/cas_capture.rs
@@ -463,6 +463,52 @@ mod tests {
     }
 
     #[test]
+    fn complete_adoption_preserves_one_hardlink_topology_across_packages() {
+        let tmp = tempdir_in_target();
+        let root = tmp.path().join("root");
+        std::fs::create_dir_all(root.join("usr/lib")).unwrap();
+        std::fs::write(root.join("usr/lib/primary"), b"shared inode").unwrap();
+        std::fs::hard_link(root.join("usr/lib/primary"), root.join("usr/lib/secondary")).unwrap();
+        let cas = CasStore::new(tmp.path().join("objects")).unwrap();
+        let captured_root =
+            conary_core::generation::root_manifest::scan_selected_root(&root, &cas).unwrap();
+        let index = SelectedRootPayloadIndex::new(&captured_root);
+
+        let primary = capture_package_files_from_selected_root(
+            "package-a",
+            &[file_tuple("/usr/lib/primary", 12, 0o100644, None, None)],
+            &index,
+            &cas,
+        )
+        .unwrap()
+        .pop()
+        .unwrap();
+        let secondary = capture_package_files_from_selected_root(
+            "package-b",
+            &[file_tuple("/usr/lib/secondary", 12, 0o100644, None, None)],
+            &index,
+            &cas,
+        )
+        .unwrap()
+        .pop()
+        .unwrap();
+
+        let PayloadNodeKind::Regular {
+            hardlink_identity: Some(primary_identity),
+        } = primary.node.source.kind
+        else {
+            panic!("global hardlink primary did not retain its identity");
+        };
+        let PayloadNodeKind::Hardlink { identity, target } = secondary.node.source.kind else {
+            panic!("second package did not retain the global hardlink alias");
+        };
+        assert_eq!(identity, primary_identity);
+        assert_eq!(target, "/usr/lib/primary");
+        assert!(primary.content.is_some());
+        assert!(secondary.content.is_none());
+    }
+
+    #[test]
     #[cfg(unix)]
     fn full_adoption_regular_file_uses_private_cas_inode() {
         use std::os::unix::fs::MetadataExt;

--- a/apps/conary/src/commands/adopt/packages.rs
+++ b/apps/conary/src/commands/adopt/packages.rs
@@ -12,11 +12,11 @@ use std::path::Path;
 use anyhow::{Context, Result, anyhow, bail};
 use conary_core::db::backup::CheckpointReason;
 use conary_core::db::models::{
-    Changeset, ChangesetStatus, ExistingDirectoryMaterialization, FileEntry, InstallSource, Trove,
-    TroveType,
+    Changeset, ChangesetStatus, ExistingDirectoryMaterialization, FileEntry, InstallReason,
+    InstallSource, Trove, TroveType,
 };
 use conary_core::packages::{
-    InstalledPackageIdentity, SystemPackageManager, dpkg_query, pacman_query, rpm_query,
+    InstalledInventorySnapshot, InstalledPackageIdentity, NativeInstallReason, SystemPackageManager,
 };
 use conary_core::repository::dependency_model::{ProvidedCapability, RepositoryRequirementGroup};
 use conary_core::repository::versioning::VersionScheme;
@@ -63,6 +63,7 @@ struct ResolvedNativePackage {
     requested: String,
     native: InstalledPackageIdentity,
     description: Option<String>,
+    install_reason: NativeInstallReason,
 }
 
 #[derive(Clone, Debug)]
@@ -70,7 +71,6 @@ enum PackageLookup {
     Found(ResolvedNativePackage),
     Missing { reason: String },
     Ambiguous { reason: String },
-    Unsupported { reason: String },
 }
 
 trait NativePackageSource {
@@ -82,15 +82,22 @@ trait NativePackageSource {
         &self,
         identity: &InstalledPackageIdentity,
     ) -> Result<Vec<ProvidedCapability>>;
+    fn revalidate(&self) -> Result<()> {
+        Ok(())
+    }
 }
 
 struct DetectedNativePackageSource {
     manager: SystemPackageManager,
+    inventory: InstalledInventorySnapshot,
 }
 
 impl DetectedNativePackageSource {
-    fn new(manager: SystemPackageManager) -> Self {
-        Self { manager }
+    fn new(manager: SystemPackageManager) -> Result<Self> {
+        Ok(Self {
+            manager,
+            inventory: InstalledInventorySnapshot::capture(manager)?,
+        })
     }
 }
 
@@ -100,102 +107,85 @@ impl NativePackageSource for DetectedNativePackageSource {
     }
 
     fn lookup(&self, requested: &str) -> PackageLookup {
-        let result = match self.manager {
-            SystemPackageManager::Rpm => {
-                rpm_query::query_package(requested).map(|record| ResolvedNativePackage {
-                    requested: requested.to_string(),
-                    native: record.identity,
-                    description: record.info.description.or(record.info.summary),
-                })
-            }
-            SystemPackageManager::Dpkg => {
-                dpkg_query::query_package(requested).map(|record| ResolvedNativePackage {
-                    requested: requested.to_string(),
-                    native: record.identity,
-                    description: record.info.description,
-                })
-            }
-            SystemPackageManager::Pacman => {
-                pacman_query::query_package(requested).map(|record| ResolvedNativePackage {
-                    requested: requested.to_string(),
-                    native: record.identity,
-                    description: record.info.description,
-                })
-            }
-            SystemPackageManager::Eopkg => {
-                conary_core::packages::eopkg::query::query_package(requested).map(|record| {
-                    ResolvedNativePackage {
-                        requested: requested.to_string(),
-                        native: record.identity,
-                        description: record.info.description,
-                    }
-                })
-            }
-            SystemPackageManager::Unknown => {
-                return PackageLookup::Unsupported {
-                    reason: "no supported native package manager is available".to_string(),
-                };
-            }
-        };
-
-        match result {
-            Ok(identity) => PackageLookup::Found(identity),
-            Err(conary_core::Error::NotFound(_)) => PackageLookup::Missing {
+        let mut matches = self
+            .inventory
+            .packages()
+            .filter(|package| {
+                package.identity.selector() == requested || package.identity.name() == requested
+            })
+            .collect::<Vec<_>>();
+        match matches.len() {
+            0 => PackageLookup::Missing {
                 reason: format!(
                     "'{requested}' is not installed in the {} database",
                     self.manager.display_name()
                 ),
             },
-            Err(conary_core::Error::ConflictError(reason)) => PackageLookup::Ambiguous { reason },
-            Err(error) => PackageLookup::Unsupported {
+            1 => {
+                let package = matches.pop().expect("one native inventory match");
+                PackageLookup::Found(ResolvedNativePackage {
+                    requested: requested.to_string(),
+                    native: package.identity.clone(),
+                    description: package.description.clone(),
+                    install_reason: package.install_reason,
+                })
+            }
+            _ => PackageLookup::Ambiguous {
                 reason: format!(
-                    "{} could not inspect '{requested}': {error}",
-                    self.manager.display_name()
+                    "Package '{requested}' matches multiple installed {} variants: {}. Use one exact installed native selector.",
+                    self.manager.display_name(),
+                    matches
+                        .iter()
+                        .map(|package| package.identity.selector())
+                        .collect::<Vec<_>>()
+                        .join(", ")
                 ),
             },
         }
     }
 
     fn query_files(&self, query_name: &str) -> Result<Vec<FileInfoTuple>> {
-        let files = match self.manager {
-            SystemPackageManager::Rpm => rpm_query::query_package_files(query_name)
-                .with_context(|| format!("RPM file query failed for '{query_name}'"))?,
-            SystemPackageManager::Dpkg => dpkg_query::query_package_files(query_name)
-                .with_context(|| format!("dpkg file query failed for '{query_name}'"))?,
-            SystemPackageManager::Pacman => pacman_query::query_package_files(query_name)
-                .with_context(|| format!("pacman file query failed for '{query_name}'"))?,
-            SystemPackageManager::Eopkg => {
-                conary_core::packages::eopkg::query::query_package_files(query_name)
-                    .with_context(|| format!("eopkg file query failed for '{query_name}'"))?
-            }
-            SystemPackageManager::Unknown => Vec::new(),
-        };
-        Ok(files
-            .into_iter()
-            .map(|file| {
-                (
-                    file.path,
-                    file.size,
-                    file.mode,
-                    file.digest,
-                    file.user,
-                    file.group,
-                    file.link_target,
-                    file.absence_policy,
-                )
-            })
+        let package = self
+            .inventory
+            .package(query_name)
+            .ok_or_else(|| anyhow!("native inventory has no exact selector '{query_name}'"))?;
+        Ok(package
+            .files
+            .iter()
+            .map(super::system::inventory_file_tuple)
             .collect())
     }
 
     fn query_requirements(&self, query_name: &str) -> Result<Vec<RepositoryRequirementGroup>> {
-        super::requirements::query_package_requirements(self.manager, query_name)
+        Ok(self
+            .inventory
+            .package(query_name)
+            .ok_or_else(|| anyhow!("native inventory has no exact selector '{query_name}'"))?
+            .requirements
+            .clone())
     }
 
     fn query_provides(
         &self,
         identity: &InstalledPackageIdentity,
     ) -> Result<Vec<ProvidedCapability>> {
-        super::provides::query_package_provides(self.manager, identity)
+        Ok(self
+            .inventory
+            .package(identity.selector())
+            .ok_or_else(|| {
+                anyhow!(
+                    "native inventory has no exact selector '{}'",
+                    identity.selector()
+                )
+            })?
+            .provides
+            .clone())
+    }
+
+    fn revalidate(&self) -> Result<()> {
+        let current = InstalledInventorySnapshot::capture(self.manager)?;
+        self.inventory.require_unchanged(&current)?;
+        Ok(())
     }
 }
 
@@ -318,7 +308,7 @@ pub async fn cmd_adopt(
     if !manager.is_available() {
         bail!("No supported package manager found. Conary supports RPM, dpkg, pacman, and eopkg.");
     }
-    let source = DetectedNativePackageSource::new(manager);
+    let source = DetectedNativePackageSource::new(manager)?;
     cmd_adopt_with_source(packages, db_path, full, dry_run, &source)
 }
 
@@ -343,7 +333,7 @@ fn cmd_adopt_with_source(
     let plan = build_adoption_plan(&conn, packages, mode, source)?;
     render_non_ready_outcomes(&plan);
     refuse_empty_actionable_plan(&plan)?;
-    execute_adoption_plan(&mut conn, db_path, &plan)
+    execute_adoption_plan(&mut conn, db_path, &plan, source)
 }
 
 fn open_preview_db(path: &str) -> Result<Connection> {
@@ -425,12 +415,6 @@ fn build_adoption_plan(
             }),
             PackageLookup::Ambiguous { reason } => {
                 outcomes.push(PackagePlanOutcome::Ambiguous {
-                    requested: requested.clone(),
-                    reason,
-                });
-            }
-            PackageLookup::Unsupported { reason } => {
-                outcomes.push(PackagePlanOutcome::Unsupported {
                     requested: requested.clone(),
                     reason,
                 });
@@ -797,6 +781,7 @@ fn execute_adoption_plan(
     conn: &mut Connection,
     db_path: &str,
     plan: &PackageAdoptionPlan,
+    source: &dyn NativePackageSource,
 ) -> Result<()> {
     let ready = plan
         .outcomes
@@ -874,6 +859,11 @@ fn execute_adoption_plan(
             trove.description = identity.description.clone();
             trove.installed_by_changeset_id = Some(changeset_id);
             trove.selection_reason = Some("Adopted from the native package manager".to_string());
+            if identity.install_reason == NativeInstallReason::Dependency {
+                trove.install_reason = InstallReason::Dependency;
+                trove.selection_reason =
+                    Some("Auto-installed dependency (from native package manager)".to_string());
+            }
             trove.native_package_identity = Some(identity.native.clone());
             let trove_id = trove.insert(tx)?;
 
@@ -913,6 +903,11 @@ fn execute_adoption_plan(
                 &package.provides,
             )?;
 
+            source.revalidate().map_err(|error| {
+                conary_core::Error::ConflictError(format!(
+                    "native inventory changed before adopting {selector}: {error}"
+                ))
+            })?;
             changeset.update_status(tx, ChangesetStatus::Applied)?;
             Ok(changeset_id)
         })?;

--- a/apps/conary/src/commands/adopt/packages/tests.rs
+++ b/apps/conary/src/commands/adopt/packages/tests.rs
@@ -4,7 +4,9 @@ use std::fs;
 use std::path::PathBuf;
 
 use conary_core::db;
-use conary_core::db::models::{FileEntry, InstallSource, ProvideEntry, Trove, TroveType};
+use conary_core::db::models::{
+    FileEntry, InstallReason, InstallSource, ProvideEntry, Trove, TroveType,
+};
 use conary_core::payload::{PayloadContentAuthority, PayloadNodeKind};
 use walkdir::WalkDir;
 
@@ -18,6 +20,7 @@ struct FixtureSource {
     file_errors: HashMap<String, String>,
     requirements: HashMap<String, Vec<RepositoryRequirementGroup>>,
     provides: HashMap<String, Vec<ProvidedCapability>>,
+    revalidation_error: Option<String>,
 }
 
 impl FixtureSource {
@@ -47,6 +50,7 @@ impl FixtureSource {
                 )
                 .unwrap(),
                 description: Some("Fixture package".to_string()),
+                install_reason: NativeInstallReason::Explicit,
             }),
         );
         self.files.insert(selector.clone(), vec![file]);
@@ -115,6 +119,7 @@ impl FixtureSource {
                 )
                 .unwrap(),
                 description: Some("Debian fixture package".to_string()),
+                install_reason: NativeInstallReason::Explicit,
             }),
         );
         self.files.insert(requested.to_string(), vec![file]);
@@ -138,6 +143,11 @@ impl FixtureSource {
     fn with_file_error(mut self, selector: &str, reason: &str) -> Self {
         self.file_errors
             .insert(selector.to_string(), reason.to_string());
+        self
+    }
+
+    fn with_revalidation_error(mut self, reason: &str) -> Self {
+        self.revalidation_error = Some(reason.to_string());
         self
     }
 }
@@ -180,6 +190,13 @@ impl NativePackageSource for FixtureSource {
             .get(identity.selector())
             .cloned()
             .unwrap_or_default())
+    }
+
+    fn revalidate(&self) -> Result<()> {
+        if let Some(reason) = &self.revalidation_error {
+            return Err(anyhow!(reason.clone()));
+        }
+        Ok(())
     }
 }
 
@@ -239,6 +256,42 @@ fn dpkg_adoption_persists_exact_multi_arch_authority() {
             .and_then(InstalledPackageIdentity::debian_multi_arch),
         trove.debian_multi_arch
     );
+}
+
+#[test]
+fn package_adoption_persists_snapshot_install_reason() {
+    let (temp, db_path) = temp_db();
+    let payload = temp.path().join("dependency-fixture");
+    fs::write(&payload, b"fixture").unwrap();
+    let mut source =
+        FixtureSource::default().with_ready("fixture", "fixture", file_tuple(&payload, 0o100644));
+    let PackageLookup::Found(package) = source.lookups.get_mut("fixture").unwrap() else {
+        panic!("fixture should be a found package");
+    };
+    package.install_reason = NativeInstallReason::Dependency;
+
+    cmd_adopt_with_source(&["fixture".to_string()], &db_path, false, false, &source).unwrap();
+
+    let conn = db::open(&db_path).unwrap();
+    let trove = Trove::find_by_name(&conn, "fixture").unwrap().remove(0);
+    assert_eq!(trove.install_reason, InstallReason::Dependency);
+}
+
+#[test]
+fn native_inventory_change_rolls_back_package_adoption_before_commit() {
+    let (temp, db_path) = temp_db();
+    let payload = temp.path().join("mutation-fixture");
+    fs::write(&payload, b"fixture").unwrap();
+    let source = FixtureSource::default()
+        .with_ready("fixture", "fixture", file_tuple(&payload, 0o100644))
+        .with_revalidation_error("forced native inventory token change");
+
+    let error = cmd_adopt_with_source(&["fixture".to_string()], &db_path, false, false, &source)
+        .unwrap_err();
+
+    assert!(error.to_string().contains("native inventory changed"));
+    let conn = db::open(&db_path).unwrap();
+    assert!(Trove::find_by_name(&conn, "fixture").unwrap().is_empty());
 }
 
 fn file_tuple(path: &Path, mode: i32) -> FileInfoTuple {
@@ -438,7 +491,7 @@ fn ready_package(plan: &PackageAdoptionPlan) -> &PlannedPackage {
 }
 
 #[test]
-fn plan_classifies_ready_tracked_missing_ambiguous_unsupported_and_conflict() {
+fn plan_classifies_ready_tracked_missing_ambiguous_and_conflict() {
     let (temp, db_path) = temp_db();
     let ready_path = temp.path().join("root/usr/bin/ready");
     let tracked_path = temp.path().join("root/usr/bin/tracked");
@@ -469,23 +522,9 @@ fn plan_classifies_ready_tracked_missing_ambiguous_unsupported_and_conflict() {
             PackageLookup::Ambiguous {
                 reason: "two native variants match".to_string(),
             },
-        )
-        .with_lookup(
-            "unsupported",
-            PackageLookup::Unsupported {
-                reason: "metadata cannot be represented".to_string(),
-            },
         );
     let conn = db::open(&db_path).unwrap();
-    let packages = [
-        "ready",
-        "tracked",
-        "missing",
-        "ambiguous",
-        "unsupported",
-        "conflicting",
-    ]
-    .map(str::to_string);
+    let packages = ["ready", "tracked", "missing", "ambiguous", "conflicting"].map(str::to_string);
 
     let plan = build_adoption_plan(&conn, &packages, AdoptionMode::Track, &source).unwrap();
 
@@ -504,10 +543,6 @@ fn plan_classifies_ready_tracked_missing_ambiguous_unsupported_and_conflict() {
     ));
     assert!(matches!(
         plan.outcomes[4],
-        PackagePlanOutcome::Unsupported { .. }
-    ));
-    assert!(matches!(
-        plan.outcomes[5],
         PackagePlanOutcome::Conflict { .. }
     ));
 }

--- a/apps/conary/src/commands/adopt/provides.rs
+++ b/apps/conary/src/commands/adopt/provides.rs
@@ -1,37 +1,11 @@
 // apps/conary/src/commands/adopt/provides.rs
 
-//! Typed installed-provider acquisition and persistence for native adoption.
+//! Typed installed-provider persistence for native adoption.
 
-use anyhow::{Context, Result, bail};
 use conary_core::db::models::ProvideEntry;
-use conary_core::packages::{
-    InstalledPackageIdentity, SystemPackageManager, dpkg_query, pacman_query, rpm_query,
-};
+use conary_core::packages::InstalledPackageIdentity;
 use conary_core::repository::dependency_model::ProvidedCapability;
 use rusqlite::Connection;
-
-pub(super) fn query_package_provides(
-    manager: SystemPackageManager,
-    identity: &InstalledPackageIdentity,
-) -> Result<Vec<ProvidedCapability>> {
-    let provides = match manager {
-        SystemPackageManager::Rpm => rpm_query::query_package_provides(identity),
-        SystemPackageManager::Dpkg => dpkg_query::query_package_provides(identity),
-        SystemPackageManager::Pacman => pacman_query::query_package_provides(identity),
-        SystemPackageManager::Eopkg => {
-            conary_core::packages::eopkg::query::query_package_provides(identity)
-        }
-        SystemPackageManager::Unknown => bail!("unsupported native package manager"),
-    }
-    .with_context(|| {
-        format!(
-            "could not inspect exact provides for '{}'",
-            identity.selector()
-        )
-    })?;
-
-    Ok(provides)
-}
 
 pub(super) fn insert_package_provides(
     conn: &Connection,

--- a/apps/conary/src/commands/adopt/refresh.rs
+++ b/apps/conary/src/commands/adopt/refresh.rs
@@ -10,7 +10,6 @@ use super::super::open_db;
 use super::cas_capture::{CapturedAdoptionFile, capture_package_files};
 use super::checkpoint::write_db_checkpoint;
 use super::outcome::write_warning_metadata;
-use super::system::FileInfoTuple;
 use crate::commands::AdoptionWarning;
 use anyhow::Result;
 use conary_core::db::backup::CheckpointReason;
@@ -18,7 +17,7 @@ use conary_core::db::models::{
     Changeset, ChangesetStatus, ExistingDirectoryMaterialization, InstallSource, Trove,
 };
 use conary_core::packages::{
-    InstalledPackageIdentity, SystemPackageManager, dpkg_query, pacman_query, rpm_query,
+    InstalledInventorySnapshot, InstalledPackageIdentity, SystemPackageManager,
 };
 use conary_core::repository::dependency_model::{ProvidedCapability, RepositoryRequirementGroup};
 use conary_core::repository::versioning::VersionScheme;
@@ -164,8 +163,16 @@ pub async fn cmd_adopt_refresh(
         println!("Checking {} adopted package(s) for drift...", adopted.len());
     }
 
-    // Preserve every exact native package-manager record.
-    let system_packages = query_all_current(pkg_mgr)?;
+    // Preserve every exact native package-manager record and every ownership,
+    // relation, reason, config, and lifecycle field under one token.
+    let inventory = InstalledInventorySnapshot::capture(pkg_mgr)?;
+    let system_packages = inventory
+        .packages()
+        .map(|package| CurrentNativePackage {
+            identity: package.identity.clone(),
+            description: package.description.clone(),
+        })
+        .collect::<Vec<_>>();
 
     // Classify each adopted trove
     let mut results: Vec<(&Trove, DriftOutcome)> = Vec::new();
@@ -279,44 +286,19 @@ pub async fn cmd_adopt_refresh(
             let use_cas = trove.install_source == InstallSource::AdoptedFull;
 
             // Query PM metadata outside the transaction.
-            let raw_files = match query_package_files(pkg_mgr, identity.selector()) {
-                Ok(f) => f,
-                Err(e) => {
-                    warn!(
-                        "Failed to query files for '{}': {}; skipping",
-                        identity.selector(),
-                        e
-                    );
-                    skip_ids.insert(trove_id);
-                    continue;
-                }
-            };
-            let requirements =
-                match super::requirements::query_package_requirements(pkg_mgr, identity.selector())
-                {
-                    Ok(d) => d,
-                    Err(e) => {
-                        warn!(
-                            "Failed to query deps for '{}': {}; skipping",
-                            identity.selector(),
-                            e
-                        );
-                        skip_ids.insert(trove_id);
-                        continue;
-                    }
-                };
-            let mut provides = match super::provides::query_package_provides(pkg_mgr, identity) {
-                Ok(p) => p,
-                Err(e) => {
-                    warn!(
-                        "Failed to query provides for '{}': {}; skipping",
-                        identity.selector(),
-                        e
-                    );
-                    skip_ids.insert(trove_id);
-                    continue;
-                }
-            };
+            let native = inventory.package(identity.selector()).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "exact native refresh identity '{}' disappeared from coherent inventory",
+                    identity.selector()
+                )
+            })?;
+            let raw_files = native
+                .files
+                .iter()
+                .map(super::system::inventory_file_tuple)
+                .collect::<Vec<_>>();
+            let requirements = native.requirements.clone();
+            let mut provides = native.provides.clone();
 
             // Capture exact live nodes and bytes outside the transaction.
             let captured_files = match capture_package_files(
@@ -445,6 +427,8 @@ pub async fn cmd_adopt_refresh(
 
         write_warning_metadata(tx, changeset_id, adoption_warnings)
             .map_err(|e| conary_core::Error::Io(std::io::Error::other(e.to_string())))?;
+        let current_inventory = InstalledInventorySnapshot::capture(pkg_mgr)?;
+        inventory.require_unchanged(&current_inventory)?;
         changeset.update_status(tx, ChangesetStatus::Applied)?;
         Ok(changeset_id)
     })?;
@@ -605,77 +589,6 @@ fn replace_refresh_children_for_package_for_test(
         &replacement,
         RefreshFailureInjection::after_delete(fail_after_delete),
     )
-}
-
-/// Query every exact currently installed native package-manager record.
-fn query_all_current(pkg_mgr: SystemPackageManager) -> Result<Vec<CurrentNativePackage>> {
-    let packages = match pkg_mgr {
-        SystemPackageManager::Rpm => rpm_query::query_all_packages()?
-            .into_iter()
-            .map(|record| CurrentNativePackage {
-                identity: record.identity,
-                description: record.info.description.or(record.info.summary),
-            })
-            .collect(),
-        SystemPackageManager::Dpkg => dpkg_query::query_all_packages()?
-            .into_iter()
-            .map(|record| CurrentNativePackage {
-                identity: record.identity,
-                description: record.info.description,
-            })
-            .collect(),
-        SystemPackageManager::Pacman => pacman_query::query_all_packages()?
-            .into_iter()
-            .map(|record| CurrentNativePackage {
-                identity: record.identity,
-                description: record.info.description,
-            })
-            .collect(),
-        SystemPackageManager::Eopkg => conary_core::packages::eopkg::query::query_all_packages()?
-            .into_iter()
-            .map(|record| CurrentNativePackage {
-                identity: record.identity,
-                description: record.info.description,
-            })
-            .collect(),
-        _ => return Err(anyhow::anyhow!("Unsupported package manager")),
-    };
-    Ok(packages)
-}
-
-/// Query files for a package from the active package manager.
-///
-/// Returns an error on PM query failure so callers can skip the package
-/// rather than recording it with an empty file list.
-fn query_package_files(pkg_mgr: SystemPackageManager, name: &str) -> Result<Vec<FileInfoTuple>> {
-    let raw = match pkg_mgr {
-        SystemPackageManager::Rpm => rpm_query::query_package_files(name)
-            .map_err(|e| anyhow::anyhow!("RPM file query failed for '{name}': {e}"))?,
-        SystemPackageManager::Dpkg => dpkg_query::query_package_files(name)
-            .map_err(|e| anyhow::anyhow!("DPKG file query failed for '{name}': {e}"))?,
-        SystemPackageManager::Pacman => pacman_query::query_package_files(name)
-            .map_err(|e| anyhow::anyhow!("Pacman file query failed for '{name}': {e}"))?,
-        SystemPackageManager::Eopkg => {
-            conary_core::packages::eopkg::query::query_package_files(name)
-                .map_err(|e| anyhow::anyhow!("eopkg file query failed for '{name}': {e}"))?
-        }
-        _ => return Ok(Vec::new()),
-    };
-    Ok(raw
-        .into_iter()
-        .map(|f| {
-            (
-                f.path,
-                f.size,
-                f.mode,
-                f.digest,
-                f.user,
-                f.group,
-                f.link_target,
-                f.absence_policy,
-            )
-        })
-        .collect())
 }
 
 #[cfg(test)]

--- a/apps/conary/src/commands/adopt/requirements.rs
+++ b/apps/conary/src/commands/adopt/requirements.rs
@@ -1,31 +1,12 @@
 // apps/conary/src/commands/adopt/requirements.rs
 
-//! Exact installed requirement acquisition and persistence for native adoption.
+//! Exact installed requirement persistence for native adoption.
 
-use anyhow::{Context, Result, bail};
+use anyhow::Result;
 use conary_core::db::models::InstalledRequirementGroup;
-use conary_core::packages::{SystemPackageManager, dpkg_query, pacman_query, rpm_query};
 use conary_core::repository::dependency_model::RepositoryRequirementGroup;
 use conary_core::repository::versioning::VersionScheme;
 use rusqlite::Connection;
-
-pub(super) fn query_package_requirements(
-    manager: SystemPackageManager,
-    package_name: &str,
-) -> Result<Vec<RepositoryRequirementGroup>> {
-    match manager {
-        SystemPackageManager::Rpm => rpm_query::query_package_requirement_groups(package_name),
-        SystemPackageManager::Dpkg => dpkg_query::query_package_requirement_groups(package_name),
-        SystemPackageManager::Pacman => {
-            pacman_query::query_package_requirement_groups(package_name)
-        }
-        SystemPackageManager::Eopkg => {
-            conary_core::packages::eopkg::query::query_package_requirement_groups(package_name)
-        }
-        SystemPackageManager::Unknown => bail!("unsupported native package manager"),
-    }
-    .with_context(|| format!("could not inspect exact requirements for '{package_name}'"))
-}
 
 pub(super) fn insert_package_requirements(
     conn: &Connection,

--- a/apps/conary/src/commands/adopt/system.rs
+++ b/apps/conary/src/commands/adopt/system.rs
@@ -20,8 +20,8 @@ use conary_core::db::models::{
     InstallSource, PayloadClaim, Trove, TroveType,
 };
 use conary_core::packages::{
-    InstalledFileAbsencePolicy, InstalledPackageIdentity, SystemPackageManager, dpkg_query,
-    pacman_query, rpm_query,
+    InstalledFileAbsencePolicy, InstalledInventoryFile, InstalledInventorySnapshot,
+    InstalledPackageIdentity, NativeInstallReason, SystemPackageManager,
 };
 use conary_core::repository::dependency_model::{ProvidedCapability, RepositoryRequirementGroup};
 use std::collections::HashMap;
@@ -55,12 +55,6 @@ pub type FileInfoTuple = (
     Option<String>,
     InstalledFileAbsencePolicy,
 );
-
-#[derive(Debug)]
-struct InstalledSystemPackage {
-    identity: InstalledPackageIdentity,
-    description: Option<String>,
-}
 
 struct PackageData {
     identity: InstalledPackageIdentity,
@@ -151,11 +145,7 @@ pub async fn cmd_adopt_system(
     let include_pattern = parse_package_pattern("--pattern", pattern)?;
     let exclude_pattern = parse_package_pattern("--exclude", exclude)?;
     let complete_full_root_scope = full && pattern.is_none() && exclude.is_none() && !explicit_only;
-    let eopkg_database = if pkg_mgr == SystemPackageManager::Eopkg {
-        Some(conary_core::packages::eopkg::query::InstalledEopkgDatabase::load()?)
-    } else {
-        None
-    };
+    let inventory = InstalledInventorySnapshot::capture(pkg_mgr)?;
 
     let mut conn = open_db(db_path)?;
 
@@ -176,64 +166,13 @@ pub async fn cmd_adopt_system(
     // Get every exact installed package-manager record. The typed selector is
     // kept distinct from the package name so multilib/multiarch variants
     // survive inventory and all follow-up queries target the intended record.
-    let installed: Vec<InstalledSystemPackage> = match pkg_mgr {
-        SystemPackageManager::Rpm => rpm_query::query_all_packages()?
-            .into_iter()
-            .map(|record| InstalledSystemPackage {
-                identity: record.identity,
-                description: record.info.description.or(record.info.summary),
-            })
-            .collect(),
-        SystemPackageManager::Dpkg => dpkg_query::query_all_packages()?
-            .into_iter()
-            .map(|record| InstalledSystemPackage {
-                identity: record.identity,
-                description: record.info.description,
-            })
-            .collect(),
-        SystemPackageManager::Pacman => pacman_query::query_all_packages()?
-            .into_iter()
-            .map(|record| InstalledSystemPackage {
-                identity: record.identity,
-                description: record.info.description,
-            })
-            .collect(),
-        SystemPackageManager::Eopkg => eopkg_database
-            .as_ref()
-            .expect("eopkg manager owns installed database snapshot")
-            .packages()
-            .into_iter()
-            .map(|record| InstalledSystemPackage {
-                identity: record.identity,
-                description: record.info.description,
-            })
-            .collect(),
-        _ => return Err(anyhow::anyhow!("Unsupported package manager")),
-    };
+    let installed = inventory.packages().collect::<Vec<_>>();
     if complete_full_root_scope {
         ensure_complete_native_partition(
             &tracked_packages,
             installed.iter().map(|package| package.identity.selector()),
         )?;
     }
-
-    // Exact install-reason authority is required. An empty set means the
-    // package manager explicitly reported no user-installed packages; query
-    // failure is not reinterpreted as "everything is explicit."
-    let user_installed: std::collections::HashSet<String> = match pkg_mgr {
-        SystemPackageManager::Rpm => rpm_query::query_user_installed()
-            .map_err(|error| anyhow::anyhow!("RPM install-reason query failed: {error}"))?,
-        SystemPackageManager::Dpkg => dpkg_query::query_user_installed()
-            .map_err(|error| anyhow::anyhow!("dpkg install-reason query failed: {error}"))?,
-        SystemPackageManager::Pacman => pacman_query::query_user_installed()
-            .map_err(|error| anyhow::anyhow!("pacman install-reason query failed: {error}"))?,
-        SystemPackageManager::Eopkg => eopkg_database
-            .as_ref()
-            .expect("eopkg manager owns installed database snapshot")
-            .user_installed()
-            .map_err(|error| anyhow::anyhow!("eopkg install-reason query failed: {error}"))?,
-        _ => return Err(anyhow::anyhow!("Unsupported package manager")),
-    };
 
     // Apply selective filters
     let pre_filter_count = installed.len();
@@ -250,9 +189,7 @@ pub async fn cmd_adopt_system(
             {
                 return false;
             }
-            if explicit_only
-                && !user_installed.contains(&package.identity.install_reason_selector())
-            {
+            if explicit_only && package.install_reason != NativeInstallReason::Explicit {
                 return false;
             }
             true
@@ -284,7 +221,7 @@ pub async fn cmd_adopt_system(
                 }
             } else {
                 to_adopt += 1;
-                if !user_installed.contains(&package.identity.install_reason_selector()) {
+                if package.install_reason == NativeInstallReason::Dependency {
                     dep_count += 1;
                 } else {
                     explicit_count += 1;
@@ -398,72 +335,18 @@ pub async fn cmd_adopt_system(
 
         progress.set_phase(selector, AdoptPhase::Querying);
 
-        // Query ALL PM metadata before opening the DB transaction.
-        let files: Vec<FileInfoTuple> =
-            match query_pm_files(pkg_mgr, selector, eopkg_database.as_ref()) {
-                Ok(f) => f,
-                Err(e) => {
-                    warn!("Failed to query files for '{}': {}; skipping", selector, e);
-                    progress.fail_package(selector, &e.to_string());
-                    error_count += 1;
-                    failures.push(BulkAdoptionFailure::new(
-                        selector,
-                        BulkAdoptionFailureStage::FileQuery,
-                        e.to_string(),
-                    ));
-                    continue;
-                }
-            };
+        let files = package
+            .files
+            .iter()
+            .map(inventory_file_tuple)
+            .collect::<Vec<_>>();
         let (requirements, mut provides) = if promote_trove_id.is_some() {
             // Track adoption already persisted the native metadata. Promotion
             // changes only its payload authority from discovery hashes to
             // privately captured CAS content.
             (Vec::new(), Vec::new())
         } else {
-            let requirement_result = match eopkg_database.as_ref() {
-                Some(database) => database
-                    .package_requirement_groups(selector)
-                    .map_err(anyhow::Error::from),
-                None => super::requirements::query_package_requirements(pkg_mgr, selector),
-            };
-            let requirements = match requirement_result {
-                Ok(d) => d,
-                Err(e) => {
-                    warn!("Failed to query deps for '{}': {}; skipping", selector, e);
-                    progress.fail_package(selector, &e.to_string());
-                    error_count += 1;
-                    failures.push(BulkAdoptionFailure::new(
-                        selector,
-                        BulkAdoptionFailureStage::RequirementQuery,
-                        e.to_string(),
-                    ));
-                    continue;
-                }
-            };
-            let provide_result = match eopkg_database.as_ref() {
-                Some(database) => database
-                    .package_provides(&package.identity)
-                    .map_err(anyhow::Error::from),
-                None => super::provides::query_package_provides(pkg_mgr, &package.identity),
-            };
-            let provides = match provide_result {
-                Ok(p) => p,
-                Err(e) => {
-                    warn!(
-                        "Failed to query provides for '{}': {}; skipping",
-                        selector, e
-                    );
-                    progress.fail_package(selector, &e.to_string());
-                    error_count += 1;
-                    failures.push(BulkAdoptionFailure::new(
-                        selector,
-                        BulkAdoptionFailureStage::ProvideQuery,
-                        e.to_string(),
-                    ));
-                    continue;
-                }
-            };
-            (requirements, provides)
+            (package.requirements.clone(), package.provides.clone())
         };
 
         // Capture exact live nodes and bytes outside the transaction. Full
@@ -511,7 +394,7 @@ pub async fn cmd_adopt_system(
             captured_files.iter().map(|file| file.source.0.as_str()),
         )?;
 
-        let is_dependency = !user_installed.contains(&package.identity.install_reason_selector());
+        let is_dependency = package.install_reason == NativeInstallReason::Dependency;
 
         pre_collected.push(PackageData {
             identity: package.identity.clone(),
@@ -647,6 +530,12 @@ pub async fn cmd_adopt_system(
             captured_root_sync = Some(synchronize_captured_root(tx, changeset_id, captured)?);
         }
 
+        // Re-read every native authority immediately before committing the
+        // ownership handoff. Any package, path, relation, reason, config, or
+        // lifecycle change rolls this entire Conary transaction back.
+        let current_inventory = InstalledInventorySnapshot::capture(pkg_mgr)?;
+        inventory.require_unchanged(&current_inventory)?;
+
         changeset.update_status(tx, ChangesetStatus::Applied)?;
         Ok(changeset_id)
     })?;
@@ -767,39 +656,17 @@ fn promote_track_package(
 
 const LIVE_ROOT_PACKAGE_NAME: &str = "conary-live-root";
 
-fn query_pm_files(
-    pkg_mgr: SystemPackageManager,
-    name: &str,
-    eopkg_database: Option<&conary_core::packages::eopkg::query::InstalledEopkgDatabase>,
-) -> Result<Vec<FileInfoTuple>> {
-    let raw = match pkg_mgr {
-        SystemPackageManager::Rpm => rpm_query::query_package_files(name)
-            .map_err(|e| anyhow::anyhow!("RPM file query failed for '{name}': {e}"))?,
-        SystemPackageManager::Dpkg => dpkg_query::query_package_files(name)
-            .map_err(|e| anyhow::anyhow!("DPKG file query failed for '{name}': {e}"))?,
-        SystemPackageManager::Pacman => pacman_query::query_package_files(name)
-            .map_err(|e| anyhow::anyhow!("Pacman file query failed for '{name}': {e}"))?,
-        SystemPackageManager::Eopkg => eopkg_database
-            .ok_or_else(|| anyhow::anyhow!("eopkg installed database snapshot is absent"))?
-            .package_files(name)
-            .map_err(|e| anyhow::anyhow!("eopkg file query failed for '{name}': {e}"))?,
-        _ => return Ok(Vec::new()),
-    };
-    Ok(raw
-        .into_iter()
-        .map(|f| {
-            (
-                f.path,
-                f.size,
-                f.mode,
-                f.digest,
-                f.user,
-                f.group,
-                f.link_target,
-                f.absence_policy,
-            )
-        })
-        .collect())
+pub(super) fn inventory_file_tuple(file: &InstalledInventoryFile) -> FileInfoTuple {
+    (
+        file.file.path.clone(),
+        file.file.size,
+        file.file.mode,
+        file.file.digest.clone(),
+        file.file.user.clone(),
+        file.file.group.clone(),
+        file.file.link_target.clone(),
+        file.file.absence_policy,
+    )
 }
 
 #[cfg(test)]

--- a/apps/conary/src/commands/adopt/system.rs
+++ b/apps/conary/src/commands/adopt/system.rs
@@ -25,7 +25,7 @@ use conary_core::packages::{
 };
 use conary_core::repository::dependency_model::{ProvidedCapability, RepositoryRequirementGroup};
 use std::collections::HashMap;
-use tracing::warn;
+use tracing::{debug, warn};
 
 mod captured_root;
 mod live_root;
@@ -274,12 +274,19 @@ pub async fn cmd_adopt_system(
     };
     let cas_batch = cas.as_ref().map(|cas| cas.private_copy_batch());
     let captured_selected_root = if complete_full_root_scope {
-        Some(capture_live_selected_root(
+        let (captured, work) = capture_live_selected_root(
             db_path,
             cas_batch
                 .as_ref()
                 .expect("complete full-root capture requires an initialized CAS"),
-        )?)
+        )?;
+        debug!(
+            paths_examined = work.paths_examined,
+            regular_content_streams = work.regular_content_streams,
+            unique_regular_inodes = work.unique_regular_inodes,
+            "completed one selected-root adoption traversal"
+        );
+        Some(captured)
     } else {
         None
     };

--- a/apps/conary/src/commands/adopt/system/captured_root.rs
+++ b/apps/conary/src/commands/adopt/system/captured_root.rs
@@ -12,8 +12,8 @@ use conary_core::db::models::{
 };
 use conary_core::filesystem::PrivateCasWriter;
 use conary_core::generation::root_manifest::{
-    CapturedSelectedRoot, GenerationRootEntry, SelectedRootCaptureExclusions,
-    scan_selected_root_with_exclusions,
+    CapturedSelectedRoot, GenerationRootEntry, SelectedRootCaptureExclusions, SelectedRootScanWork,
+    scan_selected_root_with_exclusions_and_work,
 };
 use conary_core::repository::versioning::VersionScheme;
 use conary_core::runtime_root::ConaryRuntimeRoot;
@@ -60,9 +60,9 @@ pub(super) fn ensure_complete_native_partition<'a>(
 pub(super) fn capture_live_selected_root(
     db_path: &str,
     cas: &dyn PrivateCasWriter,
-) -> Result<CapturedSelectedRoot> {
+) -> Result<(CapturedSelectedRoot, SelectedRootScanWork)> {
     let exclusions = capture_exclusions(db_path)?;
-    scan_selected_root_with_exclusions(Path::new("/"), cas, &exclusions)
+    scan_selected_root_with_exclusions_and_work(Path::new("/"), cas, &exclusions)
         .map_err(anyhow::Error::from)
         .context("failed to capture exact selected-root continuity state")
 }

--- a/apps/conary/src/commands/adopt/system/live_root.rs
+++ b/apps/conary/src/commands/adopt/system/live_root.rs
@@ -35,7 +35,7 @@ pub(super) fn adopt_live_root_as_full_package(
     }
 
     let cas = CasStore::new(conary_core::db::paths::objects_dir(db_path))?;
-    let captured = capture_live_selected_root(db_path, &cas)?;
+    let (captured, _work) = capture_live_selected_root(db_path, &cas)?;
     let mut conn = open_db(db_path)?;
     let mut changeset = Changeset::new(format!(
         "Synchronize selected-root authority ({LIVE_ROOT_PACKAGE_NAME})"

--- a/apps/conary/src/commands/generation/takeover.rs
+++ b/apps/conary/src/commands/generation/takeover.rs
@@ -22,7 +22,7 @@ use anyhow::{Context, Result, anyhow};
 use conary_core::db::models::{InstallSource, Trove};
 use conary_core::model;
 use conary_core::packages::{
-    InstalledPackageIdentity, SystemPackageManager, dpkg_query, pacman_query, rpm_query,
+    InstalledInventorySnapshot, InstalledPackageIdentity, SystemPackageManager,
 };
 use std::collections::HashMap;
 use std::io::Write;
@@ -66,7 +66,18 @@ pub fn plan_takeover(
         ));
     }
 
-    let system_packages = query_all_system_packages(&pm)?;
+    let inventory = InstalledInventorySnapshot::capture(pm)?;
+    plan_takeover_from_inventory(conn, &inventory).map_err(Into::into)
+}
+
+fn plan_takeover_from_inventory(
+    conn: &rusqlite::Connection,
+    inventory: &InstalledInventorySnapshot,
+) -> conary_core::Result<TakeoverPlan> {
+    let system_packages = inventory
+        .packages()
+        .map(|package| package.identity.clone())
+        .collect();
     // Match exact installed variants; name-only matching collapses multilib and
     // parallel native versions.
     let tracked: HashMap<String, InstallSource> = Trove::list_all(conn)?
@@ -204,6 +215,11 @@ pub async fn cmd_system_takeover(
             .context("Failed to resume interrupted eopkg authority removal")?;
     }
     let bootloader = detect_bootloader();
+    let inventory = if completed_handoff_packages.is_none() {
+        Some(InstalledInventorySnapshot::capture(pm)?)
+    } else {
+        None
+    };
     let mut plan = {
         let conn = open_db(db_path)?;
         if let Some(packages) = completed_handoff_packages {
@@ -218,7 +234,12 @@ pub async fn cmd_system_takeover(
                 .collect::<HashMap<_, _>>();
             classify_takeover_inventory(packages, &tracked)
         } else {
-            plan_takeover(&conn, pm)?
+            plan_takeover_from_inventory(
+                &conn,
+                inventory
+                    .as_ref()
+                    .expect("active native authority has a captured inventory"),
+            )?
         }
     };
     let mut record = incomplete_record.unwrap_or_else(|| {
@@ -341,7 +362,13 @@ pub async fn cmd_system_takeover(
             "  Upgrading {} track-only packages to CAS ...",
             plan.needs_cas_upgrade.len()
         );
-        let cas_upgrade_failures = upgrade_to_cas_backed(db_path, &plan.needs_cas_upgrade, &pm)?;
+        let cas_upgrade_failures = upgrade_to_cas_backed(
+            db_path,
+            &plan.needs_cas_upgrade,
+            inventory
+                .as_ref()
+                .expect("CAS upgrade requires active native authority"),
+        )?;
         if !cas_upgrade_failures.is_empty() {
             let failure_count = cas_upgrade_failures.len();
             record.record_cas_upgrade_failures(cas_upgrade_failures);
@@ -382,7 +409,13 @@ pub async fn cmd_system_takeover(
     if plan.needs_pm_removal.is_empty() {
         info!("No packages need PM removal");
     } else {
-        let ownership_report = match take_ownership(db_path, &plan.needs_pm_removal, pm) {
+        let ownership_report = match take_ownership(
+            db_path,
+            &plan.needs_pm_removal,
+            inventory
+                .as_ref()
+                .expect("ownership transfer requires active native authority"),
+        ) {
             Ok(report) => report,
             Err(error) => {
                 record.mark_failed(format!("Ownership transfer failed: {error}"));
@@ -663,37 +696,6 @@ fn preflight_checks(check_composefs: bool) -> Result<()> {
 
 fn takeover_requires_composefs(level: TakeoverLevel, dry_run: bool) -> bool {
     !dry_run && matches!(level, TakeoverLevel::Generation)
-}
-
-// ---------------------------------------------------------------------------
-// System PM query
-// ---------------------------------------------------------------------------
-
-/// Query every exact installed package-manager database identity.
-fn query_all_system_packages(pm: &SystemPackageManager) -> Result<Vec<InstalledPackageIdentity>> {
-    match pm {
-        SystemPackageManager::Rpm => Ok(rpm_query::query_all_packages()?
-            .into_iter()
-            .map(|record| record.identity)
-            .collect()),
-        SystemPackageManager::Dpkg => Ok(dpkg_query::query_all_packages()?
-            .into_iter()
-            .map(|record| record.identity)
-            .collect()),
-        SystemPackageManager::Pacman => Ok(pacman_query::query_all_packages()?
-            .into_iter()
-            .map(|record| record.identity)
-            .collect()),
-        SystemPackageManager::Eopkg => {
-            Ok(conary_core::packages::eopkg::query::query_all_packages()?
-                .into_iter()
-                .map(|record| record.identity)
-                .collect())
-        }
-        SystemPackageManager::Unknown => {
-            Err(anyhow!("No supported system package manager detected"))
-        }
-    }
 }
 
 #[cfg(test)]

--- a/apps/conary/src/commands/generation/takeover/ownership.rs
+++ b/apps/conary/src/commands/generation/takeover/ownership.rs
@@ -14,7 +14,8 @@ use conary_core::db::models::{
 use conary_core::db::paths::objects_dir;
 use conary_core::filesystem::CasStore;
 use conary_core::packages::{
-    InstalledPackageIdentity, SystemPackageManager, dpkg_query, pacman_query, rpm_query,
+    InstalledInventoryPackage, InstalledInventorySnapshot, InstalledPackageIdentity,
+    SystemPackageManager, dpkg_query, pacman_query, rpm_query,
 };
 use rusqlite::params;
 use tracing::warn;
@@ -51,36 +52,25 @@ fn prepare_takeover_entry(
 pub(super) fn upgrade_to_cas_backed(
     db_path: &str,
     packages: &[String],
-    pm: &SystemPackageManager,
+    inventory: &InstalledInventorySnapshot,
 ) -> Result<Vec<String>> {
     let cas = CasStore::new(objects_dir(db_path))?;
-    let eopkg_database = if *pm == SystemPackageManager::Eopkg {
-        Some(conary_core::packages::eopkg::query::InstalledEopkgDatabase::load()?)
-    } else {
-        None
-    };
 
     let mut entries: Vec<PreparedTakeoverEntry> = Vec::with_capacity(packages.len());
     let mut skipped = Vec::new();
     for selector in packages {
-        let identity = match query_package_identity(*pm, selector, eopkg_database.as_ref()) {
-            Ok(identity) => identity,
-            Err(error) => {
-                warn!("Skipping CAS upgrade for '{selector}': {error}");
-                skipped.push(format!("{selector}: {error}"));
-                continue;
-            }
-        };
-        let files = match query_package_files(*pm, selector, eopkg_database.as_ref()) {
-            Ok(files) => files,
-            Err(error) => {
-                warn!("Skipping CAS upgrade for '{selector}': {error}");
-                skipped.push(format!("{selector}: {error}"));
-                continue;
-            }
+        let Some(package) = inventory.package(selector) else {
+            let error = "exact selector is absent from the coherent native inventory";
+            warn!("Skipping CAS upgrade for '{selector}': {error}");
+            skipped.push(format!("{selector}: {error}"));
+            continue;
         };
 
-        match prepare_takeover_entry(identity, files, &cas) {
+        match prepare_takeover_entry(
+            package.identity.clone(),
+            inventory_file_tuples(package),
+            &cas,
+        ) {
             Ok(entry) => entries.push(entry),
             Err(error) => {
                 warn!("Skipping CAS upgrade for '{selector}': {error}");
@@ -92,7 +82,10 @@ pub(super) fn upgrade_to_cas_backed(
         return Ok(skipped);
     }
 
-    // DB-only transaction: all PM queries and CAS writes are already done.
+    inventory.require_unchanged(&InstalledInventorySnapshot::capture(inventory.manager())?)?;
+
+    // DB-only transaction: the coherent native inventory and CAS writes are
+    // complete and the exact token was revalidated immediately above.
     let mut conn = open_db(db_path)?;
     conary_core::db::transaction(&mut conn, |tx| {
         let mut changeset = Changeset::new("Takeover: CAS-upgrade track-only packages".into());
@@ -148,30 +141,25 @@ pub(super) fn upgrade_to_cas_backed(
 pub(super) fn take_ownership(
     db_path: &str,
     packages: &[String],
-    pm: SystemPackageManager,
+    inventory: &InstalledInventorySnapshot,
 ) -> Result<OwnershipTransferReport> {
-    let eopkg_database = if pm == SystemPackageManager::Eopkg {
-        Some(conary_core::packages::eopkg::query::InstalledEopkgDatabase::load()?)
-    } else {
-        None
-    };
-
+    let pm = inventory.manager();
     let mut identities = Vec::with_capacity(packages.len());
     let mut report = OwnershipTransferReport::default();
     for selector in packages {
-        let identity = match query_package_identity(pm, selector, eopkg_database.as_ref()) {
-            Ok(identity) => identity,
-            Err(error) => {
-                warn!("Ownership identity query failed for '{selector}': {error}");
-                report.query_failures.push(format!("{selector}: {error}"));
-                continue;
-            }
+        let Some(package) = inventory.package(selector) else {
+            let error = "exact selector is absent from the coherent native inventory";
+            warn!("Ownership identity query failed for '{selector}': {error}");
+            report.query_failures.push(format!("{selector}: {error}"));
+            continue;
         };
-        identities.push(identity);
+        identities.push(package.identity.clone());
     }
     if !report.query_failures.is_empty() {
         return Ok(report);
     }
+
+    inventory.require_unchanged(&InstalledInventorySnapshot::capture(pm)?)?;
 
     // Mark first so a crash after successful PM removal cannot leave an
     // unowned payload. Reported removal failures are compensated below.
@@ -215,45 +203,77 @@ pub(super) fn take_ownership(
         })?;
     }
 
-    if pm == SystemPackageManager::Eopkg {
-        let selectors = identities
-            .iter()
-            .map(|identity| identity.selector().to_string())
-            .collect::<Vec<_>>();
-        if let Err(error) = conary_core::packages::eopkg::takeover::remove_all_from_db(&selectors) {
-            if conary_core::packages::eopkg::takeover::authority_removal_pending() {
-                return Err(anyhow!(
-                    "eopkg authority-removal batch is durably pending and will resume on the next takeover run: {error}"
-                ));
-            }
-            restore_native_manager_authority(db_path, &identities)?;
-            report
-                .pm_removal_failures
-                .push(format!("eopkg authority removal did not start: {error}"));
+    println!(
+        "  Removing {} package records from {} database in one batch ...",
+        identities.len(),
+        pm.display_name()
+    );
+    if let Err(error) = remove_batch_from_system_pm(pm, &identities) {
+        if pm == SystemPackageManager::Eopkg
+            && conary_core::packages::eopkg::takeover::authority_removal_pending()
+        {
+            return Err(anyhow!(
+                "eopkg authority-removal batch is durably pending and will resume on the next takeover run: {error}"
+            ));
         }
-        return Ok(report);
+        restore_native_manager_authority(db_path, &identities)?;
+        report.pm_removal_failures.push(format!(
+            "{} authority-removal batch failed for {} package(s): {error}",
+            pm.display_name(),
+            identities.len()
+        ));
     }
-
-    let mut failed_identities = Vec::new();
-    for identity in &identities {
-        println!(
-            "  Removing {} from {} database ...",
-            identity.selector(),
-            pm.display_name()
-        );
-        if let Err(error) = remove_from_system_pm(pm, identity.selector()) {
-            warn!("Failed to remove {} from PM: {error}", identity.selector());
-            report
-                .pm_removal_failures
-                .push(format!("{}: {error}", identity.selector()));
-            failed_identities.push(identity.clone());
-        }
-    }
-    if !failed_identities.is_empty() {
-        restore_native_manager_authority(db_path, &failed_identities)?;
-    }
-
     Ok(report)
+}
+
+fn inventory_file_tuples(package: &InstalledInventoryPackage) -> Vec<FileInfoTuple> {
+    package
+        .files
+        .iter()
+        .map(|file| {
+            let file = &file.file;
+            (
+                file.path.clone(),
+                file.size,
+                file.mode,
+                file.digest.clone(),
+                file.user.clone(),
+                file.group.clone(),
+                file.link_target.clone(),
+                file.absence_policy,
+            )
+        })
+        .collect()
+}
+
+fn remove_batch_from_system_pm(
+    package_manager: SystemPackageManager,
+    identities: &[InstalledPackageIdentity],
+) -> Result<()> {
+    let selectors = identities
+        .iter()
+        .map(InstalledPackageIdentity::selector)
+        .collect::<Vec<_>>();
+    match package_manager {
+        SystemPackageManager::Rpm => {
+            rpm_query::remove_batch_from_db_only(&selectors).map_err(|error| anyhow!("{error}"))
+        }
+        SystemPackageManager::Dpkg => {
+            dpkg_query::remove_batch_from_db_only(identities).map_err(|error| anyhow!("{error}"))
+        }
+        SystemPackageManager::Pacman => {
+            pacman_query::remove_batch_from_db_only(&selectors).map_err(|error| anyhow!("{error}"))
+        }
+        SystemPackageManager::Eopkg => {
+            let selectors = selectors
+                .into_iter()
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            conary_core::packages::eopkg::takeover::remove_all_from_db(&selectors)
+                .map_err(|error| anyhow!("{error}"))
+        }
+        SystemPackageManager::Unknown => Err(anyhow!("No supported package manager")),
+    }
 }
 
 fn restore_native_manager_authority(
@@ -306,78 +326,6 @@ fn find_trove_for_identity(
             "native identity '{}' matches {count} Conary troves",
             identity.selector()
         ))),
-    }
-}
-
-fn query_package_identity(
-    package_manager: SystemPackageManager,
-    selector: &str,
-    eopkg_database: Option<&conary_core::packages::eopkg::query::InstalledEopkgDatabase>,
-) -> Result<InstalledPackageIdentity> {
-    match package_manager {
-        SystemPackageManager::Rpm => Ok(rpm_query::query_package(selector)?.identity),
-        SystemPackageManager::Dpkg => Ok(dpkg_query::query_package(selector)?.identity),
-        SystemPackageManager::Pacman => Ok(pacman_query::query_package(selector)?.identity),
-        SystemPackageManager::Eopkg => Ok(eopkg_database
-            .ok_or_else(|| anyhow!("eopkg installed database snapshot is absent"))?
-            .package(selector)?
-            .identity),
-        SystemPackageManager::Unknown => Err(anyhow!("No supported package manager")),
-    }
-}
-
-fn query_package_files(
-    package_manager: SystemPackageManager,
-    name: &str,
-    eopkg_database: Option<&conary_core::packages::eopkg::query::InstalledEopkgDatabase>,
-) -> Result<Vec<FileInfoTuple>> {
-    let raw_files = match package_manager {
-        SystemPackageManager::Rpm => rpm_query::query_package_files(name)
-            .map_err(|error| anyhow!("RPM file query failed for '{name}': {error}"))?,
-        SystemPackageManager::Dpkg => dpkg_query::query_package_files(name)
-            .map_err(|error| anyhow!("DPKG file query failed for '{name}': {error}"))?,
-        SystemPackageManager::Pacman => pacman_query::query_package_files(name)
-            .map_err(|error| anyhow!("Pacman file query failed for '{name}': {error}"))?,
-        SystemPackageManager::Eopkg => eopkg_database
-            .ok_or_else(|| anyhow!("eopkg installed database snapshot is absent"))?
-            .package_files(name)
-            .map_err(|error| anyhow!("eopkg file query failed for '{name}': {error}"))?,
-        SystemPackageManager::Unknown => {
-            return Err(anyhow!("No supported package manager"));
-        }
-    };
-    Ok(raw_files
-        .into_iter()
-        .map(|file| {
-            (
-                file.path,
-                file.size,
-                file.mode,
-                file.digest,
-                file.user,
-                file.group,
-                file.link_target,
-                file.absence_policy,
-            )
-        })
-        .collect())
-}
-
-fn remove_from_system_pm(package_manager: SystemPackageManager, name: &str) -> Result<()> {
-    match package_manager {
-        SystemPackageManager::Rpm => {
-            rpm_query::remove_from_db_only(name).map_err(|error| anyhow!("{error}"))
-        }
-        SystemPackageManager::Dpkg => {
-            dpkg_query::remove_from_db_only(name).map_err(|error| anyhow!("{error}"))
-        }
-        SystemPackageManager::Pacman => {
-            pacman_query::remove_from_db_only(name).map_err(|error| anyhow!("{error}"))
-        }
-        SystemPackageManager::Eopkg => Err(anyhow!(
-            "eopkg ownership removal must use its transaction-wide batch"
-        )),
-        SystemPackageManager::Unknown => Err(anyhow!("No supported package manager")),
     }
 }
 

--- a/apps/conary/tests/live_host_mutation_safety.rs
+++ b/apps/conary/tests/live_host_mutation_safety.rs
@@ -484,6 +484,8 @@ fn system_adopt_package_dry_run_previews_without_mutation_or_ack_prompt() {
             "system",
             "adopt",
             "base-files",
+            "--package-manager",
+            "dpkg",
             "--dry-run",
             "--db-path",
             &db_path,

--- a/apps/conary/tests/live_host_mutation_safety.rs
+++ b/apps/conary/tests/live_host_mutation_safety.rs
@@ -3,8 +3,6 @@
 mod common;
 
 use std::fs;
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -13,14 +11,6 @@ fn run_conary(args: &[&str]) -> std::process::Output {
         .args(args)
         .output()
         .expect("failed to run conary")
-}
-
-#[cfg(unix)]
-fn write_executable(path: &Path, contents: &str) {
-    fs::write(path, contents).unwrap();
-    let mut permissions = fs::metadata(path).unwrap().permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(path, permissions).unwrap();
 }
 
 fn tree_snapshot(root: &Path, db_name: &str) -> Vec<(PathBuf, String, Vec<u8>)> {
@@ -472,52 +462,14 @@ fn system_adopt_status_bypasses_gate() {
 #[cfg(unix)]
 #[test]
 fn system_adopt_package_dry_run_previews_without_mutation_or_ack_prompt() {
+    if !Path::new("/var/lib/dpkg/info/base-files.list").is_file()
+        || !Path::new("/usr/bin/dpkg-query").is_file()
+        || !Path::new("/usr/bin/apt-mark").is_file()
+    {
+        return;
+    }
     let (tmp, db_path, conn) = common::create_test_db();
     drop(conn);
-
-    let live_root = tmp.path().join("live-root");
-    let live_file = live_root.join("usr/bin/fixture");
-    fs::create_dir_all(live_file.parent().unwrap()).unwrap();
-    fs::write(&live_file, b"native fixture payload").unwrap();
-
-    let fake_bin = tmp.path().join("fake-bin");
-    fs::create_dir(&fake_bin).unwrap();
-    write_executable(
-        &fake_bin.join("dpkg-query"),
-        "#!/bin/sh
-if [ \"$1\" = \"--version\" ]; then
-    printf 'dpkg-query fixture 1.0\\n'
-    exit 0
-fi
-case \"$3\" in
-    *Description*)
-        printf 'fixture\\036fixture\\0361.2.3\\036amd64\\036Fixture package\\036Test maintainer\\036\\036utils\\036optional\\0361\\036foreign\\037'
-        ;;
-    *Depends*)
-        printf '\\036libc6 (>= 2.0)\\037'
-        ;;
-    *Provides*)
-        printf 'fixture\\036fixture\\0361.2.3\\036fixture-capability\\037'
-        ;;
-    *)
-        exit 1
-        ;;
-esac
-",
-    );
-    write_executable(
-        &fake_bin.join("dpkg"),
-        &format!(
-            "#!/bin/sh
-if [ \"$1\" = \"-L\" ] && [ \"$2\" = \"fixture\" ]; then
-    printf '%s\\n' '{}'
-    exit 0
-fi
-exit 1
-",
-            live_file.display()
-        ),
-    );
 
     let db_name = Path::new(&db_path)
         .file_name()
@@ -526,18 +478,17 @@ exit 1
         .into_owned();
     let database_before = common::database_snapshot(&db_path);
     let tree_before = tree_snapshot(tmp.path(), &db_name);
-    let live_file_before = fs::read(&live_file).unwrap();
 
     let output = Command::new(env!("CARGO_BIN_EXE_conary"))
         .args([
             "system",
             "adopt",
-            "fixture",
+            "base-files",
             "--dry-run",
             "--db-path",
             &db_path,
         ])
-        .env("PATH", &fake_bin)
+        .env("PATH", "/usr/sbin:/usr/bin:/sbin:/bin")
         .output()
         .expect("failed to run conary package adoption preview");
 
@@ -550,14 +501,12 @@ exit 1
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stdout.contains("Package adoption preview"));
-    assert!(stdout.contains("fixture 1.2.3 [amd64]"));
+    assert!(stdout.contains("base-files"));
     assert!(stdout.contains("track (metadata only)"));
-    assert!(stdout.contains("1 package, 1 files, 1 dependencies, 3 provides"));
     assert!(stderr.contains("Preview only:"));
     assert!(!stderr.contains("--allow-live-system-mutation"));
     assert!(!stderr.contains("--yes"));
 
     assert_eq!(common::database_snapshot(&db_path), database_before);
     assert_eq!(tree_snapshot(tmp.path(), &db_name), tree_before);
-    assert_eq!(fs::read(&live_file).unwrap(), live_file_before);
 }

--- a/crates/conary-core/Cargo.toml
+++ b/crates/conary-core/Cargo.toml
@@ -171,3 +171,7 @@ harness = false
 [[bench]]
 name = "generation_db_snapshot"
 harness = false
+
+[[bench]]
+name = "installed_inventory"
+harness = false

--- a/crates/conary-core/benches/installed_inventory.rs
+++ b/crates/conary-core/benches/installed_inventory.rs
@@ -1,0 +1,86 @@
+// conary-core/benches/installed_inventory.rs
+
+use conary_core::packages::{
+    InstalledFileAbsencePolicy, InstalledFileInfo, InstalledInventoryFile,
+    InstalledInventoryPackage, InstalledInventorySnapshot, InstalledInventoryWork,
+    InstalledPackageIdentity, NativeInstallReason, SystemPackageManager,
+};
+use conary_core::repository::dependency_model::DebianMultiArch;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+
+fn inventory_packages(package_count: usize) -> Vec<InstalledInventoryPackage> {
+    (0..package_count)
+        .map(|index| {
+            let name = format!("fixture-{index:05}");
+            let files = [
+                format!("/usr/bin/{name}"),
+                format!("/usr/lib/{name}.so"),
+                format!("/usr/share/doc/{name}/README"),
+                "/usr/share/doc".to_string(),
+            ]
+            .into_iter()
+            .map(|path| InstalledInventoryFile {
+                file: InstalledFileInfo {
+                    path,
+                    size: 64,
+                    mode: i32::try_from(libc::S_IFREG | 0o644).unwrap(),
+                    digest: None,
+                    user: None,
+                    group: None,
+                    link_target: None,
+                    mtime: None,
+                    absence_policy: InstalledFileAbsencePolicy::Required,
+                },
+                config: None,
+            })
+            .collect();
+            InstalledInventoryPackage {
+                identity: InstalledPackageIdentity::dpkg(
+                    &name,
+                    &name,
+                    "1.0-1",
+                    "amd64",
+                    DebianMultiArch::No,
+                )
+                .unwrap(),
+                description: None,
+                install_reason: NativeInstallReason::Dependency,
+                files,
+                requirements: Vec::new(),
+                provides: Vec::new(),
+                lifecycle: Vec::new(),
+            }
+        })
+        .collect()
+}
+
+fn benchmark_inventory_projection(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("installed_inventory/coherent_projection");
+    for (label, package_count) in [("small", 100), ("distribution", 2_500)] {
+        group.bench_with_input(
+            BenchmarkId::new(label, package_count),
+            &package_count,
+            |bencher, package_count| {
+                bencher.iter(|| {
+                    let snapshot = InstalledInventorySnapshot::from_packages(
+                        SystemPackageManager::Dpkg,
+                        inventory_packages(*package_count),
+                        InstalledInventoryWork {
+                            manager_processes: 2,
+                            database_bulk_reads: 2,
+                            ownership_records: u64::try_from(*package_count * 4).unwrap(),
+                        },
+                    )
+                    .unwrap();
+                    black_box(snapshot.token().as_str());
+                    black_box(snapshot.owners_by_path().len());
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_inventory_projection);
+criterion_main!(benches);

--- a/crates/conary-core/src/generation/root_manifest.rs
+++ b/crates/conary-core/src/generation/root_manifest.rs
@@ -31,8 +31,9 @@ pub use overlay::{
     probe_selected_root_overlay_profile,
 };
 pub use scan::{
-    SelectedRootCaptureExclusions, capture_existing_payload_node, capture_root_node,
-    scan_payload_tree, scan_selected_root, scan_selected_root_with_exclusions,
+    SelectedRootCaptureExclusions, SelectedRootScanWork, capture_existing_payload_node,
+    capture_root_node, scan_payload_tree, scan_selected_root, scan_selected_root_with_exclusions,
+    scan_selected_root_with_exclusions_and_work,
 };
 
 pub const GENERATION_ROOT_MANIFEST_FILE: &str = "generation-root.json";

--- a/crates/conary-core/src/generation/root_manifest/scan.rs
+++ b/crates/conary-core/src/generation/root_manifest/scan.rs
@@ -35,6 +35,14 @@ struct FilesystemIdentity {
     inode: u64,
 }
 
+/// Deterministic work performed by one complete selected-root traversal.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SelectedRootScanWork {
+    pub paths_examined: u64,
+    pub regular_content_streams: u64,
+    pub unique_regular_inodes: u64,
+}
+
 // A live selected root has no global filesystem snapshot. Keep the retry budget
 // local to one node so unrelated paths are never read again after a conflict.
 const STABLE_NODE_CAPTURE_ATTEMPTS: usize = 8;
@@ -88,7 +96,16 @@ pub fn scan_selected_root_with_exclusions(
     cas: &dyn PrivateCasWriter,
     exclusions: &SelectedRootCaptureExclusions,
 ) -> crate::Result<CapturedSelectedRoot> {
-    let (root_node, candidates) =
+    scan_selected_root_with_exclusions_and_work(root, cas, exclusions)
+        .map(|(captured, _work)| captured)
+}
+
+pub fn scan_selected_root_with_exclusions_and_work(
+    root: &Path,
+    cas: &dyn PrivateCasWriter,
+    exclusions: &SelectedRootCaptureExclusions,
+) -> crate::Result<(CapturedSelectedRoot, SelectedRootScanWork)> {
+    let (root_node, candidates, work) =
         capture_payload_tree(root, cas, false, "selected-root", exclusions)?;
 
     let mut immutable = Vec::new();
@@ -116,7 +133,7 @@ pub fn scan_selected_root_with_exclusions(
     };
     captured.generation.validate()?;
     captured.state.validate()?;
-    Ok(captured)
+    Ok((captured, work))
 }
 
 /// Capture a complete package/build output tree without discarding any path
@@ -130,7 +147,7 @@ pub fn scan_payload_tree(
     cas: &dyn PrivateCasWriter,
     hardlink_namespace: &str,
 ) -> crate::Result<(ResolvedPayloadNode, Vec<GenerationRootEntry>)> {
-    let (root_node, candidates) = capture_payload_tree(
+    let (root_node, candidates, _work) = capture_payload_tree(
         root,
         cas,
         true,
@@ -155,7 +172,7 @@ pub(super) fn scan_selected_root_overlay_upper(
     cas: &dyn PrivateCasWriter,
     hardlink_namespace: &str,
 ) -> crate::Result<(ResolvedPayloadNode, Vec<GenerationRootEntry>)> {
-    let (root_node, candidates) = capture_payload_tree(
+    let (root_node, candidates, _work) = capture_payload_tree(
         root,
         cas,
         false,
@@ -175,7 +192,11 @@ fn capture_payload_tree(
     include_ephemeral: bool,
     hardlink_namespace: &str,
     exclusions: &SelectedRootCaptureExclusions,
-) -> crate::Result<(ResolvedPayloadNode, Vec<CapturedCandidate>)> {
+) -> crate::Result<(
+    ResolvedPayloadNode,
+    Vec<CapturedCandidate>,
+    SelectedRootScanWork,
+)> {
     if hardlink_namespace.is_empty() || hardlink_namespace.contains('\0') {
         return Err(crate::Error::InvalidPath(
             "payload-tree hardlink namespace must be non-empty and NUL-free".to_string(),
@@ -184,6 +205,7 @@ fn capture_payload_tree(
     let root_node = capture_root_node(root)?;
     let mut candidates = Vec::new();
     let mut captured_regular_inodes = std::collections::BTreeSet::new();
+    let mut work = SelectedRootScanWork::default();
     let walker = WalkDir::new(root)
         .follow_links(false)
         .sort_by(|left, right| {
@@ -213,6 +235,9 @@ fn capture_payload_tree(
         if entry.depth() == 0 {
             continue;
         }
+        work.paths_examined = work.paths_examined.checked_add(1).ok_or_else(|| {
+            crate::Error::InternalError("selected-root path counter overflowed u64".to_string())
+        })?;
         let path = root_manifest_path(root, entry.path())?;
         if exclusions.excludes(&path) {
             continue;
@@ -228,6 +253,7 @@ fn capture_payload_tree(
             .filter(|metadata| metadata.file_type().is_file())
             .map(|metadata| filesystem_identity(&metadata))
             .filter(|identity| captured_regular_inodes.contains(identity));
+        let reused_regular_inode = known_regular_inode.is_some();
         let candidate = capture_path_stably_with_known_inode(
             path,
             entry.path().to_path_buf(),
@@ -241,13 +267,24 @@ fn capture_payload_tree(
         ) && candidate.entry.content.is_some()
         {
             captured_regular_inodes.insert(candidate.identity);
+            if !reused_regular_inode {
+                work.regular_content_streams =
+                    work.regular_content_streams.checked_add(1).ok_or_else(|| {
+                        crate::Error::InternalError(
+                            "selected-root content-stream counter overflowed u64".to_string(),
+                        )
+                    })?;
+            }
         }
         candidates.push(candidate);
     }
     candidates.sort_by(|left, right| left.entry.path.cmp(&right.entry.path));
 
     assign_hardlinks(&mut candidates, hardlink_namespace)?;
-    Ok((root_node, candidates))
+    work.unique_regular_inodes = u64::try_from(captured_regular_inodes.len()).map_err(|_| {
+        crate::Error::InternalError("selected-root unique-inode count does not fit u64".to_string())
+    })?;
+    Ok((root_node, candidates, work))
 }
 
 /// Capture exact metadata authority for the selected-root directory itself.
@@ -977,8 +1014,16 @@ mod tests {
             reader_calls: Cell::new(0),
         };
 
-        let captured = scan_selected_root(&root, &writer).unwrap();
+        let (captured, work) = scan_selected_root_with_exclusions_and_work(
+            &root,
+            &writer,
+            &SelectedRootCaptureExclusions::empty(),
+        )
+        .unwrap();
         assert_eq!(writer.reader_calls.get(), 1);
+        assert_eq!(work.paths_examined, 4);
+        assert_eq!(work.regular_content_streams, 1);
+        assert_eq!(work.unique_regular_inodes, 1);
         let primary = captured
             .generation
             .entries

--- a/crates/conary-core/src/packages/dpkg_query.rs
+++ b/crates/conary-core/src/packages/dpkg_query.rs
@@ -23,7 +23,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::process::Command;
-use tracing::debug;
+use tracing::{debug, warn};
 
 mod inventory;
 pub use inventory::query_installed_inventory;
@@ -705,11 +705,29 @@ fn remove_dpkg_records_at(
         mode,
     )?;
 
+    // The status database is dpkg's installed-package authority. Once its
+    // durable rewrite succeeds, ancillary info-file cleanup must not turn the
+    // completed authority transfer into a reported failure: takeover would
+    // otherwise compensate Conary back to AdoptedFull even though dpkg no
+    // longer has the package stanza. Keep cleanup best-effort and visible.
+    if let Err(error) = cleanup_dpkg_info_records(&selectors, info_dir) {
+        warn!(
+            "dpkg authority removal committed, but ancillary info cleanup under {} failed: {error}",
+            info_dir.display()
+        );
+    }
+
+    debug!(
+        "Successfully removed {} package records from dpkg database",
+        identities.len()
+    );
+    Ok(())
+}
+
+fn cleanup_dpkg_info_records(selectors: &BTreeSet<String>, info_dir: &Path) -> Result<()> {
     for entry in std::fs::read_dir(info_dir)? {
         let entry = entry?;
-        let name = entry.file_name().into_string().map_err(|_| {
-            Error::ParseError("dpkg info directory contains a non-UTF-8 filename".to_string())
-        })?;
+        let name = entry.file_name().to_string_lossy().into_owned();
         if selectors
             .iter()
             .any(|selector| name.starts_with(&format!("{selector}.")))
@@ -718,11 +736,6 @@ fn remove_dpkg_records_at(
         }
     }
     std::fs::File::open(info_dir)?.sync_all()?;
-
-    debug!(
-        "Successfully removed {} package records from dpkg database",
-        identities.len()
-    );
     Ok(())
 }
 
@@ -863,6 +876,27 @@ mod tests {
         let error = filter_dpkg_status(status, &targets).unwrap_err();
 
         assert!(error.to_string().contains("fixture:arm64"));
+    }
+
+    #[test]
+    fn committed_status_removal_is_not_rejected_by_ancillary_cleanup_failure() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let status = temp.path().join("status");
+        let missing_info = temp.path().join("missing-info");
+        std::fs::write(
+            &status,
+            "Package: fixture\nArchitecture: amd64\nStatus: install ok installed\n\n",
+        )
+        .unwrap();
+
+        remove_dpkg_records_at(
+            &[dpkg_identity("fixture:amd64", "amd64")],
+            &status,
+            &missing_info,
+        )
+        .unwrap();
+
+        assert!(std::fs::read_to_string(status).unwrap().is_empty());
     }
 
     #[test]

--- a/crates/conary-core/src/packages/dpkg_query.rs
+++ b/crates/conary-core/src/packages/dpkg_query.rs
@@ -19,7 +19,9 @@ use crate::repository::dependency_model::{
 };
 use crate::repository::requirement::parse_native_requirement;
 use crate::repository::versioning::VersionScheme;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
 use std::process::Command;
 use tracing::debug;
 
@@ -637,11 +639,19 @@ fn acquire_dpkg_lock(path: &str) -> Result<DpkgLockGuard> {
 /// lock-frontend then lock) per /usr/share/doc/dpkg/spec/frontend-api.txt,
 /// and uses atomic rename to prevent corruption from crashes.
 pub fn remove_from_db_only(name: &str) -> Result<()> {
-    use std::io::Write;
+    let record = query_package(name)?;
+    remove_batch_from_db_only(&[record.identity])
+}
 
-    debug!("Removing {} from dpkg database only", name);
-
-    let status_path = "/var/lib/dpkg/status";
+/// Remove exact dpkg identities in one locked database rewrite.
+pub fn remove_batch_from_db_only(identities: &[InstalledPackageIdentity]) -> Result<()> {
+    if identities.is_empty() {
+        return Ok(());
+    }
+    debug!(
+        "Removing {} package records from dpkg database only",
+        identities.len()
+    );
 
     // Acquire dpkg locks per the frontend protocol spec:
     // 1. lock-frontend (frontend mutex — excludes apt, aptitude, etc.)
@@ -649,68 +659,117 @@ pub fn remove_from_db_only(name: &str) -> Result<()> {
     // Both use POSIX fcntl F_SETLK write locks as dpkg expects.
     let _frontend_lock = acquire_dpkg_lock("/var/lib/dpkg/lock-frontend")?;
     let _db_lock = acquire_dpkg_lock("/var/lib/dpkg/lock")?;
+    remove_dpkg_records_at(
+        identities,
+        Path::new("/var/lib/dpkg/status"),
+        Path::new("/var/lib/dpkg/info"),
+    )
+}
 
-    // Read /var/lib/dpkg/status, filter out the target package stanza
-    let content = std::fs::read_to_string(status_path)
-        .map_err(|e| Error::InitError(format!("Failed to read {}: {}", status_path, e)))?;
-
-    let mut output_lines = Vec::new();
-    let mut in_target_stanza = false;
-
-    for line in content.lines() {
-        if line.starts_with("Package: ") {
-            let pkg = line.strip_prefix("Package: ").unwrap_or("").trim();
-            in_target_stanza = pkg == name;
-        } else if line.is_empty() && in_target_stanza {
-            in_target_stanza = false;
-            continue; // Skip the blank line after the removed stanza
+fn remove_dpkg_records_at(
+    identities: &[InstalledPackageIdentity],
+    status_path: &Path,
+    info_dir: &Path,
+) -> Result<()> {
+    let mut targets = BTreeSet::new();
+    let mut selectors = BTreeSet::new();
+    for identity in identities {
+        let InstalledPackageIdentity::Dpkg {
+            selector,
+            name,
+            architecture,
+            ..
+        } = identity
+        else {
+            return Err(Error::ConfigError(format!(
+                "dpkg authority removal received non-dpkg identity '{}'",
+                identity.selector()
+            )));
+        };
+        if !targets.insert((name.clone(), architecture.clone())) {
+            return Err(Error::ConflictError(format!(
+                "dpkg authority-removal batch repeated {name}:{architecture}"
+            )));
         }
-
-        if !in_target_stanza {
-            output_lines.push(line);
-        }
+        selectors.insert(selector.clone());
     }
 
-    // Atomic write: write to temp file in same directory, then rename
-    let new_content = output_lines.join("\n") + "\n";
-    let tmp_path = format!("{}.conary-tmp", status_path);
-
-    let mut tmp_file = std::fs::File::create(&tmp_path)
-        .map_err(|e| Error::InitError(format!("Failed to create temp file {}: {}", tmp_path, e)))?;
-    tmp_file
-        .write_all(new_content.as_bytes())
-        .map_err(|e| Error::InitError(format!("Failed to write temp file {}: {}", tmp_path, e)))?;
-    tmp_file
-        .sync_all()
-        .map_err(|e| Error::InitError(format!("Failed to sync temp file: {}", e)))?;
-    drop(tmp_file);
-
-    std::fs::rename(&tmp_path, status_path).map_err(|e| {
-        Error::InitError(format!(
-            "Failed to rename {} -> {}: {}",
-            tmp_path, status_path, e
-        ))
+    let content = std::fs::read_to_string(status_path).map_err(|error| {
+        Error::InitError(format!("Failed to read {}: {error}", status_path.display()))
     })?;
+    let filtered = filter_dpkg_status(&content, &targets)?;
+    let mode = std::fs::metadata(status_path)?.permissions().mode();
+    crate::filesystem::durable::write_file_atomic_with_mode(
+        status_path,
+        filtered.as_bytes(),
+        mode,
+    )?;
 
-    // Lock is released when lock_file is dropped
-
-    // Remove /var/lib/dpkg/info/<name>.* files
-    let info_dir = "/var/lib/dpkg/info";
-    if let Ok(entries) = std::fs::read_dir(info_dir) {
-        for entry in entries.flatten() {
-            let fname = entry.file_name();
-            let fname_str = fname.to_string_lossy();
-            // Match <name>.* and <name>:<arch>.*
-            if fname_str.starts_with(&format!("{}.", name))
-                || fname_str.starts_with(&format!("{}:", name))
-            {
-                let _ = std::fs::remove_file(entry.path());
-            }
+    for entry in std::fs::read_dir(info_dir)? {
+        let entry = entry?;
+        let name = entry.file_name().into_string().map_err(|_| {
+            Error::ParseError("dpkg info directory contains a non-UTF-8 filename".to_string())
+        })?;
+        if selectors
+            .iter()
+            .any(|selector| name.starts_with(&format!("{selector}.")))
+        {
+            std::fs::remove_file(entry.path())?;
         }
     }
+    std::fs::File::open(info_dir)?.sync_all()?;
 
-    debug!("Successfully removed {} from dpkg database", name);
+    debug!(
+        "Successfully removed {} package records from dpkg database",
+        identities.len()
+    );
     Ok(())
+}
+
+fn filter_dpkg_status(content: &str, targets: &BTreeSet<(String, String)>) -> Result<String> {
+    let mut retained = Vec::new();
+    let mut removed = BTreeSet::new();
+    for stanza in content
+        .split("\n\n")
+        .filter(|stanza| !stanza.trim().is_empty())
+    {
+        let package = control_field(stanza, "Package");
+        let architecture = control_field(stanza, "Architecture");
+        match (package, architecture) {
+            (Some(package), Some(architecture))
+                if targets.contains(&(package.to_string(), architecture.to_string())) =>
+            {
+                if !removed.insert((package.to_string(), architecture.to_string())) {
+                    return Err(Error::ConflictError(format!(
+                        "dpkg status repeated target stanza {package}:{architecture}"
+                    )));
+                }
+            }
+            _ => retained.push(stanza),
+        }
+    }
+    if removed != *targets {
+        let missing = targets
+            .difference(&removed)
+            .map(|(name, architecture)| format!("{name}:{architecture}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(Error::NotFound(format!(
+            "dpkg status is missing exact authority-removal target(s): {missing}"
+        )));
+    }
+    let mut output = retained.join("\n\n");
+    if !output.is_empty() {
+        output.push_str("\n\n");
+    }
+    Ok(output)
+}
+
+fn control_field<'a>(stanza: &'a str, field: &str) -> Option<&'a str> {
+    let prefix = format!("{field}: ");
+    stanza
+        .lines()
+        .find_map(|line| line.strip_prefix(&prefix).map(str::trim))
 }
 
 /// Check if dpkg is available on this system
@@ -725,6 +784,17 @@ pub fn is_dpkg_available() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn dpkg_identity(selector: &str, architecture: &str) -> InstalledPackageIdentity {
+        InstalledPackageIdentity::dpkg(
+            selector,
+            "fixture",
+            "1.0-1",
+            architecture,
+            DebianMultiArch::Same,
+        )
+        .unwrap()
+    }
 
     #[test]
     fn test_is_dpkg_available() {
@@ -748,6 +818,51 @@ mod tests {
 
         assert_eq!(info.full_version(), "1.0.0-1ubuntu1");
         assert_eq!(info.version_only(), "1.0.0-1ubuntu1");
+    }
+
+    #[test]
+    fn batch_removal_targets_exact_multiarch_stanzas_and_info_records() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let status = temp.path().join("status");
+        let info = temp.path().join("info");
+        std::fs::create_dir(&info).unwrap();
+        std::fs::write(
+            &status,
+            "Package: fixture\nArchitecture: amd64\nStatus: install ok installed\n\nPackage: fixture\nArchitecture: i386\nStatus: install ok installed\n\nPackage: retained\nArchitecture: amd64\nStatus: install ok installed\n\n",
+        )
+        .unwrap();
+        for name in [
+            "fixture:amd64.list",
+            "fixture:amd64.postinst",
+            "fixture:i386.list",
+            "retained.list",
+        ] {
+            std::fs::write(info.join(name), b"fixture").unwrap();
+        }
+
+        remove_dpkg_records_at(&[dpkg_identity("fixture:amd64", "amd64")], &status, &info).unwrap();
+
+        let remaining = std::fs::read_to_string(status).unwrap();
+        assert!(
+            !remaining
+                .contains("Architecture: amd64\nStatus: install ok installed\n\nPackage: fixture")
+        );
+        assert!(remaining.contains("Package: fixture\nArchitecture: i386"));
+        assert!(remaining.contains("Package: retained\nArchitecture: amd64"));
+        assert!(!info.join("fixture:amd64.list").exists());
+        assert!(!info.join("fixture:amd64.postinst").exists());
+        assert!(info.join("fixture:i386.list").exists());
+        assert!(info.join("retained.list").exists());
+    }
+
+    #[test]
+    fn batch_removal_rejects_a_missing_exact_variant_without_rewriting_status() {
+        let targets = BTreeSet::from([("fixture".to_string(), "arm64".to_string())]);
+        let status = "Package: fixture\nArchitecture: amd64\n\n";
+
+        let error = filter_dpkg_status(status, &targets).unwrap_err();
+
+        assert!(error.to_string().contains("fixture:arm64"));
     }
 
     #[test]

--- a/crates/conary-core/src/packages/dpkg_query.rs
+++ b/crates/conary-core/src/packages/dpkg_query.rs
@@ -23,6 +23,9 @@ use std::collections::{HashMap, HashSet};
 use std::process::Command;
 use tracing::debug;
 
+mod inventory;
+pub use inventory::query_installed_inventory;
+
 const DPKG_PACKAGE_RECORD_FORMAT: &str = "${binary:Package}\x1e${Package}\x1e${Version}\x1e${Architecture}\x1e${Description}\x1e${Maintainer}\x1e${Homepage}\x1e${Section}\x1e${Priority}\x1e${Installed-Size}\x1e${Multi-Arch}\x1f";
 
 /// Information about an installed dpkg package

--- a/crates/conary-core/src/packages/dpkg_query/inventory.rs
+++ b/crates/conary-core/src/packages/dpkg_query/inventory.rs
@@ -203,31 +203,38 @@ fn project_files(
     };
     list.lines()
         .enumerate()
-        .map(|(index, path)| {
+        .filter_map(|(index, path)| {
             if path.is_empty() {
-                return Err(Error::ParseError(format!(
+                return Some(Err(Error::ParseError(format!(
                     "dpkg ownership record {list_name:?} has an empty path at line {}",
                     index + 1
-                )));
+                ))));
             }
-            *ownership_records = ownership_records.checked_add(1).ok_or_else(|| {
-                Error::ParseError("dpkg ownership record count overflowed u64".to_string())
-            })?;
-            let path = crate::packages::archive_utils::normalize_path(path)
-                .map_err(|error| Error::ParseError(error.to_string()))?;
-            let digest_path = path.strip_prefix('/').unwrap_or(&path);
-            let digest = digests.get(digest_path).cloned();
-            Ok(InstalledFileInfo {
-                path,
-                size: 0,
-                mode: 0,
-                digest,
-                user: None,
-                group: None,
-                link_target: None,
-                mtime: None,
-                absence_policy: InstalledFileAbsencePolicy::Required,
-            })
+            // dpkg's installed `.list` grammar may carry `/.` as the root
+            // anchor. It is not a deployable package payload node.
+            if matches!(path, "/" | "/.") {
+                return None;
+            }
+            Some((|| {
+                *ownership_records = ownership_records.checked_add(1).ok_or_else(|| {
+                    Error::ParseError("dpkg ownership record count overflowed u64".to_string())
+                })?;
+                let path = crate::packages::archive_utils::normalize_path(path)
+                    .map_err(|error| Error::ParseError(error.to_string()))?;
+                let digest_path = path.strip_prefix('/').unwrap_or(&path);
+                let digest = digests.get(digest_path).cloned();
+                Ok(InstalledFileInfo {
+                    path,
+                    size: 0,
+                    mode: 0,
+                    digest,
+                    user: None,
+                    group: None,
+                    link_target: None,
+                    mtime: None,
+                    absence_policy: InstalledFileAbsencePolicy::Required,
+                })
+            })())
         })
         .collect()
 }
@@ -313,7 +320,7 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         fs::write(
             root.path().join("fixture:amd64.list"),
-            "/etc/fixture.conf\n/usr/bin/fixture\n",
+            "/.\n/etc/fixture.conf\n/usr/bin/fixture\n",
         )
         .unwrap();
         fs::write(

--- a/crates/conary-core/src/packages/dpkg_query/inventory.rs
+++ b/crates/conary-core/src/packages/dpkg_query/inventory.rs
@@ -73,8 +73,11 @@ fn capture_from_authority(
         let config = parse_conffiles(fields[15])?;
         let mut files = package_files
             .into_iter()
-            .map(|file| {
+            .map(|mut file| {
                 let authority = config.get(&file.path).cloned();
+                if authority.is_some() {
+                    file.absence_policy = InstalledFileAbsencePolicy::DpkgConffile;
+                }
                 InstalledInventoryFile {
                     file,
                     config: authority,
@@ -97,14 +100,16 @@ fn capture_from_authority(
                         mode: i32::try_from(libc::S_IFREG | 0o644)
                             .expect("portable dpkg discovery mode fits i32"),
                         digest: match authority {
-                            InstalledConfigAuthority::Dpkg { md5, .. } => Some(md5.clone()),
+                            InstalledConfigAuthority::Dpkg { original_md5, .. } => {
+                                original_md5.clone()
+                            }
                             _ => unreachable!("dpkg config parser emits dpkg authority"),
                         },
                         user: None,
                         group: None,
                         link_target: None,
                         mtime: None,
-                        absence_policy: InstalledFileAbsencePolicy::Required,
+                        absence_policy: InstalledFileAbsencePolicy::DpkgConffile,
                     },
                     config: Some(authority.clone()),
                 });
@@ -243,30 +248,41 @@ fn parse_conffiles(field: &str) -> Result<BTreeMap<String, InstalledConfigAuthor
     let mut config = BTreeMap::new();
     for (index, line) in field.lines().filter(|line| !line.is_empty()).enumerate() {
         let value = line.trim();
+        let (value, remove_on_upgrade) = value
+            .strip_suffix(" remove-on-upgrade")
+            .map(|value| (value, true))
+            .unwrap_or((value, false));
         let (value, obsolete) = value
             .strip_suffix(" obsolete")
             .map(|value| (value, true))
             .unwrap_or((value, false));
-        let (path, md5) = value.rsplit_once(' ').ok_or_else(|| {
+        let (path, digest) = value.rsplit_once(' ').ok_or_else(|| {
             Error::ParseError(format!(
                 "dpkg Conffiles record {} has no path/digest separator",
                 index + 1
             ))
         })?;
-        if md5.len() != 32 || !md5.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-            return Err(Error::ParseError(format!(
-                "dpkg Conffiles record {} has an invalid MD5 digest",
-                index + 1
-            )));
-        }
+        let original_md5 = match digest {
+            "newconffile" => None,
+            md5 if md5.len() == 32 && md5.bytes().all(|byte| byte.is_ascii_hexdigit()) => {
+                Some(md5.to_string())
+            }
+            _ => {
+                return Err(Error::ParseError(format!(
+                    "dpkg Conffiles record {} has an invalid digest authority",
+                    index + 1
+                )));
+            }
+        };
         let path = crate::packages::archive_utils::normalize_path(path)
             .map_err(|error| Error::ParseError(error.to_string()))?;
         if config
             .insert(
                 path.clone(),
                 InstalledConfigAuthority::Dpkg {
-                    md5: md5.to_string(),
+                    original_md5,
                     obsolete,
+                    remove_on_upgrade,
                 },
             )
             .is_some()
@@ -345,7 +361,16 @@ mod tests {
 
         assert_eq!(package.install_reason, NativeInstallReason::Explicit);
         assert_eq!(package.files.len(), 2);
-        assert!(package.files[0].config.is_some());
+        let config = package
+            .files
+            .iter()
+            .find(|file| file.file.path == "/etc/fixture.conf")
+            .unwrap();
+        assert!(config.config.is_some());
+        assert_eq!(
+            config.file.absence_policy,
+            InstalledFileAbsencePolicy::DpkgConffile
+        );
         assert_eq!(package.requirements.len(), 2);
         assert_eq!(package.provides.len(), 2);
         assert_eq!(package.lifecycle.len(), 1);
@@ -376,6 +401,55 @@ mod tests {
         assert_eq!(
             second.package("fixture:amd64").unwrap().install_reason,
             NativeInstallReason::Dependency
+        );
+    }
+
+    #[test]
+    fn dpkg_conffiles_preserve_digest_sentinels_and_ordered_flags() {
+        let config = parse_conffiles(concat!(
+            " /etc/ordinary.conf 0123456789abcdef0123456789abcdef\n",
+            " /etc/path with spaces.conf fedcba9876543210fedcba9876543210 obsolete\n",
+            " /etc/removed.conf newconffile remove-on-upgrade\n",
+            " /etc/both.conf newconffile obsolete remove-on-upgrade\n",
+        ))
+        .unwrap();
+
+        assert_eq!(
+            config.get("/etc/ordinary.conf"),
+            Some(&InstalledConfigAuthority::Dpkg {
+                original_md5: Some("0123456789abcdef0123456789abcdef".to_string()),
+                obsolete: false,
+                remove_on_upgrade: false,
+            })
+        );
+        assert_eq!(
+            config.get("/etc/path with spaces.conf"),
+            Some(&InstalledConfigAuthority::Dpkg {
+                original_md5: Some("fedcba9876543210fedcba9876543210".to_string()),
+                obsolete: true,
+                remove_on_upgrade: false,
+            })
+        );
+        assert_eq!(
+            config.get("/etc/removed.conf"),
+            Some(&InstalledConfigAuthority::Dpkg {
+                original_md5: None,
+                obsolete: false,
+                remove_on_upgrade: true,
+            })
+        );
+        assert_eq!(
+            config.get("/etc/both.conf"),
+            Some(&InstalledConfigAuthority::Dpkg {
+                original_md5: None,
+                obsolete: true,
+                remove_on_upgrade: true,
+            })
+        );
+
+        assert!(parse_conffiles(" /etc/fixture.conf newconffile unknown\n").is_err());
+        assert!(
+            parse_conffiles(" /etc/fixture.conf newconffile remove-on-upgrade obsolete\n").is_err()
         );
     }
 }

--- a/crates/conary-core/src/packages/dpkg_query/inventory.rs
+++ b/crates/conary-core/src/packages/dpkg_query/inventory.rs
@@ -1,0 +1,374 @@
+// conary-core/src/packages/dpkg_query/inventory.rs
+
+//! Fixed-work dpkg installed-inventory acquisition.
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::fs;
+use std::path::Path;
+
+use crate::error::{Error, Result};
+#[cfg(test)]
+use crate::packages::install_reason::parse_package_name_lines;
+use crate::packages::install_reason::query_package_names;
+use crate::packages::{
+    DpkgInstalledControlMember, InstalledConfigAuthority, InstalledFileAbsencePolicy,
+    InstalledFileInfo, InstalledInventoryFile, InstalledInventoryPackage,
+    InstalledInventorySnapshot, InstalledInventoryWork, InstalledLifecycleAuthority,
+    NativeInstallReason, SystemPackageManager,
+};
+use crate::repository::dependency_model::RepositoryRequirementKind;
+use crate::repository::requirement::parse_native_requirement;
+use crate::repository::versioning::VersionScheme;
+
+const INVENTORY_FORMAT: &str = "${binary:Package}\x1e${Package}\x1e${Version}\x1e${Architecture}\x1e${Description}\x1e${Maintainer}\x1e${Homepage}\x1e${Section}\x1e${Priority}\x1e${Installed-Size}\x1e${Multi-Arch}\x1e${db:Status-Status}\x1e${Pre-Depends}\x1e${Depends}\x1e${Provides}\x1e${Conffiles}\x1f";
+
+/// Capture installed dpkg identity and control fields in one query, then scan
+/// the info directory once for ownership and lifecycle records.
+pub fn query_installed_inventory() -> Result<InstalledInventorySnapshot> {
+    let packages = crate::packages::query_common::run_query_command(
+        "dpkg-query",
+        &["-W", "-f", INVENTORY_FORMAT],
+    )?;
+    let manual = query_package_names("APT", "apt-mark", &["showmanual"])
+        .map_err(|error| Error::InitError(error.to_string()))?;
+    capture_from_authority(&packages, &manual, Path::new("/var/lib/dpkg/info"), 2)
+}
+
+fn capture_from_authority(
+    output: &str,
+    manual: &HashSet<String>,
+    info_root: &Path,
+    manager_processes: u64,
+) -> Result<InstalledInventorySnapshot> {
+    let info = read_info_directory(info_root)?;
+    let mut packages = Vec::new();
+    let mut ownership_records = 0_u64;
+    for (record_index, record) in output
+        .split('\x1f')
+        .filter(|record| !record.is_empty())
+        .enumerate()
+    {
+        let fields = record.split('\x1e').collect::<Vec<_>>();
+        if fields.len() != 16 {
+            return Err(Error::ParseError(format!(
+                "dpkg bulk inventory record {} has {} fields; expected 16",
+                record_index + 1,
+                fields.len()
+            )));
+        }
+        if fields[11] != "installed" {
+            continue;
+        }
+        let identity_record = format!("{}\x1f", fields[..11].join("\x1e"));
+        let mut identities = super::parse_package_query_records(&identity_record)?;
+        let package_record = identities.pop().ok_or_else(|| {
+            Error::ParseError(format!(
+                "dpkg bulk inventory record {} produced no installed identity",
+                record_index + 1
+            ))
+        })?;
+        let identity = package_record.identity;
+        let selector = identity.selector();
+        let package_files = project_files(selector, &info, &mut ownership_records)?;
+        let config = parse_conffiles(fields[15])?;
+        let mut files = package_files
+            .into_iter()
+            .map(|file| {
+                let authority = config.get(&file.path).cloned();
+                InstalledInventoryFile {
+                    file,
+                    config: authority,
+                }
+            })
+            .collect::<Vec<_>>();
+        let known_paths = files
+            .iter()
+            .map(|file| file.file.path.clone())
+            .collect::<BTreeSet<_>>();
+        for (path, authority) in &config {
+            if !known_paths.contains(path) {
+                ownership_records = ownership_records.checked_add(1).ok_or_else(|| {
+                    Error::ParseError("dpkg ownership record count overflowed u64".to_string())
+                })?;
+                files.push(InstalledInventoryFile {
+                    file: InstalledFileInfo {
+                        path: path.clone(),
+                        size: 0,
+                        mode: i32::try_from(libc::S_IFREG | 0o644)
+                            .expect("portable dpkg discovery mode fits i32"),
+                        digest: match authority {
+                            InstalledConfigAuthority::Dpkg { md5, .. } => Some(md5.clone()),
+                            _ => unreachable!("dpkg config parser emits dpkg authority"),
+                        },
+                        user: None,
+                        group: None,
+                        link_target: None,
+                        mtime: None,
+                        absence_policy: InstalledFileAbsencePolicy::Required,
+                    },
+                    config: Some(authority.clone()),
+                });
+            }
+        }
+        let mut requirements = Vec::new();
+        for (kind, field) in [
+            (RepositoryRequirementKind::PreDepends, fields[12]),
+            (RepositoryRequirementKind::Depends, fields[13]),
+        ] {
+            for native in super::split_debian_requirement_field(field)? {
+                requirements.push(
+                    parse_native_requirement(kind, VersionScheme::Debian, native)
+                        .map_err(Error::ParseError)?,
+                );
+            }
+        }
+        let provides_record = format!(
+            "{}\x1e{}\x1e{}\x1e{}",
+            identity.selector(),
+            identity.name(),
+            identity.version(),
+            fields[14]
+        );
+        let provides = super::parse_dpkg_provide_record(&identity, &provides_record)?;
+        let lifecycle = project_lifecycle(selector, &info)?;
+        let is_explicit = manual.contains(&identity.install_reason_selector());
+        packages.push(InstalledInventoryPackage {
+            identity,
+            description: package_record.info.description,
+            install_reason: if is_explicit {
+                NativeInstallReason::Explicit
+            } else {
+                NativeInstallReason::Dependency
+            },
+            files,
+            requirements,
+            provides,
+            lifecycle,
+        });
+    }
+    InstalledInventorySnapshot::from_packages(
+        SystemPackageManager::Dpkg,
+        packages,
+        InstalledInventoryWork {
+            manager_processes,
+            database_bulk_reads: 2,
+            ownership_records,
+        },
+    )
+}
+
+fn read_info_directory(root: &Path) -> Result<BTreeMap<String, Vec<u8>>> {
+    let mut files = BTreeMap::new();
+    for entry in fs::read_dir(root).map_err(|error| {
+        Error::IoError(format!(
+            "failed to traverse dpkg info directory {}: {error}",
+            root.display()
+        ))
+    })? {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let name = entry.file_name().into_string().map_err(|_| {
+            Error::ParseError("dpkg info directory contains a non-UTF-8 filename".to_string())
+        })?;
+        files.insert(name, fs::read(entry.path())?);
+    }
+    Ok(files)
+}
+
+fn project_files(
+    selector: &str,
+    info: &BTreeMap<String, Vec<u8>>,
+    ownership_records: &mut u64,
+) -> Result<Vec<InstalledFileInfo>> {
+    let list_name = format!("{selector}.list");
+    let list = info.get(&list_name).ok_or_else(|| {
+        Error::NotFound(format!(
+            "installed dpkg selector {selector:?} has no exact {list_name:?} ownership record"
+        ))
+    })?;
+    let list = std::str::from_utf8(list).map_err(|error| {
+        Error::ParseError(format!(
+            "dpkg ownership record {list_name:?} is not UTF-8: {error}"
+        ))
+    })?;
+    let digests = match info.get(&format!("{selector}.md5sums")) {
+        Some(bytes) => super::parse_md5sums(std::str::from_utf8(bytes).map_err(|error| {
+            Error::ParseError(format!(
+                "dpkg md5sums record for {selector:?} is not UTF-8: {error}"
+            ))
+        })?)?,
+        None => std::collections::HashMap::new(),
+    };
+    list.lines()
+        .enumerate()
+        .map(|(index, path)| {
+            if path.is_empty() {
+                return Err(Error::ParseError(format!(
+                    "dpkg ownership record {list_name:?} has an empty path at line {}",
+                    index + 1
+                )));
+            }
+            *ownership_records = ownership_records.checked_add(1).ok_or_else(|| {
+                Error::ParseError("dpkg ownership record count overflowed u64".to_string())
+            })?;
+            let path = crate::packages::archive_utils::normalize_path(path)
+                .map_err(|error| Error::ParseError(error.to_string()))?;
+            let digest_path = path.strip_prefix('/').unwrap_or(&path);
+            let digest = digests.get(digest_path).cloned();
+            Ok(InstalledFileInfo {
+                path,
+                size: 0,
+                mode: 0,
+                digest,
+                user: None,
+                group: None,
+                link_target: None,
+                mtime: None,
+                absence_policy: InstalledFileAbsencePolicy::Required,
+            })
+        })
+        .collect()
+}
+
+fn parse_conffiles(field: &str) -> Result<BTreeMap<String, InstalledConfigAuthority>> {
+    let mut config = BTreeMap::new();
+    for (index, line) in field.lines().filter(|line| !line.is_empty()).enumerate() {
+        let value = line.trim();
+        let (value, obsolete) = value
+            .strip_suffix(" obsolete")
+            .map(|value| (value, true))
+            .unwrap_or((value, false));
+        let (path, md5) = value.rsplit_once(' ').ok_or_else(|| {
+            Error::ParseError(format!(
+                "dpkg Conffiles record {} has no path/digest separator",
+                index + 1
+            ))
+        })?;
+        if md5.len() != 32 || !md5.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err(Error::ParseError(format!(
+                "dpkg Conffiles record {} has an invalid MD5 digest",
+                index + 1
+            )));
+        }
+        let path = crate::packages::archive_utils::normalize_path(path)
+            .map_err(|error| Error::ParseError(error.to_string()))?;
+        if config
+            .insert(
+                path.clone(),
+                InstalledConfigAuthority::Dpkg {
+                    md5: md5.to_string(),
+                    obsolete,
+                },
+            )
+            .is_some()
+        {
+            return Err(Error::ConflictError(format!(
+                "dpkg Conffiles repeats path {path:?}"
+            )));
+        }
+    }
+    Ok(config)
+}
+
+fn project_lifecycle(
+    selector: &str,
+    info: &BTreeMap<String, Vec<u8>>,
+) -> Result<Vec<InstalledLifecycleAuthority>> {
+    [
+        ("config", DpkgInstalledControlMember::Config),
+        ("preinst", DpkgInstalledControlMember::PreInstall),
+        ("postinst", DpkgInstalledControlMember::PostInstall),
+        ("prerm", DpkgInstalledControlMember::PreRemove),
+        ("postrm", DpkgInstalledControlMember::PostRemove),
+        ("triggers", DpkgInstalledControlMember::Triggers),
+        ("templates", DpkgInstalledControlMember::Templates),
+    ]
+    .into_iter()
+    .filter_map(|(extension, member)| {
+        info.get(&format!("{selector}.{extension}")).map(|bytes| {
+            InstalledLifecycleAuthority::Dpkg {
+                member,
+                sha256: format!("sha256:{}", crate::hash::sha256(bytes)),
+                size: bytes.len() as u64,
+            }
+        })
+    })
+    .map(Ok)
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn output(reason_version: &str) -> String {
+        format!(
+            "fixture:amd64\x1efixture\x1e{reason_version}\x1eamd64\x1edescription\x1emaintainer\x1e\x1eutils\x1eoptional\x1e42\x1esame\x1einstalled\x1elibc6 (>= 2.42)\x1ezlib1g | libz1\x1efixture-abi (= 1)\x1e /etc/fixture.conf 0123456789abcdef0123456789abcdef\x1f"
+        )
+    }
+
+    fn info_root() -> tempfile::TempDir {
+        let root = tempfile::tempdir().unwrap();
+        fs::write(
+            root.path().join("fixture:amd64.list"),
+            "/etc/fixture.conf\n/usr/bin/fixture\n",
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("fixture:amd64.md5sums"),
+            "fedcba9876543210fedcba9876543210  usr/bin/fixture\n",
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("fixture:amd64.postinst"),
+            "#!/bin/sh\nexit 0\n",
+        )
+        .unwrap();
+        root
+    }
+
+    #[test]
+    fn dpkg_inventory_uses_two_fixed_manager_processes_and_two_bulk_reads() {
+        let root = info_root();
+        let manual = parse_package_name_lines("APT", "fixture:amd64\n").unwrap();
+        let snapshot = capture_from_authority(&output("1.0-1"), &manual, root.path(), 2).unwrap();
+        let package = snapshot.package("fixture:amd64").unwrap();
+
+        assert_eq!(package.install_reason, NativeInstallReason::Explicit);
+        assert_eq!(package.files.len(), 2);
+        assert!(package.files[0].config.is_some());
+        assert_eq!(package.requirements.len(), 2);
+        assert_eq!(package.provides.len(), 2);
+        assert_eq!(package.lifecycle.len(), 1);
+        assert_eq!(
+            snapshot.work(),
+            InstalledInventoryWork {
+                manager_processes: 2,
+                database_bulk_reads: 2,
+                ownership_records: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn dpkg_version_reason_config_and_lifecycle_change_token() {
+        let root = info_root();
+        let explicit = parse_package_name_lines("APT", "fixture:amd64\n").unwrap();
+        let first = capture_from_authority(&output("1.0-1"), &explicit, root.path(), 2).unwrap();
+        fs::write(
+            root.path().join("fixture:amd64.postinst"),
+            "#!/bin/sh\nchanged\n",
+        )
+        .unwrap();
+        let second =
+            capture_from_authority(&output("1.0-2"), &HashSet::new(), root.path(), 2).unwrap();
+
+        assert_ne!(first.token(), second.token());
+        assert_eq!(
+            second.package("fixture:amd64").unwrap().install_reason,
+            NativeInstallReason::Dependency
+        );
+    }
+}

--- a/crates/conary-core/src/packages/eopkg/inventory.rs
+++ b/crates/conary-core/src/packages/eopkg/inventory.rs
@@ -1,0 +1,156 @@
+// conary-core/src/packages/eopkg/inventory.rs
+
+//! Shared installed-inventory projection for retained eopkg XML authority.
+
+use crate::error::{Error, Result};
+use crate::packages::{
+    InstalledConfigAuthority, InstalledFileAbsencePolicy, InstalledFileInfo,
+    InstalledInventoryFile, InstalledInventoryPackage, InstalledInventorySnapshot,
+    InstalledInventoryWork, NativeInstallReason, SystemPackageManager,
+};
+use crate::repository::dependency_model::RepositoryRequirementKind;
+
+use super::query::InstalledEopkgDatabase;
+
+pub(super) fn from_database(
+    database: &InstalledEopkgDatabase,
+) -> Result<InstalledInventorySnapshot> {
+    let explicit = database.user_installed()?;
+    let mut ownership_records = 0_u64;
+    let mut packages = Vec::with_capacity(database.entries.len());
+    for entry in database.entries.values() {
+        let identity = entry.package.identity.clone();
+        let is_explicit = explicit.contains(identity.selector());
+        let files = entry
+            .files
+            .iter()
+            .map(|record| {
+                ownership_records = ownership_records.checked_add(1).ok_or_else(|| {
+                    Error::ParseError("eopkg ownership record count overflowed u64".to_string())
+                })?;
+                let path = crate::packages::archive_utils::normalize_path(&record.path)
+                    .map_err(|error| Error::ParseError(error.to_string()))?;
+                let size = i64::try_from(record.size.unwrap_or(0)).map_err(|_| {
+                    Error::ParseError(format!("eopkg installed size for {path:?} exceeds i64"))
+                })?;
+                let permissions = record.mode.unwrap_or(0);
+                let mode = i32::try_from(libc::S_IFREG | permissions).map_err(|_| {
+                    Error::ParseError(format!("eopkg installed mode for {path:?} exceeds i32"))
+                })?;
+                Ok(InstalledInventoryFile {
+                    file: InstalledFileInfo {
+                        path,
+                        size,
+                        mode,
+                        digest: record.sha1.clone(),
+                        user: record.uid.map(|value| value.to_string()),
+                        group: record.gid.map(|value| value.to_string()),
+                        link_target: None,
+                        mtime: None,
+                        absence_policy: if record.permanent {
+                            InstalledFileAbsencePolicy::EopkgPermanent
+                        } else {
+                            InstalledFileAbsencePolicy::Required
+                        },
+                    },
+                    config: record
+                        .permanent
+                        .then_some(InstalledConfigAuthority::Eopkg { permanent: true }),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let requirements = super::relation_groups(
+            entry.metadata.dependencies.clone(),
+            RepositoryRequirementKind::Depends,
+        )?;
+        let provides = super::query::project_provides(&entry.metadata, &identity)?;
+        packages.push(InstalledInventoryPackage {
+            identity,
+            description: entry.package.info.description.clone(),
+            install_reason: if is_explicit {
+                NativeInstallReason::Explicit
+            } else {
+                NativeInstallReason::Dependency
+            },
+            files,
+            requirements,
+            provides,
+            // Current eopkg authority has one transaction-global usysconf
+            // event and no per-package installed script body.
+            lifecycle: Vec::new(),
+        });
+    }
+    InstalledInventorySnapshot::from_packages(
+        SystemPackageManager::Eopkg,
+        packages,
+        InstalledInventoryWork {
+            manager_processes: 0,
+            database_bulk_reads: 2,
+            ownership_records,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    const METADATA: &[u8] = include_bytes!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/eopkg/jq-metadata.xml"
+    ));
+    const FILES: &[u8] = include_bytes!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/eopkg/jq-files.xml"
+    ));
+
+    fn fixture_database(automatic: &str) -> (tempfile::TempDir, InstalledEopkgDatabase) {
+        let root = tempfile::tempdir().unwrap();
+        let package_root = root.path().join("package");
+        let package = package_root.join("jq-1.8.2-13");
+        fs::create_dir_all(&package).unwrap();
+        fs::write(package.join("metadata.xml"), METADATA).unwrap();
+        fs::write(package.join("files.xml"), FILES).unwrap();
+        let automatic_path = root.path().join("info/autoinstalled");
+        fs::create_dir_all(automatic_path.parent().unwrap()).unwrap();
+        fs::write(&automatic_path, automatic).unwrap();
+        let database = InstalledEopkgDatabase::load_roots(&package_root, automatic_path).unwrap();
+        (root, database)
+    }
+
+    #[test]
+    fn eopkg_inventory_is_one_fixed_database_capture() {
+        let (_root, database) = fixture_database("");
+        let snapshot = database.inventory_snapshot().unwrap();
+        let package = snapshot.package("jq").unwrap();
+
+        assert_eq!(package.install_reason, NativeInstallReason::Explicit);
+        assert_eq!(package.files.len(), 8);
+        assert_eq!(package.requirements.len(), 2);
+        assert!(package.provides.iter().any(|provide| provide.name == "jq"));
+        assert_eq!(
+            snapshot.work(),
+            InstalledInventoryWork {
+                manager_processes: 0,
+                database_bulk_reads: 2,
+                ownership_records: 8,
+            }
+        );
+    }
+
+    #[test]
+    fn eopkg_automatic_state_participates_in_snapshot_token() {
+        let (_explicit_root, explicit_db) = fixture_database("");
+        let (_automatic_root, automatic_db) = fixture_database("jq\n");
+        let explicit = explicit_db.inventory_snapshot().unwrap();
+        let automatic = automatic_db.inventory_snapshot().unwrap();
+
+        assert_eq!(
+            automatic.package("jq").unwrap().install_reason,
+            NativeInstallReason::Dependency
+        );
+        assert_ne!(explicit.token(), automatic.token());
+    }
+}

--- a/crates/conary-core/src/packages/eopkg/mod.rs
+++ b/crates/conary-core/src/packages/eopkg/mod.rs
@@ -3,6 +3,7 @@
 //! Solus eopkg/PISI 1.2 package support.
 
 pub mod authority;
+mod inventory;
 mod payload;
 pub mod query;
 pub mod takeover;

--- a/crates/conary-core/src/packages/eopkg/query.rs
+++ b/crates/conary-core/src/packages/eopkg/query.rs
@@ -14,7 +14,7 @@ use crate::repository::dependency_model::{
 use crate::repository::versioning::VersionScheme;
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone)]
 pub struct InstalledEopkgInfo {
@@ -24,10 +24,10 @@ pub struct InstalledEopkgInfo {
     pub description: Option<String>,
 }
 
-struct InstalledEopkgEntry {
-    package: InstalledPackageRecord<InstalledEopkgInfo>,
-    metadata: xml::Metadata,
-    files: Vec<xml::FileRecord>,
+pub(super) struct InstalledEopkgEntry {
+    pub(super) package: InstalledPackageRecord<InstalledEopkgInfo>,
+    pub(super) metadata: xml::Metadata,
+    pub(super) files: Vec<xml::FileRecord>,
 }
 
 /// One exact snapshot of eopkg's retained installed-package authority.
@@ -36,7 +36,8 @@ struct InstalledEopkgEntry {
 /// the complete package database for each package field is both unnecessary
 /// and quadratic in the number of installed packages.
 pub struct InstalledEopkgDatabase {
-    entries: BTreeMap<String, InstalledEopkgEntry>,
+    pub(super) entries: BTreeMap<String, InstalledEopkgEntry>,
+    automatic_path: PathBuf,
 }
 
 impl InstalledEopkgDatabase {
@@ -45,9 +46,21 @@ impl InstalledEopkgDatabase {
     }
 
     pub fn load_root(root: &Path) -> Result<Self> {
+        let automatic_path = root
+            .parent()
+            .unwrap_or(root)
+            .join("info")
+            .join("autoinstalled");
+        Self::load_roots(root, automatic_path)
+    }
+
+    pub(crate) fn load_roots(root: &Path, automatic_path: PathBuf) -> Result<Self> {
         let mut entries = BTreeMap::new();
         if !root.exists() {
-            return Ok(Self { entries });
+            return Ok(Self {
+                entries,
+                automatic_path,
+            });
         }
         for directory in fs::read_dir(root)? {
             let directory = directory?;
@@ -103,7 +116,10 @@ impl InstalledEopkgDatabase {
                 )));
             }
         }
-        Ok(Self { entries })
+        Ok(Self {
+            entries,
+            automatic_path,
+        })
     }
 
     pub fn packages(&self) -> Vec<InstalledPackageRecord<InstalledEopkgInfo>> {
@@ -139,7 +155,7 @@ impl InstalledEopkgDatabase {
     }
 
     pub fn user_installed(&self) -> Result<std::collections::HashSet<String>> {
-        let automatic = fs::read_to_string("/var/lib/eopkg/info/autoinstalled")
+        let automatic = fs::read_to_string(&self.automatic_path)
             .unwrap_or_default()
             .split_whitespace()
             .map(str::to_string)
@@ -150,6 +166,11 @@ impl InstalledEopkgDatabase {
             .map(|entry| entry.package.identity.install_reason_selector())
             .filter(|name| !automatic.contains(name))
             .collect())
+    }
+
+    /// Project this parsed database into the shared coherent inventory.
+    pub fn inventory_snapshot(&self) -> Result<crate::packages::InstalledInventorySnapshot> {
+        super::inventory::from_database(self)
     }
 
     fn entry(&self, name: &str) -> Result<&InstalledEopkgEntry> {
@@ -232,7 +253,7 @@ pub fn query_package_provides(
     InstalledEopkgDatabase::load()?.package_provides(identity)
 }
 
-fn project_provides(
+pub(super) fn project_provides(
     metadata: &xml::Metadata,
     identity: &InstalledPackageIdentity,
 ) -> Result<Vec<ProvidedCapability>> {

--- a/crates/conary-core/src/packages/installed_inventory.rs
+++ b/crates/conary-core/src/packages/installed_inventory.rs
@@ -34,7 +34,7 @@ pub enum InstalledConfigAuthority {
         obsolete: bool,
     },
     Pacman {
-        original_md5: String,
+        original_md5: Option<String>,
     },
     Eopkg {
         permanent: bool,

--- a/crates/conary-core/src/packages/installed_inventory.rs
+++ b/crates/conary-core/src/packages/installed_inventory.rs
@@ -30,8 +30,9 @@ pub enum InstalledConfigAuthority {
         ghost: bool,
     },
     Dpkg {
-        md5: String,
+        original_md5: Option<String>,
         obsolete: bool,
+        remove_on_upgrade: bool,
     },
     Pacman {
         original_md5: Option<String>,

--- a/crates/conary-core/src/packages/installed_inventory.rs
+++ b/crates/conary-core/src/packages/installed_inventory.rs
@@ -19,6 +19,19 @@ pub enum NativeInstallReason {
     Dependency,
 }
 
+/// Exact digest state retained for one ALPM backup declaration.
+///
+/// Pacman normally persists an MD5 digest. A deliberately empty local-db
+/// field and the `(null)` spelling emitted when libalpm has no digest are
+/// distinct native states and must remain distinct in the inventory token.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "value", rename_all = "kebab-case")]
+pub enum PacmanInstalledBackupDigest {
+    Md5(String),
+    Empty,
+    Unavailable,
+}
+
 /// Source-specific configuration declaration retained by an installed manager.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "manager", rename_all = "kebab-case", deny_unknown_fields)]
@@ -35,7 +48,7 @@ pub enum InstalledConfigAuthority {
         remove_on_upgrade: bool,
     },
     Pacman {
-        original_md5: Option<String>,
+        original_digest: PacmanInstalledBackupDigest,
     },
     Eopkg {
         permanent: bool,

--- a/crates/conary-core/src/packages/installed_inventory.rs
+++ b/crates/conary-core/src/packages/installed_inventory.rs
@@ -1,0 +1,427 @@
+// conary-core/src/packages/installed_inventory.rs
+
+//! Coherent installed native-package inventory authority.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+use crate::repository::dependency_model::{ProvidedCapability, RepositoryRequirementGroup};
+
+use super::{InstalledFileInfo, InstalledPackageIdentity, SystemPackageManager};
+
+/// Exact native install reason at inventory capture time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum NativeInstallReason {
+    Explicit,
+    Dependency,
+}
+
+/// Source-specific configuration declaration retained by an installed manager.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "manager", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum InstalledConfigAuthority {
+    Rpm {
+        config: bool,
+        noreplace: bool,
+        missing_ok: bool,
+        ghost: bool,
+    },
+    Dpkg {
+        md5: String,
+        obsolete: bool,
+    },
+    Pacman {
+        original_md5: String,
+    },
+    Eopkg {
+        permanent: bool,
+    },
+}
+
+/// RPM lifecycle slot names retained in an installed header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RpmInstalledLifecycleSlot {
+    PreInstall,
+    PostInstall,
+    PreRemove,
+    PostRemove,
+    PreTransaction,
+    PostTransaction,
+    PreUntransaction,
+    PostUntransaction,
+    Verify,
+    Trigger,
+    FileTrigger,
+    TransactionFileTrigger,
+}
+
+/// Debian control members retained below `/var/lib/dpkg/info`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DpkgInstalledControlMember {
+    Config,
+    PreInstall,
+    PostInstall,
+    PreRemove,
+    PostRemove,
+    Triggers,
+    Templates,
+}
+
+/// ALPM lifecycle records retained in the local database.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PacmanInstalledLifecycleKind {
+    InstallScript,
+    Mtree,
+}
+
+/// Digest authority for source-specific installed lifecycle state.
+///
+/// Adoption does not execute these records. Their exact byte digest and size
+/// participate in the snapshot token so a native lifecycle change cannot pass
+/// pre-commit revalidation unnoticed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "manager", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum InstalledLifecycleAuthority {
+    Rpm {
+        slot: RpmInstalledLifecycleSlot,
+        sha256: String,
+        size: u64,
+    },
+    Dpkg {
+        member: DpkgInstalledControlMember,
+        sha256: String,
+        size: u64,
+    },
+    Pacman {
+        kind: PacmanInstalledLifecycleKind,
+        sha256: String,
+        size: u64,
+    },
+    Eopkg {
+        component: String,
+        sha256: String,
+        size: u64,
+    },
+}
+
+/// One normalized native ownership declaration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstalledInventoryFile {
+    pub file: InstalledFileInfo,
+    pub config: Option<InstalledConfigAuthority>,
+}
+
+/// All installed authority for one exact native package identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstalledInventoryPackage {
+    pub identity: InstalledPackageIdentity,
+    pub description: Option<String>,
+    pub install_reason: NativeInstallReason,
+    pub files: Vec<InstalledInventoryFile>,
+    pub requirements: Vec<RepositoryRequirementGroup>,
+    pub provides: Vec<ProvidedCapability>,
+    pub lifecycle: Vec<InstalledLifecycleAuthority>,
+}
+
+/// Fixed-work observations emitted by one backend acquisition.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstalledInventoryWork {
+    /// Native-manager child processes spawned for the complete inventory.
+    pub manager_processes: u64,
+    /// Logical whole-database reads or directory traversals.
+    pub database_bulk_reads: u64,
+    /// Native ownership path records decoded.
+    pub ownership_records: u64,
+}
+
+/// Content identity of every mutation-relevant installed-manager field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct InstalledInventoryToken(String);
+
+impl InstalledInventoryToken {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// One coherent installed native-package inventory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstalledInventorySnapshot {
+    manager: SystemPackageManager,
+    token: InstalledInventoryToken,
+    packages: BTreeMap<String, InstalledInventoryPackage>,
+    owners_by_path: BTreeMap<String, Vec<String>>,
+    work: InstalledInventoryWork,
+}
+
+#[derive(Serialize)]
+struct TokenAuthority<'a> {
+    version: u32,
+    manager: SystemPackageManager,
+    packages: &'a BTreeMap<String, InstalledInventoryPackage>,
+    owners_by_path: &'a BTreeMap<String, Vec<String>>,
+}
+
+impl InstalledInventorySnapshot {
+    pub const TOKEN_VERSION: u32 = 1;
+
+    pub fn from_packages(
+        manager: SystemPackageManager,
+        packages: Vec<InstalledInventoryPackage>,
+        work: InstalledInventoryWork,
+    ) -> Result<Self> {
+        if !manager.is_available() {
+            return Err(Error::ConfigError(
+                "installed inventory requires a concrete native package manager".to_string(),
+            ));
+        }
+        let mut by_selector = BTreeMap::new();
+        let mut owners = BTreeMap::<String, BTreeSet<String>>::new();
+        for mut package in packages {
+            package.identity.validate()?;
+            if SystemPackageManager::from_version_scheme(package.identity.version_scheme())
+                != Some(manager)
+            {
+                return Err(Error::ConflictError(format!(
+                    "installed inventory manager '{}' disagrees with package identity '{}'",
+                    manager.cli_name(),
+                    package.identity.selector()
+                )));
+            }
+            normalize_package(&mut package)?;
+            let selector = package.identity.selector().to_string();
+            for file in &package.files {
+                owners
+                    .entry(file.file.path.clone())
+                    .or_default()
+                    .insert(selector.clone());
+            }
+            if by_selector.insert(selector.clone(), package).is_some() {
+                return Err(Error::ConflictError(format!(
+                    "installed inventory repeated exact selector '{selector}'"
+                )));
+            }
+        }
+        let owners_by_path = owners
+            .into_iter()
+            .map(|(path, owners)| (path, owners.into_iter().collect()))
+            .collect::<BTreeMap<_, _>>();
+        let token_bytes = serde_json::to_vec(&TokenAuthority {
+            version: Self::TOKEN_VERSION,
+            manager,
+            packages: &by_selector,
+            owners_by_path: &owners_by_path,
+        })
+        .map_err(|error| {
+            Error::ParseError(format!(
+                "failed to encode installed inventory token: {error}"
+            ))
+        })?;
+        let token =
+            InstalledInventoryToken(format!("sha256:{}", crate::hash::sha256(&token_bytes)));
+        Ok(Self {
+            manager,
+            token,
+            packages: by_selector,
+            owners_by_path,
+            work,
+        })
+    }
+
+    pub const fn manager(&self) -> SystemPackageManager {
+        self.manager
+    }
+
+    pub fn token(&self) -> &InstalledInventoryToken {
+        &self.token
+    }
+
+    pub fn packages(&self) -> impl ExactSizeIterator<Item = &InstalledInventoryPackage> {
+        self.packages.values()
+    }
+
+    pub fn package(&self, selector: &str) -> Option<&InstalledInventoryPackage> {
+        self.packages.get(selector)
+    }
+
+    pub fn owners_by_path(&self) -> &BTreeMap<String, Vec<String>> {
+        &self.owners_by_path
+    }
+
+    pub const fn work(&self) -> InstalledInventoryWork {
+        self.work
+    }
+
+    pub fn require_unchanged(&self, current: &Self) -> Result<()> {
+        if self.manager != current.manager || self.token != current.token {
+            return Err(Error::ConflictError(format!(
+                "native {} inventory changed during adoption (planned {}, current {})",
+                self.manager.display_name(),
+                self.token.as_str(),
+                current.token.as_str()
+            )));
+        }
+        Ok(())
+    }
+}
+
+fn normalize_package(package: &mut InstalledInventoryPackage) -> Result<()> {
+    let selector = package.identity.selector();
+    let mut paths = BTreeSet::new();
+    for file in &mut package.files {
+        file.file.path = super::archive_utils::normalize_path(&file.file.path)
+            .map_err(|error| Error::ParseError(error.to_string()))?;
+        if !paths.insert(file.file.path.clone()) {
+            return Err(Error::ConflictError(format!(
+                "installed package '{selector}' repeats owned path '{}'",
+                file.file.path
+            )));
+        }
+    }
+    package
+        .files
+        .sort_by(|left, right| left.file.path.cmp(&right.file.path));
+    package.requirements.sort_by(|left, right| {
+        serde_json::to_string(left)
+            .expect("requirement serialization is infallible")
+            .cmp(&serde_json::to_string(right).expect("requirement serialization is infallible"))
+    });
+    package.provides.sort_by(|left, right| {
+        serde_json::to_string(left)
+            .expect("provide serialization is infallible")
+            .cmp(&serde_json::to_string(right).expect("provide serialization is infallible"))
+    });
+    package.lifecycle.sort_by(|left, right| {
+        serde_json::to_string(left)
+            .expect("lifecycle serialization is infallible")
+            .cmp(&serde_json::to_string(right).expect("lifecycle serialization is infallible"))
+    });
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::packages::InstalledFileAbsencePolicy;
+    use crate::repository::dependency_model::DebianMultiArch;
+
+    fn package(selector: &str, architecture: &str, path: &str) -> InstalledInventoryPackage {
+        InstalledInventoryPackage {
+            identity: InstalledPackageIdentity::dpkg(
+                selector,
+                "libfixture",
+                "1.0-1",
+                architecture,
+                DebianMultiArch::Same,
+            )
+            .unwrap(),
+            description: None,
+            install_reason: NativeInstallReason::Dependency,
+            files: vec![InstalledInventoryFile {
+                file: InstalledFileInfo {
+                    path: path.to_string(),
+                    size: 0,
+                    mode: 0,
+                    digest: None,
+                    user: None,
+                    group: None,
+                    link_target: None,
+                    mtime: None,
+                    absence_policy: InstalledFileAbsencePolicy::Required,
+                },
+                config: None,
+            }],
+            requirements: Vec::new(),
+            provides: Vec::new(),
+            lifecycle: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn snapshot_preserves_multiarch_and_every_shared_path_owner() {
+        let snapshot = InstalledInventorySnapshot::from_packages(
+            SystemPackageManager::Dpkg,
+            vec![
+                package("libfixture:amd64", "amd64", "/usr/share/doc/fixture"),
+                package("libfixture:i386", "i386", "/usr/share/doc/fixture"),
+            ],
+            InstalledInventoryWork::default(),
+        )
+        .unwrap();
+
+        assert_eq!(snapshot.packages().len(), 2);
+        assert_eq!(
+            snapshot.owners_by_path()["/usr/share/doc/fixture"],
+            ["libfixture:amd64", "libfixture:i386"]
+        );
+    }
+
+    #[test]
+    fn token_is_order_independent_but_changes_with_native_reason() {
+        let amd64 = package("libfixture:amd64", "amd64", "/usr/lib/fixture");
+        let i386 = package("libfixture:i386", "i386", "/usr/lib32/fixture");
+        let first = InstalledInventorySnapshot::from_packages(
+            SystemPackageManager::Dpkg,
+            vec![amd64.clone(), i386.clone()],
+            InstalledInventoryWork {
+                manager_processes: 99,
+                database_bulk_reads: 99,
+                ownership_records: 2,
+            },
+        )
+        .unwrap();
+        let reordered = InstalledInventorySnapshot::from_packages(
+            SystemPackageManager::Dpkg,
+            vec![i386, amd64.clone()],
+            InstalledInventoryWork::default(),
+        )
+        .unwrap();
+        assert_eq!(first.token(), reordered.token());
+
+        let mut changed = amd64;
+        changed.install_reason = NativeInstallReason::Explicit;
+        let current = InstalledInventorySnapshot::from_packages(
+            SystemPackageManager::Dpkg,
+            vec![changed],
+            InstalledInventoryWork::default(),
+        )
+        .unwrap();
+        assert!(first.require_unchanged(&current).is_err());
+    }
+
+    #[test]
+    fn duplicate_normalized_path_is_rejected() {
+        let mut duplicate = package("libfixture:amd64", "amd64", "/usr/lib/fixture");
+        duplicate.files.push(InstalledInventoryFile {
+            file: InstalledFileInfo {
+                path: "usr/lib/fixture".to_string(),
+                size: 0,
+                mode: 0,
+                digest: None,
+                user: None,
+                group: None,
+                link_target: None,
+                mtime: None,
+                absence_policy: InstalledFileAbsencePolicy::Required,
+            },
+            config: None,
+        });
+        let error = InstalledInventorySnapshot::from_packages(
+            SystemPackageManager::Dpkg,
+            vec![duplicate],
+            InstalledInventoryWork::default(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("repeats owned path"));
+    }
+}

--- a/crates/conary-core/src/packages/installed_inventory.rs
+++ b/crates/conary-core/src/packages/installed_inventory.rs
@@ -175,6 +175,21 @@ struct TokenAuthority<'a> {
 impl InstalledInventorySnapshot {
     pub const TOKEN_VERSION: u32 = 1;
 
+    /// Acquire one complete inventory from the selected backend.
+    pub fn capture(manager: SystemPackageManager) -> Result<Self> {
+        match manager {
+            SystemPackageManager::Rpm => super::rpm_query::query_installed_inventory(),
+            SystemPackageManager::Dpkg => super::dpkg_query::query_installed_inventory(),
+            SystemPackageManager::Pacman => super::pacman_query::query_installed_inventory(),
+            SystemPackageManager::Eopkg => {
+                super::eopkg::query::InstalledEopkgDatabase::load()?.inventory_snapshot()
+            }
+            SystemPackageManager::Unknown => Err(Error::ConfigError(
+                "cannot capture an installed inventory for unknown native authority".to_string(),
+            )),
+        }
+    }
+
     pub fn from_packages(
         manager: SystemPackageManager,
         packages: Vec<InstalledInventoryPackage>,

--- a/crates/conary-core/src/packages/mod.rs
+++ b/crates/conary-core/src/packages/mod.rs
@@ -32,7 +32,7 @@ pub use installed_inventory::{
     DpkgInstalledControlMember, InstalledConfigAuthority, InstalledInventoryFile,
     InstalledInventoryPackage, InstalledInventorySnapshot, InstalledInventoryToken,
     InstalledInventoryWork, InstalledLifecycleAuthority, NativeInstallReason,
-    PacmanInstalledLifecycleKind, RpmInstalledLifecycleSlot,
+    PacmanInstalledBackupDigest, PacmanInstalledLifecycleKind, RpmInstalledLifecycleSlot,
 };
 pub use registry::{PackageFormatType, detect_format, parse_package};
 

--- a/crates/conary-core/src/packages/mod.rs
+++ b/crates/conary-core/src/packages/mod.rs
@@ -14,6 +14,7 @@ pub mod dpkg_query;
 pub mod eopkg;
 pub mod install_reason;
 pub mod installed_identity;
+pub mod installed_inventory;
 pub mod native_abi;
 #[doc(hidden)]
 pub mod native_scriptlet_support;
@@ -27,6 +28,12 @@ pub mod source_authority;
 pub mod traits;
 
 pub use installed_identity::InstalledPackageIdentity;
+pub use installed_inventory::{
+    DpkgInstalledControlMember, InstalledConfigAuthority, InstalledInventoryFile,
+    InstalledInventoryPackage, InstalledInventorySnapshot, InstalledInventoryToken,
+    InstalledInventoryWork, InstalledLifecycleAuthority, NativeInstallReason,
+    PacmanInstalledLifecycleKind, RpmInstalledLifecycleSlot,
+};
 pub use registry::{PackageFormatType, detect_format, parse_package};
 
 use crate::error::{Error, Result};
@@ -42,7 +49,10 @@ pub use rpm_query::InstalledRpmInfo;
 pub use traits::{ExtractedFile, PackageFormat};
 
 /// Detect the system package manager
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "kebab-case")]
 pub enum SystemPackageManager {
     Rpm,
     Dpkg,

--- a/crates/conary-core/src/packages/pacman_query.rs
+++ b/crates/conary-core/src/packages/pacman_query.rs
@@ -569,22 +569,37 @@ pub fn query_user_installed()
 /// from the pacman database without touching any files on disk. This transfers
 /// ownership of the files from pacman to Conary.
 pub fn remove_from_db_only(name: &str) -> Result<()> {
-    debug!("Removing {} from pacman database only (--dbonly)", name);
+    remove_batch_from_db_only(&[name])
+}
+
+/// Remove exact package records in one ALPM database-only transaction.
+pub fn remove_batch_from_db_only(selectors: &[&str]) -> Result<()> {
+    if selectors.is_empty() {
+        return Ok(());
+    }
+    debug!(
+        "Removing {} package records from pacman database only (--dbonly)",
+        selectors.len()
+    );
 
     let output = Command::new("pacman")
-        .args(["-Rdd", "--dbonly", "--noconfirm", name])
+        .args(["-Rdd", "--dbonly", "--noconfirm"])
+        .args(selectors)
         .output()
         .map_err(|e| Error::InitError(format!("Failed to run pacman -Rdd --dbonly: {}", e)))?;
 
     if !output.status.success() {
         return Err(Error::InitError(format!(
-            "pacman -Rdd --dbonly {} failed: {}",
-            name,
+            "pacman -Rdd --dbonly batch failed for [{}]: {}",
+            selectors.join(", "),
             String::from_utf8_lossy(&output.stderr)
         )));
     }
 
-    debug!("Successfully removed {} from pacman database", name);
+    debug!(
+        "Successfully removed {} package records from pacman database",
+        selectors.len()
+    );
     Ok(())
 }
 

--- a/crates/conary-core/src/packages/pacman_query.rs
+++ b/crates/conary-core/src/packages/pacman_query.rs
@@ -24,6 +24,9 @@ use std::collections::HashSet;
 use std::process::Command;
 use tracing::debug;
 
+mod inventory;
+pub use inventory::query_installed_inventory;
+
 /// Information about an installed pacman package
 #[derive(Debug, Clone)]
 pub struct InstalledPacmanInfo {

--- a/crates/conary-core/src/packages/pacman_query/inventory.rs
+++ b/crates/conary-core/src/packages/pacman_query/inventory.rs
@@ -12,7 +12,8 @@ use crate::packages::{
     InstalledConfigAuthority, InstalledFileAbsencePolicy, InstalledFileInfo,
     InstalledInventoryFile, InstalledInventoryPackage, InstalledInventorySnapshot,
     InstalledInventoryWork, InstalledLifecycleAuthority, InstalledPackageIdentity,
-    NativeInstallReason, PacmanInstalledLifecycleKind, SystemPackageManager,
+    NativeInstallReason, PacmanInstalledBackupDigest, PacmanInstalledLifecycleKind,
+    SystemPackageManager,
 };
 use crate::repository::dependency_model::{
     CapabilityProvenance, ProvideArchitectureQualifier, ProvideVersionRelation, ProvidedCapability,
@@ -195,7 +196,7 @@ fn project_package(
                 config: backup
                     .get(&path)
                     .map(|digest| InstalledConfigAuthority::Pacman {
-                        original_md5: digest.clone(),
+                        original_digest: digest.clone(),
                     }),
             })
         })
@@ -282,22 +283,31 @@ fn project_package(
     })
 }
 
-fn parse_backup(records: &[String]) -> Result<BTreeMap<String, Option<String>>> {
+fn parse_backup(records: &[String]) -> Result<BTreeMap<String, PacmanInstalledBackupDigest>> {
     let mut backup = BTreeMap::new();
     for record in records {
         let (path, digest) = record.split_once('\t').ok_or_else(|| {
             Error::ParseError("ALPM %BACKUP% record has no path/digest separator".to_string())
         })?;
-        if !digest.is_empty()
-            && (digest.len() != 32 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit()))
-        {
-            return Err(Error::ParseError(format!(
-                "ALPM backup path {path:?} has an invalid MD5 digest"
-            )));
-        }
         let path = crate::packages::archive_utils::normalize_path(path)
             .map_err(|error| Error::ParseError(error.to_string()))?;
-        let digest = (!digest.is_empty()).then(|| digest.to_string());
+        // libalpm 7.1 normally stores the MD5 computed after extraction. If
+        // extraction is skipped by NoExtract (or digest computation otherwise
+        // fails), backup->hash remains NULL and glibc's `%s` serialization in
+        // _alpm_local_db_write() persists the exact `(null)` spelling:
+        // https://gitlab.archlinux.org/pacman/pacman/-/blob/54d94116164b0b2202c6061c4a59c6f3e70820d8/lib/libalpm/be_local.c#L1119-1125
+        let digest = match digest {
+            "" => PacmanInstalledBackupDigest::Empty,
+            "(null)" => PacmanInstalledBackupDigest::Unavailable,
+            value if value.len() == 32 && value.bytes().all(|byte| byte.is_ascii_hexdigit()) => {
+                PacmanInstalledBackupDigest::Md5(value.to_string())
+            }
+            _ => {
+                return Err(Error::ParseError(format!(
+                    "ALPM backup path {path:?} has an invalid digest state"
+                )));
+            }
+        };
         if backup.insert(path.clone(), digest).is_some() {
             return Err(Error::ConflictError(format!(
                 "ALPM database repeats backup path {path:?}"
@@ -406,7 +416,49 @@ mod tests {
         let snapshot = capture_local_root(temp.path(), 1).unwrap();
         assert!(matches!(
             snapshot.package("fixture").unwrap().files[0].config,
-            Some(InstalledConfigAuthority::Pacman { original_md5: None })
+            Some(InstalledConfigAuthority::Pacman {
+                original_digest: PacmanInstalledBackupDigest::Empty
+            })
         ));
+    }
+
+    #[test]
+    fn unavailable_alpm_backup_digest_is_distinct_snapshot_authority() {
+        let empty_root = tempfile::tempdir().unwrap();
+        write_package(empty_root.path(), "1.0-1", "0");
+        let empty_files = empty_root.path().join("fixture-1.0-1/files");
+        let empty_content = fs::read_to_string(&empty_files).unwrap();
+        fs::write(
+            &empty_files,
+            empty_content.replace(
+                "etc/fixture.conf\t0123456789abcdef0123456789abcdef",
+                "etc/fixture.conf\t",
+            ),
+        )
+        .unwrap();
+
+        let unavailable_root = tempfile::tempdir().unwrap();
+        write_package(unavailable_root.path(), "1.0-1", "0");
+        let unavailable_files = unavailable_root.path().join("fixture-1.0-1/files");
+        let unavailable_content = fs::read_to_string(&unavailable_files).unwrap();
+        fs::write(
+            &unavailable_files,
+            unavailable_content.replace(
+                "etc/fixture.conf\t0123456789abcdef0123456789abcdef",
+                "etc/fixture.conf\t(null)",
+            ),
+        )
+        .unwrap();
+
+        let empty = capture_local_root(empty_root.path(), 1).unwrap();
+        let unavailable = capture_local_root(unavailable_root.path(), 1).unwrap();
+
+        assert!(matches!(
+            unavailable.package("fixture").unwrap().files[0].config,
+            Some(InstalledConfigAuthority::Pacman {
+                original_digest: PacmanInstalledBackupDigest::Unavailable
+            })
+        ));
+        assert_ne!(empty.token(), unavailable.token());
     }
 }

--- a/crates/conary-core/src/packages/pacman_query/inventory.rs
+++ b/crates/conary-core/src/packages/pacman_query/inventory.rs
@@ -282,20 +282,23 @@ fn project_package(
     })
 }
 
-fn parse_backup(records: &[String]) -> Result<BTreeMap<String, String>> {
+fn parse_backup(records: &[String]) -> Result<BTreeMap<String, Option<String>>> {
     let mut backup = BTreeMap::new();
     for record in records {
         let (path, digest) = record.split_once('\t').ok_or_else(|| {
             Error::ParseError("ALPM %BACKUP% record has no path/digest separator".to_string())
         })?;
-        if digest.len() != 32 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        if !digest.is_empty()
+            && (digest.len() != 32 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        {
             return Err(Error::ParseError(format!(
                 "ALPM backup path {path:?} has an invalid MD5 digest"
             )));
         }
         let path = crate::packages::archive_utils::normalize_path(path)
             .map_err(|error| Error::ParseError(error.to_string()))?;
-        if backup.insert(path.clone(), digest.to_string()).is_some() {
+        let digest = (!digest.is_empty()).then(|| digest.to_string());
+        if backup.insert(path.clone(), digest).is_some() {
             return Err(Error::ConflictError(format!(
                 "ALPM database repeats backup path {path:?}"
             )));
@@ -383,5 +386,27 @@ mod tests {
             snapshot.package("fixture").unwrap().install_reason,
             NativeInstallReason::Explicit
         );
+    }
+
+    #[test]
+    fn absent_alpm_backup_digest_remains_exact_config_authority() {
+        let temp = tempfile::tempdir().unwrap();
+        write_package(temp.path(), "1.0-1", "0");
+        let files = temp.path().join("fixture-1.0-1/files");
+        let content = fs::read_to_string(&files).unwrap();
+        fs::write(
+            &files,
+            content.replace(
+                "etc/fixture.conf\t0123456789abcdef0123456789abcdef",
+                "etc/fixture.conf\t",
+            ),
+        )
+        .unwrap();
+
+        let snapshot = capture_local_root(temp.path(), 1).unwrap();
+        assert!(matches!(
+            snapshot.package("fixture").unwrap().files[0].config,
+            Some(InstalledConfigAuthority::Pacman { original_md5: None })
+        ));
     }
 }

--- a/crates/conary-core/src/packages/pacman_query/inventory.rs
+++ b/crates/conary-core/src/packages/pacman_query/inventory.rs
@@ -1,0 +1,387 @@
+// conary-core/src/packages/pacman_query/inventory.rs
+
+//! Coherent ALPM local-database inventory acquisition.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use crate::error::{Error, Result};
+use crate::packages::{
+    InstalledConfigAuthority, InstalledFileAbsencePolicy, InstalledFileInfo,
+    InstalledInventoryFile, InstalledInventoryPackage, InstalledInventorySnapshot,
+    InstalledInventoryWork, InstalledLifecycleAuthority, InstalledPackageIdentity,
+    NativeInstallReason, PacmanInstalledLifecycleKind, SystemPackageManager,
+};
+use crate::repository::dependency_model::{
+    CapabilityProvenance, ProvideArchitectureQualifier, ProvideVersionRelation, ProvidedCapability,
+    RepositoryCapabilityKind, RepositoryRequirementKind, SourcePackageFormat,
+};
+use crate::repository::package_relation::parse_arch_provide;
+use crate::repository::requirement::parse_native_requirement;
+use crate::repository::versioning::VersionScheme;
+
+/// Capture every installed ALPM record with one database-root traversal.
+pub fn query_installed_inventory() -> Result<InstalledInventorySnapshot> {
+    let output = Command::new("pacman-conf")
+        .arg("DBPath")
+        .env("LC_ALL", "C")
+        .output()
+        .map_err(|error| Error::InitError(format!("Failed to run pacman-conf DBPath: {error}")))?;
+    if !output.status.success() {
+        return Err(Error::InitError(format!(
+            "pacman-conf DBPath failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    let stdout = String::from_utf8(output.stdout)
+        .map_err(|error| Error::ParseError(format!("pacman-conf output is not UTF-8: {error}")))?;
+    let values = stdout.lines().collect::<Vec<_>>();
+    if values.len() != 1 || values[0].is_empty() || !Path::new(values[0]).is_absolute() {
+        return Err(Error::ParseError(
+            "pacman-conf DBPath must emit one absolute database path".to_string(),
+        ));
+    }
+    capture_local_root(&Path::new(values[0]).join("local"), 1)
+}
+
+fn capture_local_root(root: &Path, manager_processes: u64) -> Result<InstalledInventorySnapshot> {
+    let mut packages = Vec::new();
+    let mut ownership_records = 0_u64;
+    let entries = fs::read_dir(root).map_err(|error| {
+        Error::IoError(format!(
+            "failed to traverse ALPM local database {}: {error}",
+            root.display()
+        ))
+    })?;
+    for entry in entries {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let directory = entry.path();
+        let desc = parse_sections(&fs::read(directory.join("desc"))?, "desc")?;
+        let files = parse_sections(&fs::read(directory.join("files"))?, "files")?;
+        let package = project_package(&directory, &desc, &files, &mut ownership_records)?;
+        packages.push(package);
+    }
+    InstalledInventorySnapshot::from_packages(
+        SystemPackageManager::Pacman,
+        packages,
+        InstalledInventoryWork {
+            manager_processes,
+            database_bulk_reads: 1,
+            ownership_records,
+        },
+    )
+}
+
+fn parse_sections(bytes: &[u8], document: &str) -> Result<BTreeMap<String, Vec<String>>> {
+    let input = std::str::from_utf8(bytes).map_err(|error| {
+        Error::ParseError(format!("ALPM local {document} is not UTF-8: {error}"))
+    })?;
+    let mut fields = BTreeMap::new();
+    let mut lines = input.lines().peekable();
+    while let Some(line) = lines.next() {
+        if line.is_empty() {
+            continue;
+        }
+        let key = line
+            .strip_prefix('%')
+            .and_then(|line| line.strip_suffix('%'))
+            .filter(|key| {
+                !key.is_empty()
+                    && key
+                        .bytes()
+                        .all(|byte| byte.is_ascii_uppercase() || byte == b'_')
+            })
+            .ok_or_else(|| {
+                Error::ParseError(format!(
+                    "ALPM local {document} has malformed field marker {line:?}"
+                ))
+            })?;
+        let mut values = Vec::new();
+        while let Some(value) = lines.peek().copied() {
+            if value.is_empty() {
+                lines.next();
+                break;
+            }
+            if value.starts_with('%') && value.ends_with('%') {
+                return Err(Error::ParseError(format!(
+                    "ALPM local {document} field %{key}% has no blank terminator"
+                )));
+            }
+            values.push(lines.next().expect("peeked value").to_string());
+        }
+        if fields.insert(key.to_string(), values).is_some() {
+            return Err(Error::ParseError(format!(
+                "ALPM local {document} repeats field %{key}%"
+            )));
+        }
+    }
+    Ok(fields)
+}
+
+fn one<'a>(fields: &'a BTreeMap<String, Vec<String>>, key: &str) -> Result<&'a str> {
+    let values = fields
+        .get(key)
+        .ok_or_else(|| Error::ParseError(format!("ALPM local database omitted %{key}%")))?;
+    if values.len() != 1 || values[0].is_empty() {
+        return Err(Error::ParseError(format!(
+            "ALPM local database %{key}% must contain one non-empty value"
+        )));
+    }
+    Ok(&values[0])
+}
+
+fn many<'a>(fields: &'a BTreeMap<String, Vec<String>>, key: &str) -> &'a [String] {
+    fields.get(key).map(Vec::as_slice).unwrap_or_default()
+}
+
+fn project_package(
+    directory: &Path,
+    desc: &BTreeMap<String, Vec<String>>,
+    files: &BTreeMap<String, Vec<String>>,
+    ownership_records: &mut u64,
+) -> Result<InstalledInventoryPackage> {
+    let name = one(desc, "NAME")?;
+    let version = one(desc, "VERSION")?;
+    let architecture = one(desc, "ARCH")?;
+    let identity = InstalledPackageIdentity::pacman(name, name, version, architecture)?;
+    let reason = match desc.get("REASON").map(Vec::as_slice) {
+        None | Some([]) => NativeInstallReason::Explicit,
+        Some([value]) if value == "0" => NativeInstallReason::Explicit,
+        Some([value]) if value == "1" => NativeInstallReason::Dependency,
+        Some(values) => {
+            return Err(Error::ParseError(format!(
+                "ALPM local package {name:?} has unsupported %REASON% values {values:?}"
+            )));
+        }
+    };
+    let backup = parse_backup(many(files, "BACKUP"))?;
+    let mut seen_paths = BTreeSet::new();
+    let inventory_files = many(files, "FILES")
+        .iter()
+        .map(|raw_path| {
+            *ownership_records = ownership_records.checked_add(1).ok_or_else(|| {
+                Error::ParseError("ALPM ownership record count overflowed u64".to_string())
+            })?;
+            let directory = raw_path.ends_with('/');
+            let path = crate::packages::archive_utils::normalize_path(raw_path)
+                .map_err(|error| Error::ParseError(error.to_string()))?;
+            if !seen_paths.insert(path.clone()) {
+                return Err(Error::ConflictError(format!(
+                    "ALPM package {name:?} repeats owned path {path:?}"
+                )));
+            }
+            Ok(InstalledInventoryFile {
+                file: InstalledFileInfo {
+                    path: path.clone(),
+                    size: 0,
+                    mode: i32::try_from(if directory {
+                        libc::S_IFDIR | 0o755
+                    } else {
+                        libc::S_IFREG | 0o644
+                    })
+                    .expect("portable ALPM discovery mode fits i32"),
+                    digest: None,
+                    user: None,
+                    group: None,
+                    link_target: None,
+                    mtime: None,
+                    absence_policy: InstalledFileAbsencePolicy::Required,
+                },
+                config: backup
+                    .get(&path)
+                    .map(|digest| InstalledConfigAuthority::Pacman {
+                        original_md5: digest.clone(),
+                    }),
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    if let Some(path) = backup.keys().find(|path| !seen_paths.contains(*path)) {
+        return Err(Error::ParseError(format!(
+            "ALPM package {name:?} declares backup path {path:?} outside %FILES%"
+        )));
+    }
+
+    let requirements = many(desc, "DEPENDS")
+        .iter()
+        .map(|requirement| {
+            parse_native_requirement(
+                RepositoryRequirementKind::Depends,
+                VersionScheme::Arch,
+                requirement,
+            )
+            .map_err(Error::ParseError)
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let mut provides = vec![ProvidedCapability {
+        kind: RepositoryCapabilityKind::PackageName,
+        name: name.to_string(),
+        version: Some(version.to_string()),
+        version_relation: Some(ProvideVersionRelation::Equal),
+        version_scheme: VersionScheme::Arch,
+        architecture_qualifier: ProvideArchitectureQualifier::Implicit,
+        provenance: CapabilityProvenance::ExactIdentity,
+    }];
+    for (record_index, native) in many(desc, "PROVIDES").iter().enumerate() {
+        let parsed = parse_arch_provide(native, name).map_err(Error::ParseError)?;
+        provides.push(ProvidedCapability {
+            kind: parsed.kind,
+            name: parsed.name,
+            version_relation: parsed
+                .version
+                .as_ref()
+                .map(|_| ProvideVersionRelation::Equal),
+            version: parsed.version,
+            version_scheme: VersionScheme::Arch,
+            architecture_qualifier: ProvideArchitectureQualifier::Implicit,
+            provenance: CapabilityProvenance::SourceDeclared {
+                format: SourcePackageFormat::Alpm,
+                record_index: u32::try_from(record_index).map_err(|_| {
+                    Error::ParseError("ALPM provide record index exceeds u32".to_string())
+                })?,
+            },
+        });
+    }
+    for provide in &provides {
+        provide.validate()?;
+    }
+    let lifecycle = [
+        ("install", PacmanInstalledLifecycleKind::InstallScript),
+        ("mtree", PacmanInstalledLifecycleKind::Mtree),
+    ]
+    .into_iter()
+    .filter_map(|(file, kind)| {
+        let path = directory.join(file);
+        match fs::read(&path) {
+            Ok(bytes) => Some(Ok(InstalledLifecycleAuthority::Pacman {
+                kind,
+                sha256: format!("sha256:{}", crate::hash::sha256(&bytes)),
+                size: bytes.len() as u64,
+            })),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => Some(Err(Error::IoError(format!(
+                "failed to read ALPM lifecycle record {}: {error}",
+                path.display()
+            )))),
+        }
+    })
+    .collect::<Result<Vec<_>>>()?;
+
+    Ok(InstalledInventoryPackage {
+        identity,
+        description: desc.get("DESC").and_then(|values| values.first()).cloned(),
+        install_reason: reason,
+        files: inventory_files,
+        requirements,
+        provides,
+        lifecycle,
+    })
+}
+
+fn parse_backup(records: &[String]) -> Result<BTreeMap<String, String>> {
+    let mut backup = BTreeMap::new();
+    for record in records {
+        let (path, digest) = record.split_once('\t').ok_or_else(|| {
+            Error::ParseError("ALPM %BACKUP% record has no path/digest separator".to_string())
+        })?;
+        if digest.len() != 32 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err(Error::ParseError(format!(
+                "ALPM backup path {path:?} has an invalid MD5 digest"
+            )));
+        }
+        let path = crate::packages::archive_utils::normalize_path(path)
+            .map_err(|error| Error::ParseError(error.to_string()))?;
+        if backup.insert(path.clone(), digest.to_string()).is_some() {
+            return Err(Error::ConflictError(format!(
+                "ALPM database repeats backup path {path:?}"
+            )));
+        }
+    }
+    Ok(backup)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_package(root: &Path, suffix: &str, reason: &str) {
+        let package = root.join(format!("fixture-{suffix}"));
+        fs::create_dir_all(&package).unwrap();
+        fs::write(
+            package.join("desc"),
+            format!(
+                "%NAME%\nfixture\n\n%VERSION%\n{suffix}\n\n%ARCH%\nx86_64\n\n%DESC%\nfixture package\n\n%REASON%\n{reason}\n\n%DEPENDS%\nglibc>=2.42\n\n%PROVIDES%\nfixture-abi=1\n\n"
+            ),
+        )
+        .unwrap();
+        fs::write(
+            package.join("files"),
+            "%FILES%\netc/fixture.conf\nusr/\nusr/bin/fixture\n\n%BACKUP%\netc/fixture.conf\t0123456789abcdef0123456789abcdef\n\n",
+        )
+        .unwrap();
+        fs::write(package.join("install"), b"post_install() { :; }\n").unwrap();
+    }
+
+    #[test]
+    fn alpm_inventory_uses_one_fixed_database_traversal() {
+        let temp = tempfile::tempdir().unwrap();
+        write_package(temp.path(), "1.0-1", "0");
+
+        let snapshot = capture_local_root(temp.path(), 1).unwrap();
+        let package = snapshot.package("fixture").unwrap();
+        assert_eq!(package.install_reason, NativeInstallReason::Explicit);
+        assert_eq!(package.files.len(), 3);
+        assert!(package.files[0].config.is_some());
+        assert_eq!(package.requirements.len(), 1);
+        assert_eq!(package.provides.len(), 2);
+        assert_eq!(package.lifecycle.len(), 1);
+        assert_eq!(
+            snapshot.work(),
+            InstalledInventoryWork {
+                manager_processes: 1,
+                database_bulk_reads: 1,
+                ownership_records: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn alpm_reason_and_lifecycle_bytes_change_snapshot_token() {
+        let explicit_root = tempfile::tempdir().unwrap();
+        write_package(explicit_root.path(), "1.0-1", "0");
+        let dependency_root = tempfile::tempdir().unwrap();
+        write_package(dependency_root.path(), "1.0-1", "1");
+        fs::write(
+            dependency_root.path().join("fixture-1.0-1/install"),
+            b"post_install() { changed; }\n",
+        )
+        .unwrap();
+
+        let explicit = capture_local_root(explicit_root.path(), 1).unwrap();
+        let dependency = capture_local_root(dependency_root.path(), 1).unwrap();
+        assert_ne!(explicit.token(), dependency.token());
+        assert_eq!(
+            dependency.package("fixture").unwrap().install_reason,
+            NativeInstallReason::Dependency
+        );
+    }
+
+    #[test]
+    fn absent_alpm_reason_is_the_explicit_default() {
+        let temp = tempfile::tempdir().unwrap();
+        write_package(temp.path(), "1.0-1", "0");
+        let desc = temp.path().join("fixture-1.0-1/desc");
+        let content = fs::read_to_string(&desc).unwrap();
+        fs::write(&desc, content.replace("%REASON%\n0\n\n", "")).unwrap();
+
+        let snapshot = capture_local_root(temp.path(), 1).unwrap();
+        assert_eq!(
+            snapshot.package("fixture").unwrap().install_reason,
+            NativeInstallReason::Explicit
+        );
+    }
+}

--- a/crates/conary-core/src/packages/query_common.rs
+++ b/crates/conary-core/src/packages/query_common.rs
@@ -16,6 +16,8 @@ pub enum InstalledFileAbsencePolicy {
     RpmMissingOk,
     /// The RPM record carries both `%ghost` and `missingok`.
     RpmGhostAndMissingOk,
+    /// A dpkg conffile declaration survives intentional local deletion.
+    DpkgConffile,
     /// An eopkg permanent record may remain declared without live payload.
     EopkgPermanent,
 }

--- a/crates/conary-core/src/packages/query_common.rs
+++ b/crates/conary-core/src/packages/query_common.rs
@@ -2,9 +2,11 @@
 //! Shared types and helpers for native package manager queries.
 
 use crate::packages::InstalledPackageIdentity;
+use serde::{Deserialize, Serialize};
 
 /// Native package-manager authority for a file record that is absent on disk.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum InstalledFileAbsencePolicy {
     /// The native record describes required live payload.
     Required,
@@ -26,7 +28,8 @@ impl InstalledFileAbsencePolicy {
 }
 
 /// Information about a single installed file from a native package manager.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct InstalledFileInfo {
     pub path: String,
     pub size: i64,

--- a/crates/conary-core/src/packages/rpm_query.rs
+++ b/crates/conary-core/src/packages/rpm_query.rs
@@ -42,6 +42,9 @@ const DNF4_USER_INSTALLED_ARGS: &[&str] = &[
 mod provides;
 pub use provides::query_package_provides;
 
+mod inventory;
+pub use inventory::query_installed_inventory;
+
 /// RPM's reserved name for imported public keys.
 ///
 /// `rpmkeys --import` stores each trusted key as a header in the same database

--- a/crates/conary-core/src/packages/rpm_query.rs
+++ b/crates/conary-core/src/packages/rpm_query.rs
@@ -515,22 +515,37 @@ fn query_user_installed_with(
 /// the RPM database without touching any files on disk. This is used
 /// during takeover to transfer ownership from RPM to Conary.
 pub fn remove_from_db_only(name: &str) -> Result<()> {
-    debug!("Removing {} from RPM database only (--justdb)", name);
+    remove_batch_from_db_only(&[name])
+}
+
+/// Remove exact package records in one RPM database-only transaction.
+pub fn remove_batch_from_db_only(selectors: &[&str]) -> Result<()> {
+    if selectors.is_empty() {
+        return Ok(());
+    }
+    debug!(
+        "Removing {} package records from RPM database only (--justdb)",
+        selectors.len()
+    );
 
     let output = Command::new("rpm")
-        .args(["-e", "--justdb", "--nodeps", name])
+        .args(["-e", "--justdb", "--nodeps"])
+        .args(selectors)
         .output()
         .map_err(|e| Error::InitError(format!("Failed to run rpm -e --justdb: {}", e)))?;
 
     if !output.status.success() {
         return Err(Error::InitError(format!(
-            "rpm -e --justdb {} failed: {}",
-            name,
+            "rpm -e --justdb batch failed for [{}]: {}",
+            selectors.join(", "),
             String::from_utf8_lossy(&output.stderr)
         )));
     }
 
-    debug!("Successfully removed {} from RPM database", name);
+    debug!(
+        "Successfully removed {} package records from RPM database",
+        selectors.len()
+    );
     Ok(())
 }
 

--- a/crates/conary-core/src/packages/rpm_query/inventory.rs
+++ b/crates/conary-core/src/packages/rpm_query/inventory.rs
@@ -1,0 +1,320 @@
+// conary-core/src/packages/rpm_query/inventory.rs
+
+//! Fixed-process coherent RPM installed-inventory acquisition.
+
+use std::collections::{BTreeMap, HashSet};
+
+use rpm::FileFlags;
+
+use crate::error::{Error, Result};
+use crate::packages::install_reason::query_package_names;
+use crate::packages::{
+    InstalledConfigAuthority, InstalledInventoryFile, InstalledInventoryPackage,
+    InstalledInventorySnapshot, InstalledInventoryWork, InstalledLifecycleAuthority,
+    NativeInstallReason, RpmInstalledLifecycleSlot, SystemPackageManager,
+};
+
+const LIFECYCLE_FORMAT: &str = concat!(
+    "%{PREINPROG}\x1e%{PREIN}\x1f\x1d",
+    "%{POSTINPROG}\x1e%{POSTIN}\x1f\x1d",
+    "%{PREUNPROG}\x1e%{PREUN}\x1f\x1d",
+    "%{POSTUNPROG}\x1e%{POSTUN}\x1f\x1d",
+    "%{PRETRANSPROG}\x1e%{PRETRANS}\x1f\x1d",
+    "%{POSTTRANSPROG}\x1e%{POSTTRANS}\x1f\x1d",
+    "%{PREUNTRANSPROG}\x1e%{PREUNTRANS}\x1f\x1d",
+    "%{POSTUNTRANSPROG}\x1e%{POSTUNTRANS}\x1f\x1d",
+    "%{VERIFYSCRIPTPROG}\x1e%{VERIFYSCRIPT}\x1f\x1d",
+    "[%{TRIGGERSCRIPTPROG}\x1e%{TRIGGERSCRIPTS}\x1f]\x1d",
+    "[%{FILETRIGGERSCRIPTPROG}\x1e%{FILETRIGGERSCRIPTS}\x1f]\x1d",
+    "[%{TRANSFILETRIGGERSCRIPTPROG}\x1e%{TRANSFILETRIGGERSCRIPTS}\x1f]",
+);
+
+/// Query all installed header fields in one rpmdb iteration and DNF reason
+/// authority in at most two fixed probes.
+pub fn query_installed_inventory() -> Result<InstalledInventorySnapshot> {
+    let format = format!(
+        "{}\x1d{}\x1d{}\x1d{}\x1d{}\x1c",
+        super::RPM_PACKAGE_RECORD_FORMAT,
+        super::RPM_FILE_RECORD_FORMAT,
+        super::RPM_REQUIREMENT_RECORD_FORMAT,
+        super::provides::RPM_PROVIDE_RECORD_FORMAT,
+        LIFECYCLE_FORMAT,
+    );
+    let output = crate::packages::query_common::run_query_command(
+        "rpm",
+        &["-qa", "--queryformat", &format],
+    )?;
+    let mut reason_processes = 0_u64;
+    let explicit = super::query_user_installed_with(|authority, command, args| {
+        reason_processes += 1;
+        query_package_names(authority, command, args)
+    })
+    .map_err(|error| Error::InitError(error.to_string()))?;
+    capture_from_output(&output, &explicit, 1 + reason_processes)
+}
+
+fn capture_from_output(
+    output: &str,
+    explicit: &HashSet<String>,
+    manager_processes: u64,
+) -> Result<InstalledInventorySnapshot> {
+    let mut packages = Vec::new();
+    let mut ownership_records = 0_u64;
+    for (record_index, record) in output
+        .split('\x1c')
+        .filter(|record| !record.is_empty())
+        .enumerate()
+    {
+        let sections = record.splitn(5, '\x1d').collect::<Vec<_>>();
+        if sections.len() != 5 {
+            return Err(Error::ParseError(format!(
+                "RPM bulk inventory record {} has {} sections; expected 5",
+                record_index + 1,
+                sections.len()
+            )));
+        }
+        let mut identity_records = super::parse_package_query_records(sections[0])?;
+        if identity_records.is_empty() {
+            // RPM public-key headers share the database but are not packages.
+            continue;
+        }
+        if identity_records.len() != 1 {
+            return Err(Error::ParseError(format!(
+                "RPM bulk inventory record {} produced more than one identity",
+                record_index + 1
+            )));
+        }
+        let package_record = identity_records.pop().expect("one identity");
+        let identity = package_record.identity;
+        let config = parse_file_config(sections[1])?;
+        let files = super::parse_rpm_file_records(sections[1])?
+            .into_iter()
+            .map(|file| InstalledInventoryFile {
+                config: config.get(&file.path).cloned(),
+                file,
+            })
+            .collect::<Vec<_>>();
+        ownership_records = ownership_records
+            .checked_add(u64::try_from(files.len()).map_err(|_| {
+                Error::ParseError("RPM ownership record count exceeds u64".to_string())
+            })?)
+            .ok_or_else(|| {
+                Error::ParseError("RPM ownership record count overflowed u64".to_string())
+            })?;
+        let requirements = super::parse_rpm_requirement_records(sections[2])?;
+        let provides = super::provides::parse_rpm_provide_records(&identity, sections[3])?;
+        let lifecycle = parse_lifecycle(sections[4])?;
+        let is_explicit = explicit.contains(&identity.install_reason_selector());
+        packages.push(InstalledInventoryPackage {
+            identity,
+            description: package_record
+                .info
+                .description
+                .or(package_record.info.summary),
+            install_reason: if is_explicit {
+                NativeInstallReason::Explicit
+            } else {
+                NativeInstallReason::Dependency
+            },
+            files,
+            requirements,
+            provides,
+            lifecycle,
+        });
+    }
+    InstalledInventorySnapshot::from_packages(
+        SystemPackageManager::Rpm,
+        packages,
+        InstalledInventoryWork {
+            manager_processes,
+            database_bulk_reads: 1,
+            ownership_records,
+        },
+    )
+}
+
+fn parse_file_config(output: &str) -> Result<BTreeMap<String, InstalledConfigAuthority>> {
+    let mut config = BTreeMap::new();
+    for (record_index, record) in output
+        .split('\x1f')
+        .filter(|record| !record.is_empty())
+        .enumerate()
+    {
+        let fields = record.split('\x1e').collect::<Vec<_>>();
+        if fields.len() != 10 {
+            return Err(Error::ParseError(format!(
+                "RPM file config record {} has {} fields; expected 10",
+                record_index + 1,
+                fields.len()
+            )));
+        }
+        match fields[9].parse::<i32>() {
+            Ok(0 | 3) => {}
+            Ok(1 | 2 | 4) => continue,
+            Ok(state) => {
+                return Err(Error::ParseError(format!(
+                    "RPM file config record {} has unsupported FILESTATES value {state}",
+                    record_index + 1
+                )));
+            }
+            Err(error) => {
+                return Err(Error::ParseError(format!(
+                    "RPM file config record {} has invalid FILESTATES value {:?}: {error}",
+                    record_index + 1,
+                    fields[9]
+                )));
+            }
+        }
+        let bits = u32::from_str_radix(fields[8], 16).map_err(|error| {
+            Error::ParseError(format!(
+                "RPM file config record {} has invalid FILEFLAGS {:?}: {error}",
+                record_index + 1,
+                fields[8]
+            ))
+        })?;
+        let flags = FileFlags::from_bits_retain(bits);
+        if flags.intersects(
+            FileFlags::CONFIG | FileFlags::NOREPLACE | FileFlags::MISSINGOK | FileFlags::GHOST,
+        ) {
+            let path = crate::packages::archive_utils::normalize_path(fields[0])
+                .map_err(|error| Error::ParseError(error.to_string()))?;
+            if config
+                .insert(
+                    path.clone(),
+                    InstalledConfigAuthority::Rpm {
+                        config: flags.contains(FileFlags::CONFIG),
+                        noreplace: flags.contains(FileFlags::NOREPLACE),
+                        missing_ok: flags.contains(FileFlags::MISSINGOK),
+                        ghost: flags.contains(FileFlags::GHOST),
+                    },
+                )
+                .is_some()
+            {
+                return Err(Error::ConflictError(format!(
+                    "RPM file config authority repeats path {path:?}"
+                )));
+            }
+        }
+    }
+    Ok(config)
+}
+
+fn parse_lifecycle(output: &str) -> Result<Vec<InstalledLifecycleAuthority>> {
+    let slots = [
+        RpmInstalledLifecycleSlot::PreInstall,
+        RpmInstalledLifecycleSlot::PostInstall,
+        RpmInstalledLifecycleSlot::PreRemove,
+        RpmInstalledLifecycleSlot::PostRemove,
+        RpmInstalledLifecycleSlot::PreTransaction,
+        RpmInstalledLifecycleSlot::PostTransaction,
+        RpmInstalledLifecycleSlot::PreUntransaction,
+        RpmInstalledLifecycleSlot::PostUntransaction,
+        RpmInstalledLifecycleSlot::Verify,
+        RpmInstalledLifecycleSlot::Trigger,
+        RpmInstalledLifecycleSlot::FileTrigger,
+        RpmInstalledLifecycleSlot::TransactionFileTrigger,
+    ];
+    let sections = output.split('\x1d').collect::<Vec<_>>();
+    if sections.len() != slots.len() {
+        return Err(Error::ParseError(format!(
+            "RPM lifecycle inventory has {} slot sections; expected {}",
+            sections.len(),
+            slots.len()
+        )));
+    }
+    let mut lifecycle = Vec::new();
+    for (slot, section) in slots.into_iter().zip(sections) {
+        for (record_index, record) in section
+            .split('\x1f')
+            .filter(|record| !record.is_empty())
+            .enumerate()
+        {
+            let fields = record.split('\x1e').collect::<Vec<_>>();
+            if fields.len() != 2 {
+                return Err(Error::ParseError(format!(
+                    "RPM {slot:?} lifecycle record {} has {} fields; expected 2",
+                    record_index + 1,
+                    fields.len()
+                )));
+            }
+            if fields
+                .iter()
+                .all(|field| field.is_empty() || *field == "(none)")
+            {
+                continue;
+            }
+            let bytes = [fields[0].as_bytes(), b"\0", fields[1].as_bytes()].concat();
+            lifecycle.push(InstalledLifecycleAuthority::Rpm {
+                slot,
+                sha256: format!("sha256:{}", crate::hash::sha256(&bytes)),
+                size: bytes.len() as u64,
+            });
+        }
+    }
+    Ok(lifecycle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lifecycle(post: &str) -> String {
+        let mut sections = vec!["(none)\x1e(none)\x1f".to_string(); 12];
+        sections[1] = format!("/bin/sh\x1e{post}\x1f");
+        sections.join("\x1d")
+    }
+
+    fn output(version: &str, post: &str) -> String {
+        let package = format!(
+            "fixture-{version}-1.x86_64\x1efixture\x1e{version}\x1e1\x1e(none)\x1ex86_64\x1edescription\x1esummary\x1eMIT\x1e(none)\x1e(none)\x1e(none)\x1e(none)\x1e1\x1f"
+        );
+        let files = concat!(
+            "/etc/fixture.conf\x1e1\x1e1\x1e0123456789abcdef\x1e100644\x1eroot\x1eroot\x1e\x1e11\x1e0\x1f",
+            "/usr/bin/fixture\x1e1\x1e1\x1efedcba9876543210\x1e100755\x1eroot\x1eroot\x1e\x1e0\x1e0\x1f"
+        );
+        let requirements = "glibc.so.6()(64bit)\x1e0\x1e\x1f";
+        let provides = "fixture\x1e8\x1e1.0-1\x1f";
+        format!(
+            "{package}\x1d{files}\x1d{requirements}\x1d{provides}\x1d{}\x1c",
+            lifecycle(post)
+        )
+    }
+
+    #[test]
+    fn rpm_inventory_uses_a_fixed_process_count() {
+        let explicit = HashSet::from(["fixture.x86_64".to_string()]);
+        let snapshot = capture_from_output(&output("1.0", "exit 0"), &explicit, 2).unwrap();
+        let package = snapshot.package("fixture-1.0-1.x86_64").unwrap();
+
+        assert_eq!(package.install_reason, NativeInstallReason::Explicit);
+        assert_eq!(package.files.len(), 2);
+        assert!(package.files[0].config.is_some());
+        assert_eq!(package.requirements.len(), 1);
+        assert_eq!(package.provides.len(), 2);
+        assert_eq!(package.lifecycle.len(), 1);
+        assert_eq!(
+            snapshot.work(),
+            InstalledInventoryWork {
+                manager_processes: 2,
+                database_bulk_reads: 1,
+                ownership_records: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn rpm_version_reason_config_and_lifecycle_change_token() {
+        let explicit = HashSet::from(["fixture.x86_64".to_string()]);
+        let first = capture_from_output(&output("1.0", "exit 0"), &explicit, 2).unwrap();
+        let second = capture_from_output(&output("2.0", "changed"), &HashSet::new(), 3).unwrap();
+
+        assert_ne!(first.token(), second.token());
+        assert_eq!(
+            second
+                .package("fixture-2.0-1.x86_64")
+                .unwrap()
+                .install_reason,
+            NativeInstallReason::Dependency
+        );
+    }
+}

--- a/crates/conary-core/src/packages/rpm_query/inventory.rs
+++ b/crates/conary-core/src/packages/rpm_query/inventory.rs
@@ -3,6 +3,8 @@
 //! Fixed-process coherent RPM installed-inventory acquisition.
 
 use std::collections::{BTreeMap, HashSet};
+use std::fs;
+use std::path::Path;
 
 use rpm::FileFlags;
 
@@ -29,6 +31,20 @@ const LIFECYCLE_FORMAT: &str = concat!(
     "[%{TRANSFILETRIGGERSCRIPTPROG}\x1e%{TRANSFILETRIGGERSCRIPTS}\x1f]",
 );
 
+enum RpmInstallReasonAuthority {
+    DnfExplicit(HashSet<String>),
+    LibzyppAutomatic(HashSet<String>),
+}
+
+impl RpmInstallReasonAuthority {
+    fn is_explicit(&self, identity: &crate::packages::InstalledPackageIdentity) -> bool {
+        match self {
+            Self::DnfExplicit(packages) => packages.contains(&identity.install_reason_selector()),
+            Self::LibzyppAutomatic(packages) => !packages.contains(identity.name()),
+        }
+    }
+}
+
 /// Query all installed header fields in one rpmdb iteration and DNF reason
 /// authority in at most two fixed probes.
 pub fn query_installed_inventory() -> Result<InstalledInventorySnapshot> {
@@ -44,19 +60,73 @@ pub fn query_installed_inventory() -> Result<InstalledInventorySnapshot> {
         "rpm",
         &["-qa", "--queryformat", &format],
     )?;
+    let (reasons, reason_processes, reason_reads) = query_install_reason_authority()?;
+    capture_from_output(&output, &reasons, 1 + reason_processes, 1 + reason_reads)
+}
+
+fn query_install_reason_authority() -> Result<(RpmInstallReasonAuthority, u64, u64)> {
     let mut reason_processes = 0_u64;
-    let explicit = super::query_user_installed_with(|authority, command, args| {
-        reason_processes += 1;
-        query_package_names(authority, command, args)
-    })
-    .map_err(|error| Error::InitError(error.to_string()))?;
-    capture_from_output(&output, &explicit, 1 + reason_processes)
+    let dnf = super::query_user_installed_with(|authority, command, args| {
+        let result = query_package_names(authority, command, args);
+        if !result
+            .as_ref()
+            .is_err_and(|error| error.is_command_unavailable())
+        {
+            reason_processes += 1;
+        }
+        result
+    });
+    match dnf {
+        Ok(explicit) => Ok((
+            RpmInstallReasonAuthority::DnfExplicit(explicit),
+            reason_processes,
+            0,
+        )),
+        Err(dnf_error) if dnf_error.is_command_unavailable() => {
+            let path = Path::new("/var/lib/zypp/AutoInstalled");
+            let content = fs::read_to_string(path).map_err(|error| {
+                Error::InitError(format!(
+                    "{dnf_error}; libzypp install-reason authority {} is unavailable: {error}",
+                    path.display()
+                ))
+            })?;
+            Ok((
+                RpmInstallReasonAuthority::LibzyppAutomatic(parse_libzypp_auto_installed(
+                    &content,
+                )?),
+                reason_processes,
+                1,
+            ))
+        }
+        Err(error) => Err(Error::InitError(error.to_string())),
+    }
+}
+
+/// Parse libzypp `SolvIdentFile`, pinned to upstream commit
+/// `bacd92ed16086b2e6af7182476dfba228a4a1bb5`.
+fn parse_libzypp_auto_installed(content: &str) -> Result<HashSet<String>> {
+    let mut packages = HashSet::new();
+    for (index, line) in content.lines().enumerate() {
+        let name = line.trim();
+        if name.is_empty() || name.starts_with('#') {
+            continue;
+        }
+        if name.chars().any(char::is_whitespace) {
+            return Err(Error::ParseError(format!(
+                "libzypp AutoInstalled line {} is not one exact package ident: {name:?}",
+                index + 1
+            )));
+        }
+        packages.insert(name.to_string());
+    }
+    Ok(packages)
 }
 
 fn capture_from_output(
     output: &str,
-    explicit: &HashSet<String>,
+    reasons: &RpmInstallReasonAuthority,
     manager_processes: u64,
+    database_bulk_reads: u64,
 ) -> Result<InstalledInventorySnapshot> {
     let mut packages = Vec::new();
     let mut ownership_records = 0_u64;
@@ -104,7 +174,7 @@ fn capture_from_output(
         let requirements = super::parse_rpm_requirement_records(sections[2])?;
         let provides = super::provides::parse_rpm_provide_records(&identity, sections[3])?;
         let lifecycle = parse_lifecycle(sections[4])?;
-        let is_explicit = explicit.contains(&identity.install_reason_selector());
+        let is_explicit = reasons.is_explicit(&identity);
         packages.push(InstalledInventoryPackage {
             identity,
             description: package_record
@@ -127,7 +197,7 @@ fn capture_from_output(
         packages,
         InstalledInventoryWork {
             manager_processes,
-            database_bulk_reads: 1,
+            database_bulk_reads,
             ownership_records,
         },
     )
@@ -283,7 +353,8 @@ mod tests {
     #[test]
     fn rpm_inventory_uses_a_fixed_process_count() {
         let explicit = HashSet::from(["fixture.x86_64".to_string()]);
-        let snapshot = capture_from_output(&output("1.0", "exit 0"), &explicit, 2).unwrap();
+        let reasons = RpmInstallReasonAuthority::DnfExplicit(explicit);
+        let snapshot = capture_from_output(&output("1.0", "exit 0"), &reasons, 2, 1).unwrap();
         let package = snapshot.package("fixture-1.0-1.x86_64").unwrap();
 
         assert_eq!(package.install_reason, NativeInstallReason::Explicit);
@@ -305,8 +376,20 @@ mod tests {
     #[test]
     fn rpm_version_reason_config_and_lifecycle_change_token() {
         let explicit = HashSet::from(["fixture.x86_64".to_string()]);
-        let first = capture_from_output(&output("1.0", "exit 0"), &explicit, 2).unwrap();
-        let second = capture_from_output(&output("2.0", "changed"), &HashSet::new(), 3).unwrap();
+        let first = capture_from_output(
+            &output("1.0", "exit 0"),
+            &RpmInstallReasonAuthority::DnfExplicit(explicit),
+            2,
+            1,
+        )
+        .unwrap();
+        let second = capture_from_output(
+            &output("2.0", "changed"),
+            &RpmInstallReasonAuthority::DnfExplicit(HashSet::new()),
+            2,
+            1,
+        )
+        .unwrap();
 
         assert_ne!(first.token(), second.token());
         assert_eq!(
@@ -316,5 +399,31 @@ mod tests {
                 .install_reason,
             NativeInstallReason::Dependency
         );
+    }
+
+    #[test]
+    fn libzypp_auto_installed_is_exact_dependency_authority() {
+        let automatic = parse_libzypp_auto_installed(
+            "# AutoInstalled generated by libzypp\nfixture\nother-package\n",
+        )
+        .unwrap();
+        let snapshot = capture_from_output(
+            &output("1.0", "exit 0"),
+            &RpmInstallReasonAuthority::LibzyppAutomatic(automatic),
+            1,
+            2,
+        )
+        .unwrap();
+
+        assert_eq!(
+            snapshot
+                .package("fixture-1.0-1.x86_64")
+                .unwrap()
+                .install_reason,
+            NativeInstallReason::Dependency
+        );
+        assert_eq!(snapshot.work().manager_processes, 1);
+        assert_eq!(snapshot.work().database_bulk_reads, 2);
+        assert!(parse_libzypp_auto_installed("bad package\n").is_err());
     }
 }

--- a/crates/conary-core/src/packages/rpm_query/provides.rs
+++ b/crates/conary-core/src/packages/rpm_query/provides.rs
@@ -194,4 +194,28 @@ mod tests {
             Some(ProvideVersionRelation::Equal)
         );
     }
+
+    #[test]
+    fn installed_provides_use_rpm_last_hyphen_dependency_evr_split() {
+        let identity = InstalledPackageIdentity::rpm(
+            "patterns-base-base-20200505-58.1.x86_64",
+            "patterns-base-base",
+            None,
+            "20200505",
+            "58.1",
+            "x86_64",
+        )
+        .unwrap();
+        let output = "pattern-icon()\x1e8\x1epattern-basis-addon\x1f";
+
+        let provides = parse_rpm_provide_records(&identity, output).unwrap();
+
+        assert_eq!(provides.len(), 2);
+        assert_eq!(provides[1].name, "pattern-icon()");
+        assert_eq!(provides[1].version.as_deref(), Some("pattern-basis-addon"));
+        assert_eq!(
+            provides[1].version_relation,
+            Some(ProvideVersionRelation::Equal)
+        );
+    }
 }

--- a/crates/conary-core/src/packages/rpm_query/provides.rs
+++ b/crates/conary-core/src/packages/rpm_query/provides.rs
@@ -169,4 +169,29 @@ mod tests {
         assert!(parse_rpm_provide_records(&identity, "\x1e8\x1e108\x1f").is_err());
         assert!(parse_rpm_provide_records(&identity, "dracut\x1enope\x1e108\x1f").is_err());
     }
+
+    #[test]
+    fn installed_provides_admit_rpm_dependency_boundary_characters() {
+        let identity = InstalledPackageIdentity::rpm(
+            "openSUSE-release-20260811-1.1.x86_64",
+            "openSUSE-release",
+            None,
+            "20260811",
+            "1.1",
+            "x86_64",
+        )
+        .unwrap();
+        let cpe = "cpe%3A%2Fo%3Aopensuse%3Aopensuse%3A20260811";
+        let output = format!("product-cpeid()\x1e8\x1e{cpe}\x1f");
+
+        let provides = parse_rpm_provide_records(&identity, &output).unwrap();
+
+        assert_eq!(provides.len(), 2);
+        assert_eq!(provides[1].name, "product-cpeid()");
+        assert_eq!(provides[1].version.as_deref(), Some(cpe));
+        assert_eq!(
+            provides[1].version_relation,
+            Some(ProvideVersionRelation::Equal)
+        );
+    }
 }

--- a/crates/conary-core/src/packages/rpm_query/provides.rs
+++ b/crates/conary-core/src/packages/rpm_query/provides.rs
@@ -15,7 +15,7 @@ use crate::repository::dependency_model::{
 };
 use crate::repository::versioning::VersionScheme;
 
-const RPM_PROVIDE_RECORD_FORMAT: &str =
+pub(super) const RPM_PROVIDE_RECORD_FORMAT: &str =
     "[%{PROVIDENAME}\x1e%{PROVIDEFLAGS:hex}\x1e%{PROVIDEVERSION}\x1f]";
 
 /// Query one installed RPM package's exact identity and declared provides.
@@ -54,7 +54,7 @@ pub fn query_package_provides(
     Ok(provides)
 }
 
-fn parse_rpm_provide_records(
+pub(super) fn parse_rpm_provide_records(
     identity: &InstalledPackageIdentity,
     output: &str,
 ) -> Result<Vec<ProvidedCapability>> {

--- a/crates/conary-core/src/repository/dependency_model.rs
+++ b/crates/conary-core/src/repository/dependency_model.rs
@@ -220,15 +220,20 @@ impl ProvidedCapability {
             )));
         }
         if let Some(version) = self.version.as_deref() {
-            super::versioning::validate_repo_version(self.version_scheme, version).map_err(
-                |error| {
-                    crate::error::Error::ParseError(format!(
-                        "provided capability '{}' has invalid {} provider version: {error}",
-                        self.name,
-                        self.version_scheme.as_str()
-                    ))
-                },
-            )?;
+            let validation = if self.version_scheme == VersionScheme::Rpm
+                && !matches!(&self.provenance, CapabilityProvenance::ExactIdentity)
+            {
+                super::versioning::validate_rpm_dependency_boundary(version)
+            } else {
+                super::versioning::validate_repo_version(self.version_scheme, version)
+            };
+            validation.map_err(|error| {
+                crate::error::Error::ParseError(format!(
+                    "provided capability '{}' has invalid {} provider version: {error}",
+                    self.name,
+                    self.version_scheme.as_str()
+                ))
+            })?;
         }
         if self.version_scheme != VersionScheme::Rpm
             && self

--- a/crates/conary-core/src/repository/versioning.rs
+++ b/crates/conary-core/src/repository/versioning.rs
@@ -13,6 +13,8 @@ use std::cmp::Ordering;
 use std::str::FromStr;
 use thiserror::Error;
 
+mod rpm_dependency;
+
 /// Which package ecosystem owns a version string's grammar and ordering.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -200,7 +202,7 @@ pub fn validate_repo_version(scheme: VersionScheme, raw: &str) -> VersionResult<
 /// so native capability authority is not narrowed to the package-header
 /// `VERSION`/`RELEASE` grammar.
 pub fn validate_rpm_dependency_boundary(raw: &str) -> VersionResult<()> {
-    validate_rpm_dependency_evr(raw).map_err(|reason| VersionComparisonError::InvalidVersion {
+    rpm_dependency::validate(raw).map_err(|reason| VersionComparisonError::InvalidVersion {
         scheme: VersionScheme::Rpm.as_str(),
         version: raw.to_string(),
         reason,
@@ -375,7 +377,7 @@ pub fn repo_version_satisfies(
     let ordering = if scheme == VersionScheme::Rpm {
         validate_repo_version(scheme, version)?;
         validate_rpm_dependency_boundary(expected)?;
-        rpm_dependency_boundary_cmp(&rpm_evr_parts(version), &rpm_evr_parts(expected))?
+        rpm_dependency_boundary_cmp(version, expected)?
     } else {
         compare_repo_versions(scheme, version, expected)?
     };
@@ -484,9 +486,12 @@ fn rpm_provided_range_overlaps_requirement(
         .expect("all non-Any requirement relations above have a boundary");
     validate_rpm_dependency_boundary(requirement_version)?;
 
-    let provide = rpm_evr_parts(provide_version);
-    let required = rpm_evr_parts(requirement_version);
-    let ordering = rpm_dependency_boundary_cmp(&provide, &required)?;
+    let ordering = rpm_dependency_boundary_cmp(provide_version, requirement_version)?;
+
+    let provide =
+        rpm_dependency::parse(provide_version).expect("validated RPM provided capability boundary");
+    let required =
+        rpm_dependency::parse(requirement_version).expect("validated RPM requirement boundary");
 
     // rpmverOverlap treats a missing release as an intentionally partial EVR:
     // equality on the side without a release overlaps any release at the same
@@ -535,61 +540,14 @@ fn constraint_boundary(constraint: &RepoVersionConstraint) -> Option<&str> {
     }
 }
 
-#[derive(Debug)]
-struct RpmEvrParts<'a> {
-    epoch: Option<&'a str>,
-    version: &'a str,
-    release: Option<&'a str>,
-}
-
-fn rpm_evr_parts(raw: &str) -> RpmEvrParts<'_> {
-    let (epoch, version_release) = raw
-        .split_once(':')
-        .map_or((None, raw), |(epoch, rest)| (Some(epoch), rest));
-    let (version, release) = version_release
-        .split_once('-')
-        .map_or((version_release, None), |(version, release)| {
-            (version, Some(release))
-        });
-    RpmEvrParts {
-        epoch,
-        version,
-        release,
-    }
-}
-
-fn rpm_dependency_boundary_cmp(
-    left: &RpmEvrParts<'_>,
-    right: &RpmEvrParts<'_>,
-) -> VersionResult<Ordering> {
-    let epoch = match (left.epoch, right.epoch) {
-        (Some(left), Some(right)) => left
-            .parse::<u64>()
-            .expect("validated RPM dependency epoch")
-            .cmp(
-                &right
-                    .parse::<u64>()
-                    .expect("validated RPM dependency epoch"),
-            ),
-        (Some(left), None) if left.parse::<u64>().expect("validated RPM epoch") > 0 => {
-            Ordering::Greater
+fn rpm_dependency_boundary_cmp(left: &str, right: &str) -> VersionResult<Ordering> {
+    rpm_dependency::compare(left, right).map_err(|reason| {
+        VersionComparisonError::InvalidConstraint {
+            scheme: VersionScheme::Rpm.as_str(),
+            constraint: format!("{left:?} compared with {right:?}"),
+            reason,
         }
-        (None, Some(right)) if right.parse::<u64>().expect("validated RPM epoch") > 0 => {
-            Ordering::Less
-        }
-        _ => Ordering::Equal,
-    };
-    if epoch != Ordering::Equal {
-        return Ok(epoch);
-    }
-    let version = rpm_version::rpm_evr_compare(left.version, right.version);
-    if version != Ordering::Equal {
-        return Ok(version);
-    }
-    match (left.release, right.release) {
-        (Some(left), Some(right)) => Ok(rpm_version::rpm_evr_compare(left, right)),
-        _ => Ok(Ordering::Equal),
-    }
+    })
 }
 
 const fn relation_includes_less(relation: ProvideVersionRelation) -> bool {
@@ -788,64 +746,6 @@ fn validate_rpm_evr(raw: &str) -> std::result::Result<(), String> {
     Ok(())
 }
 
-/// Validate RPM's documented dependency `[epoch:]version[-release]` grammar.
-fn validate_rpm_dependency_evr(raw: &str) -> std::result::Result<(), String> {
-    if raw.is_empty() {
-        return Err("version is empty".to_string());
-    }
-    if raw.trim() != raw {
-        return Err("leading or trailing whitespace is not allowed".to_string());
-    }
-
-    let version_release = match raw.split_once(':') {
-        Some((epoch, rest)) => {
-            if epoch.is_empty() || !epoch.bytes().all(|byte| byte.is_ascii_digit()) {
-                return Err("epoch must be a non-empty decimal integer".to_string());
-            }
-            epoch
-                .parse::<u64>()
-                .map_err(|_| "epoch exceeds the supported integer range".to_string())?;
-            rest
-        }
-        None => raw,
-    };
-    if version_release.contains(':') {
-        return Err("multiple epoch separators are not allowed".to_string());
-    }
-    let (version, release) = match version_release.split_once('-') {
-        Some((version, release)) => {
-            if release.contains('-') {
-                return Err("release must not contain '-'".to_string());
-            }
-            (version, Some(release))
-        }
-        None => (version_release, None),
-    };
-    validate_rpm_dependency_component(version, "version")?;
-    if let Some(release) = release {
-        validate_rpm_dependency_component(release, "release")?;
-    }
-    Ok(())
-}
-
-fn validate_rpm_dependency_component(
-    component: &str,
-    name: &str,
-) -> std::result::Result<(), String> {
-    if component.is_empty() {
-        return Err(format!("{name} component is empty"));
-    }
-    if component
-        .chars()
-        .any(|character| character == '-' || character.is_whitespace() || character.is_control())
-    {
-        return Err(format!(
-            "{name} contains a hyphen, whitespace, or control character"
-        ));
-    }
-    Ok(())
-}
-
 fn validate_rpm_component(component: &str, name: &str) -> std::result::Result<(), String> {
     if component.is_empty() {
         return Err(format!("{name} component is empty"));
@@ -977,8 +877,9 @@ mod tests {
             )
             .unwrap()
         );
+        validate_rpm_dependency_boundary("pattern-basis-addon").unwrap();
 
-        for invalid in ["", " 1", "1 ", "1 2", "1-", "1-2-3", "bad:1", "1:2:3"] {
+        for invalid in ["", " 1", "1 ", "1 2", "1-", "bad:1", "1:2:3"] {
             assert!(
                 validate_rpm_dependency_boundary(invalid).is_err(),
                 "RPM dependency boundary admitted {invalid:?}"

--- a/crates/conary-core/src/repository/versioning.rs
+++ b/crates/conary-core/src/repository/versioning.rs
@@ -193,6 +193,20 @@ pub fn validate_repo_version(scheme: VersionScheme, raw: &str) -> VersionResult<
     }
 }
 
+/// Validate an RPM dependency EVR boundary.
+///
+/// RPM dependency records deliberately admit a broader version and release
+/// alphabet than package identity fields. Keep that source grammar separate
+/// so native capability authority is not narrowed to the package-header
+/// `VERSION`/`RELEASE` grammar.
+pub fn validate_rpm_dependency_boundary(raw: &str) -> VersionResult<()> {
+    validate_rpm_dependency_evr(raw).map_err(|reason| VersionComparisonError::InvalidVersion {
+        scheme: VersionScheme::Rpm.as_str(),
+        version: raw.to_string(),
+        reason,
+    })
+}
+
 /// Compare two versions using only the parser and comparator owned by `scheme`.
 pub fn compare_repo_versions(scheme: VersionScheme, a: &str, b: &str) -> VersionResult<Ordering> {
     match scheme {
@@ -289,12 +303,15 @@ pub fn parse_repo_constraint(
             reason: "missing version operand".to_string(),
         });
     }
-    validate_repo_version(scheme, version).map_err(|error| {
-        VersionComparisonError::InvalidConstraint {
-            scheme: scheme.as_str(),
-            constraint: raw.to_string(),
-            reason: error.to_string(),
-        }
+    let validation = if scheme == VersionScheme::Rpm {
+        validate_rpm_dependency_boundary(version)
+    } else {
+        validate_repo_version(scheme, version)
+    };
+    validation.map_err(|error| VersionComparisonError::InvalidConstraint {
+        scheme: scheme.as_str(),
+        constraint: raw.to_string(),
+        reason: error.to_string(),
     })?;
 
     Ok(operator.build(version.to_string()))
@@ -355,7 +372,13 @@ pub fn repo_version_satisfies(
         | RepoVersionConstraint::NotEqual(expected) => expected,
         RepoVersionConstraint::Eopkg(_) => unreachable!("handled above"),
     };
-    let ordering = compare_repo_versions(scheme, version, expected)?;
+    let ordering = if scheme == VersionScheme::Rpm {
+        validate_repo_version(scheme, version)?;
+        validate_rpm_dependency_boundary(expected)?;
+        rpm_dependency_boundary_cmp(&rpm_evr_parts(version), &rpm_evr_parts(expected))?
+    } else {
+        compare_repo_versions(scheme, version, expected)?
+    };
     Ok(match constraint {
         RepoVersionConstraint::Any => unreachable!("handled above"),
         RepoVersionConstraint::Exact(_) => ordering == Ordering::Equal,
@@ -404,7 +427,11 @@ pub fn provided_range_matches_requirement(
         });
     };
     let provide_version = provide_version.expect("relation and version pairing checked above");
-    validate_repo_version(scheme, provide_version)?;
+    if scheme == VersionScheme::Rpm {
+        validate_rpm_dependency_boundary(provide_version)?;
+    } else {
+        validate_repo_version(scheme, provide_version)?;
+    }
 
     if matches!(requirement, RepoVersionConstraint::Any) {
         return Ok(true);
@@ -455,7 +482,7 @@ fn rpm_provided_range_overlaps_requirement(
     };
     let requirement_version = constraint_boundary(requirement)
         .expect("all non-Any requirement relations above have a boundary");
-    validate_repo_version(VersionScheme::Rpm, requirement_version)?;
+    validate_rpm_dependency_boundary(requirement_version)?;
 
     let provide = rpm_evr_parts(provide_version);
     let required = rpm_evr_parts(requirement_version);
@@ -536,7 +563,14 @@ fn rpm_dependency_boundary_cmp(
     right: &RpmEvrParts<'_>,
 ) -> VersionResult<Ordering> {
     let epoch = match (left.epoch, right.epoch) {
-        (Some(left), Some(right)) => compare_repo_versions(VersionScheme::Rpm, left, right)?,
+        (Some(left), Some(right)) => left
+            .parse::<u64>()
+            .expect("validated RPM dependency epoch")
+            .cmp(
+                &right
+                    .parse::<u64>()
+                    .expect("validated RPM dependency epoch"),
+            ),
         (Some(left), None) if left.parse::<u64>().expect("validated RPM epoch") > 0 => {
             Ordering::Greater
         }
@@ -548,12 +582,12 @@ fn rpm_dependency_boundary_cmp(
     if epoch != Ordering::Equal {
         return Ok(epoch);
     }
-    let version = compare_repo_versions(VersionScheme::Rpm, left.version, right.version)?;
+    let version = rpm_version::rpm_evr_compare(left.version, right.version);
     if version != Ordering::Equal {
         return Ok(version);
     }
     match (left.release, right.release) {
-        (Some(left), Some(right)) => compare_repo_versions(VersionScheme::Rpm, left, right),
+        (Some(left), Some(right)) => Ok(rpm_version::rpm_evr_compare(left, right)),
         _ => Ok(Ordering::Equal),
     }
 }
@@ -754,6 +788,64 @@ fn validate_rpm_evr(raw: &str) -> std::result::Result<(), String> {
     Ok(())
 }
 
+/// Validate RPM's documented dependency `[epoch:]version[-release]` grammar.
+fn validate_rpm_dependency_evr(raw: &str) -> std::result::Result<(), String> {
+    if raw.is_empty() {
+        return Err("version is empty".to_string());
+    }
+    if raw.trim() != raw {
+        return Err("leading or trailing whitespace is not allowed".to_string());
+    }
+
+    let version_release = match raw.split_once(':') {
+        Some((epoch, rest)) => {
+            if epoch.is_empty() || !epoch.bytes().all(|byte| byte.is_ascii_digit()) {
+                return Err("epoch must be a non-empty decimal integer".to_string());
+            }
+            epoch
+                .parse::<u64>()
+                .map_err(|_| "epoch exceeds the supported integer range".to_string())?;
+            rest
+        }
+        None => raw,
+    };
+    if version_release.contains(':') {
+        return Err("multiple epoch separators are not allowed".to_string());
+    }
+    let (version, release) = match version_release.split_once('-') {
+        Some((version, release)) => {
+            if release.contains('-') {
+                return Err("release must not contain '-'".to_string());
+            }
+            (version, Some(release))
+        }
+        None => (version_release, None),
+    };
+    validate_rpm_dependency_component(version, "version")?;
+    if let Some(release) = release {
+        validate_rpm_dependency_component(release, "release")?;
+    }
+    Ok(())
+}
+
+fn validate_rpm_dependency_component(
+    component: &str,
+    name: &str,
+) -> std::result::Result<(), String> {
+    if component.is_empty() {
+        return Err(format!("{name} component is empty"));
+    }
+    if component
+        .chars()
+        .any(|character| character == '-' || character.is_whitespace() || character.is_control())
+    {
+        return Err(format!(
+            "{name} contains a hyphen, whitespace, or control character"
+        ));
+    }
+    Ok(())
+}
+
 fn validate_rpm_component(component: &str, name: &str) -> std::result::Result<(), String> {
     if component.is_empty() {
         return Err(format!("{name} component is empty"));
@@ -866,6 +958,32 @@ mod tests {
         assert!(!repo_version_satisfies(VersionScheme::Arch, "1.0-9", &arch).unwrap());
 
         assert!(parse_repo_constraint(VersionScheme::Rpm, ">= broken:1.0").is_err());
+    }
+
+    #[test]
+    fn rpm_dependency_boundaries_keep_their_broader_source_grammar() {
+        let cpe = "cpe%3A%2Fo%3Aopensuse%3Aopensuse%3A20260811";
+
+        assert!(validate_repo_version(VersionScheme::Rpm, cpe).is_err());
+        validate_rpm_dependency_boundary(cpe).unwrap();
+        let requirement = parse_repo_constraint(VersionScheme::Rpm, &format!("= {cpe}"))
+            .expect("RPM dependency constraint");
+        assert!(
+            provided_range_matches_requirement(
+                VersionScheme::Rpm,
+                Some(ProvideVersionRelation::Equal),
+                Some(cpe),
+                &requirement,
+            )
+            .unwrap()
+        );
+
+        for invalid in ["", " 1", "1 ", "1 2", "1-", "1-2-3", "bad:1", "1:2:3"] {
+            assert!(
+                validate_rpm_dependency_boundary(invalid).is_err(),
+                "RPM dependency boundary admitted {invalid:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/conary-core/src/repository/versioning/rpm_dependency.rs
+++ b/crates/conary-core/src/repository/versioning/rpm_dependency.rs
@@ -1,0 +1,131 @@
+// conary-core/src/repository/versioning/rpm_dependency.rs
+
+//! RPM dependency EVR grammar and `rpmdsCompare` component ordering.
+
+use std::cmp::Ordering;
+
+/// RPM's parsed dependency boundary.
+///
+/// Unlike package `VERSION` and `RELEASE` fields, dependency EVRs found in
+/// installed headers can retain multiple hyphens. RPM 4.20's `parseEVR()`
+/// treats the final hyphen as the release separator and leaves earlier
+/// hyphens in the version component:
+/// https://github.com/rpm-software-management/rpm/blob/c8dc5ea575a2e9c1488036d12f4b75f6a5a49120/rpmio/rpmver.c#L24-L57
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct RpmDependencyEvr<'a> {
+    epoch: Option<u64>,
+    version: &'a str,
+    pub(super) release: Option<&'a str>,
+}
+
+pub(super) fn validate(raw: &str) -> Result<(), String> {
+    parse(raw).map(|_| ())
+}
+
+pub(super) fn parse(raw: &str) -> Result<RpmDependencyEvr<'_>, String> {
+    if raw.is_empty() {
+        return Err("version is empty".to_string());
+    }
+    if raw
+        .chars()
+        .any(|character| character.is_whitespace() || character.is_control())
+    {
+        return Err("whitespace and control characters are not allowed".to_string());
+    }
+    if let Some(character) = raw.chars().find(|character| {
+        character.is_ascii()
+            && !(character.is_ascii_alphanumeric()
+                || matches!(
+                    character,
+                    '.' | '_' | '+' | '%' | '{' | '}' | '~' | '^' | '-' | ':'
+                ))
+    }) {
+        return Err(format!(
+            "character {character:?} is outside RPM's dependency EVR grammar"
+        ));
+    }
+
+    let (epoch, version_release) = match raw.split_once(':') {
+        Some((epoch, rest)) => {
+            if rest.contains(':') {
+                return Err("multiple epoch separators are not allowed".to_string());
+            }
+            if epoch.is_empty() || !epoch.bytes().all(|byte| byte.is_ascii_digit()) {
+                return Err("epoch must be a non-empty decimal integer".to_string());
+            }
+            let epoch = epoch
+                .parse::<u64>()
+                .map_err(|_| "epoch exceeds the supported integer range".to_string())?;
+            (Some(epoch), rest)
+        }
+        None => (None, raw),
+    };
+    let (version, release) = version_release
+        .rsplit_once('-')
+        .map_or((version_release, None), |(version, release)| {
+            (version, Some(release))
+        });
+    if version.is_empty() {
+        return Err("version component is empty".to_string());
+    }
+    if release.is_some_and(str::is_empty) {
+        return Err("release component is empty".to_string());
+    }
+
+    Ok(RpmDependencyEvr {
+        epoch,
+        version,
+        release,
+    })
+}
+
+pub(super) fn compare(left: &str, right: &str) -> Result<Ordering, String> {
+    let left = parse(left)?;
+    let right = parse(right)?;
+    let epoch = match (left.epoch, right.epoch) {
+        (Some(left), Some(right)) => left.cmp(&right),
+        (Some(left), None) if left > 0 => Ordering::Greater,
+        (None, Some(right)) if right > 0 => Ordering::Less,
+        _ => Ordering::Equal,
+    };
+    if epoch != Ordering::Equal {
+        return Ok(epoch);
+    }
+    let version = rpm_version::rpm_evr_compare(left.version, right.version);
+    if version != Ordering::Equal {
+        return Ok(version);
+    }
+    match (left.release, right.release) {
+        (Some(left), Some(right)) => Ok(rpm_version::rpm_evr_compare(left, right)),
+        _ => Ok(Ordering::Equal),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dependency_evr_uses_rpm_last_hyphen_split() {
+        let parsed = parse("pattern-basis-addon").unwrap();
+
+        assert_eq!(parsed.epoch, None);
+        assert_eq!(parsed.version, "pattern-basis");
+        assert_eq!(parsed.release, Some("addon"));
+    }
+
+    #[test]
+    fn dependency_evr_preserves_encoded_source_boundaries() {
+        let cpe = parse("cpe%3A%2Fo%3Aopensuse%3Aopensuse%3A20260811").unwrap();
+
+        assert_eq!(cpe.version, "cpe%3A%2Fo%3Aopensuse%3Aopensuse%3A20260811");
+        assert_eq!(cpe.release, None);
+    }
+
+    #[test]
+    fn dependency_evr_rejects_unrepresentable_boundaries() {
+        for invalid in ["", " 1", "1 ", "1 2", "1-", "bad:1", "1:2:3", "1/2"] {
+            assert!(parse(invalid).is_err(), "accepted {invalid:?}");
+        }
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-14
-revision: 53
-summary: Describe workspace and release boundaries, exact native source authority, package transactions, typed generation database snapshots, lifecycle execution, carrier security, generation GC, and service boundaries
+revision: 54
+summary: Describe workspace and release boundaries, coherent native inventory adoption, exact native source authority, package transactions, typed generation database snapshots, lifecycle execution, carrier security, generation GC, and service boundaries
 ---
 
 # Conary Architecture
@@ -440,6 +440,17 @@ publish gates land.
 Conary can build and select immutable system-generation artifacts using EROFS
 images and Linux composefs. This remains an advanced, explicitly gated path in
 the limited preview.
+
+Native adoption begins with the source-independent
+`packages::InstalledInventorySnapshot` authority. RPM, dpkg, pacman, and eopkg
+adapters each populate exact package identities, path owners, install reasons,
+relations, configuration/lifecycle evidence, fixed-work counters, and one
+deterministic snapshot token through a package-count-independent number of
+manager/database reads. Single-package adoption, bulk adoption, refresh, and
+takeover consume that authority rather than package-local queries. They
+reacquire it immediately before commit or ownership handoff; token drift aborts
+before authority changes. Takeover removes exact native identities as one
+database-only batch where the manager supports transactional batch removal.
 
 Full system adoption establishes the first complete generation input without
 turning unowned host state into package ownership. One exact selected-root scan

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -254,7 +254,9 @@ commands.
   `inventory.rs`. Adoption, refresh, and takeover consume one exact tokenized
   snapshot; complete full-system adoption binds all package owners to one
   selected-root traversal and takeover performs one native database-removal
-  batch.
+  batch. RPM dependency-EVR parsing and `rpmdsCompare` component ordering live
+  in `crates/conary-core/src/repository/versioning/rpm_dependency.rs`; the
+  public cross-ecosystem dispatch remains in `repository/versioning.rs`.
 - Complete unfiltered full-system adoption starts in
   `apps/conary/src/commands/adopt/system.rs`; its exact unowned-root partition
   is owned by `adopt/system/captured_root.rs`, the finite scanner and runtime

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-14
-revision: 72
-summary: Route workspace and release boundaries, typed database rebuilds, generation snapshots and recovery deltas, exact native source identity and adopted-artifact conversion, lossless source authority and trust-import planning, exact Remi signing, selected-root mutation, rollback lineage, canonical-map authority, carrier security, generation GC, and subsystem proof through current feature owners.
+revision: 73
+summary: Route workspace and release boundaries, coherent native inventory adoption, typed database rebuilds, generation snapshots and recovery deltas, exact native source identity and adopted-artifact conversion, lossless source authority and trust-import planning, exact Remi signing, selected-root mutation, rollback lineage, canonical-map authority, carrier security, generation GC, and subsystem proof through current feature owners.
 ---
 
 # Assistant Subsystem Map
@@ -249,6 +249,12 @@ commands.
   `runtime` component.
 - Adoption preserves native package-manager authority until explicit takeover or
   selected-generation handoff.
+- Coherent RPM, dpkg, pacman, and eopkg installed-state acquisition starts in
+  `crates/conary-core/src/packages/installed_inventory.rs` and each manager's
+  `inventory.rs`. Adoption, refresh, and takeover consume one exact tokenized
+  snapshot; complete full-system adoption binds all package owners to one
+  selected-root traversal and takeover performs one native database-removal
+  batch.
 - Complete unfiltered full-system adoption starts in
   `apps/conary/src/commands/adopt/system.rs`; its exact unowned-root partition
   is owned by `adopt/system/captured_root.rs`, the finite scanner and runtime

--- a/docs/modules/source-selection.md
+++ b/docs/modules/source-selection.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-08-12
-revision: 39
-summary: Document opaque native source identity, exact native trust takeover, capability-driven targets, Remi feed presets, and lifecycle handoff
+last_updated: 2026-08-14
+revision: 40
+summary: Document coherent native inventory adoption, opaque native source identity, exact native trust takeover, capability-driven targets, Remi feed presets, and lifecycle handoff
 ---
 
 # Source Selection Module (conary-core/src/repository/ + conary-core/src/model/)
@@ -593,9 +593,13 @@ The completed filesystem is never scanned for repository-looking files.
 
 `conary system adopt <pkg> --dry-run` builds the same package-specific plan
 that apply consumes. The preview opens an existing current-schema database
-read-only and never migrates it. Native discovery resolves the exact installed
-package identity, version, and architecture, then inventories files,
-dependencies, provides, existing Conary tracking, and tracked-file ownership.
+read-only and never migrates it. Native discovery captures one typed
+`InstalledInventorySnapshot` for the selected RPM, dpkg, pacman, or eopkg
+authority. Each backend uses a fixed number of manager processes and bulk
+database traversals independent of package count. The snapshot owns exact
+identities, versions, architectures, install reasons, files, dependencies,
+provides, configuration/lifecycle evidence, the complete path-to-owner map,
+and a deterministic token over every mutation-relevant field.
 
 Each requested package is classified as ready, already tracked, missing,
 ambiguous, unsupported, or blocked by a tracked-file conflict. Shared
@@ -633,23 +637,36 @@ package manager or its database.
 
 System-wide adoption preserves the native manager's explicit-versus-dependency
 reason for every installed package. On RPM systems, Conary uses each
-generation's documented DNF contract rather than reading DNF's internal state:
-DNF5's `repoquery --userinstalled` is itself an installed-only selector, while
-DNF4 composes `repoquery --installed --userinstalled`. Configured excludes are
-disabled through the corresponding generation's documented option. A missing
-manager or malformed result is a typed failure; Conary never treats every RPM
-as explicitly installed.
+generation's documented frontend authority. DNF5's
+`repoquery --userinstalled` is itself an installed-only selector, while DNF4
+composes `repoquery --installed --userinstalled`. Configured excludes are
+disabled through the corresponding generation's documented option. RPM hosts
+without DNF use libzypp's exact `/var/lib/zypp/AutoInstalled` `SolvIdentFile`;
+each listed package ident is dependency-installed and every absent installed
+ident is explicit. A missing authority or malformed result is a typed failure;
+Conary never treats every RPM as explicitly installed.
 
 Apply consumes that plan, rechecks file ownership inside its database
-transaction, and only then writes checkpoints, package metadata, CAS objects,
-changesets, and the state snapshot. Track and full adoption both preserve
-native package-manager authority until an explicit takeover or
-selected-generation handoff.
+transaction, and reacquires the complete native inventory immediately before
+commit. Any package, version, ownership, reason, relation, configuration, or
+lifecycle token change aborts the transaction before handoff. Only an unchanged
+snapshot may write checkpoints, package metadata, CAS objects, changesets, and
+the state snapshot. Track and full adoption both preserve native
+package-manager authority until an explicit takeover or selected-generation
+handoff. Takeover consumes the same snapshot from planning through CAS upgrade,
+revalidates it before transfer, and removes complete RPM, dpkg, pacman, or
+eopkg identity sets through one database-only batch transaction where the
+manager supports it.
 
-Complete, unfiltered `conary system adopt --system --full` additionally scans
-the selected root once, after all native package payload captures succeed. The
-scan captures each walked node through a bounded pointwise-stable descriptor
-window, then derives global hardlink topology from the captured snapshots. It
+Complete, unfiltered `conary system adopt --system --full` scans the selected
+root exactly once. Package claims bind to that one path-indexed capture rather
+than rereading their declared file lists. The scanner reports paths examined,
+unique regular inodes, and content streams; every hardlinked inode is read into
+CAS once, and its global typed topology is retained even when different native
+packages own different links. Shared directories retain every exact package
+owner, and unowned content is classified during the same traversal. The scan
+captures each walked node through a bounded pointwise-stable descriptor window,
+then derives global hardlink topology from the captured snapshots. It
 uses the same finite publication domains as generation construction: `/etc` is
 config state, `/var` and `/srv` are mutable state, and other retained top-level
 paths are immutable generation input. `/proc`, `/sys`, `/dev`, `/run`, `/tmp`,

--- a/docs/specs/foreign-package-lifecycle-contracts.md
+++ b/docs/specs/foreign-package-lifecycle-contracts.md
@@ -934,6 +934,11 @@ scheme, relation, and EVR boundary from the header. `<`, `<=`, `=`, `>=`, and
 overlap, including inclusive/exclusive endpoints, unversioned existence
 provides, and RPM's partial-EVR equality behavior. It never substitutes the
 owning package EVR or reinterprets the range through another ecosystem.
+Dependency EVR decomposition follows RPM's `parseEVR()` boundary: the final
+hyphen separates release, while earlier hyphens remain part of the version.
+This is intentionally broader than package-header `VERSION` and `RELEASE`
+identity grammar because authentic installed dependency headers retain such
+boundaries.
 
 RPM rich requirements are typed source ABI, not text to split later. The
 parser is pinned to RPM


### PR DESCRIPTION
## Problem

Full-system adoption assembled identity, ownership, install reason, relations, and provides through package-count-scaled native-manager queries with no common token. Takeover repeated those reads and launched package-local native database removal.

## Outcome

- adds one source-independent `InstalledInventorySnapshot` with exact identities, normalized owners, multiarch variants, install reasons, requirements/provides, source-specific config/lifecycle authority, deterministic token, and fixed-work counters
- populates it through fixed-work RPM, dpkg, pacman, and eopkg adapters
- makes single-package adoption, full adoption, refresh, CAS upgrade, planning, and ownership transfer consume that coherent authority
- reacquires and compares the exact token immediately before commit or handoff
- binds complete full-system adoption to one selected-root traversal, one CAS content stream per regular inode, global cross-package hardlink topology, shared-directory owners, and same-pass unowned-root classification
- removes complete RPM, dpkg, pacman, and eopkg identity sets in one database-only batch where supported
- fixes exact backend evidence found by CI: dpkg root anchors and modern `newconffile`/`obsolete`/`remove-on-upgrade` conffile authority, empty and unavailable ALPM backup-digest states, libzypp `AutoInstalled` reason authority, and RPM dependency EVR parsing at the final hyphen
- makes the dpkg live-host preview fixture select its intended native authority explicitly, so an unrelated installed `rpm` client cannot redirect the test
- preserves committed dpkg database authority when ancillary info-file cleanup reports an error
- adds small and distribution-sized inventory benchmarks under #121

## Verification

- `cargo test --workspace --lib --tests --bins --quiet` — exit 0 on exact head; benchmarks deliberately excluded
- `cargo test -p conary-core --lib --quiet` — 3,627 passed, 5 ignored, 0 failed
- `cargo test -p conary --test query_scripts` — 15 passed, 0 failed
- focused ALPM inventory (5 passed), repository versioning (14 passed), and installed RPM provides (4 passed)
- `cargo clippy -p conary-core --lib -- -D warnings` — exit 0
- `cargo fmt --all -- --check` — exit 0
- `bash scripts/check-doc-truth.sh` — passed
- focused adoption, takeover, backend snapshot, mutation-token, multiarch, and selected-root hardlink regressions passed on the prior implementation head
- retained benchmark evidence from the implementation head: 100 packages, 784.01–794.57 us; 2,500 packages, 22.457–22.663 ms
- hosted PR gate is required to finish at exact head `b4b690ddbda84f3ac7c31aad6ca7d1837d8d2b7c`

The benchmark and selected-generation takeover/QEMU interaction lanes were not rerun because the CI repair changed only typed native metadata parsing and its focused tests; their existing evidence remains unchanged.

Refs #411
