### PR TITLE
perf(remi): bound parallel durable object publication

### DIFF
--- a/apps/remi/src/server/conversion/storage.rs
+++ b/apps/remi/src/server/conversion/storage.rs
@@ -2,13 +2,20 @@
 //! Signed CCS object persistence and durable R2 publication.
 
 use super::ConversionService;
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, ensure};
+use async_trait::async_trait;
 use conary_core::ccs::convert::ConversionResult;
+use conary_core::ccs::transport::CcsTransportObjectV1;
 use conary_core::db::models::ChunkAccess;
 use conary_core::filesystem::{CasStore, VerifiedObjectBatchMetrics, object_path};
+use futures::{StreamExt, stream};
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::path::Path;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
+
+const R2_PUBLICATION_CONCURRENCY: usize = 16;
 
 pub(super) struct StoredTransport {
     pub(super) transport: conary_core::ccs::CcsTransportEnvelopeV1,
@@ -17,6 +24,98 @@ pub(super) struct StoredTransport {
     pub(super) cas_metrics: VerifiedObjectBatchMetrics,
     pub(super) r2_duration: Option<Duration>,
     pub(super) r2_work: crate::server::conversion_timing::ConversionR2Work,
+}
+
+#[async_trait]
+trait ConversionChunkStore: Send + Sync {
+    async fn head_chunk(&self, hash: &str) -> Result<bool>;
+    async fn put_chunk(&self, hash: &str, data: &[u8]) -> Result<()>;
+}
+
+#[async_trait]
+impl ConversionChunkStore for crate::server::R2Store {
+    async fn head_chunk(&self, hash: &str) -> Result<bool> {
+        crate::server::R2Store::head_chunk(self, hash).await
+    }
+
+    async fn put_chunk(&self, hash: &str, data: &[u8]) -> Result<()> {
+        crate::server::R2Store::put_chunk(self, hash, data).await
+    }
+}
+
+async fn publish_transport_objects<S: ConversionChunkStore + ?Sized + 'static>(
+    store: Arc<S>,
+    objects_dir: &Path,
+    objects: &[CcsTransportObjectV1],
+    concurrency: usize,
+) -> Result<crate::server::conversion_timing::ConversionR2Work> {
+    ensure!(
+        concurrency > 0,
+        "R2 publication concurrency must be positive"
+    );
+
+    let objects_dir = objects_dir.to_path_buf();
+    let outcomes = stream::iter(objects.iter().cloned())
+        .map(|object| {
+            let store = Arc::clone(&store);
+            let objects_dir = objects_dir.clone();
+            async move {
+                let mut work = crate::server::conversion_timing::ConversionR2Work {
+                    head_requests: 1,
+                    ..Default::default()
+                };
+                if store.head_chunk(&object.sha256).await? {
+                    work.hits = 1;
+                    return Ok(work);
+                }
+
+                work.misses = 1;
+                let path = object_path(&objects_dir, &object.sha256)?;
+                let data = tokio::fs::read(&path)
+                    .await
+                    .with_context(|| format!("read signed CCS object {}", object.sha256))?;
+                conary_core::hash::verify_sha256(&data, &object.sha256)?;
+                store.put_chunk(&object.sha256, &data).await?;
+                work.put_requests = 1;
+                work.bytes_written = object.size;
+                Ok::<_, anyhow::Error>(work)
+            }
+        })
+        .buffer_unordered(concurrency)
+        .collect::<Vec<_>>()
+        .await;
+
+    outcomes.into_iter().try_fold(
+        crate::server::conversion_timing::ConversionR2Work::default(),
+        |mut total, outcome| {
+            let work = outcome?;
+            total.head_requests += work.head_requests;
+            total.hits += work.hits;
+            total.misses += work.misses;
+            total.put_requests += work.put_requests;
+            total.bytes_written += work.bytes_written;
+            Ok(total)
+        },
+    )
+}
+
+async fn publish_transport_objects_then<S, F, Fut>(
+    store: Arc<S>,
+    objects_dir: &Path,
+    objects: &[CcsTransportObjectV1],
+    concurrency: usize,
+    after_durable_publication: F,
+) -> Result<(Duration, crate::server::conversion_timing::ConversionR2Work)>
+where
+    S: ConversionChunkStore + ?Sized + 'static,
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<()>>,
+{
+    let started = Instant::now();
+    let work = publish_transport_objects(store, objects_dir, objects, concurrency).await?;
+    let duration = started.elapsed();
+    after_durable_publication().await?;
+    Ok((duration, work))
 }
 
 impl ConversionService {
@@ -84,34 +183,26 @@ impl ConversionService {
         let cas_duration = cas_started.elapsed();
         let cas_metrics = verified_set.metrics();
 
-        let mut r2_work = crate::server::conversion_timing::ConversionR2Work::default();
-        let r2_duration = if let Some(r2) = self.r2_store.clone() {
-            let started = Instant::now();
-            for object in &transport.objects {
-                r2_work.head_requests += 1;
-                if r2.head_chunk(&object.sha256).await? {
-                    r2_work.hits += 1;
-                    continue;
-                }
-                r2_work.misses += 1;
-                let path = object_path(&objects_dir, &object.sha256)?;
-                let data = tokio::fs::read(&path)
-                    .await
-                    .with_context(|| format!("read signed CCS object {}", object.sha256))?;
-                conary_core::hash::verify_sha256(&data, &object.sha256)?;
-                r2.put_chunk(&object.sha256, &data).await?;
-                r2_work.put_requests += 1;
-                r2_work.bytes_written += object.size;
-            }
-            Some(started.elapsed())
-        } else {
-            None
-        };
-
-        // Publish cache bookkeeping only after the durable write succeeds. A
+        // Publish cache bookkeeping only after every durable write succeeds. A
         // failed R2 write must not leave a non-evictable local-only cache row.
         // The upsert also refreshes the GC grace authority for CAS hits.
-        self.persist_chunk_sizes(&exact_sizes).await?;
+        let (r2_duration, r2_work) = if let Some(r2) = self.r2_store.clone() {
+            let (duration, work) = publish_transport_objects_then(
+                r2,
+                &objects_dir,
+                &transport.objects,
+                R2_PUBLICATION_CONCURRENCY,
+                || self.persist_chunk_sizes(&exact_sizes),
+            )
+            .await?;
+            (Some(duration), work)
+        } else {
+            self.persist_chunk_sizes(&exact_sizes).await?;
+            (
+                None,
+                crate::server::conversion_timing::ConversionR2Work::default(),
+            )
+        };
 
         if let (Some(r2), Some(bounded_cache)) = (&self.r2_store, &self.bounded_cache) {
             bounded_cache
@@ -174,6 +265,83 @@ impl ConversionService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    struct InFlight<'a>(&'a AtomicUsize);
+
+    impl Drop for InFlight<'_> {
+        fn drop(&mut self) {
+            self.0.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    #[derive(Default)]
+    struct InjectedStore {
+        hits: HashSet<String>,
+        failed_put: Option<String>,
+        current: AtomicUsize,
+        maximum: AtomicUsize,
+        completed: AtomicUsize,
+        uploaded: Mutex<Vec<String>>,
+    }
+
+    impl InjectedStore {
+        fn enter(&self) -> InFlight<'_> {
+            let current = self.current.fetch_add(1, Ordering::SeqCst) + 1;
+            self.maximum.fetch_max(current, Ordering::SeqCst);
+            InFlight(&self.current)
+        }
+
+        async fn overlap(&self, hash: &str) {
+            let delay = 1 + usize::from(hash.as_bytes()[0]) % 4;
+            tokio::time::sleep(Duration::from_millis(delay as u64)).await;
+        }
+    }
+
+    #[async_trait]
+    impl ConversionChunkStore for InjectedStore {
+        async fn head_chunk(&self, hash: &str) -> Result<bool> {
+            let _in_flight = self.enter();
+            self.overlap(hash).await;
+            let hit = self.hits.contains(hash);
+            if hit {
+                self.completed.fetch_add(1, Ordering::SeqCst);
+            }
+            Ok(hit)
+        }
+
+        async fn put_chunk(&self, hash: &str, _data: &[u8]) -> Result<()> {
+            let _in_flight = self.enter();
+            self.overlap(hash).await;
+            self.uploaded.lock().unwrap().push(hash.to_string());
+            self.completed.fetch_add(1, Ordering::SeqCst);
+            ensure!(
+                self.failed_put.as_deref() != Some(hash),
+                "injected PUT failure for {hash}"
+            );
+            Ok(())
+        }
+    }
+
+    fn stored_objects(
+        objects_dir: &Path,
+        count: usize,
+    ) -> (Vec<CcsTransportObjectV1>, Vec<Vec<u8>>) {
+        let cas = CasStore::new(objects_dir).unwrap();
+        let payloads = (0..count)
+            .map(|index| format!("parallel publication object {index}").into_bytes())
+            .collect::<Vec<_>>();
+        let objects = payloads
+            .iter()
+            .map(|payload| CcsTransportObjectV1 {
+                sha256: cas.store(payload).unwrap(),
+                size: payload.len() as u64,
+            })
+            .collect();
+        (objects, payloads)
+    }
 
     #[test]
     fn calculated_sha256_is_typed_and_serializes_with_algorithm() {
@@ -191,5 +359,82 @@ mod tests {
     #[test]
     fn calculate_sha256_rejects_a_missing_file() {
         assert!(ConversionService::calculate_sha256(Path::new("/nonexistent/file.pkg")).is_err());
+    }
+
+    #[tokio::test]
+    async fn r2_publication_is_bounded_and_accounts_for_out_of_order_work() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let (objects, payloads) = stored_objects(temp.path(), 9);
+        let hit_hashes = [objects[1].sha256.clone(), objects[7].sha256.clone()];
+        let store = Arc::new(InjectedStore {
+            hits: hit_hashes.into_iter().collect(),
+            ..Default::default()
+        });
+        let bookkeeping_ran = Arc::new(AtomicBool::new(false));
+        let object_count = objects.len();
+
+        let (duration, work) =
+            publish_transport_objects_then(Arc::clone(&store), temp.path(), &objects, 3, {
+                let store = Arc::clone(&store);
+                let bookkeeping_ran = Arc::clone(&bookkeeping_ran);
+                move || async move {
+                    assert_eq!(store.current.load(Ordering::SeqCst), 0);
+                    assert_eq!(store.completed.load(Ordering::SeqCst), object_count);
+                    bookkeeping_ran.store(true, Ordering::SeqCst);
+                    Ok(())
+                }
+            })
+            .await
+            .unwrap();
+
+        assert!(duration > Duration::ZERO);
+        assert!(bookkeeping_ran.load(Ordering::SeqCst));
+        assert!(store.maximum.load(Ordering::SeqCst) > 1);
+        assert!(store.maximum.load(Ordering::SeqCst) <= 3);
+        assert_eq!(work.head_requests, objects.len() as u64);
+        assert_eq!(work.hits, 2);
+        assert_eq!(work.misses, 7);
+        assert_eq!(work.put_requests, 7);
+        let expected_bytes = objects
+            .iter()
+            .zip(&payloads)
+            .filter(|(object, _)| !store.hits.contains(&object.sha256))
+            .map(|(_, payload)| payload.len() as u64)
+            .sum::<u64>();
+        assert_eq!(work.bytes_written, expected_bytes);
+        assert_eq!(store.uploaded.lock().unwrap().len(), 7);
+    }
+
+    #[tokio::test]
+    async fn r2_publication_failure_prevents_bookkeeping() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let (objects, _) = stored_objects(temp.path(), 6);
+        let failed_hash = objects[3].sha256.clone();
+        let store = Arc::new(InjectedStore {
+            failed_put: Some(failed_hash.clone()),
+            ..Default::default()
+        });
+        let bookkeeping_ran = Arc::new(AtomicBool::new(false));
+
+        let result =
+            publish_transport_objects_then(Arc::clone(&store), temp.path(), &objects, 2, {
+                let bookkeeping_ran = Arc::clone(&bookkeeping_ran);
+                move || async move {
+                    bookkeeping_ran.store(true, Ordering::SeqCst);
+                    Ok(())
+                }
+            })
+            .await;
+
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains(&format!("injected PUT failure for {failed_hash}"))
+        );
+        assert!(!bookkeeping_ran.load(Ordering::SeqCst));
+        assert_eq!(store.current.load(Ordering::SeqCst), 0);
+        assert_eq!(store.completed.load(Ordering::SeqCst), objects.len());
+        assert!(store.maximum.load(Ordering::SeqCst) <= 2);
     }
 }

