### PR TITLE
fix(remi): serialize repository database writes

### DIFF
--- a/apps/remi/src/server/admin_service.rs
+++ b/apps/remi/src/server/admin_service.rs
@@ -21,6 +21,7 @@ use conary_core::db::models::{Repository, RepositoryOwnership};
 use conary_core::repository::{
     OpenPgpTrustRoot, RepositoryParserConfig, RepositoryTrustPolicy, RpmMetadataAuthority,
 };
+use rusqlite::TransactionBehavior;
 
 use crate::federation::{Peer, PeerTier};
 use crate::server::ServerState;
@@ -606,18 +607,23 @@ pub async fn create_repo(
     }
 
     let db = db_path(state).await;
+    let database_writer = state.read().await.database_writer.clone();
     blocking(move || {
-        let conn = conary_core::db::open_fast(&db)?;
-        let mut repo = Repository::new(input.name, input.url);
-        repo.content_url = input.content_url;
-        repo.enabled = input.enabled;
-        repo.priority = input.priority;
-        repo.metadata_expire = input.metadata_expire;
-        repo.set_parser_config(input.parser)?;
-        repo.trust_policy = input.trust;
-        apply_native_source_contract(&mut repo, input.native_source)?;
-        repo.insert(&conn)?;
-        Ok(repo)
+        database_writer.execute(|| {
+            let mut conn = conary_core::db::open_fast(&db)?;
+            let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let mut repo = Repository::new(input.name, input.url);
+            repo.content_url = input.content_url;
+            repo.enabled = input.enabled;
+            repo.priority = input.priority;
+            repo.metadata_expire = input.metadata_expire;
+            repo.set_parser_config(input.parser)?;
+            repo.trust_policy = input.trust;
+            apply_native_source_contract(&mut repo, input.native_source)?;
+            repo.insert(&tx)?;
+            tx.commit()?;
+            Ok(repo)
+        })
     })
     .await
 }
@@ -657,59 +663,62 @@ pub async fn update_repo(
     }
 
     let db = db_path(state).await;
