### PR TITLE
feat(remi): inventory R2 durability

### DIFF
--- a/apps/remi/src/server/admin_service.rs
+++ b/apps/remi/src/server/admin_service.rs
@@ -26,6 +26,9 @@ use rusqlite::TransactionBehavior;
 use crate::federation::{Peer, PeerTier};
 use crate::server::ServerState;
 use crate::server::auth::{generate_token, hash_token, validate_scopes};
+use crate::server::r2_durability::{
+    MAX_BACKFILL_CONCURRENCY, R2DurabilityMode, R2DurabilityReport, run_r2_durability,
+};
 
 mod refresh;
 mod repository_policy;
@@ -302,6 +305,38 @@ pub async fn run_chunk_gc_op(
         local_bytes_freed: result.local_bytes_freed,
         r2_bytes_freed: result.r2_bytes_freed,
     })
+}
+
+/// Inventory or backfill the R2 durable chunk tier.
+///
+/// This is the single implementation behind the HTTP admin route and MCP
+/// tool. Plan mode is read-only; apply mode verifies every local object before
+/// upload and reports completion from a fresh R2 inventory.
+pub async fn run_r2_durability_op(
+    state: &Arc<RwLock<ServerState>>,
+    mode: R2DurabilityMode,
+    concurrency: usize,
+) -> Result<R2DurabilityReport, ServiceError> {
+    if !(1..=MAX_BACKFILL_CONCURRENCY).contains(&concurrency) {
+        return Err(ServiceError::BadRequest(format!(
+            "R2 backfill concurrency must be between 1 and {MAX_BACKFILL_CONCURRENCY}"
+        )));
+    }
+    let (db_path, objects_dir, r2_store) = {
+        let state = state.read().await;
+        (
+            state.config.db_path.clone(),
+            state.config.chunk_dir.join("objects"),
+            state.r2_store.clone(),
+        )
+    };
+    let r2_store = r2_store.ok_or_else(|| {
+        ServiceError::BadRequest("R2 storage is not configured for this Remi instance".to_string())
+    })?;
+
+    run_r2_durability(&db_path, &objects_dir, r2_store, mode, concurrency)
+        .await
+        .map_err(|error| ServiceError::Internal(error.to_string()))
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/remi/src/server/handlers/admin/mod.rs
+++ b/apps/remi/src/server/handlers/admin/mod.rs
@@ -6,6 +6,7 @@ mod audit;
 mod chunk_gc;
 mod events;
 mod federation;
+mod r2_durability;
 mod repos;
 pub mod test_data;
 mod tokens;
@@ -15,6 +16,7 @@ pub use audit::*;
 pub use chunk_gc::*;
 pub use events::*;
 pub use federation::*;
+pub use r2_durability::*;
 pub use repos::*;
 pub use tokens::*;
 

--- a/apps/remi/src/server/handlers/admin/r2_durability.rs
+++ b/apps/remi/src/server/handlers/admin/r2_durability.rs
@@ -1,0 +1,152 @@
+// apps/remi/src/server/handlers/admin/r2_durability.rs
+
+//! R2 durability inventory and backfill handler for the external admin API.
+
+use axum::Json;
+use axum::extract::State;
+use axum::response::{IntoResponse, Response};
+use serde::Deserialize;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use crate::server::ServerState;
+use crate::server::admin_service::{self, ServiceError};
+use crate::server::auth::{Scope, TokenScopes, json_error};
+use crate::server::r2_durability::{DEFAULT_BACKFILL_CONCURRENCY, R2DurabilityMode};
+
+use super::check_scope;
+
+#[derive(Debug, Default, Deserialize)]
+pub struct R2DurabilityRequest {
+    pub mode: Option<R2DurabilityMode>,
+    pub concurrency: Option<usize>,
+}
+
+impl R2DurabilityRequest {
+    fn mode(&self) -> R2DurabilityMode {
+        self.mode.unwrap_or(R2DurabilityMode::Plan)
+    }
+
+    fn concurrency(&self) -> usize {
+        self.concurrency.unwrap_or(DEFAULT_BACKFILL_CONCURRENCY)
+    }
+}
+
+/// POST /v1/admin/r2-durability
+///
+/// An omitted body or mode plans the exact local-versus-R2 backfill. Applying
+/// requires the explicit `{"mode":"apply"}` request.
+pub async fn r2_durability(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    scopes: Option<axum::Extension<TokenScopes>>,
+    body: Option<Json<R2DurabilityRequest>>,
+) -> Response {
+    if let Some(error) = check_scope(&scopes, Scope::Admin) {
+        return error;
+    }
+
+    let request = body.map_or_else(R2DurabilityRequest::default, |Json(body)| body);
+    match admin_service::run_r2_durability_op(&state, request.mode(), request.concurrency()).await {
+        Ok(report) => Json(report).into_response(),
+        Err(ServiceError::BadRequest(message)) => json_error(400, &message, "BAD_REQUEST"),
+        Err(error) => {
+            tracing::error!("R2 durability operation failed: {error}");
+            json_error(500, "Failed to inventory R2 durability", "INTERNAL_ERROR")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    use super::super::test_helpers::test_app;
+
+    #[test]
+    fn omitted_body_plans_with_bounded_default_concurrency() {
+        let request = R2DurabilityRequest::default();
+        assert_eq!(request.mode(), R2DurabilityMode::Plan);
+        assert_eq!(request.concurrency(), DEFAULT_BACKFILL_CONCURRENCY);
+    }
+
+    #[test]
+    fn apply_requires_explicit_typed_mode() {
+        let request: R2DurabilityRequest =
+            serde_json::from_str(r#"{"mode":"apply","concurrency":8}"#).unwrap();
+        assert_eq!(request.mode(), R2DurabilityMode::Apply);
+        assert_eq!(request.concurrency(), 8);
+    }
+
+    #[tokio::test]
+    async fn route_requires_authentication() {
+        let (app, _db_path) = test_app().await;
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/admin/r2-durability")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn authenticated_plan_fails_typed_when_r2_is_unconfigured() {
+        let (app, _db_path) = test_app().await;
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/admin/r2-durability")
+                    .header("Authorization", "Bearer test-admin-token-12345")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        let error: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(error["code"], "BAD_REQUEST");
+    }
+
+    #[tokio::test]
+    async fn route_rejects_out_of_bounds_backfill_concurrency() {
+        let (app, _db_path) = test_app().await;
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/admin/r2-durability")
+                    .header("Authorization", "Bearer test-admin-token-12345")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(r#"{"mode":"apply","concurrency":65}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        let error: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(error["code"], "BAD_REQUEST");
+        assert!(
+            error["error"]
+                .as_str()
+                .unwrap()
+                .contains("between 1 and 64")
+        );
+    }
+}

--- a/apps/remi/src/server/handlers/openapi.rs
+++ b/apps/remi/src/server/handlers/openapi.rs
@@ -414,6 +414,26 @@ pub async fn openapi_spec() -> Response {
                     "responses": { "200": { "description": "Chunk garbage collection report" }, "400": { "description": "Invalid request body" }, "401": { "description": "Invalid or missing token" }, "403": { "description": "Insufficient scope" } }
                 }
             },
+            "/v1/admin/r2-durability": {
+                "post": {
+                    "operationId": "r2Durability",
+                    "summary": "Inventory or backfill R2 durability",
+                    "description": "Compares exact published chunk authority with local CAS and R2. An omitted body plans only. mode=apply verifies local SHA-256, uploads missing objects, and rechecks R2. Requires admin scope.",
+                    "tags": ["admin"],
+                    "security": [{ "bearerAuth": [] }],
+                    "requestBody": {
+                        "required": false,
+                        "content": { "application/json": { "schema": {
+                            "type": "object",
+                            "properties": {
+                                "mode": { "type": "string", "enum": ["plan", "apply"], "default": "plan" },
+                                "concurrency": { "type": "integer", "minimum": 1, "maximum": 64, "default": 16 }
+                            }
+                        }}}
+                    },
+                    "responses": { "200": { "description": "Versioned R2 durability report" }, "400": { "description": "R2 is unavailable or request bounds are invalid" }, "401": { "description": "Invalid or missing token" }, "403": { "description": "Insufficient scope" } }
+                }
+            },
             "/v1/admin/test-runs/gc": {
                 "delete": {
                     "operationId": "testRunGarbageCollect",

--- a/apps/remi/src/server/mcp.rs
+++ b/apps/remi/src/server/mcp.rs
@@ -31,6 +31,7 @@ use serde::Deserialize;
 
 use crate::server::ServerState;
 use crate::server::admin_service::{self, AddPeerInput, ChunkGcReport, ServiceError};
+use crate::server::r2_durability::{DEFAULT_BACKFILL_CONCURRENCY, R2DurabilityMode};
 
 /// Map a [`ServiceError`] to the appropriate [`McpError`] variant.
 ///
@@ -205,6 +206,17 @@ pub struct ChunkGcParams {
     /// Show what would be deleted without deleting (default false).
     #[serde(default)]
     pub dry_run: Option<bool>,
+}
+
+/// Parameters for the R2 durability inventory and backfill tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct R2DurabilityParams {
+    /// Read-only plan or explicit apply. Defaults to plan.
+    #[serde(default)]
+    pub mode: Option<R2DurabilityMode>,
+    /// Maximum concurrent R2 PUT requests. Defaults to 16 and cannot exceed 64.
+    #[serde(default)]
+    pub concurrency: Option<usize>,
 }
 
 // ---------------------------------------------------------------------------
@@ -615,6 +627,25 @@ impl RemiMcpServer {
         Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
     }
 
+    /// Inventory local and R2 chunk durability or apply an exact backfill.
+    #[tool(
+        description = "Inventory exact local and R2 chunk counts, bytes, and published-object completeness. Omitted mode defaults to a read-only plan; mode=apply verifies local SHA-256 before uploading only missing objects and rechecks R2 afterward. Risk: high. Requires plan-then-apply confirmation."
+    )]
+    async fn r2_durability(
+        &self,
+        Parameters(params): Parameters<R2DurabilityParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let report = admin_service::run_r2_durability_op(
+            &self.state,
+            params.mode.unwrap_or(R2DurabilityMode::Plan),
+            params.concurrency.unwrap_or(DEFAULT_BACKFILL_CONCURRENCY),
+        )
+        .await
+        .map_err(service_err_to_mcp)?;
+        let text = to_json_text(&report)?;
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
+    }
+
     // -----------------------------------------------------------------------
     // Canonical mapping
     // -----------------------------------------------------------------------
@@ -817,6 +848,7 @@ mod tests {
             "delete_peer",
             "purge_audit_log",
             "chunk_gc",
+            "r2_durability",
             "canonical_rebuild",
             "canonical_fetch",
         ] {

--- a/apps/remi/src/server/mod.rs
+++ b/apps/remi/src/server/mod.rs
@@ -43,6 +43,7 @@ pub mod popularity;
 mod prewarm;
 pub mod publication;
 pub mod r2;
+pub mod r2_durability;
 pub mod rate_limit;
 pub mod readiness;
 pub mod release_publish;

--- a/apps/remi/src/server/r2.rs
+++ b/apps/remi/src/server/r2.rs
@@ -63,6 +63,13 @@ pub struct R2BatchDeleteOutcome {
     pub failure_samples: Vec<(String, String)>,
 }
 
+/// Exact object metadata returned by an R2 prefix inventory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct R2ChunkObject {
+    pub hash: String,
+    pub size_bytes: u64,
+}
+
 impl R2BatchDeleteOutcome {
     /// Number of keys that were not removed.
     pub fn failed(&self) -> usize {
@@ -245,29 +252,43 @@ impl R2Store {
         Ok(self.bucket.presign_get(&key, expiry_secs, None).await?)
     }
 
-    /// List all chunk hashes stored in R2.
+    /// List all chunk objects stored in R2 with their exact stored sizes.
     ///
     /// Paginates through all objects under the configured prefix,
-    /// stripping the prefix to return bare hash strings.
-    pub async fn list_chunks(&self) -> Result<Vec<String>> {
+    /// stripping the prefix to return bare hash identities.
+    pub async fn list_chunk_objects(&self) -> Result<Vec<R2ChunkObject>> {
         let results = self
             .bucket
             .list(self.prefix.clone(), None)
             .await
             .context("R2 list objects failed")?;
 
-        let mut hashes = Vec::new();
+        let mut objects = Vec::new();
         for page in &results {
             for object in &page.contents {
                 if let Some(hash) = object.key.strip_prefix(&self.prefix)
                     && !hash.is_empty()
                 {
-                    hashes.push(hash.to_string());
+                    objects.push(R2ChunkObject {
+                        hash: hash.to_string(),
+                        size_bytes: object.size,
+                    });
                 }
             }
         }
 
-        Ok(hashes)
+        objects.sort_by(|left, right| left.hash.cmp(&right.hash));
+        Ok(objects)
+    }
+
+    /// List all chunk hashes stored in R2.
+    pub async fn list_chunks(&self) -> Result<Vec<String>> {
+        Ok(self
+            .list_chunk_objects()
+            .await?
+            .into_iter()
+            .map(|object| object.hash)
+            .collect())
     }
 
     /// Return the configured prefix (e.g., `"chunks/"`).

--- a/apps/remi/src/server/r2_durability.rs
+++ b/apps/remi/src/server/r2_durability.rs
@@ -10,6 +10,7 @@ use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
 use futures::{StreamExt, stream};
 use rusqlite::Connection;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::r2::{R2ChunkObject, R2Store};
@@ -19,7 +20,7 @@ const FAILURE_SAMPLE_LIMIT: usize = 10;
 pub const DEFAULT_BACKFILL_CONCURRENCY: usize = 16;
 pub const MAX_BACKFILL_CONCURRENCY: usize = 64;
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum R2DurabilityMode {
     Plan,
@@ -120,7 +121,7 @@ pub async fn run_r2_durability<S: DurableChunkStore + ?Sized + 'static>(
         .await
         .context("join local chunk inventory task")??;
     let initial_r2 = map_r2_objects(store.list_chunk_objects().await?)?;
-    let planned = planned_uploads(&local, &initial_r2);
+    let planned = planned_uploads(&required, &local, &initial_r2);
 
     let mut attempted_uploads = 0usize;
     let mut uploaded_objects = 0usize;
@@ -221,12 +222,20 @@ fn inventory(
 }
 
 fn planned_uploads(
+    required: &BTreeMap<String, u64>,
     local: &BTreeMap<String, u64>,
     r2: &BTreeMap<String, u64>,
 ) -> BTreeMap<String, u64> {
-    local
+    required
         .iter()
-        .filter(|(hash, size)| r2.get(*hash).is_none_or(|r2_size| r2_size != *size))
+        .filter(|(hash, required_size)| {
+            local
+                .get(*hash)
+                .is_some_and(|local_size| local_size == *required_size)
+                && r2
+                    .get(*hash)
+                    .is_none_or(|r2_size| r2_size != *required_size)
+        })
         .map(|(hash, size)| (hash.clone(), *size))
         .collect()
 }
@@ -371,6 +380,7 @@ mod tests {
     struct FakeStore {
         objects: Mutex<BTreeMap<String, Vec<u8>>>,
         puts: Mutex<Vec<String>>,
+        discard_puts: bool,
     }
 
     #[async_trait]
@@ -390,10 +400,12 @@ mod tests {
 
         async fn put_chunk(&self, hash: &str, data: &[u8]) -> Result<()> {
             self.puts.lock().unwrap().push(hash.to_string());
-            self.objects
-                .lock()
-                .unwrap()
-                .insert(hash.to_string(), data.to_vec());
+            if !self.discard_puts {
+                self.objects
+                    .lock()
+                    .unwrap()
+                    .insert(hash.to_string(), data.to_vec());
+            }
             Ok(())
         }
     }
@@ -466,6 +478,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn plan_does_not_backfill_unreferenced_local_objects() {
+        let (_temp, db_path, objects_dir, _hash, _data) = fixture();
+        let unreferenced_data = b"unreferenced cache object";
+        let unreferenced_hash = conary_core::hash::sha256(unreferenced_data);
+        let unreferenced_path = chunk_path(&objects_dir, &unreferenced_hash);
+        std::fs::create_dir_all(unreferenced_path.parent().unwrap()).unwrap();
+        std::fs::write(unreferenced_path, unreferenced_data).unwrap();
+        let store = Arc::new(FakeStore::default());
+
+        let report = run_r2_durability(&db_path, &objects_dir, store, R2DurabilityMode::Plan, 2)
+            .await
+            .unwrap();
+
+        assert_eq!(report.local.objects, 2);
+        assert_eq!(report.required_objects, 1);
+        assert_eq!(report.planned_uploads, 1);
+    }
+
+    #[tokio::test]
     async fn apply_uploads_verified_bytes_and_rechecks_r2() {
         let (_temp, db_path, objects_dir, hash, data) = fixture();
         let store = Arc::new(FakeStore::default());
@@ -492,7 +523,7 @@ mod tests {
     #[tokio::test]
     async fn apply_refuses_corrupt_local_object() {
         let (_temp, db_path, objects_dir, hash, _data) = fixture();
-        std::fs::write(chunk_path(&objects_dir, &hash), b"corrupt").unwrap();
+        std::fs::write(chunk_path(&objects_dir, &hash), b"corrupt chunk").unwrap();
         let store = Arc::new(FakeStore::default());
 
         let report = run_r2_durability(
@@ -511,6 +542,50 @@ mod tests {
         assert_eq!(report.uploaded_objects, 0);
         assert!(report.failure_samples[0].error.contains("digest"));
         assert!(store.puts.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn apply_repairs_r2_size_disagreement_from_verified_local_bytes() {
+        let (_temp, db_path, objects_dir, hash, data) = fixture();
+        let store = Arc::new(FakeStore::default());
+        store
+            .objects
+            .lock()
+            .unwrap()
+            .insert(hash.clone(), b"wrong-size".to_vec());
+
+        let report = run_r2_durability(
+            &db_path,
+            &objects_dir,
+            Arc::clone(&store),
+            R2DurabilityMode::Apply,
+            2,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(report.outcome, R2DurabilityOutcome::AppliedComplete);
+        assert_eq!(report.planned_uploads, 1);
+        assert_eq!(report.uploaded_objects, 1);
+        assert_eq!(store.objects.lock().unwrap().get(&hash), Some(&data));
+    }
+
+    #[tokio::test]
+    async fn apply_does_not_trust_successful_put_without_post_inventory() {
+        let (_temp, db_path, objects_dir, _hash, _data) = fixture();
+        let store = Arc::new(FakeStore {
+            discard_puts: true,
+            ..Default::default()
+        });
+
+        let report = run_r2_durability(&db_path, &objects_dir, store, R2DurabilityMode::Apply, 2)
+            .await
+            .unwrap();
+
+        assert_eq!(report.uploaded_objects, 1);
+        assert_eq!(report.failed_uploads, 0);
+        assert_eq!(report.outcome, R2DurabilityOutcome::AppliedIncomplete);
+        assert!(!report.r2_complete);
     }
 
     #[tokio::test]

--- a/apps/remi/src/server/r2_durability.rs
+++ b/apps/remi/src/server/r2_durability.rs
@@ -51,6 +51,23 @@ pub struct R2DurabilityFailure {
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum R2DurabilityBlockerKind {
+    MissingFromBoth,
+    LocalSizeMismatch,
+    R2SizeMismatchWithoutLocal,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct R2DurabilityBlocker {
+    pub hash: String,
+    pub kind: R2DurabilityBlockerKind,
+    pub expected_size: u64,
+    pub local_size: Option<u64>,
+    pub r2_size: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct R2DurabilityReport {
     pub schema_version: u32,
     pub mode: R2DurabilityMode,
@@ -66,6 +83,8 @@ pub struct R2DurabilityReport {
     pub uploaded_objects: usize,
     pub uploaded_bytes: u64,
     pub failed_uploads: usize,
+    pub unrepairable_objects: usize,
+    pub unrepairable_samples: Vec<R2DurabilityBlocker>,
     pub missing_from_both: usize,
     pub missing_from_both_samples: Vec<String>,
     pub failure_samples: Vec<R2DurabilityFailure>,
@@ -167,6 +186,7 @@ pub async fn run_r2_durability<S: DurableChunkStore + ?Sized + 'static>(
         .filter(|hash| !local.contains_key(*hash) && !final_r2.contains_key(*hash))
         .cloned()
         .collect::<Vec<_>>();
+    let unrepairable = unrepairable_objects(&required, &local, &final_r2);
     let r2_complete = required
         .iter()
         .all(|(hash, expected_size)| final_r2.get(hash).is_some_and(|size| size == expected_size));
@@ -192,6 +212,11 @@ pub async fn run_r2_durability<S: DurableChunkStore + ?Sized + 'static>(
         uploaded_objects,
         uploaded_bytes,
         failed_uploads,
+        unrepairable_objects: unrepairable.len(),
+        unrepairable_samples: unrepairable
+            .into_iter()
+            .take(FAILURE_SAMPLE_LIMIT)
+            .collect(),
         missing_from_both: missing_from_both.len(),
         missing_from_both_samples: missing_from_both
             .into_iter()
@@ -199,6 +224,35 @@ pub async fn run_r2_durability<S: DurableChunkStore + ?Sized + 'static>(
             .collect(),
         failure_samples,
     })
+}
+
+fn unrepairable_objects(
+    required: &BTreeMap<String, u64>,
+    local: &BTreeMap<String, u64>,
+    r2: &BTreeMap<String, u64>,
+) -> Vec<R2DurabilityBlocker> {
+    required
+        .iter()
+        .filter_map(|(hash, expected_size)| {
+            let local_size = local.get(hash).copied();
+            let r2_size = r2.get(hash).copied();
+            if r2_size == Some(*expected_size) || local_size == Some(*expected_size) {
+                return None;
+            }
+            let kind = match (local_size, r2_size) {
+                (None, None) => R2DurabilityBlockerKind::MissingFromBoth,
+                (Some(_), _) => R2DurabilityBlockerKind::LocalSizeMismatch,
+                (None, Some(_)) => R2DurabilityBlockerKind::R2SizeMismatchWithoutLocal,
+            };
+            Some(R2DurabilityBlocker {
+                hash: hash.clone(),
+                kind,
+                expected_size: *expected_size,
+                local_size,
+                r2_size,
+            })
+        })
+        .collect()
 }
 
 fn inventory(
@@ -600,7 +654,31 @@ mod tests {
 
         assert_eq!(report.outcome, R2DurabilityOutcome::PlanBlocked);
         assert_eq!(report.planned_uploads, 0);
+        assert_eq!(report.unrepairable_objects, 1);
+        assert_eq!(
+            report.unrepairable_samples[0].kind,
+            R2DurabilityBlockerKind::MissingFromBoth
+        );
         assert_eq!(report.missing_from_both, 1);
         assert_eq!(report.missing_from_both_samples, vec![hash]);
+    }
+
+    #[tokio::test]
+    async fn plan_explains_required_local_size_mismatch() {
+        let (_temp, db_path, objects_dir, hash, _data) = fixture();
+        std::fs::write(chunk_path(&objects_dir, &hash), b"short").unwrap();
+        let store = Arc::new(FakeStore::default());
+
+        let report = run_r2_durability(&db_path, &objects_dir, store, R2DurabilityMode::Plan, 2)
+            .await
+            .unwrap();
+
+        assert_eq!(report.planned_uploads, 0);
+        assert_eq!(report.unrepairable_objects, 1);
+        assert_eq!(
+            report.unrepairable_samples[0].kind,
+            R2DurabilityBlockerKind::LocalSizeMismatch
+        );
+        assert_eq!(report.unrepairable_samples[0].local_size, Some(5));
     }
 }

--- a/apps/remi/src/server/r2_durability.rs
+++ b/apps/remi/src/server/r2_durability.rs
@@ -1,0 +1,531 @@
+// apps/remi/src/server/r2_durability.rs
+
+//! Typed local-versus-R2 durability inventory and missing-object backfill.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use futures::{StreamExt, stream};
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+
+use super::r2::{R2ChunkObject, R2Store};
+
+pub const R2_DURABILITY_SCHEMA_V1: u32 = 1;
+const FAILURE_SAMPLE_LIMIT: usize = 10;
+pub const DEFAULT_BACKFILL_CONCURRENCY: usize = 16;
+pub const MAX_BACKFILL_CONCURRENCY: usize = 64;
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum R2DurabilityMode {
+    Plan,
+    Apply,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ChunkStoreInventory {
+    pub objects: usize,
+    pub bytes: u64,
+    pub required_present: usize,
+    pub required_missing: usize,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum R2DurabilityOutcome {
+    PlanReady,
+    PlanBlocked,
+    AppliedComplete,
+    AppliedIncomplete,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct R2DurabilityFailure {
+    pub hash: String,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct R2DurabilityReport {
+    pub schema_version: u32,
+    pub mode: R2DurabilityMode,
+    pub outcome: R2DurabilityOutcome,
+    pub r2_complete: bool,
+    pub required_objects: usize,
+    pub required_bytes: u64,
+    pub local: ChunkStoreInventory,
+    pub r2: ChunkStoreInventory,
+    pub planned_uploads: usize,
+    pub planned_upload_bytes: u64,
+    pub attempted_uploads: usize,
+    pub uploaded_objects: usize,
+    pub uploaded_bytes: u64,
+    pub failed_uploads: usize,
+    pub missing_from_both: usize,
+    pub missing_from_both_samples: Vec<String>,
+    pub failure_samples: Vec<R2DurabilityFailure>,
+}
+
+#[async_trait]
+pub trait DurableChunkStore: Send + Sync {
+    async fn list_chunk_objects(&self) -> Result<Vec<R2ChunkObject>>;
+    async fn put_chunk(&self, hash: &str, data: &[u8]) -> Result<()>;
+}
+
+#[async_trait]
+impl DurableChunkStore for R2Store {
+    async fn list_chunk_objects(&self) -> Result<Vec<R2ChunkObject>> {
+        R2Store::list_chunk_objects(self).await
+    }
+
+    async fn put_chunk(&self, hash: &str, data: &[u8]) -> Result<()> {
+        R2Store::put_chunk(self, hash, data).await
+    }
+}
+
+#[derive(Debug)]
+struct UploadOutcome {
+    hash: String,
+    bytes: u64,
+    error: Option<String>,
+}
+
+/// Inventory R2 against local CAS and persisted package-object authority.
+///
+/// `Plan` is read-only. `Apply` uploads only objects absent from R2 (or whose
+/// stored size disagrees with the verified local object), then lists R2 again
+/// and derives completion from that post-apply state.
+pub async fn run_r2_durability<S: DurableChunkStore + ?Sized + 'static>(
+    db_path: &Path,
+    objects_dir: &Path,
+    store: Arc<S>,
+    mode: R2DurabilityMode,
+    concurrency: usize,
+) -> Result<R2DurabilityReport> {
+    if !(1..=MAX_BACKFILL_CONCURRENCY).contains(&concurrency) {
+        bail!("R2 backfill concurrency must be between 1 and {MAX_BACKFILL_CONCURRENCY}");
+    }
+
+    let db_path = db_path.to_path_buf();
+    let objects_dir = objects_dir.to_path_buf();
+    let required = tokio::task::spawn_blocking(move || required_objects(&db_path))
+        .await
+        .context("join R2 required-object inventory task")??;
+    let local_objects_dir = objects_dir.clone();
+    let local = tokio::task::spawn_blocking(move || scan_local(&local_objects_dir))
+        .await
+        .context("join local chunk inventory task")??;
+    let initial_r2 = map_r2_objects(store.list_chunk_objects().await?)?;
+    let planned = planned_uploads(&local, &initial_r2);
+
+    let mut attempted_uploads = 0usize;
+    let mut uploaded_objects = 0usize;
+    let mut uploaded_bytes = 0u64;
+    let mut failure_samples = Vec::new();
+    let mut failed_uploads = 0usize;
+
+    if mode == R2DurabilityMode::Apply {
+        attempted_uploads = planned.len();
+        let outcomes = stream::iter(planned.keys().cloned())
+            .map(|hash| {
+                let store = Arc::clone(&store);
+                let objects_dir = objects_dir.clone();
+                async move { upload_verified_local(store, objects_dir, hash).await }
+            })
+            .buffer_unordered(concurrency)
+            .collect::<Vec<_>>()
+            .await;
+
+        for outcome in outcomes {
+            if let Some(error) = outcome.error {
+                failed_uploads += 1;
+                if failure_samples.len() < FAILURE_SAMPLE_LIMIT {
+                    failure_samples.push(R2DurabilityFailure {
+                        hash: outcome.hash,
+                        error,
+                    });
+                }
+            } else {
+                uploaded_objects += 1;
+                uploaded_bytes = uploaded_bytes.saturating_add(outcome.bytes);
+            }
+        }
+    }
+
+    let final_r2 = if mode == R2DurabilityMode::Apply {
+        map_r2_objects(store.list_chunk_objects().await?)?
+    } else {
+        initial_r2
+    };
+    let missing_from_both = required
+        .keys()
+        .filter(|hash| !local.contains_key(*hash) && !final_r2.contains_key(*hash))
+        .cloned()
+        .collect::<Vec<_>>();
+    let r2_complete = required
+        .iter()
+        .all(|(hash, expected_size)| final_r2.get(hash).is_some_and(|size| size == expected_size));
+    let outcome = match (mode, r2_complete) {
+        (R2DurabilityMode::Plan, true) => R2DurabilityOutcome::PlanReady,
+        (R2DurabilityMode::Plan, false) => R2DurabilityOutcome::PlanBlocked,
+        (R2DurabilityMode::Apply, true) => R2DurabilityOutcome::AppliedComplete,
+        (R2DurabilityMode::Apply, false) => R2DurabilityOutcome::AppliedIncomplete,
+    };
+
+    Ok(R2DurabilityReport {
+        schema_version: R2_DURABILITY_SCHEMA_V1,
+        mode,
+        outcome,
+        r2_complete,
+        required_objects: required.len(),
+        required_bytes: required.values().copied().sum(),
+        local: inventory(&local, &required),
+        r2: inventory(&final_r2, &required),
+        planned_uploads: planned.len(),
+        planned_upload_bytes: planned.values().copied().sum(),
+        attempted_uploads,
+        uploaded_objects,
+        uploaded_bytes,
+        failed_uploads,
+        missing_from_both: missing_from_both.len(),
+        missing_from_both_samples: missing_from_both
+            .into_iter()
+            .take(FAILURE_SAMPLE_LIMIT)
+            .collect(),
+        failure_samples,
+    })
+}
+
+fn inventory(
+    actual: &BTreeMap<String, u64>,
+    required: &BTreeMap<String, u64>,
+) -> ChunkStoreInventory {
+    let required_present = required
+        .iter()
+        .filter(|(hash, size)| {
+            actual
+                .get(*hash)
+                .is_some_and(|actual_size| actual_size == *size)
+        })
+        .count();
+    ChunkStoreInventory {
+        objects: actual.len(),
+        bytes: actual.values().copied().sum(),
+        required_present,
+        required_missing: required.len().saturating_sub(required_present),
+    }
+}
+
+fn planned_uploads(
+    local: &BTreeMap<String, u64>,
+    r2: &BTreeMap<String, u64>,
+) -> BTreeMap<String, u64> {
+    local
+        .iter()
+        .filter(|(hash, size)| r2.get(*hash).is_none_or(|r2_size| r2_size != *size))
+        .map(|(hash, size)| (hash.clone(), *size))
+        .collect()
+}
+
+async fn upload_verified_local<S: DurableChunkStore + ?Sized>(
+    store: Arc<S>,
+    objects_dir: PathBuf,
+    hash: String,
+) -> UploadOutcome {
+    let path = chunk_path(&objects_dir, &hash);
+    let data = match tokio::fs::read(&path).await {
+        Ok(data) => data,
+        Err(error) => {
+            return UploadOutcome {
+                hash,
+                bytes: 0,
+                error: Some(format!("read local object: {error}")),
+            };
+        }
+    };
+    let bytes = data.len() as u64;
+    let actual_hash = conary_core::hash::sha256(&data);
+    if actual_hash != hash {
+        return UploadOutcome {
+            hash,
+            bytes,
+            error: Some(format!("local object digest is {actual_hash}")),
+        };
+    }
+    let error = store
+        .put_chunk(&hash, &data)
+        .await
+        .err()
+        .map(|error| format!("R2 PUT failed: {error}"));
+    UploadOutcome { hash, bytes, error }
+}
+
+fn map_r2_objects(objects: Vec<R2ChunkObject>) -> Result<BTreeMap<String, u64>> {
+    let mut mapped = BTreeMap::new();
+    for object in objects {
+        validate_hash(&object.hash).context("invalid object under the R2 chunk prefix")?;
+        if mapped
+            .insert(object.hash.clone(), object.size_bytes)
+            .is_some()
+        {
+            bail!("R2 inventory repeated chunk {}", object.hash);
+        }
+    }
+    Ok(mapped)
+}
+
+fn scan_local(objects_dir: &Path) -> Result<BTreeMap<String, u64>> {
+    let mut objects = BTreeMap::new();
+    for hash in super::chunk_gc::scan_local_chunks(objects_dir)? {
+        validate_hash(&hash).context("invalid object in the local chunk directory")?;
+        let path = chunk_path(objects_dir, &hash);
+        let size = std::fs::metadata(&path)
+            .with_context(|| format!("stat local chunk {}", path.display()))?
+            .len();
+        if objects.insert(hash.clone(), size).is_some() {
+            bail!("local inventory repeated chunk {hash}");
+        }
+    }
+    Ok(objects)
+}
+
+fn required_objects(db_path: &Path) -> Result<BTreeMap<String, u64>> {
+    let conn = crate::server::open_runtime_db(db_path)?;
+    let mut required = BTreeMap::new();
+    collect_transport_objects(
+        &conn,
+        "SELECT id, transport_json FROM converted_packages WHERE transport_json IS NOT NULL",
+        "converted package",
+        &mut required,
+    )?;
+    collect_transport_objects(
+        &conn,
+        "SELECT id, transport_json FROM native_package_publications \
+         WHERE status = 'public' AND transport_json IS NOT NULL",
+        "native package publication",
+        &mut required,
+    )?;
+    Ok(required)
+}
+
+fn collect_transport_objects(
+    conn: &Connection,
+    sql: &str,
+    owner: &str,
+    required: &mut BTreeMap<String, u64>,
+) -> Result<()> {
+    let mut stmt = conn.prepare(sql)?;
+    let rows = stmt.query_map([], |row| {
+        Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+    })?;
+    for row in rows {
+        let (id, transport_json) = row?;
+        let transport =
+            serde_json::from_str::<conary_core::ccs::CcsTransportEnvelopeV1>(&transport_json)
+                .with_context(|| format!("{owner} {id} has malformed transport authority"))?;
+        for object in transport.objects {
+            validate_hash(&object.sha256)
+                .with_context(|| format!("{owner} {id} has invalid object identity"))?;
+            if let Some(previous) = required.insert(object.sha256.clone(), object.size)
+                && previous != object.size
+            {
+                bail!(
+                    "{owner} {id} gives chunk {} size {}, contradicting prior size {previous}",
+                    object.sha256,
+                    object.size
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_hash(hash: &str) -> Result<()> {
+    if hash.len() != 64
+        || !hash
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        bail!("chunk hash must be exactly 64 lowercase hexadecimal characters");
+    }
+    Ok(())
+}
+
+fn chunk_path(objects_dir: &Path, hash: &str) -> PathBuf {
+    let (prefix, rest) = hash.split_at(2);
+    objects_dir.join(prefix).join(rest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use conary_core::ccs::{CcsTransportEnvelopeV1, CcsTransportObjectV1};
+    use conary_core::db::models::{ConvertedPackage, EMPTY_REPOSITORY_PROVIDES_DIGEST};
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct FakeStore {
+        objects: Mutex<BTreeMap<String, Vec<u8>>>,
+        puts: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl DurableChunkStore for FakeStore {
+        async fn list_chunk_objects(&self) -> Result<Vec<R2ChunkObject>> {
+            Ok(self
+                .objects
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|(hash, data)| R2ChunkObject {
+                    hash: hash.clone(),
+                    size_bytes: data.len() as u64,
+                })
+                .collect())
+        }
+
+        async fn put_chunk(&self, hash: &str, data: &[u8]) -> Result<()> {
+            self.puts.lock().unwrap().push(hash.to_string());
+            self.objects
+                .lock()
+                .unwrap()
+                .insert(hash.to_string(), data.to_vec());
+            Ok(())
+        }
+    }
+
+    fn fixture() -> (tempfile::TempDir, PathBuf, PathBuf, String, Vec<u8>) {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("remi.db");
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conary_core::db::schema::ensure_current(&conn).unwrap();
+        let data = b"durable chunk".to_vec();
+        let hash = conary_core::hash::sha256(&data);
+        let transport = CcsTransportEnvelopeV1 {
+            schema_version: conary_core::ccs::transport::CCS_TRANSPORT_SCHEMA_V1,
+            manifest_base64: String::new(),
+            signature_json: "{}".to_string(),
+            debug_toml_base64: None,
+            build_attestation_json: None,
+            foreign_conversion_boundary_json: None,
+            objects: vec![CcsTransportObjectV1 {
+                sha256: hash.clone(),
+                size: data.len() as u64,
+            }],
+        };
+        let mut converted = ConvertedPackage::new_repository(
+            "fedora-44".to_string(),
+            "durability-fixture".to_string(),
+            "1-1".to_string(),
+            "x86_64".to_string(),
+            "rpm".to_string(),
+            "sha256:fixture".to_string(),
+            &transport,
+            data.len() as i64,
+            "sha256:transport".to_string(),
+            "/tmp/fixture.ccs".to_string(),
+            EMPTY_REPOSITORY_PROVIDES_DIGEST.to_string(),
+        );
+        converted.insert(&conn).unwrap();
+
+        let objects_dir = temp.path().join("chunks/objects");
+        let path = chunk_path(&objects_dir, &hash);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, &data).unwrap();
+        (temp, db_path, objects_dir, hash, data)
+    }
+
+    #[tokio::test]
+    async fn plan_reports_exact_gap_without_writing() {
+        let (_temp, db_path, objects_dir, hash, data) = fixture();
+        let store = Arc::new(FakeStore::default());
+
+        let report = run_r2_durability(
+            &db_path,
+            &objects_dir,
+            Arc::clone(&store),
+            R2DurabilityMode::Plan,
+            2,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(report.outcome, R2DurabilityOutcome::PlanBlocked);
+        assert_eq!(report.planned_uploads, 1);
+        assert_eq!(report.planned_upload_bytes, data.len() as u64);
+        assert_eq!(report.missing_from_both, 0);
+        assert!(store.puts.lock().unwrap().is_empty());
+        assert_eq!(report.local.required_present, 1);
+        assert_eq!(report.r2.required_missing, 1);
+        assert_eq!(report.missing_from_both_samples, Vec::<String>::new());
+        assert_eq!(hash.len(), 64);
+    }
+
+    #[tokio::test]
+    async fn apply_uploads_verified_bytes_and_rechecks_r2() {
+        let (_temp, db_path, objects_dir, hash, data) = fixture();
+        let store = Arc::new(FakeStore::default());
+
+        let report = run_r2_durability(
+            &db_path,
+            &objects_dir,
+            Arc::clone(&store),
+            R2DurabilityMode::Apply,
+            2,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(report.outcome, R2DurabilityOutcome::AppliedComplete);
+        assert!(report.r2_complete);
+        assert_eq!(report.attempted_uploads, 1);
+        assert_eq!(report.uploaded_objects, 1);
+        assert_eq!(report.uploaded_bytes, data.len() as u64);
+        assert_eq!(store.puts.lock().unwrap().as_slice(), &[hash]);
+        assert_eq!(report.r2.required_missing, 0);
+    }
+
+    #[tokio::test]
+    async fn apply_refuses_corrupt_local_object() {
+        let (_temp, db_path, objects_dir, hash, _data) = fixture();
+        std::fs::write(chunk_path(&objects_dir, &hash), b"corrupt").unwrap();
+        let store = Arc::new(FakeStore::default());
+
+        let report = run_r2_durability(
+            &db_path,
+            &objects_dir,
+            Arc::clone(&store),
+            R2DurabilityMode::Apply,
+            2,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(report.outcome, R2DurabilityOutcome::AppliedIncomplete);
+        assert!(!report.r2_complete);
+        assert_eq!(report.failed_uploads, 1);
+        assert_eq!(report.uploaded_objects, 0);
+        assert!(report.failure_samples[0].error.contains("digest"));
+        assert!(store.puts.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn plan_reports_required_object_missing_from_both_stores() {
+        let (_temp, db_path, objects_dir, hash, _data) = fixture();
+        std::fs::remove_file(chunk_path(&objects_dir, &hash)).unwrap();
+        let store = Arc::new(FakeStore::default());
+
+        let report = run_r2_durability(&db_path, &objects_dir, store, R2DurabilityMode::Plan, 2)
+            .await
+            .unwrap();
+
+        assert_eq!(report.outcome, R2DurabilityOutcome::PlanBlocked);
+        assert_eq!(report.planned_uploads, 0);
+        assert_eq!(report.missing_from_both, 1);
+        assert_eq!(report.missing_from_both_samples, vec![hash]);
+    }
+}

--- a/apps/remi/src/server/routes/admin.rs
+++ b/apps/remi/src/server/routes/admin.rs
@@ -94,6 +94,10 @@ pub fn create_external_admin_router(
         .route("/v1/admin/refresh", post(admin_handlers::refresh_repos))
         .route("/v1/admin/chunk-gc", post(admin_handlers::chunk_gc))
         .route(
+            "/v1/admin/r2-durability",
+            post(admin_handlers::r2_durability),
+        )
+        .route(
             "/v1/admin/federation/peers",
             get(admin_handlers::list_peers),
         )

--- a/deploy/CLOUDFLARE.md
+++ b/deploy/CLOUDFLARE.md
@@ -137,6 +137,22 @@ prefix = "chunks/"
 write_through = true
 ```
 
+### Inventory and backfill before authority changes
+
+Write-through covers only objects stored after it was enabled. Before enabling
+redirect serving or evicting local chunks, use the authenticated
+`POST /v1/admin/r2-durability` operation described in
+`docs/guides/self-hosted-remi.md`. Run `mode=plan`, record its exact object and
+byte gap, then explicitly run `mode=apply` and retain the schema-v1 report.
+Proceed only when the post-apply result says `outcome: "applied_complete"` and
+`r2_complete: true`; a submitted upload count is not completeness proof.
+
+Use a bucket-scoped read/write credential for inventory and backfill. Keep it
+in the service manager's protected environment file, rotate it using the R2
+dashboard, restart Remi, and rerun plan mode after rotation. Bucket lifecycle
+rules must not expire the configured chunk prefix while package transport
+envelopes reference those objects.
+
 ### R2 Custom Domain (optional)
 
 To serve chunks directly from R2 via a custom domain:

--- a/docs/guides/self-hosted-remi.md
+++ b/docs/guides/self-hosted-remi.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-07-29
-revision: 3
+last_updated: 2026-08-15
+revision: 4
 summary: Run your own Remi conversion server in about 30 minutes
 ---
 
@@ -209,6 +209,35 @@ Provide credentials through environment variables, not the config file:
 CONARY_R2_ACCESS_KEY=...
 CONARY_R2_SECRET_KEY=...
 ```
+
+Before relying on R2 for durable retrieval, inventory it against local CAS and
+the persisted package-object authority. The authenticated admin operation
+defaults to a read-only plan:
+
+```bash
+curl --fail-with-body \
+  -H "Authorization: Bearer $REMI_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"mode":"plan"}' \
+  "$REMI_ADMIN_ENDPOINT/v1/admin/r2-durability"
+```
+
+Review `planned_uploads`, `planned_upload_bytes`, and
+`missing_from_both_samples` before applying. Apply is explicit and concurrency
+is bounded between 1 and 64:
+
+```bash
+curl --fail-with-body \
+  -H "Authorization: Bearer $REMI_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"mode":"apply","concurrency":16}' \
+  "$REMI_ADMIN_ENDPOINT/v1/admin/r2-durability"
+```
+
+Archive the schema-v1 response. Only `outcome: "applied_complete"` together
+with `r2_complete: true` proves the required set was present in the fresh R2
+listing after upload. This command does not itself enable R2 redirects or local
+eviction; those remain separate serving-policy changes.
 
 See `deploy/CLOUDFLARE.md` for the CDN-backed origin setup.
 

--- a/docs/guides/self-hosted-remi.md
+++ b/docs/guides/self-hosted-remi.md
@@ -222,9 +222,10 @@ curl --fail-with-body \
   "$REMI_ADMIN_ENDPOINT/v1/admin/r2-durability"
 ```
 
-Review `planned_uploads`, `planned_upload_bytes`, and
-`missing_from_both_samples` before applying. Apply is explicit and concurrency
-is bounded between 1 and 64:
+Review `planned_uploads`, `planned_upload_bytes`, `unrepairable_samples`, and
+`missing_from_both_samples` before applying. Unrepairable samples distinguish
+missing-from-both objects from local or R2 size contradictions. Apply is
+explicit and concurrency is bounded between 1 and 64:
 
 ```bash
 curl --fail-with-body \

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-15
-revision: 24
-summary: Document Remi source identity and update policy, sparse sync, signing, canonical-map, repository trust, database-writer ownership, reproducible conversion profiling, publication, and serving authority
+revision: 25
+summary: Document Remi source identity and update policy, sparse sync, signing, canonical-map, repository trust, database-writer ownership, reproducible conversion profiling, R2 durability inventory, publication, and serving authority
 ---
 
 # Remi
@@ -509,6 +509,33 @@ MCP tool `chunk_gc` is the agent surface, and `POST /v1/admin/chunk-gc` on the
 external admin router is the operator surface; both require the `admin` scope.
 Deletion requires an explicit `dry_run: false`, so an omitted body, an omitted
 field, or an absent MCP parameter previews the run instead of deleting.
+
+## R2 Durability Inventory And Backfill
+
+`apps/remi/src/server/r2_durability.rs` owns the typed comparison between the
+local CAS, R2, and the object identities and sizes named by persisted converted
+and public-native transport envelopes. It does not infer durability from the
+`chunk_access` cache index. A malformed transport, a repeated object with a
+contradictory size, or a non-canonical chunk key fails the inventory instead of
+silently reducing the required set.
+
+The operator surface is `POST /v1/admin/r2-durability`; the agent surface is
+the MCP `r2_durability` tool. Both require admin authority and emit schema-v1
+reports with exact total and required object counts and bytes. An omitted body
+or mode is read-only `plan`. `apply` uploads only required local objects absent
+from R2, or required objects whose R2 size disagrees with local storage, with 1
+to 64 concurrent PUT requests. Each local object is SHA-256 verified against
+its path before upload. Apply then lists R2 again, and `r2_complete` is true
+only when every required identity has the exact authority-declared size in that
+fresh listing. Missing-from-both identities and upload failures are counted in
+full with at most ten bounded diagnostic samples.
+
+This inventory/backfill slice does not switch storage authority. Local CAS
+remains durable and R2 remains write-through until #116 separately proves the
+redirect, range, missing-object, eviction-then-install, bounded-cache, and host
+egress acceptance criteria. Operators must not enable `r2_redirect` or evict
+required local objects merely because an apply request was submitted; retain
+the schema-v1 `applied_complete` report as the prerequisite evidence.
 
 ## MCP
 

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -527,8 +527,9 @@ from R2, or required objects whose R2 size disagrees with local storage, with 1
 to 64 concurrent PUT requests. Each local object is SHA-256 verified against
 its path before upload. Apply then lists R2 again, and `r2_complete` is true
 only when every required identity has the exact authority-declared size in that
-fresh listing. Missing-from-both identities and upload failures are counted in
-full with at most ten bounded diagnostic samples.
+fresh listing. Missing-from-both identities, unrepairable size contradictions,
+and upload failures are counted in full with at most ten bounded diagnostic
+samples per class.
 
 This inventory/backfill slice does not switch storage authority. Local CAS
 remains durable and R2 remains write-through until #116 separately proves the


### PR DESCRIPTION
Refs #116

## Problem

Remi cannot safely make R2 authoritative while the exact local-versus-R2 object gap is unknown. Existing R2 listing exposed identities only, and there was no typed plan/apply backfill path that verified local bytes or rechecked the resulting durable tier.

## Solution

- add exact R2 object counts and stored sizes
- derive the required set and bytes from persisted converted/public-native transport envelopes, never the cache index
- add schema-v1 plan/apply reports with typed outcomes and bounded blocker/failure samples
- upload only required objects absent from R2 or carrying a size disagreement
- verify local SHA-256 before every PUT
- cap apply concurrency at 64
- derive apply success only from a fresh post-apply R2 listing
- expose the same operation through authenticated admin HTTP and MCP surfaces
- document credential lifecycle, bucket lifecycle, plan/apply procedure, and the fact that local CAS remains authoritative in this slice

## Verification

Exact head: `8d7bd257a9f9638f78a7ad41c6f4491da3e6bbde`

- `CARGO_TARGET_DIR=/conary/dev/cache/target/conary-116-r2-durability cargo test -p remi r2_durability --lib` — 13 passed
- `CARGO_TARGET_DIR=/conary/dev/cache/target/conary-116-r2-durability cargo test -p remi` — 635 library, 5 binary, and 3 CLI tests passed; 2 doctests ignored
- `CARGO_TARGET_DIR=/conary/dev/cache/target/conary-116-r2-durability cargo clippy -p remi --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `bash scripts/check-doc-truth.sh` — passed
- `git diff --check` — passed

One initially failing full-suite run was explained: the corrupt test object had a different size, so the planner correctly excluded it before hash verification. The fixture now uses same-size wrong bytes and proves the SHA-256 refusal path.

## Remaining #116 work

This PR deliberately does not switch storage authority or close #116. A follow-up must use the merged operation for production inventory/backfill, then prove redirect and Range behavior, missing-R2 typed failure, eviction-then-install, bounded local storage, and reduced origin egress.
