### PR TITLE
fix(cas): ignore private staging objects

### DIFF
--- a/apps/remi/src/server/chunk_gc.rs
+++ b/apps/remi/src/server/chunk_gc.rs
@@ -138,8 +138,7 @@ pub fn scan_local_chunks(objects_dir: &Path) -> Result<Vec<String>> {
             continue;
         }
 
-        // Skip .tmp files (in-flight writes)
-        if entry.path().extension().is_some_and(|ext| ext == "tmp") {
+        if conary_core::filesystem::is_temporary_object_name(entry.file_name()) {
             continue;
         }
 
@@ -639,8 +638,18 @@ mod tests {
         std::fs::write(prefix_dir.join("cdef0123456789"), b"chunk data").unwrap();
         std::fs::write(prefix_dir.join("9876543210fedc"), b"chunk data 2").unwrap();
 
-        // Create a .tmp file that should be skipped
+        // Create every private CAS staging shape that should be skipped.
         std::fs::write(prefix_dir.join("incomplete.tmp"), b"partial").unwrap();
+        std::fs::write(
+            prefix_dir.join("abcdef0123456789.tmp.307631.736105"),
+            b"interrupted atomic write",
+        )
+        .unwrap();
+        std::fs::write(
+            prefix_dir.join(".tmp.307631.private-batch"),
+            b"private batch",
+        )
+        .unwrap();
 
         // Create another prefix
         let prefix_dir2 = objects_dir.join("ff");

--- a/crates/conary-core/src/filesystem/cas.rs
+++ b/crates/conary-core/src/filesystem/cas.rs
@@ -15,6 +15,7 @@
 
 use crate::error::Result;
 use crate::hash::{self, HashAlgorithm};
+use std::ffi::OsStr;
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -30,6 +31,17 @@ pub use verified_batch::{
     VerifiedObjectBatch, VerifiedObjectBatchMetrics, VerifiedObjectDisposition, VerifiedObjectSet,
 };
 pub use write_batch::{PrivateCasWriter, PrivateCopyBatch};
+
+/// Return whether a filename belongs to the CAS private staging namespace.
+///
+/// Atomic writers use `{hash}.tmp.{pid}.{counter}`, while streaming and batch
+/// writers may use leading-dot private names. A plain `.tmp` suffix is retained
+/// for the older single-writer path. Scanners must never interpret any of these
+/// private names as content identities.
+pub fn is_temporary_object_name(name: &OsStr) -> bool {
+    let name = name.to_string_lossy();
+    name.starts_with('.') || name.contains(".tmp.") || name.ends_with(".tmp")
+}
 
 /// Compute the CAS object path for a hex hash under a root directory.
 ///
@@ -234,32 +246,27 @@ impl CasStore {
 
             if file_type.is_dir() {
                 self.cleanup_temps_in_dir(&entry.path(), now, max_age, removed)?;
-            } else if file_type.is_file() {
-                let name = entry.file_name();
-                let name_str = name.to_string_lossy();
+            } else if file_type.is_file()
+                && is_temporary_object_name(&entry.file_name())
+                && let Ok(metadata) = entry.metadata()
+            {
+                let age = metadata
+                    .modified()
+                    .ok()
+                    .and_then(|mtime| now.duration_since(mtime).ok());
 
-                // Match temp files: any file whose name contains ".tmp."
-                if name_str.contains(".tmp.")
-                    && let Ok(metadata) = entry.metadata()
-                {
-                    let age = metadata
-                        .modified()
-                        .ok()
-                        .and_then(|mtime| now.duration_since(mtime).ok());
-
-                    if age.is_some_and(|a| a > max_age) {
-                        match fs::remove_file(entry.path()) {
-                            Ok(()) => {
-                                *removed += 1;
-                                debug!("Removed orphaned temp file: {}", entry.path().display());
-                            }
-                            Err(e) => {
-                                warn!(
-                                    "Failed to remove orphaned temp file {}: {}",
-                                    entry.path().display(),
-                                    e
-                                );
-                            }
+                if age.is_some_and(|a| a > max_age) {
+                    match fs::remove_file(entry.path()) {
+                        Ok(()) => {
+                            *removed += 1;
+                            debug!("Removed orphaned temp file: {}", entry.path().display());
+                        }
+                        Err(e) => {
+                            warn!(
+                                "Failed to remove orphaned temp file {}: {}",
+                                entry.path().display(),
+                                e
+                            );
                         }
                     }
                 }
@@ -754,18 +761,12 @@ impl Iterator for CasIterator {
                     }
 
                     let name = entry.file_name();
-                    let name_str = name.to_string_lossy();
 
-                    // Skip temp files: atomic_store() creates temps as
-                    // `{hash}.tmp.{pid}.{counter}` which end with a digit,
-                    // so we also match on the `.tmp.` interior marker.
-                    if name_str.starts_with('.')
-                        || name_str.contains(".tmp.")
-                        || name_str.ends_with(".tmp")
-                    {
+                    if is_temporary_object_name(&name) {
                         continue;
                     }
 
+                    let name_str = name.to_string_lossy();
                     let hash = format!("{}{}", self.current_prefix, name_str);
                     return Some(Ok((hash, entry.path())));
                 }

--- a/crates/conary-core/src/filesystem/mod.rs
+++ b/crates/conary-core/src/filesystem/mod.rs
@@ -20,7 +20,7 @@ pub mod vfs;
 
 pub use cas::{
     CasStore, PrivateCasWriter, PrivateCopyBatch, VerifiedObjectBatch, VerifiedObjectBatchMetrics,
-    VerifiedObjectDisposition, VerifiedObjectSet, object_path,
+    VerifiedObjectDisposition, VerifiedObjectSet, is_temporary_object_name, object_path,
 };
 pub use path::{safe_join, sanitize_filename, sanitize_path};
 pub use source_path::{DeploymentPath, SourcePathBytes};


### PR DESCRIPTION
## Problem

The first production R2 durability plan failed closed before any R2 write because Remi interpreted one stale CAS atomic staging file (`{hash}.tmp.{pid}.{counter}`) as a chunk identity. `scan_local_chunks` documented that it skipped temporary files but recognized only names ending in `.tmp`.

The core CAS iterator already recognized the complete private namespace, so the same filename class had two inconsistent owners.

## Change

- make `conary_core::filesystem::is_temporary_object_name` the shared classifier for leading-dot private files, `.tmp.` atomic staging names, and the older `.tmp` suffix;
- use it in core iteration, orphaned-temp cleanup, and Remi local inventory/GC scanning;
- add the exact production `.tmp.{pid}.{counter}` shape and a private batch shape to Remi's scanner regression.

Canonical non-temporary invalid paths still fail R2 inventory validation. This does not weaken object identity checks and performs no R2 write.

## Exact head

`f7bea4996b5a837007f5e675cef3e264094548ef`

## Verification

- `cargo test -p conary-core filesystem::cas` — 45 passed
- `cargo test -p remi test_scan_local_chunks_with_files --lib` — 1 passed
- `cargo test -p remi r2_durability --lib` — 14 passed
- `cargo test -p conary-core` — full unit, integration, and doctest suite passed
- `cargo test -p remi` — 636 library, 5 binary, and 3 CLI tests passed; doctests passed
- `cargo clippy -p conary-core -p remi --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Production evidence

Run `31880109836` failed before R2 listing/upload with `invalid object in the local chunk directory`. Production contains exactly one invalid scanner entry and it is the canonical private staging form; no other invalid object path was found. After exact merge/deployment, the same typed plan will be rerun with that residue still present to prove it is excluded by shared CAS authority, then the stale file will be removed as recoverable temporary data.

Refs #116