+    let database_writer = state.read().await.database_writer.clone();
     let name_owned = name.to_string();
     blocking(move || {
-        let conn = conary_core::db::open_fast(&db)?;
-        let repo = Repository::find_by_name(&conn, &name_owned)?;
-        let mut repo = match repo {
-            Some(r) => r,
-            None => return Ok(None),
-        };
-        if repo.managed_by == RepositoryOwnership::RemiConfig {
-            return Err(conary_core::Error::ConflictError(format!(
-                "repository '{}' is owned by the Remi repository manifest",
-                repo.name
-            )));
-        }
-        let previous = repo.clone();
-        let source_changed = repo.url != input.url
-            || repo.content_url != input.content_url
-            || repo.parser_config.as_ref() != Some(&input.parser)
-            || repo.trust_policy != input.trust;
-        repo.url = input.url;
-        repo.content_url = input.content_url;
-        if let Some(enabled) = input.enabled {
-            repo.enabled = enabled;
-        }
-        if let Some(priority) = input.priority {
-            repo.priority = priority;
-        }
-        if let Some(metadata_expire) = input.metadata_expire {
-            repo.metadata_expire = metadata_expire;
-        }
-        repo.set_parser_config(input.parser)?;
-        repo.trust_policy = input.trust;
-        apply_native_source_contract(&mut repo, input.native_source)?;
-        let source_changed = source_changed
-            || repo.source_policy != previous.source_policy
-            || repo.repository_identity != previous.repository_identity
-            || repo.stream_binding_sha256 != previous.stream_binding_sha256
-            || repo.pinned_snapshot != previous.pinned_snapshot;
-        let tx = conn.unchecked_transaction()?;
-        if source_changed {
-            let repository_id = repo
-                .id
-                .ok_or_else(|| conary_core::Error::MissingId("Repository has no ID".to_string()))?;
-            Repository::delete(&tx, repository_id)?;
-            repo.id = None;
-            repo.last_sync = None;
-            repo.created_at = None;
-            repo.insert(&tx)?;
-        } else {
-            repo.update(&tx)?;
-        }
-        tx.commit()?;
-        Ok(Some(repo))
+        database_writer.execute(|| {
+            let mut conn = conary_core::db::open_fast(&db)?;
+            let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let repo = Repository::find_by_name(&tx, &name_owned)?;
+            let mut repo = match repo {
+                Some(r) => r,
+                None => return Ok(None),
+            };
+            if repo.managed_by == RepositoryOwnership::RemiConfig {
+                return Err(conary_core::Error::ConflictError(format!(
+                    "repository '{}' is owned by the Remi repository manifest",
+                    repo.name
+                )));
+            }
+            let previous = repo.clone();
+            let source_changed = repo.url != input.url
+                || repo.content_url != input.content_url
+                || repo.parser_config.as_ref() != Some(&input.parser)
+                || repo.trust_policy != input.trust;
+            repo.url = input.url;
+            repo.content_url = input.content_url;
+            if let Some(enabled) = input.enabled {
+                repo.enabled = enabled;
+            }
+            if let Some(priority) = input.priority {
+                repo.priority = priority;
+            }
+            if let Some(metadata_expire) = input.metadata_expire {
+                repo.metadata_expire = metadata_expire;
+            }
+            repo.set_parser_config(input.parser)?;
+            repo.trust_policy = input.trust;
+            apply_native_source_contract(&mut repo, input.native_source)?;
+            let source_changed = source_changed
+                || repo.source_policy != previous.source_policy
+                || repo.repository_identity != previous.repository_identity
+                || repo.stream_binding_sha256 != previous.stream_binding_sha256
+                || repo.pinned_snapshot != previous.pinned_snapshot;
+            if source_changed {
+                let repository_id = repo.id.ok_or_else(|| {
+                    conary_core::Error::MissingId("Repository has no ID".to_string())
+                })?;
+                Repository::delete(&tx, repository_id)?;
+                repo.id = None;
+                repo.last_sync = None;
+                repo.created_at = None;
+                repo.insert(&tx)?;
+            } else {
+                repo.update(&tx)?;
+            }
+            tx.commit()?;
+            Ok(Some(repo))
+        })
     })
     .await
 }
