### PR TITLE
perf(db): stage package transaction rows

### DIFF
--- a/apps/conary/src/commands/adopt/packages.rs
+++ b/apps/conary/src/commands/adopt/packages.rs
@@ -12,8 +12,8 @@ use std::path::Path;
 use anyhow::{Context, Result, anyhow, bail};
 use conary_core::db::backup::CheckpointReason;
 use conary_core::db::models::{
-    Changeset, ChangesetStatus, ExistingDirectoryMaterialization, FileEntry, InstallReason,
-    InstallSource, Trove, TroveType,
+    Changeset, ChangesetStatus, FileEntry, InstallReason, InstallSource, PackageTransactionStaging,
+    StagedAnchorDisposition, StagedPayloadRow, Trove, TroveType,
 };
 use conary_core::packages::{
     InstalledInventorySnapshot, InstalledPackageIdentity, NativeInstallReason, SystemPackageManager,
@@ -868,20 +868,35 @@ fn execute_adoption_plan(
             let trove_id = trove.insert(tx)?;
 
             progress.set_phase(selector, AdoptPhase::Inserting);
+            let mut package_rows = PackageTransactionStaging::begin(tx)?;
             for captured in &captured_files {
                 let file_path = &captured.source.0;
-                let mut file_entry = captured.file_entry(trove_id);
-                file_entry
-                    .insert_or_replace(
-                        tx,
-                        ExistingDirectoryMaterialization::ApplyIncoming,
-                    )
+                package_rows
+                    .stage_payload(&StagedPayloadRow {
+                        entry: captured.file_entry(trove_id),
+                        package_name: identity.native.name().to_string(),
+                        component_name: None,
+                        directory_materialization:
+                            conary_core::db::models::ExistingDirectoryMaterialization::ApplyIncoming,
+                        disposition: StagedAnchorDisposition::Auto,
+                        selected_root_node: None,
+                        materialization_target_path: None,
+                        history: None,
+                    })
                     .map_err(|error| {
                         conary_core::Error::ConfigError(format!(
                             "failed to persist exact adopted payload authority for {file_path}: {error}"
                         ))
                     })?;
             }
+            package_rows.validate_and_reconcile()?;
+            let sqlite_work = package_rows.finish()?;
+            tracing::debug!(
+                rows_loaded = sqlite_work.rows_loaded,
+                statements = sqlite_work.total_statement_executions(),
+                query_shapes = sqlite_work.query_shapes,
+                "reconciled staged adoption package rows"
+            );
 
             super::requirements::insert_package_requirements(
                 tx,

--- a/apps/conary/src/commands/adopt/refresh.rs
+++ b/apps/conary/src/commands/adopt/refresh.rs
@@ -14,7 +14,8 @@ use crate::commands::AdoptionWarning;
 use anyhow::Result;
 use conary_core::db::backup::CheckpointReason;
 use conary_core::db::models::{
-    Changeset, ChangesetStatus, ExistingDirectoryMaterialization, InstallSource, Trove,
+    Changeset, ChangesetStatus, InstallSource, PackageTransactionStaging, StagedAnchorDisposition,
+    StagedPayloadRow, Trove,
 };
 use conary_core::packages::{
     InstalledInventorySnapshot, InstalledPackageIdentity, SystemPackageManager,
@@ -525,16 +526,35 @@ fn replace_refresh_children_for_package(
             ));
         }
 
+        let mut package_rows = PackageTransactionStaging::begin(tx)?;
         for captured in &replacement.files {
             let file_path = &captured.source.0;
-            let mut fe = captured.file_entry(trove_id);
-            fe.insert_or_replace(tx, ExistingDirectoryMaterialization::ApplyIncoming)
+            package_rows
+                .stage_payload(&StagedPayloadRow {
+                    entry: captured.file_entry(trove_id),
+                    package_name: trove_name.to_string(),
+                    component_name: None,
+                    directory_materialization:
+                        conary_core::db::models::ExistingDirectoryMaterialization::ApplyIncoming,
+                    disposition: StagedAnchorDisposition::Auto,
+                    selected_root_node: None,
+                    materialization_target_path: None,
+                    history: None,
+                })
                 .map_err(|e| {
                     anyhow::anyhow!(
                         "failed to insert refreshed file {file_path} for {trove_name}: {e}"
                     )
                 })?;
         }
+        package_rows.validate_and_reconcile()?;
+        let sqlite_work = package_rows.finish()?;
+        tracing::debug!(
+            rows_loaded = sqlite_work.rows_loaded,
+            statements = sqlite_work.total_statement_executions(),
+            query_shapes = sqlite_work.query_shapes,
+            "reconciled staged adoption refresh rows"
+        );
 
         super::requirements::replace_package_requirements(
             tx,

--- a/apps/conary/src/commands/adopt/system.rs
+++ b/apps/conary/src/commands/adopt/system.rs
@@ -16,8 +16,8 @@ use super::outcome::{BulkAdoptionFailure, BulkAdoptionFailureStage, BulkAdoption
 use anyhow::Result;
 use conary_core::db::backup::CheckpointReason;
 use conary_core::db::models::{
-    Changeset, ChangesetStatus, FileEntry, InstallReason, InstallSource, PackageTransactionStaging,
-    PayloadClaim, StagedAnchorDisposition, StagedPayloadRow, Trove, TroveType,
+    Changeset, ChangesetStatus, InstallReason, InstallSource, PackageTransactionStaging,
+    StagedAnchorDisposition, StagedPayloadRow, Trove, TroveType,
 };
 use conary_core::packages::{
     InstalledFileAbsencePolicy, InstalledInventoryFile, InstalledInventorySnapshot,
@@ -429,11 +429,18 @@ pub async fn cmd_adopt_system(
             let selector = pkg.identity.selector();
             let persisted = execute_package_savepoint(tx, || {
                 if let Some(trove_id) = pkg.promote_trove_id {
-                    promote_track_package(tx, changeset_id, &pkg.identity, trove_id, &pkg.files)
-                        .map_err(|error| PackagePersistenceFailure {
-                            stage: BulkAdoptionFailureStage::MetadataInsert,
-                            message: error.to_string(),
-                        })?;
+                    promote_track_package(
+                        tx,
+                        &mut package_rows,
+                        changeset_id,
+                        &pkg.identity,
+                        trove_id,
+                        &pkg.files,
+                    )
+                    .map_err(|error| PackagePersistenceFailure {
+                        stage: BulkAdoptionFailureStage::MetadataInsert,
+                        message: error.to_string(),
+                    })?;
                     return Ok::<bool, PackagePersistenceFailure>(true);
                 }
 
@@ -620,7 +627,8 @@ pub async fn cmd_adopt_system(
 }
 
 fn promote_track_package(
-    tx: &rusqlite::Connection,
+    tx: &rusqlite::Transaction<'_>,
+    package_rows: &mut PackageTransactionStaging<'_>,
     changeset_id: i64,
     identity: &InstalledPackageIdentity,
     trove_id: i64,
@@ -641,32 +649,21 @@ fn promote_track_package(
         )));
     }
 
+    package_rows.clear()?;
     for captured in files {
-        let path = &captured.source.0;
-        let existing = FileEntry::find_by_path(tx, path)?.ok_or_else(|| {
-            conary_core::Error::NotFound(format!(
-                "track-only package {} lost its file authority for {path}",
-                identity.selector()
-            ))
+        package_rows.stage_payload(&StagedPayloadRow {
+            entry: captured.file_entry(trove_id),
+            package_name: identity.name().to_string(),
+            component_name: None,
+            directory_materialization:
+                conary_core::db::models::ExistingDirectoryMaterialization::ApplyIncoming,
+            disposition: StagedAnchorDisposition::ReconcileOwned,
+            selected_root_node: None,
+            materialization_target_path: None,
+            history: None,
         })?;
-        let owns_path = existing.trove_id == trove_id
-            || PayloadClaim::find_by_path(tx, path)?
-                .iter()
-                .any(|claim| claim.trove_id == trove_id);
-        if !owns_path {
-            return Err(conary_core::Error::ConflictError(format!(
-                "track-only package {} no longer owns {path}",
-                identity.selector()
-            )));
-        }
-        FileEntry::replace_claimed_selected_root_materialization(
-            tx,
-            path,
-            trove_id,
-            &captured.node,
-            captured.content.as_ref(),
-        )?;
     }
+    package_rows.validate_and_reconcile()?;
 
     let updated = tx.execute(
         "UPDATE troves
@@ -706,6 +703,7 @@ pub(super) fn inventory_file_tuple(file: &InstalledInventoryFile) -> FileInfoTup
 #[cfg(test)]
 mod tests {
     use super::*;
+    use conary_core::db::models::FileEntry;
     use conary_core::payload::{PayloadContentAuthority, PayloadNode, ResolvedPayloadNode};
 
     #[test]
@@ -843,7 +841,17 @@ mod tests {
         let tx = conn.transaction().unwrap();
         let mut changeset = Changeset::new("promote fixture".to_string());
         let changeset_id = changeset.insert(&tx).unwrap();
-        promote_track_package(&tx, changeset_id, &identity, trove_id, &[captured]).unwrap();
+        let mut package_rows = PackageTransactionStaging::begin(&tx).unwrap();
+        promote_track_package(
+            &tx,
+            &mut package_rows,
+            changeset_id,
+            &identity,
+            trove_id,
+            &[captured],
+        )
+        .unwrap();
+        package_rows.finish().unwrap();
         changeset
             .update_status(&tx, ChangesetStatus::Applied)
             .unwrap();

--- a/apps/conary/src/commands/adopt/system.rs
+++ b/apps/conary/src/commands/adopt/system.rs
@@ -16,8 +16,8 @@ use super::outcome::{BulkAdoptionFailure, BulkAdoptionFailureStage, BulkAdoption
 use anyhow::Result;
 use conary_core::db::backup::CheckpointReason;
 use conary_core::db::models::{
-    Changeset, ChangesetStatus, ExistingDirectoryMaterialization, FileEntry, InstallReason,
-    InstallSource, PayloadClaim, Trove, TroveType,
+    Changeset, ChangesetStatus, FileEntry, InstallReason, InstallSource, PackageTransactionStaging,
+    PayloadClaim, StagedAnchorDisposition, StagedPayloadRow, Trove, TroveType,
 };
 use conary_core::packages::{
     InstalledFileAbsencePolicy, InstalledInventoryFile, InstalledInventorySnapshot,
@@ -423,6 +423,7 @@ pub async fn cmd_adopt_system(
     let mut captured_root_sync = None;
     let changeset_id = conary_core::db::transaction(&mut conn, |tx| {
         let changeset_id = changeset.insert(tx)?;
+        let mut package_rows = PackageTransactionStaging::begin(tx)?;
 
         for pkg in &pre_collected {
             let selector = pkg.identity.selector();
@@ -463,19 +464,37 @@ pub async fn cmd_adopt_system(
                         message: error.to_string(),
                     })?;
 
+                package_rows
+                    .clear()
+                    .map_err(|error| PackagePersistenceFailure {
+                        stage: BulkAdoptionFailureStage::MetadataInsert,
+                        message: error.to_string(),
+                    })?;
                 for captured in &pkg.files {
                     let file_path = &captured.source.0;
-                    let mut file_entry = captured.file_entry(trove_id);
-                    file_entry
-                        .insert_or_replace_in_savepoint(
-                            tx,
-                            ExistingDirectoryMaterialization::ApplyIncoming,
-                        )
+                    package_rows
+                        .stage_payload(&StagedPayloadRow {
+                            entry: captured.file_entry(trove_id),
+                            package_name: pkg.identity.name().to_string(),
+                            component_name: None,
+                            directory_materialization:
+                                conary_core::db::models::ExistingDirectoryMaterialization::ApplyIncoming,
+                            disposition: StagedAnchorDisposition::Auto,
+                            selected_root_node: None,
+                            materialization_target_path: None,
+                            history: None,
+                        })
                         .map_err(|error| PackagePersistenceFailure {
                             stage: BulkAdoptionFailureStage::MetadataInsert,
                             message: format!("file {file_path}: {error}"),
                         })?;
                 }
+                package_rows.validate_and_reconcile().map_err(|error| {
+                    PackagePersistenceFailure {
+                        stage: BulkAdoptionFailureStage::MetadataInsert,
+                        message: error.to_string(),
+                    }
+                })?;
 
                 super::requirements::insert_package_requirements(
                     tx,
@@ -536,6 +555,14 @@ pub async fn cmd_adopt_system(
         {
             captured_root_sync = Some(synchronize_captured_root(tx, changeset_id, captured)?);
         }
+
+        let sqlite_work = package_rows.finish()?;
+        debug!(
+            rows_loaded = sqlite_work.rows_loaded,
+            statements = sqlite_work.total_statement_executions(),
+            query_shapes = sqlite_work.query_shapes,
+            "reconciled staged adoption package rows"
+        );
 
         // Re-read every native authority immediately before committing the
         // ownership handoff. Any package, path, relation, reason, config, or

--- a/apps/conary/src/commands/adopt/system/captured_root.rs
+++ b/apps/conary/src/commands/adopt/system/captured_root.rs
@@ -7,8 +7,8 @@ use std::path::{Component, Path, PathBuf};
 
 use anyhow::{Context, Result};
 use conary_core::db::models::{
-    ExistingDirectoryMaterialization, FileEntry, InstallSource, PayloadClaim, ProvideEntry, Trove,
-    TroveType,
+    ExistingDirectoryMaterialization, FileEntry, InstallSource, PackageTransactionStaging,
+    PayloadClaim, ProvideEntry, StagedAnchorDisposition, StagedPayloadRow, Trove, TroveType,
 };
 use conary_core::filesystem::PrivateCasWriter;
 use conary_core::generation::root_manifest::{
@@ -143,23 +143,32 @@ pub(super) fn synchronize_captured_root(
     }
 
     let captured_trove_id = insert_captured_root_trove(tx, changeset_id)?;
-    let mut captured_entries = 0;
-    let mut package_entries = 0;
+    let mut package_rows = PackageTransactionStaging::begin(tx)?;
     for entry in entries {
-        if FileEntry::find_by_path(tx, &entry.path)?.is_some() {
-            FileEntry::reconcile_selected_root_materialization(
-                tx,
-                &entry.path,
-                &entry.node,
-                entry.content.as_ref(),
-            )?;
-            package_entries += 1;
-        } else {
-            let mut file = FileEntry::new(entry.path, entry.node, entry.content, captured_trove_id);
-            file.insert_or_replace(tx, ExistingDirectoryMaterialization::ApplyIncoming)?;
-            captured_entries += 1;
-        }
+        package_rows.stage_payload(&StagedPayloadRow {
+            entry: FileEntry::new(entry.path, entry.node, entry.content, captured_trove_id),
+            package_name: LIVE_ROOT_PACKAGE_NAME.to_string(),
+            component_name: None,
+            directory_materialization: ExistingDirectoryMaterialization::ApplyIncoming,
+            disposition: StagedAnchorDisposition::ReconcileCapturedRoot,
+            selected_root_node: None,
+            materialization_target_path: None,
+            history: None,
+        })?;
     }
+    let outcomes = package_rows.validate_and_reconcile()?;
+    let captured_entries = outcomes
+        .values()
+        .filter(|outcome| outcome.materialized)
+        .count();
+    let package_entries = outcomes.len() - captured_entries;
+    let sqlite_work = package_rows.finish()?;
+    tracing::debug!(
+        rows_loaded = sqlite_work.rows_loaded,
+        statements = sqlite_work.total_statement_executions(),
+        query_shapes = sqlite_work.query_shapes,
+        "reconciled staged captured-root rows"
+    );
 
     Ok(CapturedRootSync {
         captured_entries,

--- a/apps/conary/src/commands/install/batch.rs
+++ b/apps/conary/src/commands/install/batch.rs
@@ -36,8 +36,9 @@ use anyhow::{Context, Result};
 pub(crate) use ccs::prepare_ccs_package_for_batch;
 use conary_core::components::ComponentType;
 use conary_core::db::models::{
-    Changeset, Component, InstallReason, InstalledCcsRemoveHook, InstalledFileCapability,
-    InstalledNativeLifecycleBundle, InstalledRequirementGroup, Trove,
+    Changeset, InstallReason, InstalledCcsRemoveHook, InstalledFileCapability,
+    InstalledNativeLifecycleBundle, InstalledRequirementGroup, PackageTransactionStaging,
+    StagedAnchorDisposition, StagedPayloadRow, Trove,
 };
 use conary_core::filesystem::CasStore;
 use conary_core::packages::config_authority::SourceConfigDeclaration;
@@ -622,93 +623,105 @@ impl<'a> BatchInstaller<'a> {
     #[allow(clippy::too_many_arguments)]
     fn insert_batch_payload_rows(
         tx: &Transaction<'_>,
+        staging: &mut PackageTransactionStaging<'_>,
         changeset_id: i64,
         pkg: &PreparedPackage,
         trove_id: i64,
         files: &[inner::ResolvedInstallFile],
         directory_plan: &super::shared_directory::DirectoryInstallPlan,
     ) -> Result<()> {
-        let mut path_to_component = HashMap::new();
+        staging.clear()?;
+        let mut path_to_component = HashMap::<&str, String>::new();
         if let (Some(component_names), Some(component_names_by_path)) = (
             pkg.installed_component_names.as_ref(),
             pkg.component_names_by_path.as_ref(),
         ) {
-            let mut component_ids = HashMap::new();
             for component_name in component_names {
-                let mut component = Component::new(trove_id, component_name.clone());
-                component.description = Some(format!("{component_name} files"));
-                component_ids.insert(component_name.as_str(), component.insert(tx)?);
+                staging.stage_component(
+                    trove_id,
+                    component_name,
+                    Some(&format!("{component_name} files")),
+                    true,
+                )?;
             }
             for (path, component_name) in component_names_by_path {
-                if let Some(component_id) = component_ids.get(component_name.as_str()) {
-                    path_to_component.insert(path.as_str(), *component_id);
+                if component_names.iter().any(|name| name == component_name) {
+                    path_to_component.insert(path.as_str(), component_name.clone());
                 }
             }
         } else {
-            let mut component_ids = HashMap::new();
             for comp_type in &pkg.installed_components {
-                let mut component = Component::from_type(trove_id, *comp_type);
-                component.description = Some(format!("{} files", comp_type.as_str()));
-                component_ids.insert(*comp_type, component.insert(tx)?);
+                staging.stage_component(
+                    trove_id,
+                    comp_type.as_str(),
+                    Some(&format!("{} files", comp_type.as_str())),
+                    true,
+                )?;
             }
             for (comp_type, paths) in &pkg.classified_files {
-                if let Some(component_id) = component_ids.get(comp_type) {
+                if pkg.installed_components.contains(comp_type) {
                     for path in paths {
-                        path_to_component.insert(path.as_str(), *component_id);
+                        path_to_component.insert(path.as_str(), comp_type.as_str().to_string());
                     }
                 }
             }
         }
 
-        let mut installed_file_metadata = HashMap::new();
-        for file in files {
-            if let Some(content) = file.content.as_ref() {
-                tx.execute(
-                    "INSERT OR IGNORE INTO file_contents (sha256_hash, content_path, size)
-                     VALUES (?1, ?2, ?3)",
-                    rusqlite::params![
-                        &content.sha256,
-                        format!("objects/{}/{}", &content.sha256[0..2], &content.sha256[2..]),
-                        i64::try_from(content.size)
-                            .context("payload content size exceeds SQLite range")?,
-                    ],
-                )?;
+        for removal in &pkg.relation_removals {
+            if removal.mode
+                == conary_core::repository::dependency_model::PackageRelationRemovalMode::OwnershipTransfer
+                && removal
+                    .ownership_transfer_packages
+                    .iter()
+                    .any(|incoming| incoming == &pkg.name)
+            {
+                staging.allow_replacement_of(removal.trove_id)?;
             }
-            let mut entry = conary_core::db::models::FileEntry::new(
+        }
+
+        for file in files {
+            let entry = conary_core::db::models::FileEntry::new(
                 file.path.clone(),
                 file.node.clone(),
                 file.content.clone(),
                 trove_id,
             )
             .with_claim_policy(pkg.semantics.payload_sharing_policy());
-            entry.component_id = path_to_component.get(file.path.as_str()).copied();
             directory_plan.reconcile_through_symlink_target(tx, file)?;
-            let inserted = inner::insert_file_entry_claiming_live_root_overlap(
-                tx,
-                &mut entry,
-                &pkg.name,
-                &pkg.relation_removals,
-                directory_plan.materialization_for_path(&file.path),
-                directory_plan.leaf_before(&file.path),
-            )?;
-            directory_plan.persist_through_symlink_target(tx, file, trove_id)?;
-            installed_file_metadata
-                .insert(file.path.clone(), (inserted.file_id, file.cas_hash.clone()));
-            if inserted.materialized {
-                tx.execute(
-                    "INSERT INTO file_history (changeset_id, path, sha256_hash, action)
-                     VALUES (?1, ?2, ?3, ?4)",
-                    rusqlite::params![
-                        changeset_id,
-                        &file.path,
-                        file.content.as_ref().map(|content| &content.sha256),
-                        if pkg.is_upgrade { "modify" } else { "add" },
-                    ],
-                )?;
-            }
+            let (disposition, materialization_target_path) = match directory_plan.path(&file.path) {
+                Some(super::shared_directory::DirectoryPathPlan::PreserveCompatiblePayload) => {
+                    (StagedAnchorDisposition::Share, None)
+                }
+                Some(super::shared_directory::DirectoryPathPlan::PreserveLeaf { .. }) => {
+                    (StagedAnchorDisposition::PreserveSelectedRoot, None)
+                }
+                Some(super::shared_directory::DirectoryPathPlan::ApplyDirectoryMetadata {
+                    ..
+                }) => (StagedAnchorDisposition::ApplyDirectory, None),
+                Some(super::shared_directory::DirectoryPathPlan::ApplyThroughSymlink {
+                    resolved_target_path,
+                    ..
+                }) => (
+                    StagedAnchorDisposition::PreserveSelectedRoot,
+                    Some(resolved_target_path.clone()),
+                ),
+                Some(super::shared_directory::DirectoryPathPlan::CreateOrReplace) | None => {
+                    (StagedAnchorDisposition::Replace, None)
+                }
+            };
+            staging.stage_payload(&StagedPayloadRow {
+                entry,
+                package_name: pkg.name.clone(),
+                component_name: path_to_component.get(file.path.as_str()).cloned(),
+                directory_materialization: directory_plan.materialization_for_path(&file.path),
+                disposition,
+                selected_root_node: directory_plan.leaf_before(&file.path).cloned(),
+                materialization_target_path,
+                history: Some((changeset_id, if pkg.is_upgrade { "modify" } else { "add" })),
+            })?;
         }
-        inner::reconcile_installed_hardlink_materializations(tx, files)?;
-        Self::insert_config_rows(tx, pkg, trove_id, &installed_file_metadata, files)?;
+        Self::stage_config_rows(tx, staging, pkg, trove_id, files)?;
+        let installed_file_metadata = staging.validate_and_reconcile()?;
         if let Some(ccs) = pkg.ccs.as_ref() {
             let files_by_path = files
                 .iter()

--- a/apps/conary/src/commands/install/batch/config.rs
+++ b/apps/conary/src/commands/install/batch/config.rs
@@ -5,7 +5,10 @@ use std::collections::{HashMap, HashSet};
 
 use anyhow::Result;
 use conary_core::config_transaction::{is_config_artifact_kind, is_etc_config_payload};
-use conary_core::db::models::{ConfigFile, ConfigSource, InstalledNativeLifecycleBundle};
+use conary_core::db::models::{
+    ConfigFile, ConfigSource, InstalledNativeLifecycleBundle, PackageTransactionStaging,
+    StagedConfigRow,
+};
 use rusqlite::{Connection, Transaction};
 
 use super::{BatchInstaller, PreparedPackage, inner};
@@ -26,11 +29,11 @@ impl BatchInstaller<'_> {
             || installed_bundle)
     }
 
-    pub(super) fn insert_config_rows(
+    pub(super) fn stage_config_rows(
         tx: &Transaction<'_>,
+        staging: &mut PackageTransactionStaging<'_>,
         pkg: &PreparedPackage,
         trove_id: i64,
-        installed_file_metadata: &HashMap<String, (i64, Option<String>)>,
         stored_files: &[inner::ResolvedInstallFile],
     ) -> Result<()> {
         let declared_source = super::super::config_files::source_for_semantics(pkg.semantics);
@@ -63,18 +66,20 @@ impl BatchInstaller<'_> {
                         pkg.name
                     );
                 }
-                super::super::config_files::persist_debian_remove_on_upgrade(
+                if let Some(config) = super::super::config_files::prepare_debian_remove_on_upgrade(
                     tx,
                     config_info.path(),
                     trove_id,
-                )?;
+                )? {
+                    staging.stage_config(&StagedConfigRow { config })?;
+                }
                 continue;
             }
             if config_info.ghost() {
                 let mut config = ConfigFile::new_ghost(config_info.path().to_string(), trove_id);
                 config.noreplace = config_info.noreplace();
                 config.source = declared_source;
-                config.upsert(tx)?;
+                staging.stage_config(&StagedConfigRow { config })?;
             } else if config_info.payload()
                 == conary_core::packages::config_authority::ConfigPayloadAssociation::Absent
             {
@@ -82,7 +87,7 @@ impl BatchInstaller<'_> {
                     ConfigFile::new_declaration(config_info.path().to_string(), trove_id);
                 config.noreplace = config_info.noreplace();
                 config.source = declared_source;
-                config.upsert(tx)?;
+                staging.stage_config(&StagedConfigRow { config })?;
             }
         }
 
@@ -113,14 +118,7 @@ impl BatchInstaller<'_> {
                     pkg.name
                 );
             }
-            let (file_id, hash) = installed_file_metadata.get(&file.path).ok_or_else(|| {
-                anyhow::anyhow!(
-                    "config payload {} from {} has no installed file identity",
-                    file.path,
-                    pkg.name
-                )
-            })?;
-            let hash = hash.as_ref().ok_or_else(|| {
+            let hash = file.cas_hash.as_ref().ok_or_else(|| {
                 anyhow::anyhow!(
                     "config payload {} from {} has no exact content identity",
                     file.path,
@@ -149,9 +147,8 @@ impl BatchInstaller<'_> {
                 declaration.is_some(),
                 extracted,
             )?;
-            config.file_id = Some(*file_id);
             config.source = declaration.map_or(ConfigSource::Auto, |_| declared_source);
-            config.upsert(tx)?;
+            staging.stage_config(&StagedConfigRow { config })?;
             persisted.insert(file.path.as_str());
         }
 

--- a/apps/conary/src/commands/install/batch/execution.rs
+++ b/apps/conary/src/commands/install/batch/execution.rs
@@ -9,7 +9,8 @@ use conary_core::ccs::native_lifecycle::SourceFormat;
 use conary_core::ccs::native_transaction::NativePackageIdentity;
 use conary_core::config_transaction::GenerationConfigTransaction;
 use conary_core::db::models::{
-    ActivationRequest, Changeset, ChangesetStatus, InstalledNativeLifecycleBundle, Trove,
+    ActivationRequest, Changeset, ChangesetStatus, InstalledNativeLifecycleBundle,
+    PackageTransactionStaging, Trove,
 };
 use conary_core::filesystem::CasStore;
 use conary_core::scriptlet::ExecutionMode;
@@ -80,6 +81,7 @@ impl BatchInstaller<'_> {
                 None,
                 rollback_root,
             )?;
+            let mut package_rows = PackageTransactionStaging::begin(&tx)?;
             let mut config_transaction = GenerationConfigTransaction::default();
             self.drive_graph(
                 &tx,
@@ -96,7 +98,15 @@ impl BatchInstaller<'_> {
                 native_execution_mode,
                 &graph_inputs,
                 &retained_upgrade_trove_ids,
+                &mut package_rows,
             )?;
+            let sqlite_work = package_rows.finish()?;
+            tracing::debug!(
+                rows_loaded = sqlite_work.rows_loaded,
+                statements = sqlite_work.total_statement_executions(),
+                query_shapes = sqlite_work.query_shapes,
+                "reconciled staged package transaction rows"
+            );
             super::promises::verify_promised_paths_materialized(promise_plan, &selected_root)?;
             let mut activation_requests = native_transaction.take_activation_requests();
             for (package, executor) in packages.iter().zip(ccs_hook_executors.iter()) {
@@ -264,6 +274,7 @@ impl BatchInstaller<'_> {
         native_execution_mode: &ExecutionMode,
         inputs: &GraphExecutionInputs,
         retained_trove_ids: &[i64],
+        package_rows: &mut PackageTransactionStaging<'_>,
     ) -> Result<()> {
         let retained_trove_ids = retained_trove_ids.iter().copied().collect::<BTreeSet<_>>();
         let mut payload = BatchGraphPayload {
@@ -280,6 +291,7 @@ impl BatchInstaller<'_> {
             inputs,
             retained_trove_ids: &retained_trove_ids,
             native_transaction,
+            package_rows,
         };
         super::super::native_graph::drive_native_graph(
             tx,
@@ -292,7 +304,7 @@ impl BatchInstaller<'_> {
     }
 }
 
-struct BatchGraphPayload<'a, R> {
+struct BatchGraphPayload<'a, 'staging, R> {
     tx: &'a rusqlite::Transaction<'a>,
     root_mutation: &'a mut R,
     selected_root: &'a Path,
@@ -306,9 +318,10 @@ struct BatchGraphPayload<'a, R> {
     inputs: &'a GraphExecutionInputs,
     retained_trove_ids: &'a BTreeSet<i64>,
     native_transaction: &'a PreparedNativeTransaction,
+    package_rows: &'a mut PackageTransactionStaging<'staging>,
 }
 
-impl<R> super::super::native_graph::NativeGraphPayloadMutation for BatchGraphPayload<'_, R>
+impl<R> super::super::native_graph::NativeGraphPayloadMutation for BatchGraphPayload<'_, '_, R>
 where
     R: super::super::native_graph::TransactionRootMutation,
 {
@@ -399,6 +412,7 @@ where
             }
             BatchInstaller::insert_batch_payload_rows(
                 self.tx,
+                self.package_rows,
                 self.changeset_id,
                 package,
                 *self

--- a/apps/conary/src/commands/install/config_files.rs
+++ b/apps/conary/src/commands/install/config_files.rs
@@ -127,8 +127,20 @@ pub(crate) fn persist_debian_remove_on_upgrade(
     path: &str,
     trove_id: i64,
 ) -> Result<()> {
-    let Some(mut config) = ConfigFile::find_by_path(conn, path)? else {
+    let Some(mut config) = prepare_debian_remove_on_upgrade(conn, path, trove_id)? else {
         return Ok(());
+    };
+    config.upsert(conn)?;
+    Ok(())
+}
+
+pub(crate) fn prepare_debian_remove_on_upgrade(
+    conn: &Connection,
+    path: &str,
+    trove_id: i64,
+) -> Result<Option<ConfigFile>> {
+    let Some(mut config) = ConfigFile::find_by_path(conn, path)? else {
+        return Ok(None);
     };
     if config.source != ConfigSource::Deb || config.original_md5.is_none() {
         bail!(
@@ -142,8 +154,7 @@ pub(crate) fn persist_debian_remove_on_upgrade(
     config.status = ConfigStatus::Missing;
     config.modified_at = None;
     config.remove_on_upgrade = true;
-    config.upsert(conn)?;
-    Ok(())
+    Ok(Some(config))
 }
 
 #[derive(Debug)]

--- a/apps/conary/src/commands/remove/transaction.rs
+++ b/apps/conary/src/commands/remove/transaction.rs
@@ -7,7 +7,10 @@ use super::{
 use crate::commands::progress::{RemovePhase, RemoveProgress};
 use crate::commands::{TroveSnapshot, capture_trove_snapshot};
 use anyhow::Result;
-use conary_core::db::models::{ConfigFile, ConfigSource, FileEntry, Trove};
+use conary_core::db::models::{
+    ConfigFile, FileEntry, PackageTransactionStaging, StagedHistoryAction, StagedHistoryRow, Trove,
+};
+use std::collections::BTreeMap;
 
 pub(crate) struct PreparedRemove {
     pub(crate) snapshot: TroveSnapshot,
@@ -108,54 +111,34 @@ pub(crate) fn commit_remove_db(
         .id
         .ok_or_else(|| anyhow::anyhow!("Trove has no ID"))?;
 
+    let snapshot_by_path = prepared
+        .snapshot
+        .files
+        .iter()
+        .map(|file| (file.path.as_str(), file))
+        .collect::<BTreeMap<_, _>>();
+    let mut package_rows = PackageTransactionStaging::begin(tx)?;
     for path in &prepared.materialized_removal_paths {
-        let use_hash = if let Some(content) = prepared
-            .snapshot
-            .files
-            .iter()
-            .find(|file| file.path == *path)
-            .and_then(|file| file.content.as_ref())
-        {
-            let hash_exists: bool = tx.query_row(
-                "SELECT EXISTS(SELECT 1 FROM file_contents WHERE sha256_hash = ?1)",
-                [&content.sha256],
-                |row| row.get(0),
-            )?;
-            if hash_exists {
-                Some(content.sha256.as_str())
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
-        match use_hash {
-            Some(hash) => {
-                tx.execute(
-                    "INSERT INTO file_history (changeset_id, path, sha256_hash, action) VALUES (?1, ?2, ?3, ?4)",
-                    [&changeset_id.to_string(), path, hash, "delete"],
-                )?;
-            }
-            None => {
-                tx.execute(
-                    "INSERT INTO file_history (changeset_id, path, sha256_hash, action) VALUES (?1, ?2, NULL, ?3)",
-                    [&changeset_id.to_string(), path, "delete"],
-                )?;
-            }
-        }
+        package_rows.stage_history(&StagedHistoryRow {
+            changeset_id,
+            path: path.clone(),
+            sha256_hash: snapshot_by_path
+                .get(path.as_str())
+                .and_then(|file| file.content.as_ref())
+                .map(|content| content.sha256.clone()),
+            action: StagedHistoryAction::Delete,
+        })?;
     }
+    package_rows.validate_and_reconcile()?;
+    let sqlite_work = package_rows.finish()?;
+    tracing::debug!(
+        rows_loaded = sqlite_work.rows_loaded,
+        statements = sqlite_work.total_statement_executions(),
+        query_shapes = sqlite_work.query_shapes,
+        "reconciled staged package removal rows"
+    );
 
-    for config in ConfigFile::find_by_trove(tx, trove_id)? {
-        if config.source != ConfigSource::Deb {
-            ConfigFile::delete(
-                tx,
-                config
-                    .id
-                    .ok_or_else(|| anyhow::anyhow!("tracked config has no database identity"))?,
-            )?;
-        }
-    }
+    ConfigFile::delete_non_debian_by_trove(tx, trove_id)?;
     Trove::delete(tx, trove_id)?;
 
     Ok(RemoveInnerResult {

--- a/apps/conary/src/commands/system/rollback_command.rs
+++ b/apps/conary/src/commands/system/rollback_command.rs
@@ -5,7 +5,8 @@
 use super::rollback_restore;
 use anyhow::{Context, Result, anyhow, bail};
 use conary_core::db::models::{
-    Changeset, ChangesetKind, ChangesetStatus, GenerationPublication, Trove,
+    Changeset, ChangesetKind, ChangesetStatus, GenerationPublication, PackageTransactionStaging,
+    StagedHistoryAction, StagedHistoryRow, Trove,
 };
 use conary_core::runtime_root::ConaryRuntimeRoot;
 use conary_core::transaction::{TransactionConfig, TransactionEngine};
@@ -337,6 +338,7 @@ fn delete_reverted_trove(
         .iter()
         .map(|entry| (entry.path.as_str(), entry))
         .collect::<std::collections::BTreeMap<_, _>>();
+    let mut package_rows = PackageTransactionStaging::begin(tx)?;
     for path in payload.materialized_removal_paths() {
         let entry = entries.get(path.as_str()).ok_or_else(|| {
             anyhow!(
@@ -345,19 +347,21 @@ fn delete_reverted_trove(
                 trove.name
             )
         })?;
-        tx.execute(
-            "INSERT INTO file_history (changeset_id, path, sha256_hash, action)
-             VALUES (?1, ?2, ?3, 'delete')",
-            rusqlite::params![
-                rollback_changeset_id,
-                path,
-                entry
-                    .content
-                    .as_ref()
-                    .map(|content| content.sha256.as_str())
-            ],
-        )?;
+        package_rows.stage_history(&StagedHistoryRow {
+            changeset_id: rollback_changeset_id,
+            path: path.clone(),
+            sha256_hash: entry.content.as_ref().map(|content| content.sha256.clone()),
+            action: StagedHistoryAction::Delete,
+        })?;
     }
+    package_rows.validate_and_reconcile()?;
+    let sqlite_work = package_rows.finish()?;
+    tracing::debug!(
+        rows_loaded = sqlite_work.rows_loaded,
+        statements = sqlite_work.total_statement_executions(),
+        query_shapes = sqlite_work.query_shapes,
+        "reconciled staged rollback removal rows"
+    );
     conary_core::db::models::ConfigFile::delete_by_trove(tx, trove_id)?;
     Trove::delete(tx, trove_id)?;
     Ok(())

--- a/crates/conary-core/Cargo.toml
+++ b/crates/conary-core/Cargo.toml
@@ -175,3 +175,7 @@ harness = false
 [[bench]]
 name = "installed_inventory"
 harness = false
+
+[[bench]]
+name = "package_transaction_staging"
+harness = false

--- a/crates/conary-core/benches/package_transaction_staging.rs
+++ b/crates/conary-core/benches/package_transaction_staging.rs
@@ -1,0 +1,87 @@
+// conary-core/benches/package_transaction_staging.rs
+
+//! Package transaction persistence scaling for many-tiny-file workloads.
+
+use conary_core::db::models::{
+    Changeset, ExistingDirectoryMaterialization, FileEntry, PackageTransactionStaging,
+    StagedAnchorDisposition, StagedPayloadRow, Trove, TroveType,
+};
+use conary_core::payload::{PayloadContentAuthority, PayloadNode, ResolvedPayloadNode};
+use conary_core::repository::versioning::VersionScheme;
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rusqlite::Connection;
+use std::hint::black_box;
+use std::time::Duration;
+
+fn database() -> (Connection, i64, i64) {
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute("PRAGMA foreign_keys = ON", []).unwrap();
+    conary_core::db::schema::ensure_current(&conn).unwrap();
+    let mut trove = Trove::new(
+        "tiny-fixture".to_string(),
+        "1.0.0".to_string(),
+        TroveType::Package,
+        VersionScheme::Conary,
+    );
+    let trove_id = trove.insert(&conn).unwrap();
+    let mut changeset = Changeset::new("tiny fixture benchmark".to_string());
+    let changeset_id = changeset.insert(&conn).unwrap();
+    (conn, trove_id, changeset_id)
+}
+
+fn rows(path_count: usize, trove_id: i64, changeset_id: i64) -> Vec<StagedPayloadRow> {
+    (0..path_count)
+        .map(|index| StagedPayloadRow {
+            entry: FileEntry::new(
+                format!("/usr/share/tiny-fixture/{index:05}"),
+                ResolvedPayloadNode::from_numeric_source(PayloadNode::regular(0o644)).unwrap(),
+                Some(PayloadContentAuthority {
+                    sha256: format!("{index:064x}"),
+                    size: 1,
+                }),
+                trove_id,
+            ),
+            package_name: "tiny-fixture".to_string(),
+            component_name: None,
+            directory_materialization: ExistingDirectoryMaterialization::ApplyIncoming,
+            disposition: StagedAnchorDisposition::Replace,
+            selected_root_node: None,
+            materialization_target_path: None,
+            history: Some((changeset_id, "add")),
+        })
+        .collect()
+}
+
+fn benchmark_package_transaction_staging(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("package_transaction_staging/many_tiny_files");
+    group.sample_size(20);
+    group.warm_up_time(Duration::from_secs(2));
+    group.measurement_time(Duration::from_secs(6));
+
+    for path_count in [100_usize, 2_500] {
+        let (mut conn, trove_id, changeset_id) = database();
+        let rows = rows(path_count, trove_id, changeset_id);
+        group.throughput(Throughput::Elements(path_count as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(path_count),
+            &rows,
+            |bencher, rows| {
+                bencher.iter(|| {
+                    let tx = conn.transaction().unwrap();
+                    let mut staging = PackageTransactionStaging::begin(&tx).unwrap();
+                    for row in rows {
+                        staging.stage_payload(black_box(row)).unwrap();
+                    }
+                    let outcomes = staging.validate_and_reconcile().unwrap();
+                    let work = staging.finish().unwrap();
+                    black_box((outcomes.len(), work));
+                    tx.rollback().unwrap();
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_package_transaction_staging);
+criterion_main!(benches);

--- a/crates/conary-core/src/db/models/config.rs
+++ b/crates/conary-core/src/db/models/config.rs
@@ -364,6 +364,15 @@ impl ConfigFile {
         Ok(())
     }
 
+    /// Delete package-owned config rows while retaining Debian conffile state.
+    pub fn delete_non_debian_by_trove(conn: &Connection, trove_id: i64) -> Result<()> {
+        conn.execute(
+            "DELETE FROM config_files WHERE trove_id = ?1 AND source != 'deb'",
+            [trove_id],
+        )?;
+        Ok(())
+    }
+
     /// Check if user has modified this config file
     pub fn is_modified(&self) -> bool {
         self.status == ConfigStatus::Modified

--- a/crates/conary-core/src/db/models/mod.rs
+++ b/crates/conary-core/src/db/models/mod.rs
@@ -49,6 +49,7 @@ mod metadata;
 mod native_lifecycle_residual_state;
 mod native_publication;
 mod package_payload_ownership;
+mod package_transaction_staging;
 mod payload_claim;
 mod persisted_value;
 mod provenance;
@@ -112,6 +113,10 @@ pub use native_publication::{
     NATIVE_NOARCH, NativePackagePublication, NativePublicationStatus, normalize_native_architecture,
 };
 pub use package_payload_ownership::{PackagePayloadEntry, PackagePayloadOwnership};
+pub use package_transaction_staging::{
+    PackageTransactionSqlWork, PackageTransactionStaging, StagedAnchorDisposition, StagedConfigRow,
+    StagedHistoryAction, StagedHistoryRow, StagedPayloadOutcome, StagedPayloadRow,
+};
 pub use payload_claim::{PayloadClaim, PayloadClaimAnchorPolicy};
 pub use persisted_value::{InvalidPersistedValue, PersistedValueCorruption};
 pub use provenance::Provenance;

--- a/crates/conary-core/src/db/models/package_transaction_staging.rs
+++ b/crates/conary-core/src/db/models/package_transaction_staging.rs
@@ -9,12 +9,14 @@ use rusqlite::{OptionalExtension, Transaction, params};
 use std::collections::BTreeMap;
 
 use self::planning::{
-    PlannedDecision, StagedAnchorInput, anchor_policy, parse_anchor_policy, parse_content,
-    parse_disposition, parse_node, persisted_content_size, validate_staged_payload,
+    LoadedClaim, PlannedDecision, StagedAnchorInput, StagedClaimInput, anchor_policy,
+    parse_anchor_policy, parse_content, parse_disposition, parse_node, persisted_content_size,
+    validate_staged_payload,
 };
 use self::sql::{CLEAR_STAGING_SQL, DROP_STAGING_SQL, STAGING_SCHEMA_SQL};
 
 mod planning;
+mod reconcile;
 mod sql;
 
 /// Typed materialization action established before canonical package rows change.
@@ -30,6 +32,10 @@ pub enum StagedAnchorDisposition {
     ApplyDirectory,
     /// Preserve an existing selected-root directory or symlink-to-directory anchor.
     PreserveSelectedRoot,
+    /// Reconcile an anchor already owned by the staged package without replacing its claim.
+    ReconcileOwned,
+    /// Reconcile complete selected-root materialization without claiming owned paths.
+    ReconcileCapturedRoot,
 }
 
 impl StagedAnchorDisposition {
@@ -40,6 +46,8 @@ impl StagedAnchorDisposition {
             Self::Share => "share",
             Self::ApplyDirectory => "apply-directory",
             Self::PreserveSelectedRoot => "preserve-selected-root",
+            Self::ReconcileOwned => "reconcile-owned",
+            Self::ReconcileCapturedRoot => "reconcile-captured-root",
         }
     }
 }
@@ -374,15 +382,83 @@ impl<'tx> PackageTransactionStaging<'tx> {
             .collect::<std::result::Result<Vec<_>, _>>()?;
         drop(statement);
         self.count_validation_query();
+        let claims = self.load_claims()?;
 
         let mut decisions = Vec::with_capacity(rows.len());
         for row in rows {
-            decisions.push(self.plan_anchor_decision(row)?);
+            decisions.push(Self::plan_anchor_decision(row, &claims)?);
         }
         Ok(decisions)
     }
 
-    fn plan_anchor_decision(&mut self, row: StagedAnchorInput) -> Result<PlannedDecision> {
+    fn load_claims(&mut self) -> Result<BTreeMap<String, Vec<LoadedClaim>>> {
+        let mut statement = self.tx.prepare(
+            "SELECT pc.path, pc.trove_id, pc.component_id, pc.sharing_policy,
+                    pc.anchor_policy, pc.materialization_target_path,
+                    pc.payload_node_json, pc.content_sha256, pc.content_size,
+                    owner.name, owner.install_source,
+                    allowed.trove_id IS NOT NULL
+             FROM payload_claims pc
+             JOIN troves owner ON owner.id = pc.trove_id
+             LEFT JOIN conary_tx_replacement_owners allowed ON allowed.trove_id = pc.trove_id
+             WHERE pc.path IN (SELECT path FROM conary_tx_payload)
+                OR pc.materialization_target_path IN (SELECT path FROM conary_tx_payload)
+             ORDER BY pc.path, pc.trove_id",
+        )?;
+        let raw = statement
+            .query_map([], |row| {
+                Ok(StagedClaimInput {
+                    path: row.get(0)?,
+                    trove_id: row.get(1)?,
+                    component_id: row.get(2)?,
+                    sharing_policy: row.get(3)?,
+                    anchor_policy: row.get(4)?,
+                    materialization_target_path: row.get(5)?,
+                    node_json: row.get(6)?,
+                    content_sha256: row.get(7)?,
+                    content_size: row.get(8)?,
+                    owner_name: row.get(9)?,
+                    owner_install_source: row.get(10)?,
+                    replacement_allowed: row.get(11)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        drop(statement);
+        self.count_validation_query();
+
+        let mut claims = BTreeMap::<String, Vec<LoadedClaim>>::new();
+        for row in raw {
+            let claim = PayloadClaim::new(
+                row.path.clone(),
+                row.trove_id,
+                parse_node(&row.path, &row.node_json)?,
+                parse_content(&row.path, row.content_sha256, row.content_size)?,
+                crate::payload::PayloadSharingPolicy::parse(&row.sharing_policy)
+                    .map_err(|error| Error::ParseError(error.to_string()))?,
+            )?
+            .with_component(row.component_id)
+            .with_anchor_policy(parse_anchor_policy(&row.anchor_policy)?)
+            .with_materialization_target(row.materialization_target_path.clone());
+            let loaded = LoadedClaim {
+                claim,
+                owner_name: row.owner_name,
+                owner_install_source: row.owner_install_source,
+                replacement_allowed: row.replacement_allowed,
+            };
+            if let Some(target) = row.materialization_target_path
+                && target != row.path
+            {
+                claims.entry(target).or_default().push(loaded.clone());
+            }
+            claims.entry(row.path).or_default().push(loaded);
+        }
+        Ok(claims)
+    }
+
+    fn plan_anchor_decision(
+        row: StagedAnchorInput,
+        claims_by_path: &BTreeMap<String, Vec<LoadedClaim>>,
+    ) -> Result<PlannedDecision> {
         let incoming_node = parse_node(&row.path, &row.incoming_node_json)?;
         let incoming_content = parse_content(&row.path, row.incoming_sha256, row.incoming_size)?;
         let incoming_claim = PayloadClaim::new(
@@ -433,27 +509,29 @@ impl<'tx> PackageTransactionStaging<'tx> {
                     incoming_claim.validate_anchor(existing)?;
                     return Ok(PlannedDecision::apply_directory(row.path, row.trove_id));
                 }
-                if self.claims_are_compatible(&incoming_claim)? {
+                if Self::claims_are_compatible(&incoming_claim, claims_by_path)? {
                     incoming_claim.validate_anchor(existing)?;
                     return Ok(PlannedDecision::keep(row.path, row.trove_id, false));
                 }
-                self.require_replaceable_claims(
+                Self::require_replaceable_claims(
                     &row.path,
                     &row.package_name,
                     existing.trove_id,
                     row.existing_owner_name.as_deref(),
                     row.existing_install_source.as_deref(),
+                    claims_by_path,
                 )?;
                 Ok(PlannedDecision::replace(row.path, row.trove_id))
             }
             StagedAnchorDisposition::Replace => {
                 if let Some(existing) = existing.as_ref() {
-                    self.require_replaceable_claims(
+                    Self::require_replaceable_claims(
                         &row.path,
                         &row.package_name,
                         existing.trove_id,
                         row.existing_owner_name.as_deref(),
                         row.existing_install_source.as_deref(),
+                        claims_by_path,
                     )?;
                 }
                 Ok(PlannedDecision::replace(row.path, row.trove_id))
@@ -468,7 +546,7 @@ impl<'tx> PackageTransactionStaging<'tx> {
                         row.trove_id,
                     ));
                 };
-                self.require_compatible_claims(&incoming_claim)?;
+                Self::require_compatible_claims(&incoming_claim, claims_by_path)?;
                 incoming_claim.validate_anchor(&existing)?;
                 Ok(PlannedDecision::keep(row.path, row.trove_id, false))
             }
@@ -517,37 +595,146 @@ impl<'tx> PackageTransactionStaging<'tx> {
                     ))
                 }
             }
+            StagedAnchorDisposition::ReconcileOwned => {
+                let existing = existing.ok_or_else(|| {
+                    Error::NotFound(format!(
+                        "owned staged payload {} has no materialized anchor",
+                        row.path
+                    ))
+                })?;
+                let candidate = FileEntry {
+                    id: existing.id,
+                    path: row.path.clone(),
+                    node: incoming_claim.node.clone(),
+                    content: incoming_claim.content.clone(),
+                    trove_id: existing.trove_id,
+                    installed_at: existing.installed_at.clone(),
+                    component_id: existing.component_id,
+                    claim_policy: crate::payload::PayloadSharingPolicy::Exclusive,
+                };
+                Self::validate_owned_reconciled_anchor(
+                    &candidate,
+                    &incoming_claim,
+                    claims_by_path,
+                )?;
+                Ok(PlannedDecision::reconcile_owned(row.path, row.trove_id))
+            }
+            StagedAnchorDisposition::ReconcileCapturedRoot => {
+                let Some(existing) = existing.as_ref() else {
+                    return Ok(PlannedDecision::replace(row.path, row.trove_id));
+                };
+                let candidate = FileEntry {
+                    id: existing.id,
+                    path: row.path.clone(),
+                    node: incoming_claim.node.clone(),
+                    content: incoming_claim.content.clone(),
+                    trove_id: existing.trove_id,
+                    installed_at: existing.installed_at.clone(),
+                    component_id: existing.component_id,
+                    claim_policy: crate::payload::PayloadSharingPolicy::Exclusive,
+                };
+                Self::validate_reconciled_anchor(&candidate, claims_by_path)?;
+                Ok(PlannedDecision::reconcile_materialization(
+                    row.path,
+                    row.trove_id,
+                ))
+            }
         }
     }
 
+    fn validate_reconciled_anchor(
+        candidate: &FileEntry,
+        claims_by_path: &BTreeMap<String, Vec<LoadedClaim>>,
+    ) -> Result<()> {
+        let retainers = claims_by_path
+            .get(&candidate.path)
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        if retainers.is_empty() {
+            return Err(Error::ConfigError(format!(
+                "materialized payload {} has no package claim",
+                candidate.path
+            )));
+        }
+        for loaded in retainers {
+            if loaded.claim.path == candidate.path {
+                loaded.claim.validate_anchor(candidate)?;
+            } else if !matches!(candidate.node.source.kind, PayloadNodeKind::Directory) {
+                return Err(Error::ConflictError(format!(
+                    "selected-root node {} is incompatible with claim {} anchor policy '{}'",
+                    candidate.path,
+                    loaded.claim.trove_id,
+                    loaded.claim.anchor_policy.as_str()
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_owned_reconciled_anchor(
+        candidate: &FileEntry,
+        incoming: &PayloadClaim,
+        claims_by_path: &BTreeMap<String, Vec<LoadedClaim>>,
+    ) -> Result<()> {
+        let retainers = claims_by_path
+            .get(&candidate.path)
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        let mut owns_path = false;
+        for loaded in retainers {
+            if loaded.claim.path == candidate.path && loaded.claim.trove_id == incoming.trove_id {
+                owns_path = true;
+                incoming.validate_anchor(candidate)?;
+            } else if loaded.claim.path == candidate.path {
+                incoming.compatible_with(&loaded.claim).map_err(|mismatch| {
+                    Error::ConflictError(format!(
+                        "replacement payload claim {} from trove {} is incompatible with trove {}: {mismatch}",
+                        candidate.path, incoming.trove_id, loaded.claim.trove_id
+                    ))
+                })?;
+                loaded.claim.validate_anchor(candidate)?;
+            } else if !matches!(candidate.node.source.kind, PayloadNodeKind::Directory) {
+                return Err(Error::ConflictError(format!(
+                    "selected-root node {} is incompatible with claim {} anchor policy '{}'",
+                    candidate.path,
+                    loaded.claim.trove_id,
+                    loaded.claim.anchor_policy.as_str()
+                )));
+            }
+        }
+        if !owns_path {
+            return Err(Error::NotFound(format!(
+                "staged package {} does not own materialized payload {}",
+                incoming.trove_id, candidate.path
+            )));
+        }
+        Ok(())
+    }
+
     fn require_replaceable_claims(
-        &mut self,
         path: &str,
         package_name: &str,
         existing_trove_id: i64,
         existing_owner_name: Option<&str>,
         existing_install_source: Option<&str>,
+        claims_by_path: &BTreeMap<String, Vec<LoadedClaim>>,
     ) -> Result<()> {
-        let blocked = self
-            .tx
-            .query_row(
-                "SELECT pc.trove_id, t.name
-             FROM payload_claims pc
-             JOIN troves t ON t.id = pc.trove_id
-             LEFT JOIN conary_tx_replacement_owners allowed ON allowed.trove_id = pc.trove_id
-             WHERE pc.path = ?1
-               AND allowed.trove_id IS NULL
-               AND t.name != ?2
-               AND t.install_source != 'captured-root'
-             ORDER BY pc.trove_id LIMIT 1",
-                params![path, package_name],
-                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
-            )
-            .optional()?;
-        self.count_validation_query();
-        if let Some((trove_id, owner)) = blocked {
+        let blocked = claims_by_path
+            .get(path)
+            .into_iter()
+            .flatten()
+            .filter(|loaded| loaded.claim.path == path)
+            .find(|loaded| {
+                !loaded.replacement_allowed
+                    && loaded.owner_name != package_name
+                    && loaded.owner_install_source != "captured-root"
+            });
+        if let Some(blocked) = blocked {
             return Err(Error::ConflictError(format!(
-                "staged payload {path} cannot replace claim from package {owner} ({trove_id})"
+                "staged payload {path} cannot replace claim from package {} ({})",
+                blocked.owner_name, blocked.claim.trove_id
             )));
         }
         if existing_owner_name.is_none() {
@@ -557,14 +744,13 @@ impl<'tx> PackageTransactionStaging<'tx> {
         }
         let anchor_allowed = existing_owner_name == Some(package_name)
             || existing_install_source == Some("captured-root")
-            || self.tx.query_row(
-                "SELECT EXISTS(
-                    SELECT 1 FROM conary_tx_replacement_owners WHERE trove_id = ?1
-                 )",
-                [existing_trove_id],
-                |row| row.get::<_, bool>(0),
-            )?;
-        self.count_validation_query();
+            || claims_by_path
+                .get(path)
+                .into_iter()
+                .flatten()
+                .any(|loaded| {
+                    loaded.claim.trove_id == existing_trove_id && loaded.replacement_allowed
+                });
         if !anchor_allowed {
             return Err(Error::ConflictError(format!(
                 "staged payload {path} cannot replace package {}",
@@ -574,29 +760,45 @@ impl<'tx> PackageTransactionStaging<'tx> {
         Ok(())
     }
 
-    fn require_compatible_claims(&mut self, incoming: &PayloadClaim) -> Result<()> {
-        let claims = PayloadClaim::find_by_path(self.tx, &incoming.path)?;
-        self.count_validation_query();
+    fn require_compatible_claims(
+        incoming: &PayloadClaim,
+        claims_by_path: &BTreeMap<String, Vec<LoadedClaim>>,
+    ) -> Result<()> {
+        let claims = claims_by_path
+            .get(&incoming.path)
+            .into_iter()
+            .flatten()
+            .filter(|loaded| loaded.claim.path == incoming.path)
+            .collect::<Vec<_>>();
         if claims.is_empty() {
             return Err(Error::ConfigError(format!(
                 "materialized payload {} has no package claim",
                 incoming.path
             )));
         }
-        for claim in claims {
-            incoming.compatible_with(&claim).map_err(|mismatch| {
-                Error::ConflictError(format!(
-                    "staged payload {} is incompatible with trove {}: {mismatch}",
-                    incoming.path, claim.trove_id
-                ))
-            })?;
+        for loaded in claims {
+            incoming
+                .compatible_with(&loaded.claim)
+                .map_err(|mismatch| {
+                    Error::ConflictError(format!(
+                        "staged payload {} is incompatible with trove {}: {mismatch}",
+                        incoming.path, loaded.claim.trove_id
+                    ))
+                })?;
         }
         Ok(())
     }
 
-    fn claims_are_compatible(&mut self, incoming: &PayloadClaim) -> Result<bool> {
-        let claims = PayloadClaim::find_by_path(self.tx, &incoming.path)?;
-        self.count_validation_query();
+    fn claims_are_compatible(
+        incoming: &PayloadClaim,
+        claims_by_path: &BTreeMap<String, Vec<LoadedClaim>>,
+    ) -> Result<bool> {
+        let claims = claims_by_path
+            .get(&incoming.path)
+            .into_iter()
+            .flatten()
+            .filter(|loaded| loaded.claim.path == incoming.path)
+            .collect::<Vec<_>>();
         if claims.is_empty() {
             return Err(Error::ConfigError(format!(
                 "materialized payload {} has no package claim",
@@ -605,7 +807,7 @@ impl<'tx> PackageTransactionStaging<'tx> {
         }
         Ok(claims
             .iter()
-            .all(|claim| incoming.compatible_with(claim).is_ok()))
+            .all(|loaded| incoming.compatible_with(&loaded.claim).is_ok()))
     }
 
     fn persist_decisions(&mut self, decisions: &[PlannedDecision]) -> Result<()> {
@@ -625,271 +827,6 @@ impl<'tx> PackageTransactionStaging<'tx> {
         }
         self.work.query_shapes += 1;
         Ok(())
-    }
-
-    fn reconcile_components(&mut self) -> Result<()> {
-        self.tx.execute(
-            "INSERT INTO components (parent_trove_id, name, description, is_installed)
-             SELECT trove_id, name, description, is_installed
-             FROM conary_tx_components
-             ORDER BY trove_id, name
-             ON CONFLICT(parent_trove_id, name) DO UPDATE SET
-                description = excluded.description,
-                is_installed = excluded.is_installed",
-            [],
-        )?;
-        self.count_reconciliation_statement();
-        Ok(())
-    }
-
-    fn reconcile_contents(&mut self) -> Result<()> {
-        self.tx.execute(
-            "INSERT OR IGNORE INTO file_contents (sha256_hash, content_path, size)
-             SELECT DISTINCT content_sha256,
-                    'objects/' || substr(content_sha256, 1, 2) || '/' || substr(content_sha256, 3),
-                    content_size
-             FROM conary_tx_payload
-             WHERE content_sha256 IS NOT NULL
-             ORDER BY content_sha256",
-            [],
-        )?;
-        self.count_reconciliation_statement();
-        Ok(())
-    }
-
-    fn reconcile_anchors(&mut self) -> Result<()> {
-        self.tx.execute(
-            "DELETE FROM payload_claims
-             WHERE path IN (
-                 SELECT path FROM conary_tx_decisions WHERE anchor_action = 'replace'
-             )
-             AND (
-                 trove_id IN (SELECT trove_id FROM conary_tx_replacement_owners)
-                 OR trove_id IN (
-                     SELECT t.id FROM troves t
-                     JOIN conary_tx_payload p ON p.package_name = t.name
-                     WHERE p.path = payload_claims.path
-                 )
-                 OR trove_id IN (
-                     SELECT id FROM troves WHERE install_source = 'captured-root'
-                 )
-             )",
-            [],
-        )?;
-        self.count_reconciliation_statement();
-
-        self.tx.execute(
-            "INSERT INTO files (
-                path, payload_node_json, content_sha256, content_size,
-                trove_id, component_id
-             )
-             SELECT p.path,
-                    CASE d.anchor_action
-                        WHEN 'insert-selected-root' THEN p.selected_root_node_json
-                        ELSE p.payload_node_json
-                    END,
-                    CASE d.anchor_action
-                        WHEN 'insert-selected-root' THEN NULL
-                        ELSE p.content_sha256
-                    END,
-                    CASE d.anchor_action
-                        WHEN 'insert-selected-root' THEN NULL
-                        ELSE p.content_size
-                    END,
-                    p.trove_id,
-                    c.id
-             FROM conary_tx_payload p
-             JOIN conary_tx_decisions d USING(path, trove_id)
-             LEFT JOIN components c
-               ON c.parent_trove_id = p.trove_id AND c.name = p.component_name
-             WHERE d.anchor_action IN ('replace', 'apply-directory', 'insert-selected-root')
-             ORDER BY p.path, p.trove_id
-             ON CONFLICT(path) DO UPDATE SET
-                payload_node_json = excluded.payload_node_json,
-                content_sha256 = excluded.content_sha256,
-                content_size = excluded.content_size,
-                trove_id = excluded.trove_id,
-                component_id = excluded.component_id",
-            [],
-        )?;
-        self.count_reconciliation_statement();
-        Ok(())
-    }
-
-    fn reconcile_claims(&mut self) -> Result<()> {
-        self.tx.execute(
-            "INSERT INTO payload_claims (
-                path, trove_id, component_id, sharing_policy, anchor_policy,
-                materialization_target_path, payload_node_json,
-                content_sha256, content_size
-             )
-             SELECT p.path, p.trove_id, c.id, p.sharing_policy, p.anchor_policy,
-                    p.materialization_target_path, p.payload_node_json,
-                    p.content_sha256, p.content_size
-             FROM conary_tx_payload p
-             LEFT JOIN components c
-               ON c.parent_trove_id = p.trove_id AND c.name = p.component_name
-             ORDER BY p.path, p.trove_id
-             ON CONFLICT(path, trove_id) DO UPDATE SET
-                component_id = excluded.component_id,
-                sharing_policy = excluded.sharing_policy,
-                anchor_policy = excluded.anchor_policy,
-                materialization_target_path = excluded.materialization_target_path,
-                payload_node_json = excluded.payload_node_json,
-                content_sha256 = excluded.content_sha256,
-                content_size = excluded.content_size",
-            [],
-        )?;
-        self.count_reconciliation_statement();
-        Ok(())
-    }
-
-    fn reconcile_hardlinks(&mut self) -> Result<()> {
-        let missing_target = self
-            .tx
-            .query_row(
-                "SELECT p.path, json_extract(p.payload_node_json, '$.source.kind.target')
-             FROM conary_tx_payload p
-             LEFT JOIN files target
-               ON target.path = json_extract(p.payload_node_json, '$.source.kind.target')
-             WHERE json_extract(p.payload_node_json, '$.source.kind.type') = 'hardlink'
-               AND (
-                   target.path IS NULL
-                   OR json_extract(target.payload_node_json, '$.source.kind.type') != 'regular'
-               )
-             ORDER BY p.path LIMIT 1",
-                [],
-                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
-            )
-            .optional()?;
-        self.count_validation_query();
-        if let Some((path, target)) = missing_target {
-            return Err(Error::ConflictError(format!(
-                "staged hardlink {path} has no regular materialization target {target}"
-            )));
-        }
-
-        self.tx.execute(
-            "UPDATE files
-             SET payload_node_json = json_set(
-                 payload_node_json,
-                 '$.source.kind.hardlink_identity',
-                 'path:' || path
-             )
-             WHERE path IN (
-                 SELECT DISTINCT json_extract(payload_node_json, '$.source.kind.target')
-                 FROM conary_tx_payload
-                 WHERE json_extract(payload_node_json, '$.source.kind.type') = 'hardlink'
-             )",
-            [],
-        )?;
-        self.count_reconciliation_statement();
-        self.tx.execute(
-            "UPDATE files
-             SET payload_node_json = json_set(
-                 payload_node_json,
-                 '$.source.kind.identity',
-                 'path:' || json_extract(payload_node_json, '$.source.kind.target')
-             )
-             WHERE json_extract(payload_node_json, '$.source.kind.type') = 'hardlink'
-               AND json_extract(payload_node_json, '$.source.kind.target') IN (
-                   SELECT DISTINCT json_extract(payload_node_json, '$.source.kind.target')
-                   FROM conary_tx_payload
-                   WHERE json_extract(payload_node_json, '$.source.kind.type') = 'hardlink'
-               )",
-            [],
-        )?;
-        self.count_reconciliation_statement();
-        Ok(())
-    }
-
-    fn reconcile_history(&mut self) -> Result<()> {
-        self.tx.execute(
-            "INSERT INTO file_history (changeset_id, path, sha256_hash, action)
-             SELECT p.history_changeset_id, p.path, p.content_sha256, p.history_action
-             FROM conary_tx_payload p
-             JOIN conary_tx_decisions d USING(path, trove_id)
-             WHERE p.history_changeset_id IS NOT NULL AND d.materialized = 1
-             ORDER BY p.path, p.trove_id",
-            [],
-        )?;
-        self.count_reconciliation_statement();
-        self.tx.execute(
-            "INSERT INTO file_history (changeset_id, path, sha256_hash, action)
-             SELECT h.changeset_id, h.path,
-                    CASE WHEN content.sha256_hash IS NULL THEN NULL ELSE h.sha256_hash END,
-                    h.action
-             FROM conary_tx_history h
-             LEFT JOIN file_contents content ON content.sha256_hash = h.sha256_hash
-             ORDER BY h.path, h.action",
-            [],
-        )?;
-        self.count_reconciliation_statement();
-        Ok(())
-    }
-
-    fn reconcile_configs(&mut self) -> Result<()> {
-        self.tx.execute(
-            "INSERT INTO config_files (
-                file_id, path, trove_id, package_name, package_version,
-                package_architecture, original_hash, original_md5, current_hash,
-                noreplace, ghost, materialized, remove_on_upgrade, status,
-                modified_at, source
-             )
-             SELECT CASE WHEN s.materialized = 1 THEN f.id ELSE NULL END,
-                    s.path, s.trove_id, t.name, t.version, t.architecture,
-                    s.original_hash, s.original_md5, s.current_hash,
-                    s.noreplace, s.ghost, s.materialized, s.remove_on_upgrade,
-                    s.status, s.modified_at, s.source
-             FROM conary_tx_configs s
-             JOIN troves t ON t.id = s.trove_id
-             LEFT JOIN files f ON f.path = s.path
-             ORDER BY s.path
-             ON CONFLICT(path) DO UPDATE SET
-                file_id = excluded.file_id,
-                trove_id = excluded.trove_id,
-                package_name = excluded.package_name,
-                package_version = excluded.package_version,
-                package_architecture = excluded.package_architecture,
-                original_hash = excluded.original_hash,
-                original_md5 = excluded.original_md5,
-                current_hash = excluded.current_hash,
-                noreplace = excluded.noreplace,
-                ghost = excluded.ghost,
-                materialized = excluded.materialized,
-                remove_on_upgrade = excluded.remove_on_upgrade,
-                status = excluded.status,
-                modified_at = excluded.modified_at,
-                source = excluded.source",
-            [],
-        )?;
-        self.count_reconciliation_statement();
-        Ok(())
-    }
-
-    fn load_outcomes(&mut self) -> Result<BTreeMap<String, StagedPayloadOutcome>> {
-        let mut statement = self.tx.prepare(
-            "SELECT p.path, f.id, f.content_sha256, d.materialized
-             FROM conary_tx_payload p
-             JOIN conary_tx_decisions d USING(path, trove_id)
-             JOIN files f ON f.path = p.path
-             ORDER BY p.path, p.trove_id",
-        )?;
-        let rows = statement
-            .query_map([], |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    StagedPayloadOutcome {
-                        file_id: row.get(1)?,
-                        content_sha256: row.get(2)?,
-                        materialized: row.get(3)?,
-                    },
-                ))
-            })?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-        drop(statement);
-        self.count_validation_query();
-        Ok(rows.into_iter().collect())
     }
 
     fn count_loaded_row(&mut self) {

--- a/crates/conary-core/src/db/models/package_transaction_staging.rs
+++ b/crates/conary-core/src/db/models/package_transaction_staging.rs
@@ -1,0 +1,914 @@
+// conary-core/src/db/models/package_transaction_staging.rs
+
+//! Transaction-local package row staging and set-based reconciliation.
+
+use super::{ConfigFile, ExistingDirectoryMaterialization, FileEntry, PayloadClaim};
+use crate::error::{Error, Result};
+use crate::payload::{PayloadNodeKind, ResolvedPayloadNode};
+use rusqlite::{OptionalExtension, Transaction, params};
+use std::collections::BTreeMap;
+
+use self::planning::{
+    PlannedDecision, StagedAnchorInput, anchor_policy, parse_anchor_policy, parse_content,
+    parse_disposition, parse_node, persisted_content_size, validate_staged_payload,
+};
+use self::sql::{CLEAR_STAGING_SQL, DROP_STAGING_SQL, STAGING_SCHEMA_SQL};
+
+mod planning;
+mod sql;
+
+/// Typed materialization action established before canonical package rows change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StagedAnchorDisposition {
+    /// Derive insert/share/directory behavior from exact canonical claims.
+    Auto,
+    /// Replace an absent or explicitly superseded materialization anchor.
+    Replace,
+    /// Join an existing source-compatible materialization without rewriting it.
+    Share,
+    /// Apply incoming directory metadata while retaining compatible peer claims.
+    ApplyDirectory,
+    /// Preserve an existing selected-root directory or symlink-to-directory anchor.
+    PreserveSelectedRoot,
+}
+
+impl StagedAnchorDisposition {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Replace => "replace",
+            Self::Share => "share",
+            Self::ApplyDirectory => "apply-directory",
+            Self::PreserveSelectedRoot => "preserve-selected-root",
+        }
+    }
+}
+
+/// One prepared package payload row.
+#[derive(Debug, Clone)]
+pub struct StagedPayloadRow {
+    pub entry: FileEntry,
+    pub package_name: String,
+    pub component_name: Option<String>,
+    pub directory_materialization: ExistingDirectoryMaterialization,
+    pub disposition: StagedAnchorDisposition,
+    pub selected_root_node: Option<ResolvedPayloadNode>,
+    pub materialization_target_path: Option<String>,
+    pub history: Option<(i64, &'static str)>,
+}
+
+/// One prepared config projection. File identity is resolved set-wise by path.
+#[derive(Debug, Clone)]
+pub struct StagedConfigRow {
+    pub config: ConfigFile,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StagedHistoryAction {
+    Add,
+    Modify,
+    Delete,
+}
+
+impl StagedHistoryAction {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Add => "add",
+            Self::Modify => "modify",
+            Self::Delete => "delete",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StagedHistoryRow {
+    pub changeset_id: i64,
+    pub path: String,
+    pub sha256_hash: Option<String>,
+    pub action: StagedHistoryAction,
+}
+
+/// Canonical identity returned after set-based reconciliation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StagedPayloadOutcome {
+    pub file_id: i64,
+    pub content_sha256: Option<String>,
+    pub materialized: bool,
+}
+
+/// Counted SQLite work owned by the staging authority.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PackageTransactionSqlWork {
+    pub rows_loaded: u64,
+    pub load_statement_executions: u64,
+    pub validation_query_executions: u64,
+    pub reconciliation_statement_executions: u64,
+    pub query_shapes: u64,
+}
+
+impl PackageTransactionSqlWork {
+    pub const fn total_statement_executions(self) -> u64 {
+        self.load_statement_executions
+            + self.validation_query_executions
+            + self.reconciliation_statement_executions
+    }
+}
+
+/// Ephemeral package-row authority scoped to one SQLite transaction.
+pub struct PackageTransactionStaging<'tx> {
+    tx: &'tx Transaction<'tx>,
+    work: PackageTransactionSqlWork,
+}
+
+impl<'tx> PackageTransactionStaging<'tx> {
+    pub fn begin(tx: &'tx Transaction<'tx>) -> Result<Self> {
+        tx.execute_batch(STAGING_SCHEMA_SQL)?;
+        Ok(Self {
+            tx,
+            work: PackageTransactionSqlWork {
+                reconciliation_statement_executions: 1,
+                query_shapes: 1,
+                ..PackageTransactionSqlWork::default()
+            },
+        })
+    }
+
+    pub fn clear(&mut self) -> Result<()> {
+        self.tx.execute_batch(CLEAR_STAGING_SQL)?;
+        self.work.reconciliation_statement_executions += 1;
+        self.work.query_shapes += 1;
+        Ok(())
+    }
+
+    pub fn stage_component(
+        &mut self,
+        trove_id: i64,
+        name: &str,
+        description: Option<&str>,
+        is_installed: bool,
+    ) -> Result<()> {
+        self.tx
+            .prepare_cached(
+                "INSERT INTO conary_tx_components (trove_id, name, description, is_installed)
+             VALUES (?1, ?2, ?3, ?4)",
+            )?
+            .execute(params![trove_id, name, description, is_installed])?;
+        self.count_loaded_row();
+        Ok(())
+    }
+
+    pub fn allow_replacement_of(&mut self, trove_id: i64) -> Result<()> {
+        self.tx
+            .prepare_cached(
+                "INSERT OR IGNORE INTO conary_tx_replacement_owners (trove_id) VALUES (?1)",
+            )?
+            .execute([trove_id])?;
+        self.count_loaded_row();
+        Ok(())
+    }
+
+    pub fn stage_payload(&mut self, row: &StagedPayloadRow) -> Result<()> {
+        validate_staged_payload(row)?;
+        let node_json = super::file_entry::canonical_node_json(&row.entry.node)?;
+        let selected_root_node_json = row
+            .selected_root_node
+            .as_ref()
+            .map(super::file_entry::canonical_node_json)
+            .transpose()?;
+        let content_size = persisted_content_size(row.entry.content.as_ref())?;
+        let anchor_policy = anchor_policy(row.directory_materialization, &row.entry.node);
+        let (history_changeset_id, history_action) =
+            row.history.map_or((None, None), |(changeset_id, action)| {
+                (Some(changeset_id), Some(action))
+            });
+        self.tx
+            .prepare_cached(
+                "INSERT INTO conary_tx_payload (
+                path, trove_id, package_name, component_name, payload_node_json,
+                content_sha256, content_size, sharing_policy, anchor_policy,
+                disposition, selected_root_node_json, materialization_target_path,
+                history_changeset_id, history_action
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+            )?
+            .execute(params![
+                &row.entry.path,
+                row.entry.trove_id,
+                &row.package_name,
+                &row.component_name,
+                node_json,
+                row.entry.content.as_ref().map(|content| &content.sha256),
+                content_size,
+                row.entry.claim_policy.as_str(),
+                anchor_policy.as_str(),
+                row.disposition.as_str(),
+                selected_root_node_json,
+                &row.materialization_target_path,
+                history_changeset_id,
+                history_action,
+            ])?;
+        self.count_loaded_row();
+        Ok(())
+    }
+
+    pub fn stage_config(&mut self, row: &StagedConfigRow) -> Result<()> {
+        let config = &row.config;
+        let trove_id = config.trove_id.ok_or_else(|| {
+            Error::ConfigError(format!(
+                "staged config {} has no trove authority",
+                config.path
+            ))
+        })?;
+        self.tx
+            .prepare_cached(
+                "INSERT INTO conary_tx_configs (
+                path, trove_id, original_hash, original_md5, current_hash,
+                noreplace, ghost, materialized, remove_on_upgrade, status,
+                modified_at, source
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            )?
+            .execute(params![
+                &config.path,
+                trove_id,
+                &config.original_hash,
+                &config.original_md5,
+                &config.current_hash,
+                config.noreplace,
+                config.ghost,
+                config.materialized,
+                config.remove_on_upgrade,
+                config.status.as_str(),
+                &config.modified_at,
+                config.source.as_str(),
+            ])?;
+        self.count_loaded_row();
+        Ok(())
+    }
+
+    pub fn stage_history(&mut self, row: &StagedHistoryRow) -> Result<()> {
+        if let Some(hash) = row.sha256_hash.as_deref()
+            && (hash.len() != 64
+                || !hash
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)))
+        {
+            return Err(Error::ParseError(format!(
+                "staged history {} has invalid SHA-256 identity",
+                row.path
+            )));
+        }
+        self.tx
+            .prepare_cached(
+                "INSERT INTO conary_tx_history (changeset_id, path, sha256_hash, action)
+                 VALUES (?1, ?2, ?3, ?4)",
+            )?
+            .execute(params![
+                row.changeset_id,
+                &row.path,
+                &row.sha256_hash,
+                row.action.as_str(),
+            ])?;
+        self.count_loaded_row();
+        Ok(())
+    }
+
+    pub fn validate_and_reconcile(&mut self) -> Result<BTreeMap<String, StagedPayloadOutcome>> {
+        self.validate_references()?;
+        let decisions = self.plan_anchor_decisions()?;
+        self.persist_decisions(&decisions)?;
+        self.reconcile_components()?;
+        self.reconcile_contents()?;
+        self.reconcile_anchors()?;
+        self.reconcile_claims()?;
+        self.reconcile_hardlinks()?;
+        self.reconcile_history()?;
+        self.reconcile_configs()?;
+        self.load_outcomes()
+    }
+
+    pub fn finish(mut self) -> Result<PackageTransactionSqlWork> {
+        self.tx.execute_batch(DROP_STAGING_SQL)?;
+        self.work.reconciliation_statement_executions += 1;
+        self.work.query_shapes += 1;
+        Ok(self.work)
+    }
+
+    fn validate_references(&mut self) -> Result<()> {
+        let missing_trove = self
+            .tx
+            .query_row(
+                "SELECT p.path
+             FROM conary_tx_payload p
+             LEFT JOIN troves t ON t.id = p.trove_id
+             WHERE t.id IS NULL
+             ORDER BY p.path LIMIT 1",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        self.count_validation_query();
+        if let Some(path) = missing_trove {
+            return Err(Error::ConfigError(format!(
+                "staged payload {path} references a missing trove"
+            )));
+        }
+
+        let missing_component = self
+            .tx
+            .query_row(
+                "SELECT p.path, p.component_name
+             FROM conary_tx_payload p
+             LEFT JOIN conary_tx_components c
+               ON c.trove_id = p.trove_id AND c.name = p.component_name
+             LEFT JOIN components existing
+               ON existing.parent_trove_id = p.trove_id AND existing.name = p.component_name
+             WHERE p.component_name IS NOT NULL
+               AND c.name IS NULL AND existing.name IS NULL
+             ORDER BY p.path LIMIT 1",
+                [],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            )
+            .optional()?;
+        self.count_validation_query();
+        if let Some((path, component)) = missing_component {
+            return Err(Error::ConfigError(format!(
+                "staged payload {path} references missing component {component}"
+            )));
+        }
+        Ok(())
+    }
+
+    fn plan_anchor_decisions(&mut self) -> Result<Vec<PlannedDecision>> {
+        let mut statement = self.tx.prepare(
+            "SELECT p.path, p.trove_id, p.package_name, p.payload_node_json,
+                    p.content_sha256, p.content_size, p.sharing_policy,
+                    p.anchor_policy, p.disposition, p.selected_root_node_json,
+                    f.id, f.payload_node_json, f.content_sha256, f.content_size,
+                    f.trove_id, owner.name, owner.install_source
+             FROM conary_tx_payload p
+             LEFT JOIN files f ON f.path = p.path
+             LEFT JOIN troves owner ON owner.id = f.trove_id
+             ORDER BY p.path, p.trove_id",
+        )?;
+        let rows = statement
+            .query_map([], |row| {
+                Ok(StagedAnchorInput {
+                    path: row.get(0)?,
+                    trove_id: row.get(1)?,
+                    package_name: row.get(2)?,
+                    incoming_node_json: row.get(3)?,
+                    incoming_sha256: row.get(4)?,
+                    incoming_size: row.get(5)?,
+                    incoming_policy: row.get(6)?,
+                    anchor_policy: row.get(7)?,
+                    disposition: row.get(8)?,
+                    selected_root_node_json: row.get(9)?,
+                    existing_id: row.get(10)?,
+                    existing_node_json: row.get(11)?,
+                    existing_sha256: row.get(12)?,
+                    existing_size: row.get(13)?,
+                    existing_trove_id: row.get(14)?,
+                    existing_owner_name: row.get(15)?,
+                    existing_install_source: row.get(16)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        drop(statement);
+        self.count_validation_query();
+
+        let mut decisions = Vec::with_capacity(rows.len());
+        for row in rows {
+            decisions.push(self.plan_anchor_decision(row)?);
+        }
+        Ok(decisions)
+    }
+
+    fn plan_anchor_decision(&mut self, row: StagedAnchorInput) -> Result<PlannedDecision> {
+        let incoming_node = parse_node(&row.path, &row.incoming_node_json)?;
+        let incoming_content = parse_content(&row.path, row.incoming_sha256, row.incoming_size)?;
+        let incoming_claim = PayloadClaim::new(
+            row.path.clone(),
+            row.trove_id,
+            incoming_node.clone(),
+            incoming_content,
+            crate::payload::PayloadSharingPolicy::parse(&row.incoming_policy)
+                .map_err(|error| Error::ParseError(error.to_string()))?,
+        )?
+        .with_anchor_policy(parse_anchor_policy(&row.anchor_policy)?);
+        let disposition = parse_disposition(&row.disposition)?;
+
+        let existing = match (
+            row.existing_id,
+            row.existing_node_json,
+            row.existing_trove_id,
+        ) {
+            (Some(id), Some(node_json), Some(trove_id)) => Some(FileEntry {
+                id: Some(id),
+                path: row.path.clone(),
+                node: parse_node(&row.path, &node_json)?,
+                content: parse_content(&row.path, row.existing_sha256, row.existing_size)?,
+                trove_id,
+                installed_at: None,
+                component_id: None,
+                claim_policy: crate::payload::PayloadSharingPolicy::Exclusive,
+            }),
+            (None, None, None) => None,
+            _ => {
+                return Err(Error::ConfigError(format!(
+                    "materialized payload {} has incomplete canonical authority",
+                    row.path
+                )));
+            }
+        };
+
+        match disposition {
+            StagedAnchorDisposition::Auto => {
+                let Some(existing) = existing.as_ref() else {
+                    return Ok(PlannedDecision::replace(row.path, row.trove_id));
+                };
+                if matches!(incoming_node.source.kind, PayloadNodeKind::Directory)
+                    && incoming_claim
+                        .anchor_policy
+                        .accepts_kind(&existing.node.source.kind)
+                {
+                    incoming_claim.validate_anchor(existing)?;
+                    return Ok(PlannedDecision::apply_directory(row.path, row.trove_id));
+                }
+                if self.claims_are_compatible(&incoming_claim)? {
+                    incoming_claim.validate_anchor(existing)?;
+                    return Ok(PlannedDecision::keep(row.path, row.trove_id, false));
+                }
+                self.require_replaceable_claims(
+                    &row.path,
+                    &row.package_name,
+                    existing.trove_id,
+                    row.existing_owner_name.as_deref(),
+                    row.existing_install_source.as_deref(),
+                )?;
+                Ok(PlannedDecision::replace(row.path, row.trove_id))
+            }
+            StagedAnchorDisposition::Replace => {
+                if let Some(existing) = existing.as_ref() {
+                    self.require_replaceable_claims(
+                        &row.path,
+                        &row.package_name,
+                        existing.trove_id,
+                        row.existing_owner_name.as_deref(),
+                        row.existing_install_source.as_deref(),
+                    )?;
+                }
+                Ok(PlannedDecision::replace(row.path, row.trove_id))
+            }
+            StagedAnchorDisposition::Share => {
+                let Some(existing) = existing else {
+                    // Upgrade finalization may delete the old trove and its
+                    // compatible anchor after preflight. Re-anchor the exact
+                    // incoming authority without claiming another root write.
+                    return Ok(PlannedDecision::replace_without_materialization(
+                        row.path,
+                        row.trove_id,
+                    ));
+                };
+                self.require_compatible_claims(&incoming_claim)?;
+                incoming_claim.validate_anchor(&existing)?;
+                Ok(PlannedDecision::keep(row.path, row.trove_id, false))
+            }
+            StagedAnchorDisposition::ApplyDirectory => {
+                if !matches!(incoming_node.source.kind, PayloadNodeKind::Directory) {
+                    return Err(Error::ConfigError(format!(
+                        "staged directory application {} is not a directory",
+                        row.path
+                    )));
+                }
+                if let Some(existing) = existing.as_ref() {
+                    incoming_claim.validate_anchor(existing)?;
+                } else if row.selected_root_node_json.is_none() {
+                    return Err(Error::ConflictError(format!(
+                        "staged directory application {} has no selected-root anchor",
+                        row.path
+                    )));
+                }
+                Ok(PlannedDecision::apply_directory(row.path, row.trove_id))
+            }
+            StagedAnchorDisposition::PreserveSelectedRoot => {
+                if let Some(existing) = existing.as_ref() {
+                    incoming_claim.validate_anchor(existing)?;
+                    Ok(PlannedDecision::keep(row.path, row.trove_id, false))
+                } else {
+                    let node_json = row.selected_root_node_json.ok_or_else(|| {
+                        Error::ConflictError(format!(
+                            "staged preserved payload {} has no selected-root node",
+                            row.path
+                        ))
+                    })?;
+                    let anchor = FileEntry {
+                        id: None,
+                        path: row.path.clone(),
+                        node: parse_node(&row.path, &node_json)?,
+                        content: None,
+                        trove_id: row.trove_id,
+                        installed_at: None,
+                        component_id: None,
+                        claim_policy: crate::payload::PayloadSharingPolicy::Exclusive,
+                    };
+                    incoming_claim.validate_anchor(&anchor)?;
+                    Ok(PlannedDecision::insert_selected_root(
+                        row.path,
+                        row.trove_id,
+                    ))
+                }
+            }
+        }
+    }
+
+    fn require_replaceable_claims(
+        &mut self,
+        path: &str,
+        package_name: &str,
+        existing_trove_id: i64,
+        existing_owner_name: Option<&str>,
+        existing_install_source: Option<&str>,
+    ) -> Result<()> {
+        let blocked = self
+            .tx
+            .query_row(
+                "SELECT pc.trove_id, t.name
+             FROM payload_claims pc
+             JOIN troves t ON t.id = pc.trove_id
+             LEFT JOIN conary_tx_replacement_owners allowed ON allowed.trove_id = pc.trove_id
+             WHERE pc.path = ?1
+               AND allowed.trove_id IS NULL
+               AND t.name != ?2
+               AND t.install_source != 'captured-root'
+             ORDER BY pc.trove_id LIMIT 1",
+                params![path, package_name],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+            )
+            .optional()?;
+        self.count_validation_query();
+        if let Some((trove_id, owner)) = blocked {
+            return Err(Error::ConflictError(format!(
+                "staged payload {path} cannot replace claim from package {owner} ({trove_id})"
+            )));
+        }
+        if existing_owner_name.is_none() {
+            return Err(Error::ConfigError(format!(
+                "materialized payload {path} references missing trove {existing_trove_id}"
+            )));
+        }
+        let anchor_allowed = existing_owner_name == Some(package_name)
+            || existing_install_source == Some("captured-root")
+            || self.tx.query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM conary_tx_replacement_owners WHERE trove_id = ?1
+                 )",
+                [existing_trove_id],
+                |row| row.get::<_, bool>(0),
+            )?;
+        self.count_validation_query();
+        if !anchor_allowed {
+            return Err(Error::ConflictError(format!(
+                "staged payload {path} cannot replace package {}",
+                existing_owner_name.unwrap_or("<missing>")
+            )));
+        }
+        Ok(())
+    }
+
+    fn require_compatible_claims(&mut self, incoming: &PayloadClaim) -> Result<()> {
+        let claims = PayloadClaim::find_by_path(self.tx, &incoming.path)?;
+        self.count_validation_query();
+        if claims.is_empty() {
+            return Err(Error::ConfigError(format!(
+                "materialized payload {} has no package claim",
+                incoming.path
+            )));
+        }
+        for claim in claims {
+            incoming.compatible_with(&claim).map_err(|mismatch| {
+                Error::ConflictError(format!(
+                    "staged payload {} is incompatible with trove {}: {mismatch}",
+                    incoming.path, claim.trove_id
+                ))
+            })?;
+        }
+        Ok(())
+    }
+
+    fn claims_are_compatible(&mut self, incoming: &PayloadClaim) -> Result<bool> {
+        let claims = PayloadClaim::find_by_path(self.tx, &incoming.path)?;
+        self.count_validation_query();
+        if claims.is_empty() {
+            return Err(Error::ConfigError(format!(
+                "materialized payload {} has no package claim",
+                incoming.path
+            )));
+        }
+        Ok(claims
+            .iter()
+            .all(|claim| incoming.compatible_with(claim).is_ok()))
+    }
+
+    fn persist_decisions(&mut self, decisions: &[PlannedDecision]) -> Result<()> {
+        let mut statement = self.tx.prepare_cached(
+            "INSERT INTO conary_tx_decisions (path, trove_id, anchor_action, materialized)
+             VALUES (?1, ?2, ?3, ?4)",
+        )?;
+        for decision in decisions {
+            statement.execute(params![
+                &decision.path,
+                decision.trove_id,
+                decision.anchor_action,
+                decision.materialized,
+            ])?;
+            self.work.rows_loaded += 1;
+            self.work.load_statement_executions += 1;
+        }
+        self.work.query_shapes += 1;
+        Ok(())
+    }
+
+    fn reconcile_components(&mut self) -> Result<()> {
+        self.tx.execute(
+            "INSERT INTO components (parent_trove_id, name, description, is_installed)
+             SELECT trove_id, name, description, is_installed
+             FROM conary_tx_components
+             ORDER BY trove_id, name
+             ON CONFLICT(parent_trove_id, name) DO UPDATE SET
+                description = excluded.description,
+                is_installed = excluded.is_installed",
+            [],
+        )?;
+        self.count_reconciliation_statement();
+        Ok(())
+    }
+
+    fn reconcile_contents(&mut self) -> Result<()> {
+        self.tx.execute(
+            "INSERT OR IGNORE INTO file_contents (sha256_hash, content_path, size)
+             SELECT DISTINCT content_sha256,
+                    'objects/' || substr(content_sha256, 1, 2) || '/' || substr(content_sha256, 3),
+                    content_size
+             FROM conary_tx_payload
+             WHERE content_sha256 IS NOT NULL
+             ORDER BY content_sha256",
+            [],
+        )?;
+        self.count_reconciliation_statement();
+        Ok(())
+    }
+
+    fn reconcile_anchors(&mut self) -> Result<()> {
+        self.tx.execute(
+            "DELETE FROM payload_claims
+             WHERE path IN (
+                 SELECT path FROM conary_tx_decisions WHERE anchor_action = 'replace'
+             )
+             AND (
+                 trove_id IN (SELECT trove_id FROM conary_tx_replacement_owners)
+                 OR trove_id IN (
+                     SELECT t.id FROM troves t
+                     JOIN conary_tx_payload p ON p.package_name = t.name
+                     WHERE p.path = payload_claims.path
+                 )
+                 OR trove_id IN (
+                     SELECT id FROM troves WHERE install_source = 'captured-root'
+                 )
+             )",
+            [],
+        )?;
+        self.count_reconciliation_statement();
+
+        self.tx.execute(
+            "INSERT INTO files (
+                path, payload_node_json, content_sha256, content_size,
+                trove_id, component_id
+             )
+             SELECT p.path,
+                    CASE d.anchor_action
+                        WHEN 'insert-selected-root' THEN p.selected_root_node_json
+                        ELSE p.payload_node_json
+                    END,
+                    CASE d.anchor_action
+                        WHEN 'insert-selected-root' THEN NULL
+                        ELSE p.content_sha256
+                    END,
+                    CASE d.anchor_action
+                        WHEN 'insert-selected-root' THEN NULL
+                        ELSE p.content_size
+                    END,
+                    p.trove_id,
+                    c.id
+             FROM conary_tx_payload p
+             JOIN conary_tx_decisions d USING(path, trove_id)
+             LEFT JOIN components c
+               ON c.parent_trove_id = p.trove_id AND c.name = p.component_name
+             WHERE d.anchor_action IN ('replace', 'apply-directory', 'insert-selected-root')
+             ORDER BY p.path, p.trove_id
+             ON CONFLICT(path) DO UPDATE SET
+                payload_node_json = excluded.payload_node_json,
+                content_sha256 = excluded.content_sha256,
+                content_size = excluded.content_size,
+                trove_id = excluded.trove_id,
+                component_id = excluded.component_id",
+            [],
+        )?;
+        self.count_reconciliation_statement();
+        Ok(())
+    }
+
+    fn reconcile_claims(&mut self) -> Result<()> {
+        self.tx.execute(
+            "INSERT INTO payload_claims (
+                path, trove_id, component_id, sharing_policy, anchor_policy,
+                materialization_target_path, payload_node_json,
+                content_sha256, content_size
+             )
+             SELECT p.path, p.trove_id, c.id, p.sharing_policy, p.anchor_policy,
+                    p.materialization_target_path, p.payload_node_json,
+                    p.content_sha256, p.content_size
+             FROM conary_tx_payload p
+             LEFT JOIN components c
+               ON c.parent_trove_id = p.trove_id AND c.name = p.component_name
+             ORDER BY p.path, p.trove_id
+             ON CONFLICT(path, trove_id) DO UPDATE SET
+                component_id = excluded.component_id,
+                sharing_policy = excluded.sharing_policy,
+                anchor_policy = excluded.anchor_policy,
+                materialization_target_path = excluded.materialization_target_path,
+                payload_node_json = excluded.payload_node_json,
+                content_sha256 = excluded.content_sha256,
+                content_size = excluded.content_size",
+            [],
+        )?;
+        self.count_reconciliation_statement();
+        Ok(())
+    }
+
+    fn reconcile_hardlinks(&mut self) -> Result<()> {
+        let missing_target = self
+            .tx
+            .query_row(
+                "SELECT p.path, json_extract(p.payload_node_json, '$.source.kind.target')
+             FROM conary_tx_payload p
+             LEFT JOIN files target
+               ON target.path = json_extract(p.payload_node_json, '$.source.kind.target')
+             WHERE json_extract(p.payload_node_json, '$.source.kind.type') = 'hardlink'
+               AND (
+                   target.path IS NULL
+                   OR json_extract(target.payload_node_json, '$.source.kind.type') != 'regular'
+               )
+             ORDER BY p.path LIMIT 1",
+                [],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            )
+            .optional()?;
+        self.count_validation_query();
+        if let Some((path, target)) = missing_target {
+            return Err(Error::ConflictError(format!(
+                "staged hardlink {path} has no regular materialization target {target}"
+            )));
+        }
+
+        self.tx.execute(
+            "UPDATE files
+             SET payload_node_json = json_set(
+                 payload_node_json,
+                 '$.source.kind.hardlink_identity',
+                 'path:' || path
+             )
+             WHERE path IN (
+                 SELECT DISTINCT json_extract(payload_node_json, '$.source.kind.target')
+                 FROM conary_tx_payload
+                 WHERE json_extract(payload_node_json, '$.source.kind.type') = 'hardlink'
+             )",
+            [],
+        )?;
+        self.count_reconciliation_statement();
+        self.tx.execute(
+            "UPDATE files
+             SET payload_node_json = json_set(
+                 payload_node_json,
+                 '$.source.kind.identity',
+                 'path:' || json_extract(payload_node_json, '$.source.kind.target')
+             )
+             WHERE json_extract(payload_node_json, '$.source.kind.type') = 'hardlink'
+               AND json_extract(payload_node_json, '$.source.kind.target') IN (
+                   SELECT DISTINCT json_extract(payload_node_json, '$.source.kind.target')
+                   FROM conary_tx_payload
+                   WHERE json_extract(payload_node_json, '$.source.kind.type') = 'hardlink'
+               )",
+            [],
+        )?;
+        self.count_reconciliation_statement();
+        Ok(())
+    }
+
+    fn reconcile_history(&mut self) -> Result<()> {
+        self.tx.execute(
+            "INSERT INTO file_history (changeset_id, path, sha256_hash, action)
+             SELECT p.history_changeset_id, p.path, p.content_sha256, p.history_action
+             FROM conary_tx_payload p
+             JOIN conary_tx_decisions d USING(path, trove_id)
+             WHERE p.history_changeset_id IS NOT NULL AND d.materialized = 1
+             ORDER BY p.path, p.trove_id",
+            [],
+        )?;
+        self.count_reconciliation_statement();
+        self.tx.execute(
+            "INSERT INTO file_history (changeset_id, path, sha256_hash, action)
+             SELECT h.changeset_id, h.path,
+                    CASE WHEN content.sha256_hash IS NULL THEN NULL ELSE h.sha256_hash END,
+                    h.action
+             FROM conary_tx_history h
+             LEFT JOIN file_contents content ON content.sha256_hash = h.sha256_hash
+             ORDER BY h.path, h.action",
+            [],
+        )?;
+        self.count_reconciliation_statement();
+        Ok(())
+    }
+
+    fn reconcile_configs(&mut self) -> Result<()> {
+        self.tx.execute(
+            "INSERT INTO config_files (
+                file_id, path, trove_id, package_name, package_version,
+                package_architecture, original_hash, original_md5, current_hash,
+                noreplace, ghost, materialized, remove_on_upgrade, status,
+                modified_at, source
+             )
+             SELECT CASE WHEN s.materialized = 1 THEN f.id ELSE NULL END,
+                    s.path, s.trove_id, t.name, t.version, t.architecture,
+                    s.original_hash, s.original_md5, s.current_hash,
+                    s.noreplace, s.ghost, s.materialized, s.remove_on_upgrade,
+                    s.status, s.modified_at, s.source
+             FROM conary_tx_configs s
+             JOIN troves t ON t.id = s.trove_id
+             LEFT JOIN files f ON f.path = s.path
+             ORDER BY s.path
+             ON CONFLICT(path) DO UPDATE SET
+                file_id = excluded.file_id,
+                trove_id = excluded.trove_id,
+                package_name = excluded.package_name,
+                package_version = excluded.package_version,
+                package_architecture = excluded.package_architecture,
+                original_hash = excluded.original_hash,
+                original_md5 = excluded.original_md5,
+                current_hash = excluded.current_hash,
+                noreplace = excluded.noreplace,
+                ghost = excluded.ghost,
+                materialized = excluded.materialized,
+                remove_on_upgrade = excluded.remove_on_upgrade,
+                status = excluded.status,
+                modified_at = excluded.modified_at,
+                source = excluded.source",
+            [],
+        )?;
+        self.count_reconciliation_statement();
+        Ok(())
+    }
+
+    fn load_outcomes(&mut self) -> Result<BTreeMap<String, StagedPayloadOutcome>> {
+        let mut statement = self.tx.prepare(
+            "SELECT p.path, f.id, f.content_sha256, d.materialized
+             FROM conary_tx_payload p
+             JOIN conary_tx_decisions d USING(path, trove_id)
+             JOIN files f ON f.path = p.path
+             ORDER BY p.path, p.trove_id",
+        )?;
+        let rows = statement
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    StagedPayloadOutcome {
+                        file_id: row.get(1)?,
+                        content_sha256: row.get(2)?,
+                        materialized: row.get(3)?,
+                    },
+                ))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        drop(statement);
+        self.count_validation_query();
+        Ok(rows.into_iter().collect())
+    }
+
+    fn count_loaded_row(&mut self) {
+        self.work.rows_loaded += 1;
+        self.work.load_statement_executions += 1;
+        self.work.query_shapes = self.work.query_shapes.max(5);
+    }
+
+    fn count_validation_query(&mut self) {
+        self.work.validation_query_executions += 1;
+        self.work.query_shapes += 1;
+    }
+
+    fn count_reconciliation_statement(&mut self) {
+        self.work.reconciliation_statement_executions += 1;
+        self.work.query_shapes += 1;
+    }
+}
+
+#[cfg(test)]
+#[path = "package_transaction_staging/tests.rs"]
+mod tests;

--- a/crates/conary-core/src/db/models/package_transaction_staging/planning.rs
+++ b/crates/conary-core/src/db/models/package_transaction_staging/planning.rs
@@ -7,6 +7,30 @@ use crate::db::models::{ExistingDirectoryMaterialization, PayloadClaimAnchorPoli
 use crate::error::{Error, Result};
 use crate::payload::{PayloadContentAuthority, PayloadNodeKind, ResolvedPayloadNode};
 
+#[derive(Debug, Clone)]
+pub(super) struct LoadedClaim {
+    pub(super) claim: crate::db::models::PayloadClaim,
+    pub(super) owner_name: String,
+    pub(super) owner_install_source: String,
+    pub(super) replacement_allowed: bool,
+}
+
+#[derive(Debug)]
+pub(super) struct StagedClaimInput {
+    pub(super) path: String,
+    pub(super) trove_id: i64,
+    pub(super) component_id: Option<i64>,
+    pub(super) sharing_policy: String,
+    pub(super) anchor_policy: String,
+    pub(super) materialization_target_path: Option<String>,
+    pub(super) node_json: String,
+    pub(super) content_sha256: Option<String>,
+    pub(super) content_size: Option<i64>,
+    pub(super) owner_name: String,
+    pub(super) owner_install_source: String,
+    pub(super) replacement_allowed: bool,
+}
+
 #[derive(Debug)]
 pub(super) struct StagedAnchorInput {
     pub(super) path: String,
@@ -79,6 +103,24 @@ impl PlannedDecision {
             trove_id,
             anchor_action: "apply-directory",
             materialized: true,
+        }
+    }
+
+    pub(super) fn reconcile_materialization(path: String, trove_id: i64) -> Self {
+        Self {
+            path,
+            trove_id,
+            anchor_action: "reconcile-materialization",
+            materialized: false,
+        }
+    }
+
+    pub(super) fn reconcile_owned(path: String, trove_id: i64) -> Self {
+        Self {
+            path,
+            trove_id,
+            anchor_action: "reconcile-owned",
+            materialized: false,
         }
     }
 }
@@ -157,6 +199,8 @@ pub(super) fn parse_disposition(value: &str) -> Result<StagedAnchorDisposition> 
         "share" => Ok(StagedAnchorDisposition::Share),
         "apply-directory" => Ok(StagedAnchorDisposition::ApplyDirectory),
         "preserve-selected-root" => Ok(StagedAnchorDisposition::PreserveSelectedRoot),
+        "reconcile-owned" => Ok(StagedAnchorDisposition::ReconcileOwned),
+        "reconcile-captured-root" => Ok(StagedAnchorDisposition::ReconcileCapturedRoot),
         other => Err(Error::ParseError(format!(
             "unknown staged payload disposition {other:?}"
         ))),

--- a/crates/conary-core/src/db/models/package_transaction_staging/planning.rs
+++ b/crates/conary-core/src/db/models/package_transaction_staging/planning.rs
@@ -1,0 +1,215 @@
+// conary-core/src/db/models/package_transaction_staging/planning.rs
+
+//! Typed staging validation and canonical-anchor decisions.
+
+use super::{StagedAnchorDisposition, StagedPayloadRow};
+use crate::db::models::{ExistingDirectoryMaterialization, PayloadClaimAnchorPolicy};
+use crate::error::{Error, Result};
+use crate::payload::{PayloadContentAuthority, PayloadNodeKind, ResolvedPayloadNode};
+
+#[derive(Debug)]
+pub(super) struct StagedAnchorInput {
+    pub(super) path: String,
+    pub(super) trove_id: i64,
+    pub(super) package_name: String,
+    pub(super) incoming_node_json: String,
+    pub(super) incoming_sha256: Option<String>,
+    pub(super) incoming_size: Option<i64>,
+    pub(super) incoming_policy: String,
+    pub(super) anchor_policy: String,
+    pub(super) disposition: String,
+    pub(super) selected_root_node_json: Option<String>,
+    pub(super) existing_id: Option<i64>,
+    pub(super) existing_node_json: Option<String>,
+    pub(super) existing_sha256: Option<String>,
+    pub(super) existing_size: Option<i64>,
+    pub(super) existing_trove_id: Option<i64>,
+    pub(super) existing_owner_name: Option<String>,
+    pub(super) existing_install_source: Option<String>,
+}
+
+#[derive(Debug)]
+pub(super) struct PlannedDecision {
+    pub(super) path: String,
+    pub(super) trove_id: i64,
+    pub(super) anchor_action: &'static str,
+    pub(super) materialized: bool,
+}
+
+impl PlannedDecision {
+    pub(super) fn replace(path: String, trove_id: i64) -> Self {
+        Self {
+            path,
+            trove_id,
+            anchor_action: "replace",
+            materialized: true,
+        }
+    }
+
+    pub(super) fn keep(path: String, trove_id: i64, materialized: bool) -> Self {
+        Self {
+            path,
+            trove_id,
+            anchor_action: "keep",
+            materialized,
+        }
+    }
+
+    pub(super) fn replace_without_materialization(path: String, trove_id: i64) -> Self {
+        Self {
+            path,
+            trove_id,
+            anchor_action: "replace",
+            materialized: false,
+        }
+    }
+
+    pub(super) fn insert_selected_root(path: String, trove_id: i64) -> Self {
+        Self {
+            path,
+            trove_id,
+            anchor_action: "insert-selected-root",
+            materialized: false,
+        }
+    }
+
+    pub(super) fn apply_directory(path: String, trove_id: i64) -> Self {
+        Self {
+            path,
+            trove_id,
+            anchor_action: "apply-directory",
+            materialized: true,
+        }
+    }
+}
+
+pub(super) fn validate_staged_payload(row: &StagedPayloadRow) -> Result<()> {
+    row.entry
+        .node
+        .validate()
+        .and_then(|()| {
+            row.entry
+                .node
+                .source
+                .validate_content(row.entry.content.as_ref())
+        })
+        .map_err(|error| {
+            Error::ParseError(format!(
+                "staged payload authority for {} is invalid: {error}",
+                row.entry.path
+            ))
+        })?;
+    if let Some(selected_root_node) = row.selected_root_node.as_ref() {
+        selected_root_node.validate().map_err(|error| {
+            Error::ParseError(format!(
+                "staged selected-root authority for {} is invalid: {error}",
+                row.entry.path
+            ))
+        })?;
+    }
+    if let Some((_, action)) = row.history
+        && !matches!(action, "add" | "modify")
+    {
+        return Err(Error::ConfigError(format!(
+            "staged payload {} has invalid history action {action:?}",
+            row.entry.path
+        )));
+    }
+    Ok(())
+}
+
+pub(super) fn anchor_policy(
+    materialization: ExistingDirectoryMaterialization,
+    node: &ResolvedPayloadNode,
+) -> PayloadClaimAnchorPolicy {
+    if !matches!(node.source.kind, PayloadNodeKind::Directory) {
+        return PayloadClaimAnchorPolicy::Exact;
+    }
+    match materialization {
+        ExistingDirectoryMaterialization::ApplyIncoming
+        | ExistingDirectoryMaterialization::PreserveExistingDirectory => {
+            PayloadClaimAnchorPolicy::Directory
+        }
+        ExistingDirectoryMaterialization::ApplyIncomingDirectoryOrSymlinkToDirectory
+        | ExistingDirectoryMaterialization::PreserveExistingDirectoryOrSymlinkToDirectory => {
+            PayloadClaimAnchorPolicy::DirectoryOrSymlinkToDirectory
+        }
+    }
+}
+
+pub(super) fn parse_anchor_policy(value: &str) -> Result<PayloadClaimAnchorPolicy> {
+    match value {
+        "exact" => Ok(PayloadClaimAnchorPolicy::Exact),
+        "directory" => Ok(PayloadClaimAnchorPolicy::Directory),
+        "directory-or-symlink-to-directory" => {
+            Ok(PayloadClaimAnchorPolicy::DirectoryOrSymlinkToDirectory)
+        }
+        other => Err(Error::ParseError(format!(
+            "unknown staged payload anchor policy {other:?}"
+        ))),
+    }
+}
+
+pub(super) fn parse_disposition(value: &str) -> Result<StagedAnchorDisposition> {
+    match value {
+        "auto" => Ok(StagedAnchorDisposition::Auto),
+        "replace" => Ok(StagedAnchorDisposition::Replace),
+        "share" => Ok(StagedAnchorDisposition::Share),
+        "apply-directory" => Ok(StagedAnchorDisposition::ApplyDirectory),
+        "preserve-selected-root" => Ok(StagedAnchorDisposition::PreserveSelectedRoot),
+        other => Err(Error::ParseError(format!(
+            "unknown staged payload disposition {other:?}"
+        ))),
+    }
+}
+
+pub(super) fn parse_node(path: &str, json: &str) -> Result<ResolvedPayloadNode> {
+    let node = serde_json::from_str::<ResolvedPayloadNode>(json).map_err(|error| {
+        Error::ParseError(format!(
+            "staged payload {path} has invalid node JSON: {error}"
+        ))
+    })?;
+    node.validate().map_err(|error| {
+        Error::ParseError(format!("staged payload {path} has invalid node: {error}"))
+    })?;
+    Ok(node)
+}
+
+pub(super) fn parse_content(
+    path: &str,
+    sha256: Option<String>,
+    size: Option<i64>,
+) -> Result<Option<PayloadContentAuthority>> {
+    match (sha256, size) {
+        (Some(sha256), Some(size)) => {
+            let content = PayloadContentAuthority {
+                sha256,
+                size: u64::try_from(size).map_err(|_| {
+                    Error::ParseError(format!("staged payload {path} has negative content size"))
+                })?,
+            };
+            content.validate().map_err(|error| {
+                Error::ParseError(format!(
+                    "staged payload {path} has invalid content authority: {error}"
+                ))
+            })?;
+            Ok(Some(content))
+        }
+        (None, None) => Ok(None),
+        _ => Err(Error::ParseError(format!(
+            "staged payload {path} has incomplete content authority"
+        ))),
+    }
+}
+
+pub(super) fn persisted_content_size(
+    content: Option<&PayloadContentAuthority>,
+) -> Result<Option<i64>> {
+    content
+        .map(|content| {
+            i64::try_from(content.size).map_err(|_| {
+                Error::ParseError("staged payload content size exceeds SQLite range".to_string())
+            })
+        })
+        .transpose()
+}

--- a/crates/conary-core/src/db/models/package_transaction_staging/reconcile.rs
+++ b/crates/conary-core/src/db/models/package_transaction_staging/reconcile.rs
@@ -1,0 +1,311 @@
+// conary-core/src/db/models/package_transaction_staging/reconcile.rs
+
+//! Set-based projection from transaction staging into canonical package state.
+
+use super::{PackageTransactionStaging, StagedPayloadOutcome};
+use crate::error::{Error, Result};
+use rusqlite::OptionalExtension;
+use std::collections::BTreeMap;
+
+impl PackageTransactionStaging<'_> {
+    pub(super) fn reconcile_components(&mut self) -> Result<()> {
+        self.tx.execute(
+            "INSERT INTO components (parent_trove_id, name, description, is_installed)
+             SELECT trove_id, name, description, is_installed
+             FROM conary_tx_components
+             ORDER BY trove_id, name
+             ON CONFLICT(parent_trove_id, name) DO UPDATE SET
+                description = excluded.description,
+                is_installed = excluded.is_installed",
+            [],
+        )?;
+        self.count_reconciliation_statement();
+        Ok(())
+    }
+
+    pub(super) fn reconcile_contents(&mut self) -> Result<()> {
+        self.tx.execute(
+            "INSERT OR IGNORE INTO file_contents (sha256_hash, content_path, size)
+             SELECT DISTINCT content_sha256,
+                    'objects/' || substr(content_sha256, 1, 2) || '/' || substr(content_sha256, 3),
+                    content_size
+             FROM conary_tx_payload
+             WHERE content_sha256 IS NOT NULL
+             ORDER BY content_sha256",
+            [],
+        )?;
+        self.count_reconciliation_statement();
+        Ok(())
+    }
+
+    pub(super) fn reconcile_anchors(&mut self) -> Result<()> {
+        self.tx.execute(
+            "DELETE FROM payload_claims
+             WHERE path IN (
+                 SELECT path FROM conary_tx_decisions WHERE anchor_action = 'replace'
+             )
+             AND (
+                 trove_id IN (SELECT trove_id FROM conary_tx_replacement_owners)
+                 OR trove_id IN (
+                     SELECT t.id FROM troves t
+                     JOIN conary_tx_payload p ON p.package_name = t.name
+                     WHERE p.path = payload_claims.path
+                 )
+                 OR trove_id IN (
+                     SELECT id FROM troves WHERE install_source = 'captured-root'
+                 )
+             )",
+            [],
+        )?;
+        self.count_reconciliation_statement();
+
+        self.tx.execute(
+            "UPDATE files
+             SET payload_node_json = (
+                     SELECT p.payload_node_json
+                     FROM conary_tx_payload p
+                     JOIN conary_tx_decisions d USING(path, trove_id)
+                     WHERE p.path = files.path
+                       AND d.anchor_action IN ('reconcile-materialization', 'reconcile-owned')
+                 ),
+                 content_sha256 = (
+                     SELECT p.content_sha256
+                     FROM conary_tx_payload p
+                     JOIN conary_tx_decisions d USING(path, trove_id)
+                     WHERE p.path = files.path
+                       AND d.anchor_action IN ('reconcile-materialization', 'reconcile-owned')
+                 ),
+                 content_size = (
+                     SELECT p.content_size
+                     FROM conary_tx_payload p
+                     JOIN conary_tx_decisions d USING(path, trove_id)
+                     WHERE p.path = files.path
+                       AND d.anchor_action IN ('reconcile-materialization', 'reconcile-owned')
+                 )
+             WHERE path IN (
+                 SELECT path FROM conary_tx_decisions
+                 WHERE anchor_action IN ('reconcile-materialization', 'reconcile-owned')
+             )",
+            [],
+        )?;
+        self.count_reconciliation_statement();
+
+        self.tx.execute(
+            "INSERT INTO files (
+                path, payload_node_json, content_sha256, content_size,
+                trove_id, component_id
+             )
+             SELECT p.path,
+                    CASE d.anchor_action
+                        WHEN 'insert-selected-root' THEN p.selected_root_node_json
+                        ELSE p.payload_node_json
+                    END,
+                    CASE d.anchor_action
+                        WHEN 'insert-selected-root' THEN NULL
+                        ELSE p.content_sha256
+                    END,
+                    CASE d.anchor_action
+                        WHEN 'insert-selected-root' THEN NULL
+                        ELSE p.content_size
+                    END,
+                    p.trove_id,
+                    c.id
+             FROM conary_tx_payload p
+             JOIN conary_tx_decisions d USING(path, trove_id)
+             LEFT JOIN components c
+               ON c.parent_trove_id = p.trove_id AND c.name = p.component_name
+             WHERE d.anchor_action IN ('replace', 'apply-directory', 'insert-selected-root')
+             ORDER BY p.path, p.trove_id
+             ON CONFLICT(path) DO UPDATE SET
+                payload_node_json = excluded.payload_node_json,
+                content_sha256 = excluded.content_sha256,
+                content_size = excluded.content_size,
+                trove_id = excluded.trove_id,
+                component_id = excluded.component_id",
+            [],
+        )?;
+        self.count_reconciliation_statement();
+        Ok(())
+    }
+
+    pub(super) fn reconcile_claims(&mut self) -> Result<()> {
+        self.tx.execute(
+            "INSERT INTO payload_claims (
+                path, trove_id, component_id, sharing_policy, anchor_policy,
+                materialization_target_path, payload_node_json,
+                content_sha256, content_size
+             )
+             SELECT p.path, p.trove_id, c.id, p.sharing_policy, p.anchor_policy,
+                    p.materialization_target_path, p.payload_node_json,
+                    p.content_sha256, p.content_size
+             FROM conary_tx_payload p
+             JOIN conary_tx_decisions d USING(path, trove_id)
+             LEFT JOIN components c
+               ON c.parent_trove_id = p.trove_id AND c.name = p.component_name
+             WHERE d.anchor_action != 'reconcile-materialization'
+             ORDER BY p.path, p.trove_id
+             ON CONFLICT(path, trove_id) DO UPDATE SET
+                component_id = excluded.component_id,
+                sharing_policy = excluded.sharing_policy,
+                anchor_policy = excluded.anchor_policy,
+                materialization_target_path = excluded.materialization_target_path,
+                payload_node_json = excluded.payload_node_json,
+                content_sha256 = excluded.content_sha256,
+                content_size = excluded.content_size",
+            [],
+        )?;
+        self.count_reconciliation_statement();
+        Ok(())
+    }
+
+    pub(super) fn reconcile_hardlinks(&mut self) -> Result<()> {
+        let missing_target = self
+            .tx
+            .query_row(
+                "SELECT p.path, json_extract(p.payload_node_json, '$.source.kind.target')
+             FROM conary_tx_payload p
+             LEFT JOIN files target
+               ON target.path = json_extract(p.payload_node_json, '$.source.kind.target')
+             WHERE json_extract(p.payload_node_json, '$.source.kind.type') = 'hardlink'
+               AND p.disposition != 'reconcile-captured-root'
+               AND (
+                   target.path IS NULL
+                   OR json_extract(target.payload_node_json, '$.source.kind.type') != 'regular'
+               )
+             ORDER BY p.path LIMIT 1",
+                [],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            )
+            .optional()?;
+        self.count_validation_query();
+        if let Some((path, target)) = missing_target {
+            return Err(Error::ConflictError(format!(
+                "staged hardlink {path} has no regular materialization target {target}"
+            )));
+        }
+
+        self.tx.execute(
+            "UPDATE files
+             SET payload_node_json = json_set(
+                 payload_node_json,
+                 '$.source.kind.hardlink_identity',
+                 'path:' || path
+             )
+             WHERE path IN (
+                 SELECT DISTINCT json_extract(payload_node_json, '$.source.kind.target')
+                 FROM conary_tx_payload
+                 WHERE json_extract(payload_node_json, '$.source.kind.type') = 'hardlink'
+                   AND disposition != 'reconcile-captured-root'
+             )",
+            [],
+        )?;
+        self.count_reconciliation_statement();
+        self.tx.execute(
+            "UPDATE files
+             SET payload_node_json = json_set(
+                 payload_node_json,
+                 '$.source.kind.identity',
+                 'path:' || json_extract(payload_node_json, '$.source.kind.target')
+             )
+             WHERE json_extract(payload_node_json, '$.source.kind.type') = 'hardlink'
+               AND json_extract(payload_node_json, '$.source.kind.target') IN (
+                   SELECT DISTINCT json_extract(payload_node_json, '$.source.kind.target')
+                   FROM conary_tx_payload
+                   WHERE json_extract(payload_node_json, '$.source.kind.type') = 'hardlink'
+                     AND disposition != 'reconcile-captured-root'
+               )",
+            [],
+        )?;
+        self.count_reconciliation_statement();
+        Ok(())
+    }
+
+    pub(super) fn reconcile_history(&mut self) -> Result<()> {
+        self.tx.execute(
+            "INSERT INTO file_history (changeset_id, path, sha256_hash, action)
+             SELECT p.history_changeset_id, p.path, p.content_sha256, p.history_action
+             FROM conary_tx_payload p
+             JOIN conary_tx_decisions d USING(path, trove_id)
+             WHERE p.history_changeset_id IS NOT NULL AND d.materialized = 1
+             ORDER BY p.path, p.trove_id",
+            [],
+        )?;
+        self.count_reconciliation_statement();
+        self.tx.execute(
+            "INSERT INTO file_history (changeset_id, path, sha256_hash, action)
+             SELECT h.changeset_id, h.path,
+                    CASE WHEN content.sha256_hash IS NULL THEN NULL ELSE h.sha256_hash END,
+                    h.action
+             FROM conary_tx_history h
+             LEFT JOIN file_contents content ON content.sha256_hash = h.sha256_hash
+             ORDER BY h.path, h.action",
+            [],
+        )?;
+        self.count_reconciliation_statement();
+        Ok(())
+    }
+
+    pub(super) fn reconcile_configs(&mut self) -> Result<()> {
+        self.tx.execute(
+            "INSERT INTO config_files (
+                file_id, path, trove_id, package_name, package_version,
+                package_architecture, original_hash, original_md5, current_hash,
+                noreplace, ghost, materialized, remove_on_upgrade, status,
+                modified_at, source
+             )
+             SELECT CASE WHEN s.materialized = 1 THEN f.id ELSE NULL END,
+                    s.path, s.trove_id, t.name, t.version, t.architecture,
+                    s.original_hash, s.original_md5, s.current_hash,
+                    s.noreplace, s.ghost, s.materialized, s.remove_on_upgrade,
+                    s.status, s.modified_at, s.source
+             FROM conary_tx_configs s
+             JOIN troves t ON t.id = s.trove_id
+             LEFT JOIN files f ON f.path = s.path
+             ORDER BY s.path
+             ON CONFLICT(path) DO UPDATE SET
+                file_id = excluded.file_id,
+                trove_id = excluded.trove_id,
+                package_name = excluded.package_name,
+                package_version = excluded.package_version,
+                package_architecture = excluded.package_architecture,
+                original_hash = excluded.original_hash,
+                original_md5 = excluded.original_md5,
+                current_hash = excluded.current_hash,
+                noreplace = excluded.noreplace,
+                ghost = excluded.ghost,
+                materialized = excluded.materialized,
+                remove_on_upgrade = excluded.remove_on_upgrade,
+                status = excluded.status,
+                modified_at = excluded.modified_at,
+                source = excluded.source",
+            [],
+        )?;
+        self.count_reconciliation_statement();
+        Ok(())
+    }
+
+    pub(super) fn load_outcomes(&mut self) -> Result<BTreeMap<String, StagedPayloadOutcome>> {
+        let mut statement = self.tx.prepare(
+            "SELECT p.path, f.id, f.content_sha256, d.materialized
+             FROM conary_tx_payload p
+             JOIN conary_tx_decisions d USING(path, trove_id)
+             JOIN files f ON f.path = p.path
+             ORDER BY p.path, p.trove_id",
+        )?;
+        let rows = statement
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    StagedPayloadOutcome {
+                        file_id: row.get(1)?,
+                        content_sha256: row.get(2)?,
+                        materialized: row.get(3)?,
+                    },
+                ))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        drop(statement);
+        self.count_validation_query();
+        Ok(rows.into_iter().collect())
+    }
+}

--- a/crates/conary-core/src/db/models/package_transaction_staging/sql.rs
+++ b/crates/conary-core/src/db/models/package_transaction_staging/sql.rs
@@ -1,0 +1,100 @@
+// conary-core/src/db/models/package_transaction_staging/sql.rs
+
+//! Ephemeral SQLite schema owned by package transaction staging.
+
+pub(super) const STAGING_SCHEMA_SQL: &str = r#"
+CREATE TEMP TABLE conary_tx_components (
+    trove_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    is_installed INTEGER NOT NULL CHECK(is_installed IN (0, 1)),
+    PRIMARY KEY(trove_id, name)
+) WITHOUT ROWID;
+
+CREATE TEMP TABLE conary_tx_payload (
+    path TEXT NOT NULL,
+    trove_id INTEGER NOT NULL,
+    package_name TEXT NOT NULL,
+    component_name TEXT,
+    payload_node_json TEXT NOT NULL CHECK(json_valid(payload_node_json)),
+    content_sha256 TEXT,
+    content_size INTEGER,
+    sharing_policy TEXT NOT NULL CHECK(sharing_policy IN ('exclusive', 'rpm')),
+    anchor_policy TEXT NOT NULL CHECK(anchor_policy IN (
+        'exact', 'directory', 'directory-or-symlink-to-directory'
+    )),
+    disposition TEXT NOT NULL CHECK(disposition IN (
+        'auto', 'replace', 'share', 'apply-directory', 'preserve-selected-root'
+    )),
+    selected_root_node_json TEXT CHECK(
+        selected_root_node_json IS NULL OR json_valid(selected_root_node_json)
+    ),
+    materialization_target_path TEXT,
+    history_changeset_id INTEGER,
+    history_action TEXT CHECK(history_action IN ('add', 'modify')),
+    PRIMARY KEY(path, trove_id),
+    CHECK(
+        (content_sha256 IS NULL AND content_size IS NULL)
+        OR (content_sha256 IS NOT NULL AND content_size IS NOT NULL AND content_size >= 0)
+    ),
+    CHECK(
+        (history_changeset_id IS NULL AND history_action IS NULL)
+        OR (history_changeset_id IS NOT NULL AND history_action IS NOT NULL)
+    )
+) WITHOUT ROWID;
+
+CREATE TEMP TABLE conary_tx_replacement_owners (
+    trove_id INTEGER PRIMARY KEY
+) WITHOUT ROWID;
+
+CREATE TEMP TABLE conary_tx_decisions (
+    path TEXT NOT NULL,
+    trove_id INTEGER NOT NULL,
+    anchor_action TEXT NOT NULL CHECK(anchor_action IN (
+        'replace', 'keep', 'apply-directory', 'insert-selected-root'
+    )),
+    materialized INTEGER NOT NULL CHECK(materialized IN (0, 1)),
+    PRIMARY KEY(path, trove_id)
+) WITHOUT ROWID;
+
+CREATE TEMP TABLE conary_tx_configs (
+    path TEXT PRIMARY KEY,
+    trove_id INTEGER NOT NULL,
+    original_hash TEXT,
+    original_md5 TEXT,
+    current_hash TEXT,
+    noreplace INTEGER NOT NULL CHECK(noreplace IN (0, 1)),
+    ghost INTEGER NOT NULL CHECK(ghost IN (0, 1)),
+    materialized INTEGER NOT NULL CHECK(materialized IN (0, 1)),
+    remove_on_upgrade INTEGER NOT NULL CHECK(remove_on_upgrade IN (0, 1)),
+    status TEXT NOT NULL,
+    modified_at TEXT,
+    source TEXT NOT NULL
+) WITHOUT ROWID;
+
+CREATE TEMP TABLE conary_tx_history (
+    changeset_id INTEGER NOT NULL,
+    path TEXT NOT NULL,
+    sha256_hash TEXT,
+    action TEXT NOT NULL CHECK(action IN ('add', 'modify', 'delete')),
+    PRIMARY KEY(changeset_id, path, action)
+) WITHOUT ROWID;
+"#;
+
+pub(super) const CLEAR_STAGING_SQL: &str = r#"
+DELETE FROM conary_tx_history;
+DELETE FROM conary_tx_configs;
+DELETE FROM conary_tx_decisions;
+DELETE FROM conary_tx_replacement_owners;
+DELETE FROM conary_tx_payload;
+DELETE FROM conary_tx_components;
+"#;
+
+pub(super) const DROP_STAGING_SQL: &str = r#"
+DROP TABLE conary_tx_history;
+DROP TABLE conary_tx_configs;
+DROP TABLE conary_tx_decisions;
+DROP TABLE conary_tx_replacement_owners;
+DROP TABLE conary_tx_payload;
+DROP TABLE conary_tx_components;
+"#;

--- a/crates/conary-core/src/db/models/package_transaction_staging/sql.rs
+++ b/crates/conary-core/src/db/models/package_transaction_staging/sql.rs
@@ -24,7 +24,8 @@ CREATE TEMP TABLE conary_tx_payload (
         'exact', 'directory', 'directory-or-symlink-to-directory'
     )),
     disposition TEXT NOT NULL CHECK(disposition IN (
-        'auto', 'replace', 'share', 'apply-directory', 'preserve-selected-root'
+        'auto', 'replace', 'share', 'apply-directory', 'preserve-selected-root',
+        'reconcile-owned', 'reconcile-captured-root'
     )),
     selected_root_node_json TEXT CHECK(
         selected_root_node_json IS NULL OR json_valid(selected_root_node_json)
@@ -51,7 +52,8 @@ CREATE TEMP TABLE conary_tx_decisions (
     path TEXT NOT NULL,
     trove_id INTEGER NOT NULL,
     anchor_action TEXT NOT NULL CHECK(anchor_action IN (
-        'replace', 'keep', 'apply-directory', 'insert-selected-root'
+        'replace', 'keep', 'apply-directory', 'insert-selected-root',
+        'reconcile-materialization', 'reconcile-owned'
     )),
     materialized INTEGER NOT NULL CHECK(materialized IN (0, 1)),
     PRIMARY KEY(path, trove_id)

--- a/crates/conary-core/src/db/models/package_transaction_staging/tests.rs
+++ b/crates/conary-core/src/db/models/package_transaction_staging/tests.rs
@@ -3,9 +3,13 @@
 use super::*;
 use crate::db::models::{Changeset, Trove, TroveType};
 use crate::db::testing::create_test_db;
-use crate::payload::{PayloadNode, PayloadSharingPolicy};
+use crate::payload::{
+    PayloadContentAuthority, PayloadIdentity, PayloadNode, PayloadNodeKind, PayloadSharingPolicy,
+    PayloadTimestamp,
+};
 use crate::repository::versioning::VersionScheme;
 use rusqlite::Connection;
+use std::collections::BTreeMap;
 
 fn regular_entry(path: &str, trove_id: i64, bytes: &[u8]) -> FileEntry {
     FileEntry::new(
@@ -19,6 +23,58 @@ fn regular_entry(path: &str, trove_id: i64, bytes: &[u8]) -> FileEntry {
     )
 }
 
+fn directory_entry(path: &str, trove_id: i64) -> FileEntry {
+    FileEntry::new(
+        path.to_string(),
+        ResolvedPayloadNode {
+            source: PayloadNode {
+                kind: PayloadNodeKind::Directory,
+                mode: libc::S_IFDIR | 0o755,
+                user: PayloadIdentity::Numeric { id: 0 },
+                group: PayloadIdentity::Numeric { id: 0 },
+                mtime: PayloadTimestamp::UNIX_EPOCH,
+                xattrs: BTreeMap::new(),
+            },
+            uid: 0,
+            gid: 0,
+        },
+        None,
+        trove_id,
+    )
+}
+
+fn hardlink_entry(path: &str, target: &str, trove_id: i64) -> FileEntry {
+    let mut source = PayloadNode::regular(0o644);
+    source.kind = PayloadNodeKind::Hardlink {
+        target: target.to_string(),
+        identity: "fixture:hardlink-group".to_string(),
+    };
+    FileEntry::new(
+        path.to_string(),
+        ResolvedPayloadNode::from_numeric_source(source).unwrap(),
+        None,
+        trove_id,
+    )
+}
+
+fn staged_payload(
+    entry: FileEntry,
+    package_name: &str,
+    component_name: Option<&str>,
+    changeset_id: i64,
+) -> StagedPayloadRow {
+    StagedPayloadRow {
+        entry,
+        package_name: package_name.to_string(),
+        component_name: component_name.map(str::to_string),
+        directory_materialization: ExistingDirectoryMaterialization::ApplyIncoming,
+        disposition: StagedAnchorDisposition::Replace,
+        selected_root_node: None,
+        materialization_target_path: None,
+        history: Some((changeset_id, "add")),
+    }
+}
+
 fn insert_trove(conn: &Connection, name: &str) -> i64 {
     let mut trove = Trove::new(
         name.to_string(),
@@ -27,6 +83,135 @@ fn insert_trove(conn: &Connection, name: &str) -> i64 {
         VersionScheme::Conary,
     );
     trove.insert(conn).unwrap()
+}
+
+fn tiny_file_work(path_count: usize) -> PackageTransactionSqlWork {
+    let (_temp, mut conn) = create_test_db();
+    let trove_id = insert_trove(&conn, "tiny-fixture");
+    let mut changeset = Changeset::new("tiny fixture".to_string());
+    let changeset_id = changeset.insert(&conn).unwrap();
+    let tx = conn.transaction().unwrap();
+    let mut staging = PackageTransactionStaging::begin(&tx).unwrap();
+    for index in 0..path_count {
+        staging
+            .stage_payload(&staged_payload(
+                regular_entry(
+                    &format!("/usr/share/tiny-fixture/{index:05}"),
+                    trove_id,
+                    b"x",
+                ),
+                "tiny-fixture",
+                None,
+                changeset_id,
+            ))
+            .unwrap();
+    }
+    staging.validate_and_reconcile().unwrap();
+    let work = staging.finish().unwrap();
+    tx.rollback().unwrap();
+    work
+}
+
+fn query_rows(conn: &Connection, sql: &str) -> Vec<String> {
+    conn.prepare(sql)
+        .unwrap()
+        .query_map([], |row| row.get::<_, String>(0))
+        .unwrap()
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .unwrap()
+}
+
+fn canonical_snapshot(conn: &Connection) -> Vec<Vec<String>> {
+    [
+        "SELECT json_array(parent_trove_id, name, description, is_installed)
+         FROM components ORDER BY parent_trove_id, name",
+        "SELECT json_array(path, payload_node_json, content_sha256, content_size, trove_id, component_id)
+         FROM files ORDER BY path",
+        "SELECT json_array(path, trove_id, component_id, sharing_policy, anchor_policy,
+                           materialization_target_path, payload_node_json, content_sha256, content_size)
+         FROM payload_claims ORDER BY path, trove_id",
+        "SELECT json_array(path, trove_id, original_hash, current_hash, noreplace, ghost,
+                           materialized, remove_on_upgrade, status, source)
+         FROM config_files ORDER BY path",
+        "SELECT json_array(changeset_id, path, sha256_hash, action)
+         FROM file_history ORDER BY changeset_id, path, action",
+    ]
+    .into_iter()
+    .map(|sql| query_rows(conn, sql))
+    .collect()
+}
+
+fn reconcile_order_fixture(reverse: bool) -> Vec<Vec<String>> {
+    let (_temp, mut conn) = create_test_db();
+    let first = insert_trove(&conn, "first");
+    let second = insert_trove(&conn, "second");
+    let mut changeset = Changeset::new("order fixture".to_string());
+    let changeset_id = changeset.insert(&conn).unwrap();
+    let mut regular = regular_entry("/usr/lib/libfixture.so", first, b"shared");
+    regular.node.source.kind = PayloadNodeKind::Regular {
+        hardlink_identity: Some("fixture:hardlink-group".to_string()),
+    };
+    let mut rows = vec![
+        staged_payload(
+            directory_entry("/usr/share/shared", first)
+                .with_claim_policy(PayloadSharingPolicy::Rpm),
+            "first",
+            Some("runtime"),
+            changeset_id,
+        ),
+        staged_payload(
+            directory_entry("/usr/share/shared", second)
+                .with_claim_policy(PayloadSharingPolicy::Rpm),
+            "second",
+            Some("runtime"),
+            changeset_id,
+        ),
+        staged_payload(regular, "first", Some("runtime"), changeset_id),
+        staged_payload(
+            hardlink_entry(
+                "/usr/lib/libfixture.alias",
+                "/usr/lib/libfixture.so",
+                second,
+            ),
+            "second",
+            Some("runtime"),
+            changeset_id,
+        ),
+        staged_payload(
+            regular_entry("/etc/fixture.conf", second, b"setting=true\n"),
+            "second",
+            Some("runtime"),
+            changeset_id,
+        ),
+    ];
+    if reverse {
+        rows.reverse();
+    }
+
+    let tx = conn.transaction().unwrap();
+    let mut staging = PackageTransactionStaging::begin(&tx).unwrap();
+    staging
+        .stage_component(first, "runtime", Some("runtime files"), true)
+        .unwrap();
+    staging
+        .stage_component(second, "runtime", Some("runtime files"), true)
+        .unwrap();
+    for row in rows {
+        staging.stage_payload(&row).unwrap();
+    }
+    staging
+        .stage_config(&StagedConfigRow {
+            config: ConfigFile::new(
+                "/etc/fixture.conf".to_string(),
+                second,
+                crate::hash::sha256(b"setting=true\n"),
+            ),
+        })
+        .unwrap();
+    staging.validate_and_reconcile().unwrap();
+    staging.finish().unwrap();
+    tx.commit().unwrap();
+    canonical_snapshot(&conn)
 }
 
 #[test]
@@ -75,27 +260,28 @@ fn staged_payload_failure_rolls_back_canonical_rows() {
     existing.insert(&conn).unwrap();
 
     let tx = conn.transaction().unwrap();
-    let mut staging = PackageTransactionStaging::begin(&tx).unwrap();
-    staging
-        .stage_payload(&StagedPayloadRow {
-            entry: regular_entry("/usr/bin/shared", second, b"second"),
-            package_name: "second".to_string(),
-            component_name: None,
-            directory_materialization: ExistingDirectoryMaterialization::ApplyIncoming,
-            disposition: StagedAnchorDisposition::Replace,
-            selected_root_node: None,
-            materialization_target_path: None,
-            history: None,
-        })
-        .unwrap();
-    let error = staging.validate_and_reconcile().unwrap_err();
-    assert!(
-        error
-            .to_string()
-            .contains("cannot replace claim from package first"),
-        "unexpected staging error: {error}"
-    );
-    drop(staging);
+    {
+        let mut staging = PackageTransactionStaging::begin(&tx).unwrap();
+        staging
+            .stage_payload(&StagedPayloadRow {
+                entry: regular_entry("/usr/bin/shared", second, b"second"),
+                package_name: "second".to_string(),
+                component_name: None,
+                directory_materialization: ExistingDirectoryMaterialization::ApplyIncoming,
+                disposition: StagedAnchorDisposition::Replace,
+                selected_root_node: None,
+                materialization_target_path: None,
+                history: None,
+            })
+            .unwrap();
+        let error = staging.validate_and_reconcile().unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("cannot replace claim from package first"),
+            "unexpected staging error: {error}"
+        );
+    }
     tx.rollback().unwrap();
 
     let current = FileEntry::find_by_path(&conn, "/usr/bin/shared")
@@ -150,4 +336,101 @@ fn compatible_rpm_claim_shares_one_anchor() {
             .trove_id,
         first
     );
+}
+
+#[test]
+fn many_tiny_files_keep_query_shapes_fixed() {
+    let small = tiny_file_work(100);
+    let large = tiny_file_work(2_500);
+
+    assert_eq!(small.query_shapes, large.query_shapes);
+    assert_eq!(
+        small.validation_query_executions,
+        large.validation_query_executions
+    );
+    assert_eq!(
+        small.reconciliation_statement_executions,
+        large.reconciliation_statement_executions
+    );
+    assert_eq!(large.rows_loaded - small.rows_loaded, 2 * (2_500 - 100));
+    assert_eq!(
+        large.total_statement_executions() - small.total_statement_executions(),
+        2 * (2_500 - 100)
+    );
+}
+
+#[test]
+fn canonical_state_is_deterministic_across_staging_order() {
+    assert_eq!(
+        reconcile_order_fixture(false),
+        reconcile_order_fixture(true)
+    );
+}
+
+#[test]
+fn duplicate_staged_payload_fails_before_canonical_rows_change() {
+    let (_temp, mut conn) = create_test_db();
+    let trove_id = insert_trove(&conn, "duplicate");
+    let mut changeset = Changeset::new("duplicate fixture".to_string());
+    let changeset_id = changeset.insert(&conn).unwrap();
+    let row = staged_payload(
+        regular_entry("/usr/bin/duplicate", trove_id, b"duplicate"),
+        "duplicate",
+        None,
+        changeset_id,
+    );
+
+    let tx = conn.transaction().unwrap();
+    {
+        let mut staging = PackageTransactionStaging::begin(&tx).unwrap();
+        staging.stage_payload(&row).unwrap();
+        assert!(staging.stage_payload(&row).is_err());
+    }
+    tx.rollback().unwrap();
+
+    assert!(
+        FileEntry::find_by_path(&conn, "/usr/bin/duplicate")
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
+fn reconciliation_phase_failure_rolls_back_prior_canonical_writes() {
+    let (_temp, mut conn) = create_test_db();
+    let trove_id = insert_trove(&conn, "broken-hardlink");
+    let mut changeset = Changeset::new("broken hardlink fixture".to_string());
+    let changeset_id = changeset.insert(&conn).unwrap();
+
+    let tx = conn.transaction().unwrap();
+    {
+        let mut staging = PackageTransactionStaging::begin(&tx).unwrap();
+        staging
+            .stage_payload(&staged_payload(
+                hardlink_entry("/usr/bin/broken-edge", "/usr/bin/missing-target", trove_id),
+                "broken-hardlink",
+                None,
+                changeset_id,
+            ))
+            .unwrap();
+        let error = staging.validate_and_reconcile().unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("has no regular materialization target /usr/bin/missing-target"),
+            "unexpected staging error: {error}"
+        );
+    }
+    tx.rollback().unwrap();
+
+    let canonical_rows: i64 = conn
+        .query_row(
+            "SELECT (SELECT COUNT(*) FROM files)
+                    + (SELECT COUNT(*) FROM payload_claims)
+                    + (SELECT COUNT(*) FROM file_history)",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(canonical_rows, 0);
 }

--- a/crates/conary-core/src/db/models/package_transaction_staging/tests.rs
+++ b/crates/conary-core/src/db/models/package_transaction_staging/tests.rs
@@ -1,0 +1,153 @@
+// conary-core/src/db/models/package_transaction_staging/tests.rs
+
+use super::*;
+use crate::db::models::{Changeset, Trove, TroveType};
+use crate::db::testing::create_test_db;
+use crate::payload::{PayloadNode, PayloadSharingPolicy};
+use crate::repository::versioning::VersionScheme;
+use rusqlite::Connection;
+
+fn regular_entry(path: &str, trove_id: i64, bytes: &[u8]) -> FileEntry {
+    FileEntry::new(
+        path.to_string(),
+        ResolvedPayloadNode::from_numeric_source(PayloadNode::regular(0o644)).unwrap(),
+        Some(PayloadContentAuthority {
+            sha256: crate::hash::sha256(bytes),
+            size: u64::try_from(bytes.len()).unwrap(),
+        }),
+        trove_id,
+    )
+}
+
+fn insert_trove(conn: &Connection, name: &str) -> i64 {
+    let mut trove = Trove::new(
+        name.to_string(),
+        "1.0.0".to_string(),
+        TroveType::Package,
+        VersionScheme::Conary,
+    );
+    trove.insert(conn).unwrap()
+}
+
+#[test]
+fn staged_payload_reconciles_with_fixed_query_shapes() {
+    let (_temp, mut conn) = create_test_db();
+    let trove_id = insert_trove(&conn, "fixture");
+    let mut changeset = Changeset::new("stage fixture".to_string());
+    let changeset_id = changeset.insert(&conn).unwrap();
+    let tx = conn.transaction().unwrap();
+    let mut staging = PackageTransactionStaging::begin(&tx).unwrap();
+    for index in 0..100 {
+        staging
+            .stage_payload(&StagedPayloadRow {
+                entry: regular_entry(&format!("/usr/share/fixture/{index:03}"), trove_id, b"x"),
+                package_name: "fixture".to_string(),
+                component_name: None,
+                directory_materialization: ExistingDirectoryMaterialization::ApplyIncoming,
+                disposition: StagedAnchorDisposition::Replace,
+                selected_root_node: None,
+                materialization_target_path: None,
+                history: Some((changeset_id, "add")),
+            })
+            .unwrap();
+    }
+    let outcomes = staging.validate_and_reconcile().unwrap();
+    assert_eq!(outcomes.len(), 100);
+    let work = staging.finish().unwrap();
+    assert_eq!(work.rows_loaded, 200);
+    assert_eq!(work.load_statement_executions, 200);
+    assert!(work.query_shapes <= 24, "unexpected query shapes: {work:?}");
+    assert!(work.total_statement_executions() <= 225);
+    tx.commit().unwrap();
+
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM files", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(count, 100);
+}
+
+#[test]
+fn staged_payload_failure_rolls_back_canonical_rows() {
+    let (_temp, mut conn) = create_test_db();
+    let first = insert_trove(&conn, "first");
+    let second = insert_trove(&conn, "second");
+    let mut existing = regular_entry("/usr/bin/shared", first, b"first");
+    existing.insert(&conn).unwrap();
+
+    let tx = conn.transaction().unwrap();
+    let mut staging = PackageTransactionStaging::begin(&tx).unwrap();
+    staging
+        .stage_payload(&StagedPayloadRow {
+            entry: regular_entry("/usr/bin/shared", second, b"second"),
+            package_name: "second".to_string(),
+            component_name: None,
+            directory_materialization: ExistingDirectoryMaterialization::ApplyIncoming,
+            disposition: StagedAnchorDisposition::Replace,
+            selected_root_node: None,
+            materialization_target_path: None,
+            history: None,
+        })
+        .unwrap();
+    let error = staging.validate_and_reconcile().unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("cannot replace claim from package first"),
+        "unexpected staging error: {error}"
+    );
+    drop(staging);
+    tx.rollback().unwrap();
+
+    let current = FileEntry::find_by_path(&conn, "/usr/bin/shared")
+        .unwrap()
+        .unwrap();
+    assert_eq!(current.trove_id, first);
+    assert_eq!(
+        current.content.unwrap().sha256,
+        crate::hash::sha256(b"first")
+    );
+}
+
+#[test]
+fn compatible_rpm_claim_shares_one_anchor() {
+    let (_temp, mut conn) = create_test_db();
+    let first = insert_trove(&conn, "first");
+    let second = insert_trove(&conn, "second");
+    let mut existing = regular_entry("/usr/bin/shared", first, b"same")
+        .with_claim_policy(PayloadSharingPolicy::Rpm);
+    existing.insert(&conn).unwrap();
+
+    let tx = conn.transaction().unwrap();
+    let mut staging = PackageTransactionStaging::begin(&tx).unwrap();
+    staging
+        .stage_payload(&StagedPayloadRow {
+            entry: regular_entry("/usr/bin/shared", second, b"same")
+                .with_claim_policy(PayloadSharingPolicy::Rpm),
+            package_name: "second".to_string(),
+            component_name: None,
+            directory_materialization: ExistingDirectoryMaterialization::ApplyIncoming,
+            disposition: StagedAnchorDisposition::Share,
+            selected_root_node: None,
+            materialization_target_path: None,
+            history: None,
+        })
+        .unwrap();
+    let outcomes = staging.validate_and_reconcile().unwrap();
+    assert!(!outcomes["/usr/bin/shared"].materialized);
+    staging.finish().unwrap();
+    tx.commit().unwrap();
+
+    assert_eq!(
+        PayloadClaim::find_by_path(&conn, "/usr/bin/shared")
+            .unwrap()
+            .len(),
+        2
+    );
+    assert_eq!(
+        FileEntry::find_by_path(&conn, "/usr/bin/shared")
+            .unwrap()
+            .unwrap()
+            .trove_id,
+        first
+    );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-14
-revision: 54
-summary: Describe workspace and release boundaries, coherent native inventory adoption, exact native source authority, package transactions, typed generation database snapshots, lifecycle execution, carrier security, generation GC, and service boundaries
+revision: 55
+summary: Describe workspace and release boundaries, coherent native inventory adoption, exact native source authority, set-based package transactions, typed generation database snapshots, lifecycle execution, carrier security, generation GC, and service boundaries
 ---
 
 # Conary Architecture
@@ -762,6 +762,16 @@ SQLite -> publish the recorded generation. The selected root starts from the
 latest retryable snapshot, the current generation artifact, or authoritative DB/CAS
 state when no generation exists. There is no mutable-host package execution
 path.
+
+Package persistence within that SQLite transaction uses transaction-local TEMP
+tables owned by `PackageTransactionStaging`. Cached load statements accept
+typed payload nodes/content, component membership, replacement-owner decisions,
+config projections, and history rows. Validation loads canonical claims as
+sets, derives deterministic anchor decisions, and then projects content,
+anchors, claims, hardlinks, components, configs, and history through a fixed
+family of ordered SQL statements. Install/update, adoption, remove, and
+rollback history share this authority; dropping or rolling back the transaction
+removes all staging state, so it cannot become a second persisted database.
 
 Before the SQLite commit, any lifecycle, payload, config, trigger, or validation
 failure rolls back the database transaction and discards the selected root.

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-14
-revision: 73
-summary: Route workspace and release boundaries, coherent native inventory adoption, typed database rebuilds, generation snapshots and recovery deltas, exact native source identity and adopted-artifact conversion, lossless source authority and trust-import planning, exact Remi signing, selected-root mutation, rollback lineage, canonical-map authority, carrier security, generation GC, and subsystem proof through current feature owners.
+revision: 74
+summary: Route workspace and release boundaries, coherent native inventory adoption, set-based package transaction persistence, typed database rebuilds, generation snapshots and recovery deltas, exact native source identity and adopted-artifact conversion, lossless source authority and trust-import planning, exact Remi signing, selected-root mutation, rollback lineage, canonical-map authority, carrier security, generation GC, and subsystem proof through current feature owners.
 ---
 
 # Assistant Subsystem Map
@@ -104,7 +104,10 @@ commands.
   `apps/conary/src/commands/install/shared_directory.rs`; exact persisted
   claims and package-facing payload ownership start in
   `crates/conary-core/src/db/models/payload_claim.rs` and
-  `crates/conary-core/src/db/models/package_payload_ownership.rs`; bounded
+  `crates/conary-core/src/db/models/package_payload_ownership.rs`; transaction-local
+  payload/component/config/history staging and set-based canonical reconciliation
+  start in `crates/conary-core/src/db/models/package_transaction_staging.rs` and
+  `crates/conary-core/src/db/models/package_transaction_staging/`; bounded
   selected-root node inspection starts in
   `crates/conary-core/src/filesystem/selected_root.rs`. Debian dpkg process
   environment, administrative state, trigger/config capture, and

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-14
-revision: 74
-summary: Route feature ownership through typed database rebuilds, generation snapshots and recovery deltas, exact native source identity and adopted-artifact conversion, native declaration and trust-import planning, exact Remi signing, streaming package payloads, serialized selected-root mutation, typed rollback lineage, exact lifecycle, canonical-map authority, carrier security, generation GC, exact release authority, and current canonical docs
+revision: 75
+summary: Route feature ownership through set-based package transaction persistence, typed database rebuilds, generation snapshots and recovery deltas, exact native source identity and adopted-artifact conversion, native declaration and trust-import planning, exact Remi signing, streaming package payloads, serialized selected-root mutation, typed rollback lineage, exact lifecycle, canonical-map authority, carrier security, generation GC, exact release authority, and current canonical docs
 ---
 
 # Feature Ownership And Interaction Gates
@@ -273,6 +273,9 @@ mutation flows for local package operations.
 `crates/conary-core/src/db/models/payload_claim/*`;
 `crates/conary-core/src/db/models/package_payload_ownership.rs`;
 `crates/conary-core/src/db/models/package_payload_ownership/*`;
+`crates/conary-core/src/db/models/package_transaction_staging.rs`;
+`crates/conary-core/src/db/models/package_transaction_staging/*`;
+`crates/conary-core/benches/package_transaction_staging.rs`;
 `crates/conary-core/src/db/models/file_entry.rs`;
 `crates/conary-core/src/db/models/trove.rs`;
 `crates/conary-core/src/db/models/provide_entry.rs`;
@@ -293,6 +296,7 @@ mutation flows for local package operations.
 `cargo test -p conary --lib exact_installed_authority_round_trips_and_rejects_broken_relations`;
 `cargo test -p conary-core --lib db::models::payload_claim`;
 `cargo test -p conary-core --lib db::models::package_payload_ownership`;
+`cargo test -p conary-core --lib db::models::package_transaction_staging::tests`;
 `cargo test -p conary-core --lib filesystem::selected_root`;
 `cargo test -p conary-core --lib config_transaction`;
 `cargo test -p conary --lib commands::generation::config_transaction`;
@@ -332,7 +336,12 @@ per package; query, lifecycle, removal, derived-package, and rollback
 projections must use claim-aware payload ownership rather than treating the
 materialized file anchor as the only owner. A converted CCS archive retains the
 validated native source format's typed payload-sharing and
-directory-materialization contracts.
+directory-materialization contracts. Package payload, component, config, and
+history rows load into transaction-local TEMP tables through cached statements;
+typed validation establishes anchor decisions before a fixed set of canonical
+reconciliation statements. Those TEMP tables are never durable authority, and
+the selected-root session plus enclosing SQLite transaction remain the rollback
+boundary for any validation or reconciliation failure.
 
 ## Adoption, Unadoption, And Native-Authority Handoff
 

--- a/docs/modules/test-fixtures.md
+++ b/docs/modules/test-fixtures.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-08-12
-revision: 31
-summary: Map fixture ownership, including authenticated Debian-derivative roots and cross-source lifecycle proof
+last_updated: 2026-08-14
+revision: 32
+summary: Map fixture ownership, including set-based package transaction scaling, authenticated Debian-derivative roots, and cross-source lifecycle proof
 ---
 
 # Test Fixtures And Proof Maps
@@ -40,6 +40,7 @@ Each fixture family should record:
 | `ccs-v3-lifecycle-authoring-proof` | CCS v3 lifecycle authoring | `cargo test -p conary --test packaging_m4e`; `cargo test -p conary-core ccs::v3` |
 | `m4d-supported-profile-cutover` | Repository feed profiles | `cargo test -p conary-core supported_profiles`; `cargo test -p conary --test packaging_m4d`; `cargo test -p remi route` |
 | `native-lifecycle-query-fixtures` | Native lifecycle query surfaces | `cargo test -p conary --test query_scripts` |
+| `package-transaction-many-tiny-files` | Transaction-local package-row staging | `cargo test -p conary-core --lib db::models::package_transaction_staging::tests` |
 | `rpm-hardlink-transaction` | RPM payload projection and CCS conversion | `cargo test -p conary-core packages::rpm::payload`; `cargo test -p conary --test conversion_integration golden_conversion` |
 | `rpm-root-anchor-conversion` | RPM root ownership parsing and CCS omission | `cargo test -p conary-core packages::rpm::payload`; opt-in pinned-artifact test below |
 | `remi-native-ccs-publication` | Remi native publication | `cargo test -p remi release_upload_`; `cargo test -p conary --test packaging_m4c` |
@@ -48,6 +49,34 @@ Each fixture family should record:
 | `qemu-source-image-fixtures` | Bootstrap/QEMU fixture maintenance | `bash -n scripts/bootstrap-vm/rotate-qemu-test-identity.sh`; `cargo run -p conary-test -- list` |
 | `supported-host-generation-export` | Generation export boot proofs | `cargo test -p conary-core --test supported_host_generation_export_fixture_contract` |
 | `conary-test-remi-manifests` | Integration harness | `cargo run -p conary-test -- list`; `cargo test -p conary-test suite_inventory` |
+
+### package-transaction-many-tiny-files
+
+- **Owner:** transaction staging model:
+  `crates/conary-core/src/db/models/package_transaction_staging.rs` and
+  `crates/conary-core/src/db/models/package_transaction_staging/`.
+- **Purpose:** Prove package payload persistence scales with transaction rows
+  while validation and canonical reconciliation retain a near-fixed family of
+  SQL query shapes. The order fixture also proves deterministic shared-directory,
+  cross-package hardlink, config, and history authority.
+- **Fixture sources:** in-test 100- and 2,500-path builders in
+  `crates/conary-core/src/db/models/package_transaction_staging/tests.rs` and
+  the matching Criterion builder in
+  `crates/conary-core/benches/package_transaction_staging.rs`.
+- **Consumes:** core staging properties plus install, update, adoption, remove,
+  rollback, and generation interaction gates from the `install` ownership card.
+- **Fast proof:** `cargo test -p conary-core --lib
+  db::models::package_transaction_staging::tests`.
+- **Medium proof:** `cargo test -p conary --lib commands::install` and
+  `cargo test -p conary --lib commands::adopt`.
+- **Slow proof:** `cargo bench -p conary-core --bench
+  package_transaction_staging -- --noplot`; no QEMU lane is owned by this
+  fixture.
+- **Regeneration:** Hand-maintained typed Rust builders. Change row counts only
+  with matching work-counter assertions and benchmark labels.
+- **Safety notes:** The fixture uses disposable SQLite transactions and no live
+  root. Duplicate input and an injected hardlink reconciliation failure must
+  leave canonical rows unchanged after rollback.
 
 ### foreign-package-lifecycle-contracts
 


### PR DESCRIPTION
Refs #412

## Problem

Package install, adoption, remove, and rollback persistence executed canonical SQLite work inside per-path loops. Prepared statements reduced parsing but left conflict checks, content/claim reconciliation, history, components, and config projection as repeated canonical operations.

## Implementation

- Add typed transaction-local TEMP staging for components, payload/content authority, replacement owners, anchor decisions, configs, and history.
- Load rows through cached statements, load canonical claims as sets, derive typed anchor decisions, and reconcile canonical content, anchors, claims, hardlinks, components, configs, and history through ordered fixed-shape SQL.
- Hard-cut batch install/update, package/full-system adoption, track-to-full promotion, captured-root reconciliation, refresh, remove history/config cleanup, and rollback removal history onto the shared staging authority.
- Preserve source-specific sharing, selected-root directory/symlink behavior, cross-package hardlinks, config/capability projection, savepoints, generation publication, and transaction rollback.
- Split planning and reconciliation ownership into focused modules; the staging hub is 851 lines.
- Add work counters, 100/2,500-tiny-file scaling proof, order-independence proof, duplicate rejection, and a failure injected after canonical reconciliation begins.
- Document the persistence authority and fixture/benchmark routing.

## Observed benchmark

`cargo bench -p conary-core --bench package_transaction_staging -- --noplot`

- 100 paths: 6.1799-6.2524 ms, 15.994-16.182 Kelem/s
- 2,500 paths: 61.539-63.132 ms, 39.600-40.624 Kelem/s

The corresponding work-counter test proves identical validation/reconciliation query-shape counts at both sizes; only cached row loads and staged decision loads scale with transaction rows.

## Verification

- `cargo test -p conary-core --lib db::models::package_transaction_staging::tests -- --nocapture` (7 passed)
- install ownership focused gate:
  - `commands::install` (228 passed, 1 explicit network proof ignored)
  - `commands::remove` (14 passed)
  - exact installed authority (1 passed)
  - payload claims (26 passed)
  - package payload ownership (5 passed)
  - selected-root filesystem (8 passed)
  - config transaction core (17 passed)
  - generation config transaction (16 passed)
  - rollback snapshot (2 passed)
  - native transaction (47 passed)
  - live-host mutation safety (22 passed)
  - native lifecycle (61 passed)
- `cargo test -p conary --lib commands::adopt --no-fail-fast` (84 passed)
- `cargo test -p conary --lib rollback --no-fail-fast` (50 passed)
- `cargo test -p conary --lib commands::generation::publication --no-fail-fast` (6 passed)
- `cargo test -p conary --test conversion_integration --no-fail-fast` (16 passed, 1 opt-in pinned-artifact proof ignored)
- `cargo test -p conary --test query_scripts --no-fail-fast` (15 passed)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `bash scripts/check-doc-truth.sh`
- `git diff --check`

## Safety

All staging tables are transaction-local and dropped before commit. Duplicate, malformed, missing-parent, incompatible-claim, and invalid-hardlink inputs fail closed. A reconciliation-phase failure is proven to roll the enclosing transaction back after prior canonical statements, while selected-root transaction failure remains recoverable through the existing selected-root rollback boundary.