--- a/docs/modules/ccs.md
+++ b/docs/modules/ccs.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-13
-revision: 63
+revision: 64
 summary: Convert direct and exactly re-resolved adopted foreign packages through lossless source authority, typed authoring, host capability, lifecycle, and native export contracts
 ---
 
@@ -191,6 +191,14 @@ trusted permanent-CAS hits, fetches only misses, verifies the complete set, and
 reconstructs a deterministic temporary carrier for the existing install
 boundary. Update uses the same resolver path, while rollback reuses generation
 authority and never reacquires repository objects.
+
+Remi durably publishes one converted transport with at most 16 object tasks in
+flight. Each task checks R2, and a miss reads and re-verifies the canonical
+local CAS object before its PUT. Remi waits for the complete bounded set and
+publishes chunk-size/cache bookkeeping only after every required object is
+durable; any HEAD, read, hash, or PUT failure rejects the conversion before
+that bookkeeping boundary. The bound limits retained upload data to at most 16
+canonical chunks while removing per-object network round-trip serialization.
 
 RPM header arrays own installed metadata while the paired CPIO member owns
 bytes. RPM `FILEUSERNAME` and `FILEGROUPNAME` remain source identities.


### PR DESCRIPTION
## Problem

Cold converted-package publication serialized one R2 HEAD and optional PUT chain per signed CCS object. Production #116 acceptance measured R2 write-through at 400,920 ms of 425,056 ms for a 1,713-object conversion and 128,922 ms of 145,600 ms for a 529-object conversion.

