### PR TITLE
feat(remi): make R2 the durable chunk authority

### DIFF
--- a/apps/remi/src/deployment.rs
+++ b/apps/remi/src/deployment.rs
@@ -313,6 +313,15 @@ fn build_current_config(
         "max_concurrent".to_string(),
         toml::Value::Integer(options.max_concurrent as i64),
     );
+    if let Some(storage) = root.get_mut("storage").and_then(toml::Value::as_table_mut) {
+        storage.remove("eviction_threshold");
+        storage.remove("eviction_min_age");
+    }
+    if let Some(r2) = root.get_mut("r2").and_then(toml::Value::as_table_mut) {
+        r2.remove("account_id");
+        r2.remove("write_through");
+        r2.remove("r2_redirect");
+    }
     let release_publish = root
         .entry("release_publish")
         .or_insert_with(|| toml::Value::Table(toml::map::Map::new()))
@@ -731,6 +740,15 @@ admin_bind = "127.0.0.1:8081"
 
 [storage]
 root = "{}"
+eviction_threshold = 0.90
+eviction_min_age = "1h"
+
+[r2]
+enabled = true
+endpoint = "https://r2.example.test"
+account_id = "retired"
+write_through = true
+r2_redirect = false
 
 [upstream.old]
 base_url = "https://legacy.example.test"
@@ -817,6 +835,17 @@ fingerprint = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
         assert!(config.contains("repository_keys_dir"));
         assert!(config.contains("convert_top_n = 1000"));
         assert!(config.contains("distros = [\"fedora\"]"));