@@ -720,26 +729,32 @@ pub async fn delete_repo(
     name: &str,
 ) -> Result<bool, ServiceError> {
     let db = db_path(state).await;
+    let database_writer = state.read().await.database_writer.clone();
     let name_owned = name.to_string();
     blocking(move || {
-        let conn = conary_core::db::open_fast(&db)?;
-        let repo = Repository::find_by_name(&conn, &name_owned)?;
-        match repo {
-            Some(r) => {
-                if r.managed_by == RepositoryOwnership::RemiConfig {
-                    return Err(conary_core::Error::ConflictError(format!(
-                        "repository '{}' is owned by the Remi repository manifest",
-                        r.name
-                    )));
+        database_writer.execute(|| {
+            let mut conn = conary_core::db::open_fast(&db)?;
+            let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let repo = Repository::find_by_name(&tx, &name_owned)?;
+            let deleted = match repo {
+                Some(r) => {
+                    if r.managed_by == RepositoryOwnership::RemiConfig {
+                        return Err(conary_core::Error::ConflictError(format!(
+                            "repository '{}' is owned by the Remi repository manifest",
+                            r.name
+                        )));
+                    }
+                    let id = r.id.ok_or_else(|| {
+                        conary_core::Error::MissingId("Repository has no ID".to_string())
+                    })?;
+                    Repository::delete(&tx, id)?;
+                    true
                 }
-                let id = r.id.ok_or_else(|| {
-                    conary_core::Error::MissingId("Repository has no ID".to_string())
-                })?;
-                Repository::delete(&conn, id)?;
-                Ok(true)
-            }
-            None => Ok(false),
-        }
+                None => false,
+            };
+            tx.commit()?;
+            Ok(deleted)
+        })
     })
     .await
 }

--- a/apps/remi/src/server/auth.rs
+++ b/apps/remi/src/server/auth.rs
@@ -174,11 +174,15 @@ pub async fn auth_middleware(
     next: Next,
 ) -> Response {
     // Rate limiters come from an Extension layer (set once at startup),
-    // so we only need the RwLock for db_path and trusted_proxy_header.
+    // so we only need the RwLock to clone request-scoped shared state.
     let limiters = limiters.map(|Extension(l)| l);
-    let (db_path, trusted_proxy_header) = {
+    let (db_path, trusted_proxy_header, database_writer) = {
         let s = state.read().await;
-        (s.config.db_path.clone(), s.trusted_proxy_header.clone())
+        (
+            s.config.db_path.clone(),
+            s.trusted_proxy_header.clone(),
+            s.database_writer.clone(),
+        )
     };
     // Use the proxy-aware IP extraction so that rate limiting and auth
     // failure tracking use the real client IP, not the proxy's IP.
@@ -281,8 +285,10 @@ pub async fn auth_middleware(
 
     if should_touch {
         match tokio::task::spawn_blocking(move || {
-            let conn = conary_core::db::open_fast(&bg_db_path)?;
-            conary_core::db::models::admin_token::touch(&conn, bg_id)
+            database_writer.execute(|| {
+                let conn = conary_core::db::open_fast(&bg_db_path)?;
+                conary_core::db::models::admin_token::touch(&conn, bg_id)
+            })
         })
         .await
         {

--- a/apps/remi/src/server/conversion.rs
+++ b/apps/remi/src/server/conversion.rs
@@ -5,7 +5,6 @@
 //! to CCS format, storing chunks in the CAS.
 
 mod benchmark;
-mod database;
 mod lookup;
 mod metadata;
 mod persistence;
@@ -17,7 +16,7 @@ mod types;
 mod workflow;
 
 use crate::server::R2Store;
-use database::ConversionDatabaseWriter;
+use crate::server::database_writer::DatabaseWriter;
 use std::path::PathBuf;
 use std::sync::Arc;
 pub use types::{
@@ -40,7 +39,7 @@ pub struct ConversionService {
     /// Remi-owned per-distro TUF keys used to authenticate converted CCS.
     repository_keys_dir: Option<PathBuf>,
     /// Shared owner for the short SQLite mutation phases of conversion work.
-    database_writer: ConversionDatabaseWriter,
+    database_writer: DatabaseWriter,
 }
 
 impl ConversionService {
@@ -56,8 +55,13 @@ impl ConversionService {
             db_path,
             r2_store,
             repository_keys_dir: None,
-            database_writer: ConversionDatabaseWriter::default(),
+            database_writer: DatabaseWriter::default(),
         }
+    }
+
+    pub(crate) fn with_database_writer(mut self, database_writer: DatabaseWriter) -> Self {
+        self.database_writer = database_writer;
+        self
     }
 
     pub(crate) fn with_r2_store(mut self, r2_store: Option<Arc<R2Store>>) -> Self {

--- a/apps/remi/src/server/database_writer.rs
+++ b/apps/remi/src/server/database_writer.rs
@@ -1,31 +1,34 @@
-// apps/remi/src/server/conversion/database.rs
-//! Process-local ownership for Remi conversion database mutations.
+// apps/remi/src/server/database_writer.rs
+//! Process-local ownership for Remi database mutations.
 
-use anyhow::{Result, anyhow};
-use std::sync::{Arc, Mutex};
+use parking_lot::Mutex;
+use std::sync::Arc;
 
-/// Serializes the short SQLite mutation phases shared by conversion work.
+/// Serializes short SQLite mutation phases within one Remi server.
 ///
-/// SQLite admits one writer at a time. Conversion download, parsing, CCS
-/// emission, CAS storage, and R2 upload remain concurrent; only the database
-/// transactions that publish their results pass through this owner.
+/// Work that does not mutate SQLite stays outside this owner. Callers acquire
+/// it immediately before opening their write transaction and release it after
+/// commit so independent request and background paths cannot race SQLite's
+/// single-writer boundary.
 #[derive(Clone, Default)]
-pub(super) struct ConversionDatabaseWriter {
+pub(crate) struct DatabaseWriter {
     gate: Arc<Mutex<()>>,
 }
 
-impl ConversionDatabaseWriter {
-    pub(super) fn execute<T>(&self, operation: impl FnOnce() -> Result<T>) -> Result<T> {
-        let _guard = self
-            .gate
-            .lock()
-            .map_err(|_| anyhow!("conversion database writer lock is poisoned"))?;
+impl DatabaseWriter {
+    pub(crate) fn execute<T, E>(&self, operation: impl FnOnce() -> Result<T, E>) -> Result<T, E> {
+        let _guard = self.gate.lock();
         operation()
     }
 
     #[cfg(test)]
-    pub(super) fn shares_owner_with(&self, other: &Self) -> bool {
+    pub(crate) fn shares_owner_with(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.gate, &other.gate)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn hold_for_test(&self) -> impl Drop + '_ {
+        self.gate.lock()
     }
 }
 
@@ -41,7 +44,7 @@ mod tests {
         conary_core::db::init(&db_path).unwrap();
         let conn = conary_core::db::open_fast(&db_path).unwrap();
         conn.execute_batch(
-            "CREATE TABLE conversion_writer_probe (
+            "CREATE TABLE database_writer_probe (
                 value INTEGER PRIMARY KEY
             );",
         )
@@ -53,7 +56,7 @@ mod tests {
     async fn shared_writer_serializes_tiny_timeout_sqlite_transactions() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let db_path = initialized_db(&temp_dir);
-        let writer = ConversionDatabaseWriter::default();
+        let writer = DatabaseWriter::default();
 
         let mut tasks = Vec::new();
         for value in 0..32_i64 {
@@ -65,12 +68,12 @@ mod tests {
                     conn.busy_timeout(Duration::from_millis(1))?;
                     let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
                     tx.execute(
-                        "INSERT INTO conversion_writer_probe (value) VALUES (?1)",
+                        "INSERT INTO database_writer_probe (value) VALUES (?1)",
                         [value],
                     )?;
                     std::thread::sleep(Duration::from_millis(2));
                     tx.commit()?;
-                    Ok(())
+                    Ok::<_, conary_core::Error>(())
                 })
             }));
         }
@@ -81,7 +84,7 @@ mod tests {
 
         let conn = conary_core::db::open_fast(&db_path).unwrap();
         let count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM conversion_writer_probe", [], |row| {
+            .query_row("SELECT COUNT(*) FROM database_writer_probe", [], |row| {
                 row.get(0)
             })
             .unwrap();

--- a/apps/remi/src/server/handlers/admin/mod.rs
+++ b/apps/remi/src/server/handlers/admin/mod.rs
@@ -114,6 +114,15 @@ pub(crate) mod test_helpers {
     /// tests are short-lived and the OS reclaims the directory on process
     /// exit.
     pub async fn test_app() -> (axum::Router, std::path::PathBuf) {
+        let (app, db_path, _) = test_app_with_database_writer().await;
+        (app, db_path)
+    }
+
+    pub async fn test_app_with_database_writer() -> (
+        axum::Router,
+        std::path::PathBuf,
+        crate::server::database_writer::DatabaseWriter,
+    ) {
         let tmp = tempfile::tempdir().unwrap();
         let db_path = tmp.path().join("test.db");
 
@@ -141,6 +150,7 @@ pub(crate) mod test_helpers {
                 .into_owned(),
         );
         let state = Arc::new(RwLock::new(server_state));
+        let database_writer = state.read().await.database_writer.clone();
 
         // Build the external admin router (includes auth middleware)
         let app = crate::server::routes::create_external_admin_router(state, None);
@@ -157,7 +167,7 @@ pub(crate) mod test_helpers {
         // Leak the TempDir so it outlives the test (cleaned up at process exit)
         std::mem::forget(tmp);
 
-        (app, db_path)
+        (app, db_path, database_writer)
     }
 
     /// Helper to rebuild a fresh router against an existing database path.

--- a/apps/remi/src/server/handlers/admin/repos.rs
+++ b/apps/remi/src/server/handlers/admin/repos.rs
@@ -536,7 +536,7 @@ mod tests {
     use axum::http::StatusCode;
     use tower::ServiceExt;
 
-    use super::super::test_helpers::{rebuild_app, test_app};
+    use super::super::test_helpers::{rebuild_app, test_app, test_app_with_database_writer};
     use super::{RepoRefreshBatchState, refresh_status_code};
 
     #[tokio::test]
@@ -626,10 +626,16 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
+        let status = resp.status();
         let body_bytes = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
             .await
             .unwrap();
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "repository update response: {}",
+            String::from_utf8_lossy(&body_bytes)
+        );
         let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
         assert_eq!(body["priority"], 20);
 
@@ -661,6 +667,84 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn repository_update_waits_for_the_shared_database_writer() {
+        let (app, db_path, database_writer) = test_app_with_database_writer().await;
+        let create_body = serde_json::json!({
+            "name": "fedora",
+            "url": "https://93.184.216.34/fedora",
+            "parser": {"package_format": "json"}
+        });
+        let create_resp = app
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri("/v1/admin/repos")
+                    .header("Authorization", "Bearer test-admin-token-12345")
+                    .header("Content-Type", "application/json")
+                    .body(axum::body::Body::from(create_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(create_resp.status(), StatusCode::CREATED);
+
+        // Hold both the declared writer authority and SQLite's real write lock.
+        // The old repository path bypassed the former, waited out the five-second
+        // SQLite busy timeout on the latter, and returned HTTP 500. The corrected
+        // path must remain queued on the shared owner without touching SQLite.
+        let mut blocking_connection = conary_core::db::open_fast(&db_path).unwrap();
+        let blocking_transaction = blocking_connection
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .unwrap();
+        let writer_guard = database_writer.hold_for_test();
+        let update_body = serde_json::json!({
+            "url": "https://93.184.216.35/fedora",
+            "priority": 20,
+            "parser": {"package_format": "json"}
+        });
+        let mut update = tokio::spawn(
+            app.oneshot(
+                axum::http::Request::builder()
+                    .method("PUT")
+                    .uri("/v1/admin/repos/fedora")
+                    .header("Authorization", "Bearer test-admin-token-12345")
+                    .header("Content-Type", "application/json")
+                    .body(axum::body::Body::from(update_body.to_string()))
+                    .unwrap(),
+            ),
+        );
+
+        if let Ok(completed) =
+            tokio::time::timeout(std::time::Duration::from_millis(5_500), &mut update).await
+        {
+            let response = completed.unwrap().unwrap();
+            let status = response.status();
+            let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+                .await
+                .unwrap();
+            panic!(
+                "repository update bypassed the shared database writer: {status} {}",
+                String::from_utf8_lossy(&body)
+            );
+        }
+        drop(blocking_transaction);
+        drop(writer_guard);
+
+        let response = update.await.unwrap().unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "repository update response: {}",
+            String::from_utf8_lossy(&body)
+        );
     }
 
     #[tokio::test]

--- a/apps/remi/src/server/mod.rs
+++ b/apps/remi/src/server/mod.rs
@@ -27,6 +27,7 @@ pub mod chunk_gc;
 pub mod config;
 mod conversion;
 pub mod conversion_timing;
+mod database_writer;
 pub mod delta_manifests;
 pub mod federated_index;
 mod handlers;
@@ -198,6 +199,7 @@ pub struct AdminEvent {
 // TODO: Decompose ServerState into focused sub-structs to improve readability.
 pub struct ServerState {
     pub config: ServerConfig,
+    pub(crate) database_writer: database_writer::DatabaseWriter,
     pub job_manager: JobManager,
     pub chunk_cache: ChunkCache,
     pub conversion_service: ConversionService,
@@ -261,6 +263,7 @@ impl ServerState {
         negative_cache_ttl: Duration,
     ) -> Result<Self> {
         let job_manager = JobManager::new(config.max_concurrent_conversions);
+        let database_writer = database_writer::DatabaseWriter::default();
         let chunk_cache = ChunkCache::new(
             config.chunk_dir.clone(),
             config.cache_max_bytes,
@@ -273,6 +276,7 @@ impl ServerState {
             config.db_path.clone(),
             None, // R2 store set later after state initialization
         )
+        .with_database_writer(database_writer.clone())
         .with_repository_keys_dir(config.release_publish.repository_keys_dir.clone());
 
         // Initialize Bloom filter if enabled
@@ -299,6 +303,7 @@ impl ServerState {
 
         Ok(Self {
             config,
+            database_writer,
             job_manager,
             chunk_cache,
             conversion_service,

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-15
-revision: 23
-summary: Document Remi source identity and update policy, sparse sync, signing, canonical-map, repository trust, reproducible conversion profiling, publication, and serving authority
+revision: 24
+summary: Document Remi source identity and update policy, sparse sync, signing, canonical-map, repository trust, database-writer ownership, reproducible conversion profiling, publication, and serving authority
 ---
 
 # Remi
@@ -95,6 +95,16 @@ exact-profile handoff from successful refresh results into configured prewarm
 jobs; `apps/remi/src/server/prewarm/scheduler.rs` owns their bounded fair
 execution and complete outcome collection. HTTP handlers only publish events
 and project the shared batch.
+
+`apps/remi/src/server/database_writer.rs` owns the process-local gate for short
+SQLite mutation phases. `ServerState` gives that same owner to repository CRUD,
+authentication-token touches, and conversion publication. Repository create,
+update, and delete acquire it before opening an immediate transaction, and the
+multi-statement source replacement commits before releasing it. Network,
+parsing, CCS emission, CAS work, and read-only lookups stay outside the gate.
+Analytics refresh versus repository-sync coordination remains tracked by
+[issue #443](https://github.com/ConaryLabs/Conary/issues/443); a caller is not
+coordinated merely because it opens the same SQLite file.
 
 ## Sparse Client Sync
 


### PR DESCRIPTION
Closes #445
Refs #150
Refs #443

## Problem

The post-merge validation for #442 failed in `server::handlers::admin::repos::tests::test_repo_crud_lifecycle`: repository update returned HTTP 500 instead of 200 while the same test passed in isolation. Repository CRUD and authentication token touches bypassed the conversion-owned SQLite writer, leaving multiple process-local write authorities competing during the full suite.

## Fix

- promote the conversion-only database writer into a server-wide `DatabaseWriter`
- give repository CRUD, authentication token touches, and conversion publication the same writer owner
- acquire immediate transactions before repository reads and keep multi-statement replacement atomic
- retain network, parsing, CCS, CAS, and read-only work outside the short mutation gate
- include the response body when the CRUD lifecycle assertion fails
- document the ownership boundary and retain analytics versus sync coordination in #443

## Deterministic red and green proof

The regression holds the declared writer owner and a real SQLite immediate transaction across the five-second busy window. With the route temporarily given a separate writer owner, reproducing the old fragmented-authority structure, it failed exactly:

    repository update bypassed the shared database writer: 500 Internal Server Error {"code":"INTERNAL_ERROR","error":"Failed to update repository"}
    0 passed; 1 failed; finished in 5.27s

Restoring the single shared owner made the same exact test pass without retrying the update:

    1 passed; 0 failed; finished in 5.75s

## Verification at exact head 266d7ce6f66023b38dde396ee91684ede8dee472

- `cargo test -p remi --lib server::handlers::admin::repos::tests::repository_update_waits_for_the_shared_database_writer -- --exact --nocapture` — 1 passed
- `cargo test -p remi server::handlers::admin::repos::tests -- --nocapture` — 10 passed before the tightened contention assertion
- `cargo test -p remi server::database_writer::tests -- --nocapture` — 1 passed
- `cargo test -p remi server::conversion::tests -- --nocapture` — 2 passed
- `cargo test --workspace` — passed, including 622 Remi library tests
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo fmt --check` — passed
- `bash scripts/check-doc-truth.sh` — passed
- `git diff --check` — passed

The prior post-merge failure is https://github.com/ConaryLabs/Conary/actions/runs/31872950266/job/94984263915.