## Change

- publish a converted transport through at most 16 in-flight object tasks;
- retain local CAS read and exact SHA-256 verification inside each bounded task;
- collect exact HEAD/hit/miss/PUT/byte work independent of completion order;
- wait for the complete object set and fail on any object error before publishing chunk-size/cache bookkeeping;
- document the concurrency and authority boundary;
- inject a deterministic store to prove the ceiling and failure ordering.

This does not change chunk identity, signing, transport verification, deterministic CCS bytes, or R2's role as mandatory durable authority.

## Verification

- `cargo test -p remi server::conversion::storage::tests -- --nocapture` — 4 passed
- `cargo test -p remi conversion` — 79 passed, 0 failed
- `cargo test -p remi` — 642 library + 5 binary + 3 CLI tests passed
- `cargo test -p conary --test conversion_integration golden_conversion` — 4 passed
- sparse-authoring RSS gate — 33,532 KiB, passed under 256 MiB ceiling
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo test --workspace` — passed with zero failures
- `bash scripts/check-doc-truth.sh` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- all 21 hosted PR checks — passed on exact head `70fd70acd21d20254305fa2d4b295ac10d2ab010`

Exact after-deployment production evidence will be attached before #451 closes.

Refs #451
Refs #116
Refs #121
Refs #150