+        assert!(config.contains("enabled = true"));
+        assert!(config.contains("endpoint = \"https://r2.example.test\""));
+        for retired in [
+            "eviction_threshold",
+            "eviction_min_age",
+            "account_id",
+            "write_through",
+            "r2_redirect",
+        ] {
+            assert!(!config.contains(retired), "retired key survived: {retired}");
+        }
         assert_eq!(
             fs::read_to_string(&options.repository_manifest_target).unwrap(),
             repository_manifest()

--- a/apps/remi/src/server/bounded_cache.rs
+++ b/apps/remi/src/server/bounded_cache.rs
@@ -1,0 +1,248 @@
+// apps/remi/src/server/bounded_cache.rs
+//! R2-verified enforcement of the bounded local chunk cache.
+
+use crate::server::{ChunkCache, R2Store};
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use conary_core::db::models::ChunkAccess;
+use serde::Serialize;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+#[async_trait]
+pub trait DurableCacheAuthority: Send + Sync {
+    async fn contains(&self, hash: &str) -> Result<bool>;
+}
+
+#[async_trait]
+impl DurableCacheAuthority for R2Store {
+    async fn contains(&self, hash: &str) -> Result<bool> {
+        self.head_chunk(hash).await
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct BoundedCacheReport {
+    pub bytes_before: u64,
+    pub bytes_after: u64,
+    pub bytes_freed: u64,
+    pub objects_evicted: usize,
+}
+
+#[derive(Clone)]
+pub struct BoundedCache {
+    cache: ChunkCache,
+    gate: Arc<Mutex<()>>,
+}
+
+impl BoundedCache {
+    pub fn new(cache: ChunkCache) -> Self {
+        Self {
+            cache,
+            gate: Arc::new(Mutex::new(())),
+        }
+    }
+
+    pub async fn enforce<S: DurableCacheAuthority + ?Sized>(
+        &self,
+        durable: &S,
+    ) -> Result<BoundedCacheReport> {
+        let _guard = self.gate.lock().await;
+        let db_path = self.cache.db_path().to_path_buf();
+        let max_bytes = self.cache.max_bytes();
+        let (stats, candidates) = tokio::task::spawn_blocking(move || {
+            let mut conn = crate::server::open_runtime_db(&db_path)?;
+            let tx = conn.transaction()?;
+            let stats = ChunkAccess::get_stats(&tx)?;
+            let candidates = if stats.total_bytes > max_bytes {
+                ChunkAccess::get_lru_chunks_for_bytes(&tx, stats.total_bytes - max_bytes)?
+            } else {
+                Vec::new()
+            };
+            tx.commit()?;
+            Ok::<_, anyhow::Error>((stats, candidates))
+        })
+        .await
+        .context("join bounded-cache candidate query")??;
+
+        if stats.total_bytes <= max_bytes {
+            return Ok(BoundedCacheReport {
+                bytes_before: stats.total_bytes,
+                bytes_after: stats.total_bytes,
+                ..Default::default()
+            });
+        }
+
+        let bytes_to_free = stats.total_bytes - max_bytes;
+        let mut bytes_freed = 0u64;
+        let mut evicted = Vec::new();
+        for candidate in candidates {
+            if bytes_freed >= bytes_to_free {
+                break;
+            }
+            let path = self.cache.chunk_path(&candidate.hash);
+            if !path.exists() {
+                bytes_freed = bytes_freed.saturating_add(candidate.size_bytes.max(0) as u64);
+                evicted.push(candidate.hash);
+                continue;
+            }
+            if !durable.contains(&candidate.hash).await.with_context(|| {
+                format!("verify durable chunk {} before eviction", candidate.hash)
+            })? {
+                bail!(
+                    "refusing to evict local chunk {} because R2 does not contain it",
+                    candidate.hash
+                );
+            }
+            tokio::fs::remove_file(&path)
+                .await
+                .with_context(|| format!("evict local chunk {}", candidate.hash))?;
+            bytes_freed = bytes_freed.saturating_add(candidate.size_bytes.max(0) as u64);
+            evicted.push(candidate.hash);
+        }
+
+        let removed = evicted.len();
+        let cleanup_db_path = self.cache.db_path().to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            let mut conn = crate::server::open_runtime_db(&cleanup_db_path)?;
+            let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+            {
+                let mut delete = tx.prepare("DELETE FROM chunk_access WHERE hash = ?1")?;
+                for hash in evicted {
+                    delete.execute([hash])?;
+                }
+            }
+            tx.commit()?;
+            Ok::<_, anyhow::Error>(())
+        })
+        .await
+        .context("join bounded-cache bookkeeping cleanup")??;
+
+        let bytes_after = stats.total_bytes.saturating_sub(bytes_freed);
+        if bytes_after > max_bytes {
+            bail!("bounded cache remains above its limit: {bytes_after} > {max_bytes} bytes");
+        }
+        Ok(BoundedCacheReport {
+            bytes_before: stats.total_bytes,
+            bytes_after,
+            bytes_freed,
+            objects_evicted: removed,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    struct FakeDurable {
+        hashes: HashSet<String>,
+    }
+
+    struct UnreachableDurable;
+
+    #[async_trait]
+    impl DurableCacheAuthority for FakeDurable {
+        async fn contains(&self, hash: &str) -> Result<bool> {
+            Ok(self.hashes.contains(hash))
+        }
+    }
+
+    #[async_trait]
+    impl DurableCacheAuthority for UnreachableDurable {
+        async fn contains(&self, _hash: &str) -> Result<bool> {
+            bail!("simulated R2 outage")
+        }
+    }
+
+    fn test_cache(max_bytes: u64) -> (tempfile::TempDir, ChunkCache) {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("remi.db");
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conary_core::db::schema::ensure_current(&conn).unwrap();
+        drop(conn);
+        let cache = ChunkCache::new(temp.path().join("chunks"), max_bytes, db_path);
+        (temp, cache)
+    }
+
+    #[tokio::test]
+    async fn enforcement_evicts_only_after_r2_presence_and_reaches_exact_bound() {
+        let (_temp, cache) = test_cache(4);
+        let first = conary_core::hash::sha256(b"aaaa");
+        let second = conary_core::hash::sha256(b"bbbb");
+        cache.store_chunk(&first, b"aaaa").await.unwrap();
+        cache.store_chunk(&second, b"bbbb").await.unwrap();
+        let durable = FakeDurable {
+            hashes: HashSet::from([first.clone(), second.clone()]),
+        };
+
+        let report = BoundedCache::new(cache.clone())
+            .enforce(&durable)
+            .await
+            .unwrap();
+
+        assert_eq!(report.bytes_before, 8);
+        assert_eq!(report.bytes_after, 4);
+        assert_eq!(report.bytes_freed, 4);
+        assert_eq!(report.objects_evicted, 1);
+        assert_eq!(
+            usize::from(cache.has_chunk(&first).await)
+                + usize::from(cache.has_chunk(&second).await),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn enforcement_refuses_to_trade_the_only_durable_copy_for_a_bound() {
+        let (_temp, cache) = test_cache(0);
+        let hash = conary_core::hash::sha256(b"only-local");
+        cache.store_chunk(&hash, b"only-local").await.unwrap();
+
+        let error = BoundedCache::new(cache.clone())
+            .enforce(&FakeDurable {
+                hashes: HashSet::new(),
+            })
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("R2 does not contain"), "{error}");
+        assert!(cache.has_chunk(&hash).await);
+    }
+
+    #[tokio::test]
+    async fn enforcement_preserves_local_bytes_when_r2_cannot_be_checked() {
+        let (_temp, cache) = test_cache(0);
+        let hash = conary_core::hash::sha256(b"outage");
+        cache.store_chunk(&hash, b"outage").await.unwrap();
+
+        let error = BoundedCache::new(cache.clone())
+            .enforce(&UnreachableDurable)
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("verify durable chunk"), "{error}");
+        assert!(cache.has_chunk(&hash).await);
+    }
+
+    #[tokio::test]
+    async fn enforcement_reports_when_protection_prevents_the_exact_bound() {
+        let (_temp, cache) = test_cache(0);
+        let hash = conary_core::hash::sha256(b"protected");
+        cache.store_chunk(&hash, b"protected").await.unwrap();
+        cache.protect_chunks(std::slice::from_ref(&hash)).await;
+
+        let error = BoundedCache::new(cache.clone())
+            .enforce(&FakeDurable {
+                hashes: HashSet::from([hash.clone()]),
+            })
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("remains above its limit"), "{error}");
+        assert!(cache.has_chunk(&hash).await);
+    }
+}

--- a/apps/remi/src/server/cache.rs
+++ b/apps/remi/src/server/cache.rs
@@ -1,11 +1,8 @@
 // apps/remi/src/server/cache.rs
-//! LRU chunk cache management
+//! Local chunk cache storage and access bookkeeping.
 //!
-//! Tracks chunk access times and evicts old chunks when storage
-//! exceeds the configured threshold or chunks exceed TTL.
-//!
-//! Uses a database-backed LRU index (chunk_access table) for O(1) stats
-//! and efficient eviction queries, replacing legacy mtime-based scanning.
+//! Eviction is owned by `bounded_cache`, which verifies durable R2 presence
+//! before removing any local object.
 
 use crate::server::ServerState;
 use crate::server::handlers::human_bytes;
@@ -24,8 +21,6 @@ pub struct ChunkCache {
     chunk_dir: PathBuf,
     /// Maximum cache size in bytes
     max_bytes: u64,
-    /// Chunk TTL in days (chunks not accessed in this period are candidates for eviction)
-    ttl_days: u32,
     /// Path to database for tracking access
     db_path: PathBuf,
 }
@@ -45,39 +40,25 @@ pub struct CacheStats {
     pub chunk_count: usize,
     /// Percentage of cache used
     pub usage_percent: f64,
-    /// Number of chunks older than TTL
-    pub stale_chunks: usize,
-    /// Bytes in stale chunks
-    pub stale_bytes: u64,
     /// Number of protected chunks (immune to eviction)
     pub protected_chunks: usize,
-    /// TTL in days
-    pub ttl_days: u32,
-}
-
-/// Result of an eviction run
-#[derive(Debug, Clone, Serialize)]
-pub struct EvictionResult {
-    /// Number of chunks evicted
-    pub chunks_evicted: usize,
-    /// Total bytes freed
-    pub bytes_freed: u64,
-    /// Human-readable bytes freed
-    pub bytes_freed_human: String,
-    /// Reason for eviction
-    pub reason: String,
-    /// Number of chunks skipped (protected/error)
-    pub chunks_skipped: usize,
 }
 
 impl ChunkCache {
-    pub fn new(chunk_dir: PathBuf, max_bytes: u64, ttl_days: u32, db_path: PathBuf) -> Self {
+    pub fn new(chunk_dir: PathBuf, max_bytes: u64, db_path: PathBuf) -> Self {
         Self {
             chunk_dir,
             max_bytes,
-            ttl_days,
             db_path,
         }
+    }
+
+    pub(crate) fn max_bytes(&self) -> u64 {
+        self.max_bytes
+    }
+
+    pub(crate) fn db_path(&self) -> &std::path::Path {
+        &self.db_path
     }
 
     /// Get the filesystem path for a chunk
@@ -193,11 +174,6 @@ impl ChunkCache {
             0.0
         };
 
-        // TODO: Efficiently get stale stats from DB without full scan?
-        // For now reporting 0 for stale to keep this fast O(1)
-        // A full stale count would require `SELECT COUNT(*) WHERE last_accessed < ...`
-        // which is fast enough with index, let's add it if needed.
-
         Ok(CacheStats {
             total_bytes: stats.total_bytes,
             total_size_human: human_bytes(stats.total_bytes),
@@ -205,174 +181,44 @@ impl ChunkCache {
             max_size_human: human_bytes(self.max_bytes),
             chunk_count: stats.total_chunks,
             usage_percent,
-            stale_chunks: 0, // Not querying this to keep stats extremely fast
-            stale_bytes: 0,
             protected_chunks: stats.protected_chunks,
-            ttl_days: self.ttl_days,
         })
-    }
-
-    /// Run LRU eviction
-    ///
-    /// Evicts chunks based on two criteria:
-    /// 1. Stale chunks: older than ttl_days
-    /// 2. Size limit: if cache > max_bytes, evict oldest chunks until under limit
-    ///
-    /// Uses DB index for efficient candidate selection.
-    pub async fn run_eviction(&self) -> Result<EvictionResult> {
-        tracing::info!("Starting DB-backed LRU eviction check");
-
-        let db_path = self.db_path.clone();
-        let max_bytes = self.max_bytes;
-        let ttl_days = self.ttl_days;
-        let self_clone = self.clone();
-
-        tokio::task::spawn_blocking(move || {
-            let conn = crate::server::open_runtime_db(&db_path)?;
-
-            let mut freed = 0u64;
-            let mut evicted = 0usize;
-            let mut skipped = 0usize;
-            let mut reason = String::new();
-
-            // Phase 1: Evict stale chunks
-            // Calculate cutoff time
-            let now = std::time::SystemTime::now();
-            let cutoff = now - Duration::from_secs(ttl_days as u64 * 24 * 3600);
-            let datetime: chrono::DateTime<chrono::Utc> = cutoff.into();
-            let cutoff_str = datetime.format("%Y-%m-%d %H:%M:%S").to_string();
-
-            let stale_chunks = ChunkAccess::get_stale_chunks(&conn, &cutoff_str)?;
-
-            if !stale_chunks.is_empty() {
-                reason = format!(
-                    "TTL eviction ({} chunks older than {} days)",
-                    stale_chunks.len(),
-                    ttl_days
-                );
-
-                for chunk in stale_chunks {
-                    // Delete file first
-                    let path = self_clone.chunk_path(&chunk.hash);
-                    if path.exists()
-                        && let Err(e) = std::fs::remove_file(&path)
-                    {
-                        tracing::warn!("Failed to delete chunk file {}: {}", chunk.hash, e);
-                        skipped += 1;
-                        continue;
-                    }
-
-                    // Delete from DB
-                    if let Err(e) = ChunkAccess::delete(&conn, &chunk.hash) {
-                        tracing::warn!("Failed to delete chunk db record {}: {}", chunk.hash, e);
-                        // If file is gone but DB record remains, it's a "ghost" record.
-                        // Ideally we should handle this, but for now just warn.
-                    } else {
-                        freed += chunk.size_bytes as u64;
-                        evicted += 1;
-                    }
-                }
-            }
-
-            // Phase 2: Size-based eviction
-            let stats = ChunkAccess::get_stats(&conn)?;
-            let current_size = stats.total_bytes;
-
-            if current_size > max_bytes {
-                let bytes_to_free = current_size - max_bytes;
-                tracing::info!(
-                    "Cache size {} exceeds limit {}, need to free {}",
-                    human_bytes(current_size),
-                    human_bytes(max_bytes),
-                    human_bytes(bytes_to_free)
-                );
-
-                let size_reason = format!(
-                    "Size limit exceeded (need {} freed)",
-                    human_bytes(bytes_to_free)
-                );
-                if reason.is_empty() {
-                    reason = size_reason;
-                } else {
-                    reason = format!("{}; {}", reason, size_reason);
-                }
-
-                // Get LRU chunks - fetch enough to cover the deficit + buffer
-                // Estimate count based on avg chunk size (say 64KB)
-                let avg_size = if stats.total_chunks > 0 {
-                    current_size / stats.total_chunks as u64
-                } else {
-                    65536
-                };
-                let chunks_needed = (bytes_to_free / avg_size) as usize + 100;
-
-                let lru_chunks = ChunkAccess::get_lru_chunks(&conn, chunks_needed)?;
-                let mut size_freed_phase2 = 0u64;
-
-                for chunk in lru_chunks {
-                    if size_freed_phase2 >= bytes_to_free {
-                        break;
-                    }
-
-                    let path = self_clone.chunk_path(&chunk.hash);
-                    if path.exists()
-                        && let Err(e) = std::fs::remove_file(&path)
-                    {
-                        tracing::warn!("Failed to delete chunk file {}: {}", chunk.hash, e);
-                        skipped += 1;
-                        continue;
-                    }
-
-                    if let Err(e) = ChunkAccess::delete(&conn, &chunk.hash) {
-                        tracing::warn!("Failed to delete chunk db record {}: {}", chunk.hash, e);
-                    } else {
-                        size_freed_phase2 += chunk.size_bytes as u64;
-                        freed += chunk.size_bytes as u64;
-                        evicted += 1;
-                    }
-                }
-            }
-
-            if evicted == 0 && skipped == 0 {
-                reason = "No eviction needed".to_string();
-            }
-
-            Ok(EvictionResult {
-                chunks_evicted: evicted,
-                bytes_freed: freed,
-                bytes_freed_human: human_bytes(freed),
-                reason,
-                chunks_skipped: skipped,
-            })
-        })
-        .await?
     }
 }
 
 /// Background eviction loop
 ///
-/// Runs every hour to check cache size and evict old chunks.
+/// Runs every hour to enforce the configured local cache bound.
 pub async fn run_eviction_loop(state: Arc<RwLock<ServerState>>) {
     let interval = Duration::from_secs(3600); // 1 hour
 
     loop {
         tokio::time::sleep(interval).await;
 
-        // Run chunk eviction
-        {
+        let (bounded_cache, r2_store, bloom_filter) = {
             let state_guard = state.read().await;
-            match state_guard.chunk_cache.run_eviction().await {
+            (
+                state_guard.bounded_cache.clone(),
+                state_guard.r2_store.clone(),
+                state_guard.bloom_filter.clone(),
+            )
+        };
+        if let Some(r2_store) = r2_store {
+            match bounded_cache.enforce(r2_store.as_ref()).await {
                 Ok(result) => {
-                    if result.chunks_evicted > 0 {
+                    if result.objects_evicted > 0 {
+                        if let Some(bloom) = bloom_filter {
+                            bloom.mark_dirty();
+                        }
                         tracing::info!(
-                            "Scheduled eviction: {} chunks, {} freed",
-                            result.chunks_evicted,
-                            result.bytes_freed_human
+                            "Scheduled bounded eviction: {} chunks, {} bytes freed",
+                            result.objects_evicted,
+                            result.bytes_freed
                         );
                     }
                 }
                 Err(e) => {
-                    tracing::error!("Eviction loop error: {}", e);
+                    tracing::error!("Bounded cache enforcement error: {}", e);
                 }
             }
         }
@@ -410,7 +256,6 @@ mod tests {
         let cache = ChunkCache::new(
             temp_dir.path().to_path_buf(),
             1024 * 1024,
-            30,
             db_file.path().to_path_buf(),
         );
 
@@ -431,7 +276,6 @@ mod tests {
         let cache = ChunkCache::new(
             temp_dir.path().to_path_buf(),
             1024 * 1024,
-            30,
             db_file.path().to_path_buf(),
         );
 
@@ -455,7 +299,6 @@ mod tests {
         let cache = ChunkCache::new(
             temp_dir.path().to_path_buf(),
             1024 * 1024,
-            30,
             db_file.path().to_path_buf(),
         );
 
@@ -475,7 +318,6 @@ mod tests {
         let cache = ChunkCache::new(
             PathBuf::from("/data/chunks"),
             1024 * 1024,
-            30,
             PathBuf::from("/data/db.sqlite"),
         );
 
@@ -494,7 +336,6 @@ mod tests {
         let cache = ChunkCache::new(
             PathBuf::from("/data/chunks"),
             1024 * 1024,
-            30,
             PathBuf::from("/data/db.sqlite"),
         );
 
@@ -511,7 +352,6 @@ mod tests {
         let cache = ChunkCache::new(
             temp_dir.path().to_path_buf(),
             1024 * 1024,
-            30,
             db_file.path().to_path_buf(),
         );
 
@@ -545,7 +385,6 @@ mod tests {
         let cache = ChunkCache::new(
             temp_dir.path().to_path_buf(),
             max_bytes,
-            30,
             db_file.path().to_path_buf(),
         );
 
@@ -556,7 +395,6 @@ mod tests {
         let stats = cache.stats().await.unwrap();
         assert_eq!(stats.max_bytes, max_bytes);
         assert!((stats.usage_percent - 50.0).abs() < 0.1);
-        assert_eq!(stats.ttl_days, 30);
     }
 
     #[tokio::test]
@@ -566,7 +404,6 @@ mod tests {
         let cache = ChunkCache::new(
             temp_dir.path().to_path_buf(),
             0, // zero max
-            30,
             db_file.path().to_path_buf(),
         );
 
@@ -581,7 +418,6 @@ mod tests {
         let cache = ChunkCache::new(
             temp_dir.path().to_path_buf(),
             1024 * 1024,
-            30,
             db_file.path().to_path_buf(),
         );
 
@@ -610,7 +446,6 @@ mod tests {
         let cache = ChunkCache::new(
             temp_dir.path().to_path_buf(),
             1024 * 1024,
-            30,
             db_file.path().to_path_buf(),
         );
 
@@ -629,98 +464,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_eviction_no_eviction_needed() {
-        let db_file = create_test_db();
-        let temp_dir = tempfile::TempDir::new().unwrap();
-        let cache = ChunkCache::new(
-            temp_dir.path().to_path_buf(),
-            1024 * 1024, // 1MB max
-            30,
-            db_file.path().to_path_buf(),
-        );
-
-        // Store a small chunk - well within limits
-        let data = b"small chunk";
-        cache.store_chunk(&test_hash(data), data).await.unwrap();
-
-        let result = cache.run_eviction().await.unwrap();
-        assert_eq!(result.chunks_evicted, 0);
-        assert_eq!(result.bytes_freed, 0);
-        assert_eq!(result.reason, "No eviction needed");
-    }
-
-    #[tokio::test]
-    async fn test_eviction_size_based() {
-        let db_file = create_test_db();
-        let temp_dir = tempfile::TempDir::new().unwrap();
-        let cache = ChunkCache::new(
-            temp_dir.path().to_path_buf(),
-            500, // Very small max: 500 bytes
-            365, // Long TTL so we don't trigger TTL eviction
-            db_file.path().to_path_buf(),
-        );
-
-        // Store chunks totaling more than 500 bytes
-        let chunk_a = vec![0u8; 200];
-        let chunk_b = vec![1u8; 200];
-        let chunk_c = vec![2u8; 200];
-        cache
-            .store_chunk(&test_hash(&chunk_a), &chunk_a)
-            .await
-            .unwrap();
-        cache
-            .store_chunk(&test_hash(&chunk_b), &chunk_b)
-            .await
-            .unwrap();
-        cache
-            .store_chunk(&test_hash(&chunk_c), &chunk_c)
-            .await
-            .unwrap();
-
-        // Total: 600 bytes, max: 500 bytes => should evict at least 100 bytes
-        let result = cache.run_eviction().await.unwrap();
-        assert!(result.chunks_evicted > 0);
-        assert!(result.bytes_freed > 0);
-        assert!(result.reason.contains("Size limit exceeded"));
-    }
-
-    #[tokio::test]
-    async fn test_eviction_skips_protected_chunks() {
-        let db_file = create_test_db();
-        let temp_dir = tempfile::TempDir::new().unwrap();
-        let cache = ChunkCache::new(
-            temp_dir.path().to_path_buf(),
-            300, // Very small max
-            365,
-            db_file.path().to_path_buf(),
-        );
-
-        let chunk_a = vec![0u8; 200];
-        let chunk_b = vec![1u8; 200];
-        let hash1 = test_hash(&chunk_a);
-        let hash2 = test_hash(&chunk_b);
-
-        cache.store_chunk(&hash1, &chunk_a).await.unwrap();
-        cache.store_chunk(&hash2, &chunk_b).await.unwrap();
-
-        // Protect one chunk
-        cache.protect_chunks(std::slice::from_ref(&hash1)).await;
-
-        // Total: 400 bytes, max: 300 bytes
-        let _result = cache.run_eviction().await.unwrap();
-
-        // The protected chunk should still exist
-        assert!(cache.has_chunk(&hash1).await);
-    }
-
-    #[tokio::test]
     async fn test_store_chunk_atomic_write() {
         let db_file = create_test_db();
         let temp_dir = tempfile::TempDir::new().unwrap();
         let cache = ChunkCache::new(
             temp_dir.path().to_path_buf(),
             1024 * 1024,
-            30,
             db_file.path().to_path_buf(),
         );
 
@@ -743,7 +492,6 @@ mod tests {
         let cache = ChunkCache::new(
             temp_dir.path().to_path_buf(),
             1024 * 1024,
-            30,
             db_file.path().to_path_buf(),
         );
 
@@ -772,7 +520,6 @@ mod tests {
         let cache = ChunkCache::new(
             temp_dir.path().to_path_buf(),
             max_bytes,
-            30,
             db_file.path().to_path_buf(),
         );
 

--- a/apps/remi/src/server/config.rs
+++ b/apps/remi/src/server/config.rs
@@ -3,7 +3,7 @@
 //!
 //! Supports TOML configuration files with the following sections:
 //! - [server] - Bind address, workers, admin settings
-//! - [storage] - Root directory, eviction thresholds
+//! - [storage] - Root directory and local cache bound
 //! - repository_manifest - typed package-source manifest path
 //! - [conversion] - CCS conversion settings
 //! - [release_publish] - Trusted release signer and repository signing settings
@@ -130,18 +130,11 @@ fn default_true() -> bool {
 
 /// Storage configuration section
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct StorageSection {
     /// Root directory for all storage
     #[serde(default = "default_root")]
     pub root: PathBuf,
-
-    /// Eviction threshold (0.0-1.0, e.g., 0.90 = 90%)
-    #[serde(default = "default_eviction_threshold")]
-    pub eviction_threshold: f64,
-
-    /// Minimum age for eviction (e.g., "1h", "30m")
-    #[serde(default = "default_eviction_min_age")]
-    pub eviction_min_age: String,
 
     /// Negative cache TTL (e.g., "15m", "1h")
     #[serde(default = "default_negative_cache_ttl")]
@@ -162,8 +155,6 @@ impl Default for StorageSection {
     fn default() -> Self {
         Self {
             root: default_root(),
-            eviction_threshold: 0.90,
-            eviction_min_age: default_eviction_min_age(),
             negative_cache_ttl: default_negative_cache_ttl(),
             max_cache_size: None,
             readiness_min_free: None,
@@ -173,14 +164,6 @@ impl Default for StorageSection {
 
 fn default_root() -> PathBuf {
     PathBuf::from("/conary")
-}
-
-fn default_eviction_threshold() -> f64 {
-    0.90
-}
-
-fn default_eviction_min_age() -> String {
-    "1h".to_string()
 }
 
 fn default_negative_cache_ttl() -> String {
@@ -396,13 +379,11 @@ fn default_build_work_dir() -> PathBuf {
 
 /// Cloudflare R2 object storage configuration
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct R2Section {
-    /// Enable R2 write-through storage
+    /// Make R2 the durable chunk authority.
     #[serde(default)]
     pub enabled: bool,
-
-    /// R2 account ID
-    pub account_id: Option<String>,
 
     /// S3-compatible endpoint URL
     pub endpoint: Option<String>,
@@ -414,27 +395,15 @@ pub struct R2Section {
     /// Key prefix for chunks in the bucket
     #[serde(default = "default_r2_prefix")]
     pub prefix: String,
-
-    /// Write-through: upload to R2 on every chunk store
-    #[serde(default = "default_true")]
-    pub write_through: bool,
-
-    /// Enable redirect to R2 presigned URLs for chunk GET requests
-    /// When true, GET /v1/chunks/:hash returns 307 redirect to R2 instead of streaming data
-    #[serde(default)]
-    pub r2_redirect: bool,
 }
 
 impl Default for R2Section {
     fn default() -> Self {
         Self {
             enabled: false,
-            account_id: None,
             endpoint: None,
             bucket: default_r2_bucket(),
             prefix: default_r2_prefix(),
-            write_through: true,
-            r2_redirect: false,
         }
     }
 }
@@ -666,12 +635,14 @@ impl RemiConfig {
                 })?;
         }
 
-        // Validate eviction threshold
-        if !(0.0..=1.0).contains(&self.storage.eviction_threshold) {
-            anyhow::bail!(
-                "storage.eviction_threshold must be between 0.0 and 1.0, got {}",
-                self.storage.eviction_threshold
-            );
+        if self.r2.enabled
+            && self
+                .r2
+                .endpoint
+                .as_deref()
+                .is_none_or(|endpoint| endpoint.trim().is_empty())
+        {
+            anyhow::bail!("r2.endpoint is required when r2.enabled is true");
         }
 
         let prewarm_interval = parse_duration(&self.prewarm.metadata_sync_interval)
@@ -727,10 +698,6 @@ impl RemiConfig {
         }
     }
 
-    fn chunk_ttl_days(&self) -> u32 {
-        30
-    }
-
     fn readiness_min_free_bytes(&self) -> Result<u64> {
         match self.storage.readiness_min_free {
             Some(ref size_str) => parse_size(size_str),
@@ -763,7 +730,6 @@ impl RemiConfig {
             cache_dir: self.storage.root.join("cache"),
             max_concurrent_conversions: self.conversion.max_concurrent,
             cache_max_bytes: self.cache_max_bytes()?,
-            chunk_ttl_days: self.chunk_ttl_days(),
             readiness_min_free_bytes: self.readiness_min_free_bytes()?,
             enable_bloom_filter: self.enable_bloom_filter(),
             bloom_expected_chunks: self.bloom_expected_chunks(),
@@ -844,11 +810,6 @@ impl RemiConfig {
     /// Parse negative cache TTL to Duration
     pub fn negative_cache_duration(&self) -> Result<Duration> {
         parse_duration(&self.storage.negative_cache_ttl)
-    }
-
-    /// Parse eviction min age to Duration
-    pub fn eviction_min_age(&self) -> Result<Duration> {
-        parse_duration(&self.storage.eviction_min_age)
     }
 
     /// Get trusted proxy header for IP extraction

--- a/apps/remi/src/server/config/tests.rs
+++ b/apps/remi/src/server/config/tests.rs
@@ -73,7 +73,6 @@ fn test_default_remi_config_to_server_config_regression() {
     assert_eq!(runtime.cache_dir, PathBuf::from("/conary/cache"));
     assert_eq!(runtime.max_concurrent_conversions, 32);
     assert_eq!(runtime.cache_max_bytes, 700 * 1024 * 1024 * 1024);
-    assert_eq!(runtime.chunk_ttl_days, 30);
     assert!(runtime.enable_bloom_filter);
     assert_eq!(runtime.bloom_expected_chunks, 1_000_000);
     assert_eq!(runtime.upstream_url, None);
@@ -175,7 +174,6 @@ workers = 4
 
 [storage]
 root = "/conary"
-eviction_threshold = 0.90
 negative_cache_ttl = "15m"
 
 [conversion]
@@ -262,13 +260,35 @@ forgejo_token = "secret"
 }
 
 #[test]
-fn test_invalid_eviction_threshold() {
-    let toml_str = r#"
-[storage]
-eviction_threshold = 1.5
-"#;
-    let config: RemiConfig = toml::from_str(toml_str).unwrap();
-    assert!(config.validate().is_err());
+fn retired_eviction_policy_is_rejected() {
+    for (field, value) in [
+        ("eviction_threshold", "1.5"),
+        ("eviction_min_age", "\"1h\""),
+    ] {
+        let toml_str = format!("[storage]\n{field} = {value}\n");
+        let error = toml::from_str::<RemiConfig>(&toml_str)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains(field), "{error}");
+    }
+}
+
+#[test]
+fn retired_r2_mode_flags_are_rejected() {
+    for field in ["write_through", "r2_redirect", "account_id"] {
+        let toml_str = format!("[r2]\n{field} = true\n");
+        let error = toml::from_str::<RemiConfig>(&toml_str)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains(field), "{error}");
+    }
+}
+
+#[test]
+fn enabled_r2_requires_an_endpoint() {
+    let config: RemiConfig = toml::from_str("[r2]\nenabled = true\n").unwrap();
+    let error = config.validate().unwrap_err().to_string();
+    assert!(error.contains("r2.endpoint"), "{error}");
 }
 
 #[test]

--- a/apps/remi/src/server/conversion.rs
+++ b/apps/remi/src/server/conversion.rs
@@ -15,8 +15,8 @@ pub(crate) mod test_support;
 mod types;
 mod workflow;
 
-use crate::server::R2Store;
 use crate::server::database_writer::DatabaseWriter;
+use crate::server::{BoundedCache, R2Store};
 use std::path::PathBuf;
 use std::sync::Arc;
 pub use types::{
@@ -34,8 +34,10 @@ pub struct ConversionService {
     cache_dir: PathBuf,
     /// Database path
     db_path: PathBuf,
-    /// Optional R2 store for write-through
+    /// Optional R2 durable authority (absent for local-only deployments).
     r2_store: Option<Arc<R2Store>>,
+    /// Serialized owner for the R2-verified local cache bound.
+    bounded_cache: Option<BoundedCache>,
     /// Remi-owned per-distro TUF keys used to authenticate converted CCS.
     repository_keys_dir: Option<PathBuf>,
     /// Shared owner for the short SQLite mutation phases of conversion work.
@@ -54,6 +56,7 @@ impl ConversionService {
             cache_dir,
             db_path,
             r2_store,
+            bounded_cache: None,
             repository_keys_dir: None,
             database_writer: DatabaseWriter::default(),
         }
@@ -66,6 +69,11 @@ impl ConversionService {
 
     pub(crate) fn with_r2_store(mut self, r2_store: Option<Arc<R2Store>>) -> Self {
         self.r2_store = r2_store;
+        self
+    }
+
+    pub(crate) fn with_bounded_cache(mut self, bounded_cache: BoundedCache) -> Self {
+        self.bounded_cache = Some(bounded_cache);
         self
     }
 

--- a/apps/remi/src/server/conversion/storage.rs
+++ b/apps/remi/src/server/conversion/storage.rs
@@ -1,5 +1,5 @@
 // apps/remi/src/server/conversion/storage.rs
-//! Signed CCS object persistence and optional R2 write-through.
+//! Signed CCS object persistence and durable R2 publication.
 
 use super::ConversionService;
 use anyhow::{Context, Result};
@@ -34,7 +34,7 @@ impl ConversionService {
     }
 
     /// Verify the signed CCS authority, persist exactly its canonical objects,
-    /// and publish only absent objects to remote storage.
+    /// and publish only absent objects to the configured durable store.
     pub(super) async fn store_signed_ccs_path_with_timing(
         &self,
         package_path: &Path,
@@ -84,9 +84,6 @@ impl ConversionService {
         let cas_duration = cas_started.elapsed();
         let cas_metrics = verified_set.metrics();
 
-        // The upsert also refreshes the GC grace authority for CAS hits.
-        self.persist_chunk_sizes(&exact_sizes).await?;
-
         let mut r2_work = crate::server::conversion_timing::ConversionR2Work::default();
         let r2_duration = if let Some(r2) = self.r2_store.clone() {
             let started = Instant::now();
@@ -110,6 +107,18 @@ impl ConversionService {
         } else {
             None
         };
+
+        // Publish cache bookkeeping only after the durable write succeeds. A
+        // failed R2 write must not leave a non-evictable local-only cache row.
+        // The upsert also refreshes the GC grace authority for CAS hits.
+        self.persist_chunk_sizes(&exact_sizes).await?;
+
+        if let (Some(r2), Some(bounded_cache)) = (&self.r2_store, &self.bounded_cache) {
+            bounded_cache
+                .enforce(r2.as_ref())
+                .await
+                .context("enforce bounded local cache after durable R2 publication")?;
+        }
 
         Ok(StoredTransport {
             transport,

--- a/apps/remi/src/server/handlers/chunks.rs
+++ b/apps/remi/src/server/handlers/chunks.rs
@@ -1,13 +1,12 @@
 // apps/remi/src/server/handlers/chunks.rs
-//! Chunk serving endpoint - fast, dumb file server
+//! Chunk serving endpoint.
 //!
-//! This endpoint serves raw chunks from the CAS store.
-//! No conversion logic here - if a chunk is missing, return 404.
-//! Chunks are immutable and infinitely cacheable.
+//! With R2 configured, the durable store owns presence and GET requests use
+//! presigned redirects. Without R2, the endpoint serves the local CAS.
 //!
 //! Phase 0 hardening:
 //! - HEAD endpoint with Bloom filter protection
-//! - Batch endpoints for finding missing chunks
+//! - Batched missing-chunk discovery
 //! - Pull-through caching (fetch from upstream on miss)
 //! - Metrics tracking
 
@@ -69,6 +68,21 @@ fn chunk_not_found() -> Response {
     (StatusCode::NOT_FOUND, "Chunk not found").into_response()
 }
 
+fn durable_chunk_unavailable(hash: &str) -> Response {
+    Response::builder()
+        .status(StatusCode::SERVICE_UNAVAILABLE)
+        .header(header::CONTENT_TYPE, "application/json")
+        .header("x-conary-error", "durable-chunk-unavailable")
+        .body(Body::from(
+            serde_json::json!({
+                "code": "durable_chunk_unavailable",
+                "hash": hash,
+            })
+            .to_string(),
+        ))
+        .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
+}
+
 async fn chunk_servable_by_authority(
     db_path: std::path::PathBuf,
     hash: String,
@@ -107,14 +121,27 @@ pub async fn head_chunk(
     }
     let hash = normalize_hash(&hash);
 
-    let db_path = {
+    let (db_path, r2_store) = {
         let state = state.read().await;
-        state.config.db_path.clone()
+        (state.config.db_path.clone(), state.r2_store.clone())
     };
     match chunk_servable_by_authority(db_path, hash.clone()).await {
         Ok(true) => {}
         Ok(false) => return chunk_not_found(),
         Err(response) => return response,
+    }
+
+    if let Some(r2_store) = r2_store {
+        return match r2_store.head_chunk(&hash).await {
+            Ok(true) => chunk_response_builder(&hash, StatusCode::OK)
+                .body(Body::empty())
+                .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response()),
+            Ok(false) => durable_chunk_unavailable(&hash),
+            Err(error) => {
+                tracing::error!("R2 HEAD failed for durable chunk {hash}: {error}");
+                durable_chunk_unavailable(&hash)
+            }
+        };
     }
 
     let state = state.read().await;
@@ -187,10 +214,12 @@ fn parse_range_header(range_header: &str, file_size: u64) -> Option<(u64, u64)> 
 /// GET /v1/chunks/:hash
 ///
 /// Serves a chunk by its content hash. Returns:
-/// - 200 OK with chunk data and immutable cache headers
-/// - 206 Partial Content for Range requests
+/// - 307 Temporary Redirect to R2 when durable storage is configured
+/// - 200 OK with local chunk data otherwise
+/// - 206 Partial Content for local Range requests
 /// - 416 Range Not Satisfiable for invalid ranges
 /// - 404 Not Found if chunk doesn't exist
+/// - 503 Service Unavailable if published state disagrees with R2
 pub async fn get_chunk(
     State(state): State<Arc<RwLock<ServerState>>>,
     Path(hash): Path<String>,
@@ -202,14 +231,49 @@ pub async fn get_chunk(
     }
     let hash = normalize_hash(&hash);
 
-    let db_path = {
+    let (db_path, r2_store) = {
         let state_guard = state.read().await;
-        state_guard.config.db_path.clone()
+        (
+            state_guard.config.db_path.clone(),
+            state_guard.r2_store.clone(),
+        )
     };
     match chunk_servable_by_authority(db_path, hash.clone()).await {
         Ok(true) => {}
         Ok(false) => return chunk_not_found(),
         Err(response) => return response,
+    }
+
+    if let Some(r2_store) = r2_store {
+        match r2_store.head_chunk(&hash).await {
+            Ok(true) => {}
+            Ok(false) => return durable_chunk_unavailable(&hash),
+            Err(error) => {
+                tracing::error!("R2 HEAD failed for durable chunk {hash}: {error}");
+                return durable_chunk_unavailable(&hash);
+            }
+        }
+        return match r2_store.presign_get(&hash, 3600).await {
+            Ok(presigned_url) => {
+                let metrics = {
+                    let state_guard = state.read().await;
+                    state_guard.metrics.clone()
+                };
+                metrics.record_hit();
+                Response::builder()
+                    .status(StatusCode::TEMPORARY_REDIRECT)
+                    .header(header::LOCATION, presigned_url)
+                    .header(header::CACHE_CONTROL, "public, max-age=3600")
+                    .header(header::ETAG, format!("\"{hash}\""))
+                    .header(header::ACCEPT_RANGES, "bytes")
+                    .body(Body::empty())
+                    .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
+            }
+            Err(error) => {
+                tracing::error!("R2 presign failed for durable chunk {hash}: {error}");
+                durable_chunk_unavailable(&hash)
+            }
+        };
     }
 
     let state_guard = state.read().await;
@@ -238,33 +302,6 @@ pub async fn get_chunk(
         }
         state_guard.metrics.record_miss();
         return chunk_not_found();
-    }
-
-    // R2 redirect: if enabled and not a Range request, redirect to presigned R2 URL
-    let is_range_request = headers.contains_key(header::RANGE);
-    if !is_range_request
-        && state_guard.r2_redirect
-        && let Some(ref r2_store) = state_guard.r2_store
-    {
-        match r2_store.presign_get(&hash, 3600).await {
-            Ok(presigned_url) => {
-                state_guard.metrics.record_hit();
-                // Record approximate file size from metadata
-                if let Ok(meta) = tokio::fs::metadata(&chunk_path).await {
-                    state_guard.metrics.record_bytes_served(meta.len());
-                }
-                return Response::builder()
-                    .status(StatusCode::TEMPORARY_REDIRECT)
-                    .header(header::LOCATION, &presigned_url)
-                    .header(header::CACHE_CONTROL, "public, max-age=3600")
-                    .body(Body::empty())
-                    .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response());
-            }
-            Err(e) => {
-                tracing::warn!("R2 presign failed for {}, serving locally: {}", hash, e);
-                // Fall through to normal local serving
-            }
-        }
     }
 
     // Open file for streaming
@@ -571,8 +608,7 @@ pub struct FindMissingResponse {
 
 /// POST /v1/chunks/find-missing
 ///
-/// Check which chunks are missing from the cache.
-/// Useful for clients to determine what needs to be uploaded.
+/// Check which published chunks are present in the configured storage authority.
 pub async fn find_missing(
     State(state): State<Arc<RwLock<ServerState>>>,
     Json(request): Json<FindMissingRequest>,
@@ -585,12 +621,13 @@ pub async fn find_missing(
             .into_response();
     }
 
-    let (db_path, bloom_filter, chunk_cache) = {
+    let (db_path, bloom_filter, chunk_cache, r2_store) = {
         let state = state.read().await;
         (
             state.config.db_path.clone(),
             state.bloom_filter.clone(),
             state.chunk_cache.clone(),
+            state.r2_store.clone(),
         )
     };
 
@@ -612,6 +649,18 @@ pub async fn find_missing(
                 continue;
             }
             Err(response) => return response,
+        }
+
+        if let Some(r2_store) = &r2_store {
+            match r2_store.head_chunk(&hash).await {
+                Ok(true) => found.push(hash),
+                Ok(false) => return durable_chunk_unavailable(&hash),
+                Err(error) => {
+                    tracing::error!("R2 HEAD failed during find-missing for {hash}: {error}");
+                    return durable_chunk_unavailable(&hash);
+                }
+            }
+            continue;
         }
 
         // Use Bloom filter for quick rejection
@@ -637,149 +686,6 @@ pub async fn find_missing(
         invalid_count,
     })
     .into_response()
-}
-
-/// Request body for batch fetch endpoint
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct BatchFetchRequest {
-    /// List of chunk hashes to fetch
-    pub hashes: Vec<String>,
-}
-
-/// POST /v1/chunks/batch
-///
-/// Fetch multiple chunks in a single request.
-/// Returns an efficient binary `multipart/mixed` response.
-///
-/// Multipart format:
-/// ```text
-/// Content-Type: multipart/mixed; boundary=chunk-boundary
-/// --chunk-boundary
-/// X-Chunk-Hash: abc123...
-/// Content-Length: 65536
-/// <raw bytes>
-/// --chunk-boundary
-/// X-Chunk-Hash: def456...
-/// Content-Length: 32768
-/// <raw bytes>
-/// --chunk-boundary--
-/// ```
-pub async fn batch_fetch(
-    State(state): State<Arc<RwLock<ServerState>>>,
-    Json(request): Json<BatchFetchRequest>,
-) -> impl IntoResponse {
-    const MAX_BATCH_SIZE: usize = 100;
-    const BOUNDARY: &str = "chunk-boundary-7f3e9a2b";
-
-    if request.hashes.len() > MAX_BATCH_SIZE {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(
-                serde_json::json!({ "error": format!("Too many hashes (max {})", MAX_BATCH_SIZE) }),
-            ),
-        )
-            .into_response();
-    }
-
-    /// Maximum aggregate response size for batch fetch (256 MB).
-    const MAX_BATCH_BYTES: u64 = 256 * 1024 * 1024;
-
-    let (db_path, chunk_cache, metrics) = {
-        let state = state.read().await;
-        (
-            state.config.db_path.clone(),
-            state.chunk_cache.clone(),
-            state.metrics.clone(),
-        )
-    };
-
-    // Collect chunk data with aggregate size cap
-    let mut chunks_data: Vec<(String, Vec<u8>)> = Vec::new();
-    let mut missing = Vec::new();
-    let mut invalid = Vec::new();
-    let mut total_bytes: u64 = 0;
-
-    for raw_hash in &request.hashes {
-        if !is_valid_hash(raw_hash) {
-            invalid.push(raw_hash.clone());
-            continue;
-        }
-        let hash = normalize_hash(raw_hash);
-
-        match chunk_servable_by_authority(db_path.clone(), hash.clone()).await {
-            Ok(true) => {}
-            Ok(false) => {
-                missing.push(hash);
-                continue;
-            }
-            Err(response) => return response,
-        }
-
-        let path = chunk_cache.chunk_path(&hash);
-        match tokio::fs::read(&path).await {
-            Ok(data) => {
-                total_bytes += data.len() as u64;
-                if total_bytes > MAX_BATCH_BYTES {
-                    return (
-                        StatusCode::PAYLOAD_TOO_LARGE,
-                        Json(serde_json::json!({
-                            "error": format!(
-                                "Aggregate response exceeds size limit ({} MB)",
-                                MAX_BATCH_BYTES / (1024 * 1024)
-                            )
-                        })),
-                    )
-                        .into_response();
-                }
-                metrics.record_hit();
-                metrics.record_bytes_served(data.len() as u64);
-                chunks_data.push((hash.clone(), data));
-            }
-            Err(_) => {
-                missing.push(hash.clone());
-            }
-        }
-    }
-
-    // Build multipart response
-    let mut body_parts: Vec<u8> = Vec::new();
-
-    // Add metadata header as first part (JSON with missing/invalid info)
-    if !missing.is_empty() || !invalid.is_empty() {
-        body_parts.extend_from_slice(format!("--{}\r\n", BOUNDARY).as_bytes());
-        body_parts.extend_from_slice(b"Content-Type: application/json\r\n");
-        body_parts.extend_from_slice(b"X-Part-Type: metadata\r\n\r\n");
-        let metadata = serde_json::json!({
-            "missing": missing,
-            "invalid": invalid,
-        });
-        body_parts.extend_from_slice(metadata.to_string().as_bytes());
-        body_parts.extend_from_slice(b"\r\n");
-    }
-
-    // Add each chunk as a binary part
-    for (hash, data) in chunks_data {
-        body_parts.extend_from_slice(format!("--{}\r\n", BOUNDARY).as_bytes());
-        body_parts.extend_from_slice(b"Content-Type: application/octet-stream\r\n");
-        body_parts.extend_from_slice(format!("X-Chunk-Hash: {}\r\n", hash).as_bytes());
-        body_parts.extend_from_slice(format!("Content-Length: {}\r\n\r\n", data.len()).as_bytes());
-        body_parts.extend_from_slice(&data);
-        body_parts.extend_from_slice(b"\r\n");
-    }
-
-    // End boundary
-    body_parts.extend_from_slice(format!("--{}--\r\n", BOUNDARY).as_bytes());
-
-    Response::builder()
-        .status(StatusCode::OK)
-        .header(
-            header::CONTENT_TYPE,
-            format!("multipart/mixed; boundary={}", BOUNDARY),
-        )
-        .header(header::CONTENT_LENGTH, body_parts.len())
-        .body(Body::from(body_parts))
-        .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
 }
 
 mod admin;

--- a/apps/remi/src/server/handlers/chunks/admin.rs
+++ b/apps/remi/src/server/handlers/chunks/admin.rs
@@ -45,26 +45,33 @@ pub async fn cache_stats(State(state): State<Arc<RwLock<ServerState>>>) -> impl 
 ///
 /// Manually trigger LRU eviction (admin endpoint)
 pub async fn trigger_eviction(State(state): State<Arc<RwLock<ServerState>>>) -> impl IntoResponse {
-    let state = state.read().await;
+    let (bounded_cache, r2_store, bloom_filter) = {
+        let state = state.read().await;
+        (
+            state.bounded_cache.clone(),
+            state.r2_store.clone(),
+            state.bloom_filter.clone(),
+        )
+    };
+    let Some(r2_store) = r2_store else {
+        return (
+            StatusCode::CONFLICT,
+            "Bounded eviction requires configured R2 durability authority",
+        )
+            .into_response();
+    };
 
-    match state.chunk_cache.run_eviction().await {
+    match bounded_cache.enforce(r2_store.as_ref()).await {
         Ok(result) => {
             // Mark bloom filter dirty after eviction
-            if let Some(ref bloom) = state.bloom_filter {
+            if let Some(ref bloom) = bloom_filter {
                 bloom.mark_dirty();
             }
 
             tracing::info!(
-                "Manual eviction: {} chunks, {} freed",
-                result.chunks_evicted,
-                result.bytes_freed_human
-            );
-
-            state.publish_event(
-                "cache",
-                serde_json::json!({
-                    "action": "eviction_triggered",
-                }),
+                "Manual bounded eviction: {} chunks, {} bytes freed",
+                result.objects_evicted,
+                result.bytes_freed
             );
 
             Json(result).into_response()

--- a/apps/remi/src/server/handlers/chunks/tests.rs
+++ b/apps/remi/src/server/handlers/chunks/tests.rs
@@ -2,18 +2,19 @@
 use super::*;
 use crate::server::conversion::test_support::seed_repository_conversion_source;
 
-#[test]
-fn batch_fetch_request_rejects_removed_json_format() {
-    let error = serde_json::from_value::<BatchFetchRequest>(serde_json::json!({
-        "hashes": [],
-        "format": "json"
-    }))
-    .expect_err("removed JSON batch format must fail");
-    assert!(error.to_string().contains("unknown field `format`"));
-}
 use conary_core::db::models::{CONVERSION_VERSION, ChunkAccess, ConvertedPackage};
 
 const TEST_HASH: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+#[test]
+fn durable_authority_failure_has_stable_typed_http_contract() {
+    let response = durable_chunk_unavailable(TEST_HASH);
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(
+        response.headers().get("x-conary-error").unwrap(),
+        "durable-chunk-unavailable"
+    );
+}
 
 async fn chunk_state_with_db(
     hash: &str,

--- a/apps/remi/src/server/handlers/oci/tests.rs
+++ b/apps/remi/src/server/handlers/oci/tests.rs
@@ -320,7 +320,6 @@ fn test_build_manifest() {
     let chunk_cache = crate::server::ChunkCache::new(
         chunk_dir.path().to_path_buf(),
         1024 * 1024 * 1024,
-        30,
         temp_file.path().to_path_buf(),
     );
     for (hash, bytes) in [
@@ -370,7 +369,6 @@ fn test_build_manifest_not_found() {
     let chunk_cache = crate::server::ChunkCache::new(
         chunk_dir.path().to_path_buf(),
         1024 * 1024 * 1024,
-        30,
         temp_file.path().to_path_buf(),
     );
 
@@ -400,7 +398,6 @@ fn oci_manifest_ignores_stale_converted_rows() {
     let chunk_cache = crate::server::ChunkCache::new(
         chunk_dir.path().to_path_buf(),
         1024 * 1024 * 1024,
-        30,
         temp_file.path().to_path_buf(),
     );
 
@@ -424,7 +421,6 @@ fn oci_tags_catalog_and_manifest_ignore_stale_rows() {
     let chunk_cache = crate::server::ChunkCache::new(
         chunk_dir.path().to_path_buf(),
         1024 * 1024 * 1024,
-        30,
         temp_file.path().to_path_buf(),
     );
 

--- a/apps/remi/src/server/mod.rs
+++ b/apps/remi/src/server/mod.rs
@@ -3,14 +3,14 @@
 //!
 //! This module provides an HTTP server that:
 //! - Serves repository metadata (proxied through Cloudflare)
-//! - Serves CCS chunks (direct from origin)
+//! - Serves CCS chunks from R2 authority or a local-only store
 //! - Converts native package formats (RPM/DEB/Arch/eopkg) to CCS on demand
-//! - Uses LRU cache eviction to manage disk space
+//! - Uses R2-verified bounded LRU caching to manage disk space
 //!
 //! Phase 0 hardening features:
 //! - Bloom filter for fast negative lookups (DoS protection)
 //! - Pull-through caching (fetch from upstream on miss)
-//! - Batch endpoints for efficient multi-chunk operations
+//! - Batched missing-chunk discovery
 //! - Metrics tracking for observability
 //! - Rate limiting per IP/peer
 
@@ -20,6 +20,7 @@ pub mod artifact_paths;
 pub mod audit;
 pub mod auth;
 mod bloom;
+mod bounded_cache;
 mod cache;
 pub mod canonical_fetch;
 pub mod canonical_job;
@@ -56,6 +57,7 @@ pub mod test_db;
 
 pub use analytics::AnalyticsRecorder;
 pub use bloom::{BloomStats, ChunkBloomFilter};
+pub use bounded_cache::{BoundedCache, BoundedCacheReport};
 pub use cache::ChunkCache;
 pub use config::RemiConfig;
 pub use conversion::{
@@ -131,8 +133,6 @@ pub struct ServerConfig {
     pub max_concurrent_conversions: usize,
     /// LRU eviction threshold in bytes (default 700GB)
     pub cache_max_bytes: u64,
-    /// Chunk TTL in days before LRU eviction
-    pub chunk_ttl_days: u32,
     /// Free bytes the serving root must have before readiness reports ready.
     pub readiness_min_free_bytes: u64,
 
@@ -203,6 +203,7 @@ pub struct ServerState {
     pub(crate) database_writer: database_writer::DatabaseWriter,
     pub job_manager: JobManager,
     pub chunk_cache: ChunkCache,
+    pub bounded_cache: BoundedCache,
     pub conversion_service: ConversionService,
     /// Bloom filter for fast negative chunk lookups
     pub bloom_filter: Option<Arc<ChunkBloomFilter>>,
@@ -218,8 +219,6 @@ pub struct ServerState {
     pub trusted_proxy_header: Option<String>,
     /// R2 object storage for CDN-backed chunk distribution
     pub r2_store: Option<Arc<R2Store>>,
-    /// Redirect chunk GET requests to R2 presigned URLs instead of streaming locally
-    pub r2_redirect: bool,
     /// Full-text search engine (Tantivy)
     pub search_engine: Option<Arc<SearchEngine>>,
     /// Download analytics recorder (buffered writes)
@@ -268,9 +267,9 @@ impl ServerState {
         let chunk_cache = ChunkCache::new(
             config.chunk_dir.clone(),
             config.cache_max_bytes,
-            config.chunk_ttl_days,
             config.db_path.clone(),
         );
+        let bounded_cache = BoundedCache::new(chunk_cache.clone());
         let conversion_service = ConversionService::new(
             config.chunk_dir.clone(),
             config.cache_dir.clone(),
@@ -278,6 +277,7 @@ impl ServerState {
             None, // R2 store set later after state initialization
         )
         .with_database_writer(database_writer.clone())
+        .with_bounded_cache(bounded_cache.clone())
         .with_repository_keys_dir(config.release_publish.repository_keys_dir.clone());
 
         // Initialize Bloom filter if enabled
@@ -307,6 +307,7 @@ impl ServerState {
             database_writer,
             job_manager,
             chunk_cache,
+            bounded_cache,
             conversion_service,
             bloom_filter,
             http_client,
@@ -315,7 +316,6 @@ impl ServerState {
             negative_cache,
             trusted_proxy_header,
             r2_store: None,
-            r2_redirect: false,
             search_engine: None,
             analytics: None,
             federated_config: None,
@@ -444,37 +444,33 @@ pub async fn run_server_from_config(remi_config: &RemiConfig) -> Result<()> {
 
     // Initialize R2 storage if enabled
     if remi_config.r2.enabled {
-        if let Some(ref endpoint) = remi_config.r2.endpoint {
-            let r2_config = r2::R2Config {
-                endpoint: endpoint.clone(),
-                bucket: remi_config.r2.bucket.clone(),
-                prefix: remi_config.r2.prefix.clone(),
-                region: "auto".to_string(),
-            };
-            match R2Store::new(&r2_config) {
-                Ok(store) => {
-                    tracing::info!(
-                        "  R2 storage: enabled (bucket: {}, write-through: {}, redirect: {})",
-                        remi_config.r2.bucket,
-                        remi_config.r2.write_through,
-                        remi_config.r2.r2_redirect
-                    );
-                    let mut state_w = state.write().await;
-                    let store = Arc::new(store);
-                    state_w.r2_store = Some(Arc::clone(&store));
-                    state_w.conversion_service = state_w
-                        .conversion_service
-                        .clone()
-                        .with_r2_store(Some(store));
-                    state_w.r2_redirect = remi_config.r2.r2_redirect;
-                }
-                Err(e) => {
-                    tracing::error!("  R2 storage: failed to initialize: {}", e);
-                }
-            }
-        } else {
-            tracing::warn!("  R2 storage: enabled but no endpoint configured");
-        }
+        let endpoint = remi_config
+            .r2
+            .endpoint
+            .as_ref()
+            .context("r2.endpoint is required when R2 authority is enabled")?;
+        let r2_config = r2::R2Config {
+            endpoint: endpoint.clone(),
+            bucket: remi_config.r2.bucket.clone(),
+            prefix: remi_config.r2.prefix.clone(),
+            region: "auto".to_string(),
+        };
+        let store =
+            Arc::new(R2Store::new(&r2_config).context("initialize mandatory R2 chunk authority")?);
+        store
+            .head_chunk("0000000000000000000000000000000000000000000000000000000000000000")
+            .await
+            .context("probe mandatory R2 chunk authority")?;
+        tracing::info!(
+            "  R2 storage: durable authority enabled (bucket: {})",
+            remi_config.r2.bucket
+        );
+        let mut state_w = state.write().await;
+        state_w.r2_store = Some(Arc::clone(&store));
+        state_w.conversion_service = state_w
+            .conversion_service
+            .clone()
+            .with_r2_store(Some(store));
     }
 
     // Initialize search engine if enabled

--- a/apps/remi/src/server/r2.rs
+++ b/apps/remi/src/server/r2.rs
@@ -122,6 +122,14 @@ fn delete_failures(prefix: &str, response: &DeleteObjectsResult) -> Vec<(String,
         .collect()
 }
 
+fn classify_head_status(key: &str, status: u16) -> Result<bool> {
+    match status {
+        200..=299 => Ok(true),
+        404 => Ok(false),
+        _ => anyhow::bail!("R2 HEAD failed for {key}: HTTP {status}"),
+    }
+}
+
 /// Cloudflare R2 object storage backend for CAS chunks
 #[derive(Debug)]
 pub struct R2Store {
@@ -200,7 +208,7 @@ impl R2Store {
         let key = self.chunk_key(hash);
 
         match self.bucket.head_object(&key).await {
-            Ok((_, code)) => Ok(code < 300),
+            Ok((_, code)) => classify_head_status(&key, code),
             Err(e) => {
                 let msg = e.to_string();
                 if msg.contains("404") || msg.contains("NoSuchKey") {
@@ -313,6 +321,18 @@ mod tests {
         assert_eq!(config.prefix, "chunks/");
         assert_eq!(config.region, "auto");
         assert!(config.endpoint.is_empty());
+    }
+
+    #[test]
+    fn head_status_distinguishes_absence_from_authority_failure() {
+        assert!(classify_head_status("chunks/hash", 200).unwrap());
+        assert!(!classify_head_status("chunks/hash", 404).unwrap());
+        for status in [401, 403, 429, 500, 503] {
+            let error = classify_head_status("chunks/hash", status)
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains(&status.to_string()), "{error}");
+        }
     }
 
     #[test]

--- a/apps/remi/src/server/routes/public.rs
+++ b/apps/remi/src/server/routes/public.rs
@@ -49,7 +49,6 @@ pub async fn create_router(state: Arc<RwLock<ServerState>>) -> Router {
         .route("/v1/chunks/{hash}", head(chunks::head_chunk))
         .route("/v1/chunks/{hash}", get(chunks::get_chunk))
         .route("/v1/chunks/find-missing", post(chunks::find_missing))
-        .route("/v1/chunks/batch", post(chunks::batch_fetch))
         .layer(restricted_cors)
         .with_state(state.clone());
 

--- a/crates/conary-core/src/db/models/chunk_access.rs
+++ b/crates/conary-core/src/db/models/chunk_access.rs
@@ -93,30 +93,27 @@ impl ChunkAccess {
         Ok(result)
     }
 
-    /// Get least recently used chunks (for eviction)
-    pub fn get_lru_chunks(conn: &Connection, limit: usize) -> Result<Vec<Self>> {
+    /// Get the smallest LRU prefix whose bytes can satisfy an eviction target.
+    pub fn get_lru_chunks_for_bytes(conn: &Connection, bytes: u64) -> Result<Vec<Self>> {
         let sql = format!(
-            "SELECT {} FROM chunk_access \
-             WHERE protected = 0 ORDER BY last_accessed ASC LIMIT ?1",
-            Self::COLUMNS
+            "WITH lru AS (
+                SELECT {},
+                       SUM(size_bytes) OVER (
+                           ORDER BY last_accessed ASC, hash ASC
+                           ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                       ) AS cumulative_bytes
+                FROM chunk_access
+                WHERE protected = 0
+             )
+             SELECT {} FROM lru
+             WHERE cumulative_bytes - size_bytes < ?1
+             ORDER BY last_accessed ASC, hash ASC",
+            Self::COLUMNS,
+            Self::COLUMNS,
         );
         let mut stmt = conn.prepare(&sql)?;
         let results = stmt
-            .query_map([limit as i64], Self::from_row)?
-            .collect::<rusqlite::Result<Vec<_>>>()?;
-        Ok(results)
-    }
-
-    /// Get chunks older than a given timestamp
-    pub fn get_stale_chunks(conn: &Connection, before: &str) -> Result<Vec<Self>> {
-        let sql = format!(
-            "SELECT {} FROM chunk_access \
-             WHERE protected = 0 AND last_accessed < ?1 ORDER BY last_accessed ASC",
-            Self::COLUMNS
-        );
-        let mut stmt = conn.prepare(&sql)?;
-        let results = stmt
-            .query_map([before], Self::from_row)?
+            .query_map([i64::try_from(bytes).unwrap_or(i64::MAX)], Self::from_row)?
             .collect::<rusqlite::Result<Vec<_>>>()?;
         Ok(results)
     }
@@ -277,13 +274,32 @@ mod tests {
         assert!(found.protected);
 
         // LRU query should not return protected chunks
-        let lru = ChunkAccess::get_lru_chunks(&conn, 10).unwrap();
+        let lru = ChunkAccess::get_lru_chunks_for_bytes(&conn, 1).unwrap();
         assert!(lru.is_empty());
 
         // Unprotect
         ChunkAccess::set_protected(&conn, "protected_chunk", false).unwrap();
-        let lru2 = ChunkAccess::get_lru_chunks(&conn, 10).unwrap();
+        let lru2 = ChunkAccess::get_lru_chunks_for_bytes(&conn, 1).unwrap();
         assert_eq!(lru2.len(), 1);
+    }
+
+    #[test]
+    fn lru_byte_query_returns_only_the_prefix_needed_for_the_bound() {
+        let (_temp, conn) = create_test_db();
+        for (hash, size) in [("a", 3), ("b", 5), ("c", 7)] {
+            ChunkAccess::new(hash.to_string(), size)
+                .upsert(&conn)
+                .unwrap();
+        }
+
+        let candidates = ChunkAccess::get_lru_chunks_for_bytes(&conn, 4).unwrap();
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|candidate| candidate.hash.as_str())
+                .collect::<Vec<_>>(),
+            vec!["a", "b"]
+        );
     }
 
     #[test]

--- a/crates/conary-core/src/error.rs
+++ b/crates/conary-core/src/error.rs
@@ -107,6 +107,11 @@ pub enum Error {
     #[error("Download failed: {0}")]
     DownloadError(String),
 
+    /// A repository declared a chunk servable but its durable object authority
+    /// could not provide that exact object.
+    #[error("Durable chunk {hash} is unavailable from {authority}")]
+    DurableChunkUnavailable { hash: String, authority: String },
+
     /// HTTP response status from an exact repository URL
     #[error("HTTP {status} from {url}")]
     HttpStatus { status: u16, url: String },

--- a/crates/conary-core/src/repository/chunk_fetcher.rs
+++ b/crates/conary-core/src/repository/chunk_fetcher.rs
@@ -72,8 +72,6 @@ pub struct HttpChunkFetcher {
     max_concurrent: usize,
     /// Whether to verify chunk hashes
     verify_hashes: bool,
-    /// Whether to use batch endpoint for fetch_many
-    use_batch: bool,
     /// Maximum chunk size to accept (for DoS protection)
     max_chunk_size: usize,
 }
@@ -84,7 +82,6 @@ pub struct HttpChunkFetcherBuilder {
     max_concurrent: usize,
     verify_hashes: bool,
     http2_prior_knowledge: bool,
-    use_batch: bool,
     timeout_secs: u64,
     max_chunk_size: usize,
 }
@@ -97,7 +94,6 @@ impl HttpChunkFetcherBuilder {
             max_concurrent: 8,
             verify_hashes: true,
             http2_prior_knowledge: false, // Off by default for compatibility
-            use_batch: true,
             timeout_secs: 60,
             max_chunk_size: 512 * 1024, // 512KB default
         }
@@ -118,12 +114,6 @@ impl HttpChunkFetcherBuilder {
     /// Enable HTTP/2 prior knowledge (use only with known HTTP/2 servers)
     pub fn http2_prior_knowledge(mut self, enable: bool) -> Self {
         self.http2_prior_knowledge = enable;
-        self
-    }
-
-    /// Enable batch endpoint usage for fetch_many
-    pub fn use_batch(mut self, enable: bool) -> Self {
-        self.use_batch = enable;
         self
     }
 
@@ -158,7 +148,6 @@ impl HttpChunkFetcherBuilder {
             base_url: self.base_url,
             max_concurrent: self.max_concurrent,
             verify_hashes: self.verify_hashes,
-            use_batch: self.use_batch,
             max_chunk_size: self.max_chunk_size,
         })
     }
@@ -199,6 +188,17 @@ impl ChunkFetcher for HttpChunkFetcher {
             .send()
             .await
             .map_err(|e| Error::DownloadError(format!("Failed to fetch chunk {}: {e}", hash)))?;
+
+        if response
+            .headers()
+            .get("x-conary-error")
+            .is_some_and(|value| value == "durable-chunk-unavailable")
+        {
+            return Err(Error::DurableChunkUnavailable {
+                hash: hash.to_string(),
+                authority: self.base_url.clone(),
+            });
+        }
 
         if !response.status().is_success() {
             return Err(Error::DownloadError(format!(
@@ -249,18 +249,6 @@ impl ChunkFetcher for HttpChunkFetcher {
     }
 
     async fn fetch_many(&self, hashes: &[String]) -> Result<HashMap<String, Vec<u8>>> {
-        // Try batch endpoint first if enabled
-        if self.use_batch && !hashes.is_empty() {
-            match self.fetch_many_batch(hashes).await {
-                Ok(chunks) => return Ok(chunks),
-                Err(e) => {
-                    debug!("Batch fetch failed, falling back to individual: {}", e);
-                    // Fall through to individual fetches
-                }
-            }
-        }
-
-        // Fallback: individual HTTP requests with concurrency control
         self.fetch_many_individual(hashes).await
     }
 
@@ -270,94 +258,6 @@ impl ChunkFetcher for HttpChunkFetcher {
 }
 
 impl HttpChunkFetcher {
-    /// Fetch multiple chunks using the batch endpoint
-    async fn fetch_many_batch(&self, hashes: &[String]) -> Result<HashMap<String, Vec<u8>>> {
-        use serde::{Deserialize, Serialize};
-
-        #[derive(Serialize)]
-        struct BatchRequest<'a> {
-            hashes: &'a [String],
-            format: &'static str,
-        }
-
-        #[derive(Deserialize)]
-        struct ChunkData {
-            hash: String,
-            data: String, // Base64 encoded
-        }
-
-        #[derive(Deserialize)]
-        struct BatchResponse {
-            chunks: Vec<ChunkData>,
-            missing: Vec<String>,
-        }
-
-        let url = format!("{}/v1/chunks/batch", self.base_url);
-        info!("Fetching {} chunks via batch endpoint", hashes.len());
-
-        // Use JSON format for simplicity (multipart parsing is complex)
-        let request = BatchRequest {
-            hashes,
-            format: "json",
-        };
-
-        let response = self
-            .client
-            .post(&url)
-            .header(header::ACCEPT_ENCODING, "identity")
-            .json(&request)
-            .send()
-            .await
-            .map_err(|e| Error::DownloadError(format!("Batch request failed: {e}")))?;
-
-        if !response.status().is_success() {
-            return Err(Error::DownloadError(format!(
-                "Batch endpoint returned HTTP {}",
-                response.status()
-            )));
-        }
-
-        let batch_response: BatchResponse = response
-            .json()
-            .await
-            .map_err(|e| Error::DownloadError(format!("Failed to parse batch response: {e}")))?;
-
-        if !batch_response.missing.is_empty() {
-            return Err(Error::DownloadError(format!(
-                "Batch fetch missing {} chunks: {:?}",
-                batch_response.missing.len(),
-                batch_response.missing.first()
-            )));
-        }
-
-        use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
-
-        let mut chunks = HashMap::new();
-        for chunk_data in batch_response.chunks {
-            let data = BASE64
-                .decode(&chunk_data.data)
-                .map_err(|e| Error::DownloadError(format!("Invalid base64 in batch: {e}")))?;
-
-            // Size check
-            if data.len() > self.max_chunk_size {
-                return Err(Error::DownloadError(format!(
-                    "Chunk {} exceeds max size ({} > {})",
-                    chunk_data.hash,
-                    data.len(),
-                    self.max_chunk_size
-                )));
-            }
-
-            if self.verify_hashes {
-                Self::verify_hash(&chunk_data.hash, &data)?;
-            }
-
-            chunks.insert(chunk_data.hash, data);
-        }
-
-        Ok(chunks)
-    }
-
     /// Fetch chunks individually with concurrency control
     ///
     /// Uses `buffer_unordered` to limit concurrency -- no additional semaphore
@@ -523,6 +423,9 @@ impl ChunkFetcher for CompositeChunkFetcher {
                     return Ok(data);
                 }
                 Err(e) => {
+                    if matches!(e, Error::DurableChunkUnavailable { .. }) {
+                        return Err(e);
+                    }
                     debug!(
                         "Fetcher '{}' failed for chunk {}: {}",
                         fetcher.name(),
@@ -601,6 +504,9 @@ impl ChunkFetcher for CompositeChunkFetcher {
                     return Ok(results);
                 }
                 Err(e) => {
+                    if matches!(e, Error::DurableChunkUnavailable { .. }) {
+                        return Err(e);
+                    }
                     warn!("Fetcher '{}' failed for batch: {}", fetcher.name(), e);
                 }
             }
@@ -621,6 +527,35 @@ impl ChunkFetcher for CompositeChunkFetcher {
 mod tests {
     use super::*;
     use crate::hash::sha256;
+
+    struct DurableFailureFetcher;
+
+    #[async_trait]
+    impl ChunkFetcher for DurableFailureFetcher {
+        async fn fetch(&self, hash: &str) -> Result<Vec<u8>> {
+            Err(Error::DurableChunkUnavailable {
+                hash: hash.to_string(),
+                authority: "test-r2".to_string(),
+            })
+        }
+
+        fn name(&self) -> &str {
+            "durable-failure"
+        }
+    }
+
+    struct UnexpectedFallbackFetcher;
+
+    #[async_trait]
+    impl ChunkFetcher for UnexpectedFallbackFetcher {
+        async fn fetch(&self, _hash: &str) -> Result<Vec<u8>> {
+            Ok(b"fallback".to_vec())
+        }
+
+        fn name(&self) -> &str {
+            "unexpected-fallback"
+        }
+    }
 
     #[test]
     fn test_local_cache_path() {
@@ -695,6 +630,65 @@ mod tests {
 
         // Should fail for non-existent chunk
         assert!(composite.fetch("nonexistent").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn composite_preserves_durable_authority_failure_without_fallback() {
+        let composite = CompositeChunkFetcher::with_cache(
+            vec![
+                Arc::new(DurableFailureFetcher),
+                Arc::new(UnexpectedFallbackFetcher),
+            ],
+            tempfile::tempdir().unwrap().path(),
+        );
+
+        let error = composite.fetch("required-hash").await.unwrap_err();
+        assert!(matches!(error, Error::DurableChunkUnavailable { .. }));
+    }
+
+    #[tokio::test]
+    async fn composite_batch_preserves_durable_authority_failure_without_fallback() {
+        let composite = CompositeChunkFetcher::with_cache(
+            vec![
+                Arc::new(DurableFailureFetcher),
+                Arc::new(UnexpectedFallbackFetcher),
+            ],
+            tempfile::tempdir().unwrap().path(),
+        );
+
+        let error = composite
+            .fetch_many(&["required-hash".to_string()])
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::DurableChunkUnavailable { .. }));
+    }
+
+    #[tokio::test]
+    async fn http_fetcher_maps_remi_durable_failure_to_typed_error() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buffer = [0_u8; 1024];
+            let _ = socket.read(&mut buffer).await.unwrap();
+            socket
+                .write_all(
+                    b"HTTP/1.1 503 Service Unavailable\r\nX-Conary-Error: durable-chunk-unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .await
+                .unwrap();
+        });
+
+        let error = HttpChunkFetcher::new(&base_url)
+            .unwrap()
+            .fetch("required-hash")
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::DurableChunkUnavailable { .. }));
+        server.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/conary-core/src/repository/substituter.rs
+++ b/crates/conary-core/src/repository/substituter.rs
@@ -188,6 +188,9 @@ impl SubstituterChain {
                     ));
                 }
                 Err(e) => {
+                    if matches!(e, Error::DurableChunkUnavailable { .. }) {
+                        return Err(e);
+                    }
                     debug!(
                         "Source {} ({}) could not provide chunk {}: {}",
                         idx, name, hash, e
@@ -252,6 +255,9 @@ impl SubstituterChain {
                         newly_resolved.insert((*hash).as_str());
                     }
                     Err(e) => {
+                        if matches!(e, Error::DurableChunkUnavailable { .. }) {
+                            return Err(e);
+                        }
                         debug!("Source {} could not provide chunk {}: {}", name, hash, e);
                     }
                 }

--- a/crates/conary-core/src/repository/substituter/tests.rs
+++ b/crates/conary-core/src/repository/substituter/tests.rs
@@ -81,6 +81,28 @@ async fn spawn_chunk_server(routes: HashMap<String, Vec<u8>>) -> (String, Arc<Mu
     (format!("http://{addr}"), seen_paths)
 }
 
+async fn spawn_durable_failure_server() -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            let mut buffer = [0_u8; 4096];
+            if stream.read(&mut buffer).await.unwrap_or(0) == 0 {
+                continue;
+            }
+            let _ = stream
+                .write_all(
+                    b"HTTP/1.1 503 Service Unavailable\r\nX-Conary-Error: durable-chunk-unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .await;
+        }
+    });
+    format!("http://{addr}")
+}
+
 #[test]
 fn test_chain_ordering() {
     let chain = SubstituterChain::new(vec![
@@ -227,6 +249,47 @@ async fn test_resolve_chunks_falls_through_sources() {
         .unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result.chunks[&hash], b"found-in-second");
+}
+
+#[tokio::test]
+async fn durable_remi_failure_stops_single_source_fallback() {
+    let populated_cache = TempDir::new().unwrap();
+    let hash = sha256(b"must-not-fallback");
+    write_chunk_to_cache(populated_cache.path(), &hash, b"must-not-fallback");
+    let chain = SubstituterChain::new(vec![
+        SubstituterSource::Remi {
+            endpoint: spawn_durable_failure_server().await,
+            distro: "fedora-44".to_string(),
+        },
+        SubstituterSource::LocalCache {
+            cache_dir: populated_cache.path().to_path_buf(),
+        },
+    ]);
+
+    let error = chain.resolve_chunk(&hash, None).await.unwrap_err();
+    assert!(matches!(error, Error::DurableChunkUnavailable { .. }));
+}
+
+#[tokio::test]
+async fn durable_remi_failure_stops_batch_source_fallback() {
+    let populated_cache = TempDir::new().unwrap();
+    let hash = sha256(b"must-not-batch-fallback");
+    write_chunk_to_cache(populated_cache.path(), &hash, b"must-not-batch-fallback");
+    let chain = SubstituterChain::new(vec![
+        SubstituterSource::Remi {
+            endpoint: spawn_durable_failure_server().await,
+            distro: "fedora-44".to_string(),
+        },
+        SubstituterSource::LocalCache {
+            cache_dir: populated_cache.path().to_path_buf(),
+        },
+    ]);
+
+    let error = chain
+        .resolve_chunks(std::slice::from_ref(&hash), None)
+        .await
+        .unwrap_err();
+    assert!(matches!(error, Error::DurableChunkUnavailable { .. }));
 }
 
 #[test]

--- a/deploy/CLOUDFLARE.md
+++ b/deploy/CLOUDFLARE.md
@@ -130,17 +130,20 @@ Update `remi.toml`:
 ```toml
 [r2]
 enabled = true
-account_id = "your-cloudflare-account-id"
 endpoint = "https://your-account-id.r2.cloudflarestorage.com"
 bucket = "conary-chunks"
 prefix = "chunks/"
-write_through = true
 ```
 
-### Inventory and backfill before authority changes
+`enabled = true` makes R2 the durable chunk authority. Remi fails startup if
+the endpoint or credentials cannot initialize the store, writes every converted
+chunk before publication, redirects public chunk reads to presigned R2 URLs,
+and treats local storage only as the `storage.max_cache_size` bounded cache.
 
-Write-through covers only objects stored after it was enabled. Before enabling
-redirect serving or evicting local chunks, use the authenticated
+### Inventory and backfill before enabling R2 authority
+
+An existing deployment may contain objects created before R2 was configured.
+Before enabling R2 authority and bounded local eviction, use the authenticated
 `POST /v1/admin/r2-durability` operation described in
 `docs/guides/self-hosted-remi.md`. Run `mode=plan`, record its exact object and
 byte gap, then explicitly run `mode=apply` and retain the schema-v1 report.

--- a/deploy/remi.toml.example
+++ b/deploy/remi.toml.example
@@ -31,16 +31,10 @@ audit_log = true
 # Recommended: dedicated ZFS pool or XFS partition
 root = "/conary"
 
-# Eviction threshold - start evicting when cache exceeds this ratio of max_cache_size
-eviction_threshold = 0.90
-
-# Minimum age before a chunk is eligible for eviction
-eviction_min_age = "1h"
-
 # TTL for negative cache entries (caches 404 responses to avoid repeated upstream lookups)
 negative_cache_ttl = "15m"
 
-# Maximum cache size
+# Exact maximum local chunk-cache size when R2 is enabled
 # Tune this to the mounted /conary capacity; the production origin currently
 # has dedicated storage, while smaller test hosts should use a lower limit.
 max_cache_size = "700GB"
@@ -57,19 +51,14 @@ max_concurrent = 32
 # See deploy/CLOUDFLARE.md for setup instructions
 enabled = true
 
-# Uncomment and fill in your Cloudflare account details:
-# account_id = "your-cloudflare-account-id"
-# endpoint = "https://your-account-id.r2.cloudflarestorage.com"
+# Required R2 S3 endpoint
+endpoint = "https://your-account-id.r2.cloudflarestorage.com"
 
 # R2 bucket name
 bucket = "conary-chunks"
 
 # Key prefix within the bucket
 prefix = "chunks/"
-
-# Write-through: upload every chunk to R2 immediately after conversion
-# Disable for local-only operation
-write_through = true
 
 # Authentication is via environment variables:
 #   CONARY_R2_ACCESS_KEY - R2 API token access key

--- a/docs/guides/self-hosted-remi.md
+++ b/docs/guides/self-hosted-remi.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-15
-revision: 5
+revision: 6
 summary: Run your own Remi conversion server in about 30 minutes
 ---
 
@@ -55,8 +55,6 @@ audit_log = true
 
 [storage]
 root = "/conary"
-eviction_threshold = 0.90
-eviction_min_age = "1h"
 negative_cache_ttl = "15m"
 max_cache_size = "50GB"
 
@@ -198,10 +196,15 @@ section. Enable it only after the local path works:
 ```toml
 [r2]
 enabled = true
+endpoint = "https://your-account-id.r2.cloudflarestorage.com"
 bucket = "conary-chunks"
 prefix = "chunks/"
-write_through = true
 ```
+
+Enabling R2 is an authority switch, not an optional write mode: startup then
+requires the endpoint and credentials, every converted chunk is durably
+published there, and public chunk reads use presigned R2 redirects. The local
+chunk directory becomes an LRU cache bounded by `storage.max_cache_size`.
 
 Provide credentials through environment variables, not the config file:
 
@@ -237,8 +240,10 @@ curl --fail-with-body \
 
 Archive the schema-v1 response. Only `outcome: "applied_complete"` together
 with `r2_complete: true` proves the required set was present in the fresh R2
-listing after upload. This command does not itself enable R2 redirects or local
-eviction; those remain separate serving-policy changes.
+listing after upload. This command does not itself enable R2 authority. Set
+`r2.enabled = true` only after inventory reports `r2_complete: true`; restarting
+with that setting makes R2 authoritative and activates R2-verified local cache
+eviction.
 
 Host-local automation can submit the same request to
 `http://127.0.0.1:8081/v1/admin/r2-durability` without copying an external

--- a/docs/llms/subsystem-map.md
+++ b/docs/llms/subsystem-map.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-14
-revision: 74
+last_updated: 2026-08-15
+revision: 75
 summary: Route workspace and release boundaries, coherent native inventory adoption, set-based package transaction persistence, typed database rebuilds, generation snapshots and recovery deltas, exact native source identity and adopted-artifact conversion, lossless source authority and trust-import planning, exact Remi signing, selected-root mutation, rollback lineage, canonical-map authority, carrier security, generation GC, and subsystem proof through current feature owners.
 ---
 
@@ -211,8 +211,12 @@ commands.
   wiring and validation start in `apps/remi/src/deployment.rs` and
   `deploy/remi-deploy-helper.sh`. Signed object transport authority starts in
   `crates/conary-core/src/ccs/transport.rs`; Remi persistence begins in
-  `apps/remi/src/server/conversion/storage.rs`, and client CAS reuse begins in
-  `crates/conary-core/src/repository/remi.rs`.
+  `apps/remi/src/server/conversion/storage.rs`. R2 durability and local cache
+  bounds start in `apps/remi/src/server/r2.rs` and
+  `apps/remi/src/server/bounded_cache.rs`; public chunk authority starts in
+  `apps/remi/src/server/handlers/chunks.rs`, and typed client retrieval starts
+  in `crates/conary-core/src/repository/chunk_fetcher.rs`. Client CAS reuse
+  begins in `crates/conary-core/src/repository/remi.rs`.
 - conaryd routes and package jobs: `docs/modules/feature-ownership.md` slug
   `conaryd`, plus `docs/modules/conaryd.md`.
 - Exact-tag release construction, signing, immutable publication, deployment,

--- a/docs/modules/remi.md
+++ b/docs/modules/remi.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-15
-revision: 26
+revision: 27
 summary: Document Remi source identity and update policy, sparse sync, signing, canonical-map, repository trust, database-writer ownership, reproducible conversion profiling, R2 durability inventory, publication, and serving authority
 ---
 
@@ -10,7 +10,7 @@ Remi is Conary's on-demand conversion and package-serving service. For the
 limited public preview, its configured public repository feeds are Fedora 44,
 Ubuntu 26.04, and Arch. It converts upstream RPM, DEB, and Arch packages into
 CCS artifacts, stores converted content in the local content-addressed store,
-and can write chunks through to R2 when configured.
+and publishes every chunk to R2 when that durable authority is configured.
 
 M4d routes every `{distro}` path parameter through repository-feed profile
 validation before DB queries, cache/key filesystem paths, or release-upload
@@ -476,8 +476,9 @@ are regression inputs; they do not weaken verification or storage authority.
 The first committed small/median/multi-GiB baseline and its measured
 optimization are recorded in [performance evidence](../performance/README.md).
 
-When R2 flags are omitted, benchmark JSON records `r2_write_through` as skipped.
-To measure cloud write-through, pass `--r2-endpoint`, `--r2-bucket`,
+When benchmark R2 arguments are omitted, benchmark JSON records the historical
+schema-v1 phase name `r2_write_through` as skipped. To measure cloud durability,
+pass `--r2-endpoint`, `--r2-bucket`,
 `--r2-prefix`, and `--r2-region` with `CONARY_R2_ACCESS_KEY` and
 `CONARY_R2_SECRET_KEY` set in the environment.
 
@@ -541,12 +542,26 @@ and retains a public-sanitized aggregate report with all diagnostic samples
 removed. Apply fails the workflow unless the fresh post-upload report is
 `applied_complete` with `r2_complete: true`.
 
-This inventory/backfill slice does not switch storage authority. Local CAS
-remains durable and R2 remains write-through until #116 separately proves the
-redirect, range, missing-object, eviction-then-install, bounded-cache, and host
-egress acceptance criteria. Operators must not enable `r2_redirect` or evict
-required local objects merely because an apply request was submitted; retain
-the schema-v1 `applied_complete` report as the prerequisite evidence.
+When `[r2].enabled = true`, R2 is the only durable chunk authority. Startup
+requires an explicit endpoint and usable credentials; it does not continue in
+a local-durable mode when R2 initialization fails. Conversion publishes chunks
+to R2 before it publishes converted-package state. Public chunk `GET` requests
+return an R2 presigned redirect, including requests carrying `Range`; `HEAD`
+and missing-object checks query R2. Local presence never masks an absent or
+unreachable R2 object. Such disagreement returns HTTP 503 with the stable
+`x-conary-error: durable-chunk-unavailable` marker, which the core client maps
+to `DurableChunkUnavailable` without trying another repository.
+
+The local chunk directory is a bounded LRU cache owned by
+`apps/remi/src/server/bounded_cache.rs`. Conversion completion and the hourly
+maintenance loop enforce `storage.max_cache_size`; each candidate is checked
+against R2 immediately before unlink. Missing or unreachable durable state
+fails closed, protected objects remain local, and failure to reach the exact
+byte bound is an error. The retired `r2_redirect`, `write_through`,
+`eviction_threshold`, eviction-age, and batch-chunk modes are rejected instead
+of preserving multiple storage policies. With R2 disabled, Remi is an explicit
+local-only deployment and bounded eviction is unavailable because no second
+durable copy exists.
 
 ## MCP
 

--- a/docs/operations/infrastructure.md
+++ b/docs/operations/infrastructure.md
@@ -128,6 +128,12 @@ workflow.
   `apply` fails unless a fresh post-upload R2 listing proves complete, and the
   retained artifact is aggregate `public-sanitized` evidence with diagnostic
   samples removed.
+- After completeness is established, `[r2].enabled = true` is the single
+  authority switch: startup requires usable R2 configuration, public chunk
+  reads use presigned redirects, and local chunks are an R2-verified LRU cache
+  bounded by `storage.max_cache_size`. Missing durable objects fail closed;
+  operators do not restore retired redirect, write-through, threshold, or age
+  flags.
 - Conary release artifact publication through the same helper verifies the
   CI-produced `SHA256SUMS` file from the staging directory before installing
   files into `/conary/releases/<version>`. The helper copies that verified


### PR DESCRIPTION
Refs #116

## Problem

Remi currently treats the local CAS as durable and R2 as a configurable copy. The redirect and eviction flags describe multiple modes, some are ignored, missing R2 objects can fall back locally, and the TTL eviction path can delete without proving another durable copy. That prevents R2 from being a real authority and leaves host disk and egress as scaling ceilings.

## Change

- make `r2.enabled = true` the single durable-authority switch, require an endpoint and credentials, probe the bucket before startup, and distinguish 404 from R2 authorization/service failures;
- publish conversion objects to R2 before cache bookkeeping or converted-package state, then enforce the exact local byte bound;
- serve published GETs through presigned 307 redirects, query R2 for HEAD and missing-object checks, and return a stable typed 503 when durable state disagrees;
- preserve that typed failure through HTTP, composite, batch, and substituter client paths without backend fallback;
- add one serialized R2-verified LRU eviction owner that selects only the byte prefix needed, verifies each object immediately before unlink, preserves local bytes on R2 failure, and errors if protected objects prevent the bound;
- delete the batch-fetch, TTL eviction, redirect-mode, write-through-mode, threshold, age, and account-id compatibility surfaces;
- make deployment preparation remove those retired keys recoverably and update canonical/operator routing and authority documentation.

## Verification

- `cargo test -p remi` — 640 library, 5 binary, and 3 CLI tests passed; doctests passed
- `cargo test -p remi bounded_cache` — 4 passed
- `cargo test -p remi server::r2::tests` — 16 passed
- `cargo test -p remi server::handlers::chunks::tests` — 14 passed
- `cargo test -p remi server::config::tests` — 19 passed
- `cargo test -p remi deployment` — 5 passed
- `cargo test -p conary-core repository::chunk_fetcher` — 11 passed
- `cargo test -p conary-core repository::substituter` — 19 passed
- `cargo test -p conary-core db::models::chunk_access` — 7 passed
- `cargo test -p conary --test conversion_integration golden_conversion` — 4 passed
- `cargo test -p conary --test packaging_m4c` — 1 passed
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `bash scripts/check-doc-truth.sh`

## Remaining terminal proof

Keep this PR in draft until the exact head passes review and CI. After merge, #116 still requires protected production deployment plus real redirect install, range behavior if exercised, missing-R2 typed failure, eviction-then-install, sustained conversion bound, host egress measurement, health, and post-merge validation. This PR therefore references rather than closes the issue.
