### PR TITLE
ops(remi): gate production R2 backfill

### DIFF
--- a/.github/workflows/remi-r2-durability.yml
+++ b/.github/workflows/remi-r2-durability.yml
@@ -1,0 +1,158 @@
+name: remi-r2-durability
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Exact commit already merged into main and deployed to production.
+        required: true
+        type: string
+      mode:
+        description: Plan is read-only; apply uploads the exact planned missing set.
+        required: true
+        default: plan
+        type: choice
+        options:
+          - plan
+          - apply
+      concurrency:
+        description: R2 PUT concurrency for apply, from 1 through 64.
+        required: true
+        default: "16"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: remi-r2-durability-production
+  cancel-in-progress: false
+
+jobs:
+  inventory:
+    name: ${{ inputs.mode }} production R2 durability
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    environment: production
+    steps:
+      - name: Check out exact main commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.commit_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate exact deployed-main inputs
+        env:
+          CANDIDATE_SHA: ${{ inputs.commit_sha }}
+          MODE: ${{ inputs.mode }}
+          BACKFILL_CONCURRENCY: ${{ inputs.concurrency }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "commit_sha must be a full lowercase commit SHA" >&2
+            exit 1
+          }
+          [[ "$(git rev-parse HEAD)" == "$CANDIDATE_SHA" ]] || {
+            echo "checkout does not match requested commit SHA" >&2
+            exit 1
+          }
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$CANDIDATE_SHA" origin/main || {
+            echo "candidate must already be merged into origin/main" >&2
+            exit 1
+          }
+          [[ "$MODE" == plan || "$MODE" == apply ]] || {
+            echo "mode must be plan or apply" >&2
+            exit 1
+          }
+          [[ "$BACKFILL_CONCURRENCY" =~ ^[0-9]+$ ]] \
+            && (( 10#$BACKFILL_CONCURRENCY >= 1 && 10#$BACKFILL_CONCURRENCY <= 64 )) || {
+              echo "concurrency must be an integer from 1 through 64" >&2
+              exit 1
+            }
+
+      - name: Run typed host-local durability operation
+        env:
+          MODE: ${{ inputs.mode }}
+          BACKFILL_CONCURRENCY: ${{ inputs.concurrency }}
+          REMI_SSH_KEY: ${{ secrets.REMI_SSH_KEY }}
+          REMI_SSH_TARGET: ${{ secrets.REMI_SSH_TARGET }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ -n "${REMI_SSH_KEY:-}" ]] || {
+            echo "REMI_SSH_KEY is required" >&2
+            exit 1
+          }
+
+          target="${REMI_SSH_TARGET:-peter@ssh.conary.io}"
+          mkdir -p ~/.ssh
+          trap 'rm -f ~/.ssh/remi_key' EXIT
+          echo "$REMI_SSH_KEY" > ~/.ssh/remi_key
+          chmod 600 ~/.ssh/remi_key
+          ssh-keyscan -H "${target#*@}" >> ~/.ssh/known_hosts 2>/dev/null
+          ssh_opts="-i ~/.ssh/remi_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
+
+          report="$({
+            ssh $ssh_opts "$target" bash -s -- "$MODE" "$BACKFILL_CONCURRENCY" <<'REMOTE_EOF'
+          set -euo pipefail
+          mode="$1"
+          concurrency="$((10#$2))"
+          request="$(jq -nc --arg mode "$mode" --argjson concurrency "$concurrency" \
+            '{mode:$mode,concurrency:$concurrency}')"
+          curl --fail-with-body --silent --show-error --max-time 5400 \
+            -H 'Content-Type: application/json' \
+            --data "$request" \
+            http://127.0.0.1:8081/v1/admin/r2-durability
+          REMOTE_EOF
+          } 2>&1)" || {
+            printf '%s\n' "$report" >&2
+            exit 1
+          }
+
+          jq -e --arg mode "$MODE" '
+            .schema_version == 1
+            and .mode == $mode
+            and (.outcome | type == "string")
+            and (.r2_complete | type == "boolean")
+          ' <<<"$report" >/dev/null
+
+          jq 'del(.unrepairable_samples, .missing_from_both_samples, .failure_samples)' \
+            <<<"$report" > r2-durability-public-sanitized.json
+
+          {
+            echo "### Production R2 durability"
+            echo
+            echo "- commit: \`${{ inputs.commit_sha }}\`"
+            echo "- mode: \`$MODE\`"
+            jq -r '
+              "- outcome: `\(.outcome)`",
+              "- R2 complete: `\(.r2_complete)`",
+              "- required: \(.required_objects) objects / \(.required_bytes) bytes",
+              "- local: \(.local.objects) objects / \(.local.bytes) bytes; required missing: \(.local.required_missing)",
+              "- R2: \(.r2.objects) objects / \(.r2.bytes) bytes; required missing: \(.r2.required_missing)",
+              "- planned uploads: \(.planned_uploads) objects / \(.planned_upload_bytes) bytes",
+              "- attempted/uploaded/failed: \(.attempted_uploads) / \(.uploaded_objects) / \(.failed_uploads)",
+              "- unrepairable/missing-from-both: \(.unrepairable_objects) / \(.missing_from_both)"
+            ' <<<"$report"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload public-sanitized durability evidence
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: r2-durability-${{ inputs.mode }}-${{ github.run_id }}
+          path: r2-durability-public-sanitized.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Require complete applied durability
+        if: ${{ inputs.mode == 'apply' }}
+        shell: bash
+        run: |
+          jq -e '.outcome == "applied_complete" and .r2_complete == true' \
+            r2-durability-public-sanitized.json >/dev/null || {
+              echo "apply did not establish complete R2 durability" >&2
+              exit 1
+            }

--- a/apps/remi/src/server/handlers/admin/r2_durability.rs
+++ b/apps/remi/src/server/handlers/admin/r2_durability.rs
@@ -45,8 +45,27 @@ pub async fn r2_durability(
         return error;
     }
 
+    run_r2_durability_request(&state, body).await
+}
+
+/// Loopback-only variant for host-local operator automation.
+///
+/// The internal admin router enforces the loopback transport boundary. Keeping
+/// this separate from [`r2_durability`] preserves explicit scope checks on the
+/// externally reachable route.
+pub async fn r2_durability_local(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    body: Option<Json<R2DurabilityRequest>>,
+) -> Response {
+    run_r2_durability_request(&state, body).await
+}
+
+async fn run_r2_durability_request(
+    state: &Arc<RwLock<ServerState>>,
+    body: Option<Json<R2DurabilityRequest>>,
+) -> Response {
     let request = body.map_or_else(R2DurabilityRequest::default, |Json(body)| body);
-    match admin_service::run_r2_durability_op(&state, request.mode(), request.concurrency()).await {
+    match admin_service::run_r2_durability_op(state, request.mode(), request.concurrency()).await {
         Ok(report) => Json(report).into_response(),
         Err(ServiceError::BadRequest(message)) => json_error(400, &message, "BAD_REQUEST"),
         Err(error) => {
@@ -60,7 +79,9 @@ pub async fn r2_durability(
 mod tests {
     use super::*;
     use axum::body::Body;
+    use axum::extract::ConnectInfo;
     use axum::http::{Request, StatusCode};
+    use std::net::SocketAddr;
     use tower::ServiceExt;
 
     use super::super::test_helpers::test_app;
@@ -118,6 +139,48 @@ mod tests {
             .unwrap();
         let error: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(error["code"], "BAD_REQUEST");
+    }
+
+    #[tokio::test]
+    async fn loopback_router_exposes_plan_without_bearer_scope() {
+        let state = Arc::new(RwLock::new(
+            ServerState::new(crate::server::ServerConfig::default()).unwrap(),
+        ));
+        let remote_app = crate::server::routes::create_admin_router(Arc::clone(&state));
+        let mut remote_request = Request::builder()
+            .method("POST")
+            .uri("/v1/admin/r2-durability")
+            .body(Body::empty())
+            .unwrap();
+        remote_request
+            .extensions_mut()
+            .insert(ConnectInfo(SocketAddr::from(([192, 0, 2, 1], 12345))));
+        let remote_response = remote_app.oneshot(remote_request).await.unwrap();
+        assert_eq!(remote_response.status(), StatusCode::FORBIDDEN);
+
+        let app = crate::server::routes::create_admin_router(state);
+        let mut request = Request::builder()
+            .method("POST")
+            .uri("/v1/admin/r2-durability")
+            .body(Body::empty())
+            .unwrap();
+        request
+            .extensions_mut()
+            .insert(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 12345))));
+        let response = app.oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        let error: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(error["code"], "BAD_REQUEST");
+        assert!(
+            error["error"]
+                .as_str()
+                .unwrap()
+                .contains("R2 storage is not configured")
+        );
     }
 
     #[tokio::test]

--- a/apps/remi/src/server/routes/admin.rs
+++ b/apps/remi/src/server/routes/admin.rs
@@ -35,6 +35,10 @@ pub fn create_admin_router(state: Arc<RwLock<ServerState>>) -> Router {
         .route("/v1/admin/recipes/build", post(recipes::build_recipe))
         .route("/v1/admin/info", get(server_info))
         .route("/v1/admin/refresh", post(refresh_upstream))
+        .route(
+            "/v1/admin/r2-durability",
+            post(admin_handlers::r2_durability_local),
+        )
         .route("/v1/admin/models/{name}", put(models::put_model))
         .route(
             "/v1/admin/tuf/{distro}/refresh-timestamp",

--- a/docs/guides/self-hosted-remi.md
+++ b/docs/guides/self-hosted-remi.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-15
-revision: 4
+revision: 5
 summary: Run your own Remi conversion server in about 30 minutes
 ---
 
@@ -239,6 +239,15 @@ Archive the schema-v1 response. Only `outcome: "applied_complete"` together
 with `r2_complete: true` proves the required set was present in the fresh R2
 listing after upload. This command does not itself enable R2 redirects or local
 eviction; those remain separate serving-policy changes.
+
+Host-local automation can submit the same request to
+`http://127.0.0.1:8081/v1/admin/r2-durability` without copying an external
+admin token onto the host. That route is owned by the loopback-only internal
+admin listener; do not proxy or bind it to a non-loopback address. The Conary
+production workflow `.github/workflows/remi-r2-durability.yml` uses this path
+only for an exact commit already merged into `main` and deployed through the
+protected production environment. Its retained artifact removes diagnostic
+samples and contains aggregate, public-sanitized evidence only.
 
 See `deploy/CLOUDFLARE.md` for the CDN-backed origin setup.
 

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-15
-revision: 25
+revision: 26
 summary: Document Remi source identity and update policy, sparse sync, signing, canonical-map, repository trust, database-writer ownership, reproducible conversion profiling, R2 durability inventory, publication, and serving authority
 ---
 
@@ -520,16 +520,26 @@ contradictory size, or a non-canonical chunk key fails the inventory instead of
 silently reducing the required set.
 
 The operator surface is `POST /v1/admin/r2-durability`; the agent surface is
-the MCP `r2_durability` tool. Both require admin authority and emit schema-v1
-reports with exact total and required object counts and bytes. An omitted body
-or mode is read-only `plan`. `apply` uploads only required local objects absent
-from R2, or required objects whose R2 size disagrees with local storage, with 1
-to 64 concurrent PUT requests. Each local object is SHA-256 verified against
-its path before upload. Apply then lists R2 again, and `r2_complete` is true
-only when every required identity has the exact authority-declared size in that
-fresh listing. Missing-from-both identities, unrepairable size contradictions,
-and upload failures are counted in full with at most ten bounded diagnostic
-samples per class.
+the MCP `r2_durability` tool. The external HTTP and MCP routes require admin
+authority. The internal admin listener exposes the same typed operation only
+through its loopback transport boundary, allowing host-local automation to
+operate without copying a bearer token. All surfaces emit schema-v1 reports
+with exact total and required object counts and bytes. An omitted body or mode
+is read-only `plan`. `apply` uploads only required local objects absent from R2,
+or required objects whose R2 size disagrees with local storage, with 1 to 64
+concurrent PUT requests. Each local object is SHA-256 verified against its path
+before upload. Apply then lists R2 again, and `r2_complete` is true only when
+every required identity has the exact authority-declared size in that fresh
+listing. Missing-from-both identities, unrepairable size contradictions, and
+upload failures are counted in full with at most ten bounded diagnostic samples
+per class.
+
+`.github/workflows/remi-r2-durability.yml` is the production operator adapter.
+It accepts only an exact commit already merged into `main`, runs through the
+protected production environment and SSH boundary, invokes the loopback route,
+and retains a public-sanitized aggregate report with all diagnostic samples
+removed. Apply fails the workflow unless the fresh post-upload report is
+`applied_complete` with `r2_complete: true`.
 
 This inventory/backfill slice does not switch storage authority. Local CAS
 remains durable and R2 remains write-through until #116 separately proves the

--- a/docs/operations/infrastructure.md
+++ b/docs/operations/infrastructure.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-13
-revision: 25
+last_updated: 2026-08-15
+revision: 26
 summary: Non-secret infrastructure, agent-operations transport, release, Remi deploy, TLS renewal, remote development, and retired Forge staging guidance for Conary contributors and coding assistants
 ---
 
@@ -120,6 +120,14 @@ workflow.
   every exact source profile, and at least one validated converted artifact for
   every configured public profile; dispatch or a green health probe alone is
   not deployment proof.
+- Production R2 inventory and backfill use the manually dispatched
+  `remi-r2-durability` workflow after its exact `commit_sha` is merged into
+  `main` and deployed. The protected job enters through the normal Remi SSH
+  boundary and calls the typed operation on the loopback-only admin listener;
+  it does not copy an admin bearer token off the host. `plan` is read-only.
+  `apply` fails unless a fresh post-upload R2 listing proves complete, and the
+  retained artifact is aggregate `public-sanitized` evidence with diagnostic
+  samples removed.
 - Conary release artifact publication through the same helper verifies the
   CI-produced `SHA256SUMS` file from the staging directory before installing
   files into `/conary/releases/<version>`. The helper copies that verified


### PR DESCRIPTION
## Problem

PR #447 added one typed R2 durability plan/apply authority, but production correctly keeps external admin credentials on-host. There was no least-privilege production path to invoke that operation without copying or minting a bearer token.

## Change

- expose the same typed operation through the existing loopback-only internal admin listener while preserving explicit scope checks on the external route;
- add an exact-main, protected-production `remi-r2-durability` workflow over the established SSH boundary;
- keep plan read-only and require explicit apply with concurrency 1 through 64;
- upload aggregate `public-sanitized` evidence with all diagnostic samples removed, including before a failed incomplete-apply gate;
- document the operator boundary and exact deployment ordering.

This remains prerequisite operations only. It does not enable redirects or eviction.

## Exact head

`0ad888961748e8330b63c1b2b07cc57deb48b46c`

## Verification

- `cargo test -p remi r2_durability --lib` — 14 passed
- `cargo test -p remi` — 636 library, 5 binary, and 3 CLI tests passed; 2 doctests intentionally ignored
- `cargo clippy -p remi --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `bash scripts/check-github-action-runtimes.sh` — passed
- `bash scripts/check-release-matrix.sh` — passed
- `bash scripts/check-doc-truth.sh` — passed
- workflow input, operation, and final-gate shell blocks passed `bash -n`
- `git diff --check` — passed

The router regression sends both non-loopback and loopback requests through the real internal middleware: the non-loopback request is forbidden, while loopback reaches the typed service without bearer scope.

## Production proof after merge

1. wait for exact merge-validation;
2. deploy that exact merged commit with `deploy-remi-candidate`;
3. run the new workflow in plan mode;
4. if required and repairable, run apply and then a final plan;
5. record aggregate object/byte/PUT evidence and cost basis on #116.

Refs #116
