### PR TITLE
feat(corpus): make semantic coverage attributable

### DIFF
--- a/apps/conary-test/src/cli.rs
+++ b/apps/conary-test/src/cli.rs
@@ -552,6 +552,7 @@ fn run_single_distro(
                     )
                     .await?;
                 aggregate_suite.expect_corpus_cases(suite.corpus_expected());
+                aggregate_suite.expect_corpus_coverage(suite.corpus_required().iter().copied());
                 for result in suite.results {
                     aggregate_suite.record(result);
                 }
@@ -653,6 +654,7 @@ async fn run_qemu_only_suite(
                 )
                 .await?;
             aggregate_suite.expect_corpus_cases(suite.corpus_expected());
+            aggregate_suite.expect_corpus_coverage(suite.corpus_required().iter().copied());
             for result in suite.results {
                 aggregate_suite.record(result);
             }

--- a/apps/conary-test/src/config/corpus.rs
+++ b/apps/conary-test/src/config/corpus.rs
@@ -3,7 +3,9 @@
 //! Persisted declarations for attributable just-works corpus cases.
 
 use anyhow::{Result, bail};
-use conary_core::corpus::{ConversionStage, SourceArtifactDigestSource};
+use conary_core::corpus::{
+    ConversionStage, CorpusSemantic, SourceArtifactDigestSource, SourceArtifactRole,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::{Component, Path};
@@ -36,6 +38,33 @@ pub struct CorpusTargetDef {
     pub capabilities: Vec<String>,
 }
 
+/// Suite-level semantic properties that its cases must collectively claim.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CorpusSuiteDef {
+    pub required: Vec<CorpusSemantic>,
+}
+
+impl CorpusSuiteDef {
+    pub fn validate(&self) -> Result<()> {
+        if self.required.is_empty() {
+            bail!("suite corpus required coverage must not be empty");
+        }
+        if !self.required.windows(2).all(|items| items[0] < items[1]) {
+            bail!("suite corpus required coverage must be unique and canonically ordered");
+        }
+        Ok(())
+    }
+}
+
+/// One persisted semantic claim bound to exact runtime artifact roles.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CorpusCoverageClaimDef {
+    pub semantic: CorpusSemantic,
+    pub artifact_roles: Vec<SourceArtifactRole>,
+}
+
 /// Manifest-owned authority for one attributable corpus case.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -46,6 +75,7 @@ pub struct CorpusCaseDef {
     pub source_format: CorpusSourceFormat,
     pub digest_source: SourceArtifactDigestSource,
     pub target: CorpusTargetDef,
+    pub coverage: Vec<CorpusCoverageClaimDef>,
     /// Declared journey stages in their canonical execution order.
     pub stages: Vec<ConversionStage>,
 }
@@ -93,6 +123,37 @@ impl CorpusCaseDef {
                 context()
             );
         }
+        if self.coverage.is_empty() {
+            bail!(
+                "{}: at least one semantic coverage claim is required",
+                context()
+            );
+        }
+        if !self
+            .coverage
+            .windows(2)
+            .all(|claims| claims[0].semantic < claims[1].semantic)
+        {
+            bail!(
+                "{}: semantic coverage claims must be unique and canonically ordered",
+                context()
+            );
+        }
+        for claim in &self.coverage {
+            if claim.artifact_roles.is_empty() {
+                bail!("{}: coverage artifact_roles must not be empty", context());
+            }
+            if !claim
+                .artifact_roles
+                .windows(2)
+                .all(|roles| roles[0] < roles[1])
+            {
+                bail!(
+                    "{}: coverage artifact_roles must be unique and canonically ordered",
+                    context()
+                );
+            }
+        }
         Ok(())
     }
 }
@@ -112,6 +173,10 @@ mod tests {
                 init_system: "systemd".into(),
                 capabilities: vec!["native_lifecycle".into()],
             },
+            coverage: vec![CorpusCoverageClaimDef {
+                semantic: CorpusSemantic::IdentityExactVersion,
+                artifact_roles: vec![SourceArtifactRole::InstallRequest],
+            }],
             stages: vec![
                 ConversionStage::Installation,
                 ConversionStage::Update,
@@ -174,5 +239,44 @@ capabilities = ["native_lifecycle"]
         let mut case = valid_case();
         case.stages = vec![ConversionStage::Rollback, ConversionStage::Update];
         assert!(case.validate("TC01").is_err());
+    }
+
+    #[test]
+    fn empty_or_duplicate_coverage_is_rejected() {
+        let mut case = valid_case();
+        case.coverage.clear();
+        assert!(case.validate("TC01").is_err());
+
+        let mut case = valid_case();
+        case.coverage.push(case.coverage[0].clone());
+        assert!(case.validate("TC01").is_err());
+
+        let mut case = valid_case();
+        case.coverage[0]
+            .artifact_roles
+            .push(SourceArtifactRole::InstallRequest);
+        assert!(case.validate("TC01").is_err());
+    }
+
+    #[test]
+    fn suite_requirements_are_nonempty_and_unique() {
+        assert!(
+            CorpusSuiteDef {
+                required: vec![CorpusSemantic::IdentityExactVersion]
+            }
+            .validate()
+            .is_ok()
+        );
+        assert!(CorpusSuiteDef { required: vec![] }.validate().is_err());
+        assert!(
+            CorpusSuiteDef {
+                required: vec![
+                    CorpusSemantic::IdentityExactVersion,
+                    CorpusSemantic::IdentityExactVersion,
+                ]
+            }
+            .validate()
+            .is_err()
+        );
     }
 }

--- a/apps/conary-test/src/config/manifest.rs
+++ b/apps/conary-test/src/config/manifest.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{Result, bail};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Top-level test manifest (one TOML file = one suite).
 #[derive(Debug, Clone, Deserialize)]
@@ -27,6 +27,9 @@ pub struct SuiteDef {
     /// complete within this duration or remaining tests are cancelled.
     #[serde(default)]
     pub timeout: Option<u64>,
+    /// Required typed semantic coverage for corpus suites.
+    #[serde(default)]
+    pub corpus: Option<super::corpus::CorpusSuiteDef>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -438,6 +441,33 @@ impl Assertion {
 impl TestManifest {
     /// Validate all assertions in the manifest for conflicting fields.
     pub fn validate(&self) -> Result<()> {
+        let corpus_tests = self
+            .test
+            .iter()
+            .filter_map(|test| test.corpus.as_ref())
+            .collect::<Vec<_>>();
+        match (&self.suite.corpus, corpus_tests.is_empty()) {
+            (None, true) => {}
+            (None, false) => bail!("corpus tests require suite-level semantic coverage"),
+            (Some(_), true) => bail!("suite corpus coverage requires at least one corpus test"),
+            (Some(corpus), false) => {
+                corpus.validate()?;
+                let required = corpus.required.iter().copied().collect::<HashSet<_>>();
+                let claimed = corpus_tests
+                    .iter()
+                    .flat_map(|case| case.coverage.iter().map(|claim| claim.semantic))
+                    .collect::<HashSet<_>>();
+                if claimed != required {
+                    let mut missing = required.difference(&claimed).copied().collect::<Vec<_>>();
+                    let mut undeclared = claimed.difference(&required).copied().collect::<Vec<_>>();
+                    missing.sort();
+                    undeclared.sort();
+                    bail!(
+                        "suite corpus coverage and case claims disagree: missing={missing:?}, undeclared={undeclared:?}"
+                    );
+                }
+            }
+        }
         for test in &self.test {
             if let Some(corpus) = &test.corpus {
                 corpus.validate(&test.id)?;
@@ -471,6 +501,40 @@ impl TestManifest {
 mod validation_tests {
     use super::*;
 
+    fn corpus_manifest(suite_corpus: &str, semantic: &str) -> TestManifest {
+        toml::from_str(&format!(
+            r#"
+[suite]
+name = "corpus"
+phase = 4
+{suite_corpus}
+
+[[test]]
+id = "TC01"
+name = "corpus"
+description = "typed corpus"
+timeout = 30
+
+[test.corpus]
+evidence_path = "/tmp/corpus.json"
+source_profile = "fedora-44"
+source_format = "rpm"
+digest_source = "fixture_build_manifest"
+stages = ["installation"]
+
+[test.corpus.target]
+architecture = "x86_64"
+init_system = "systemd"
+capabilities = ["native_lifecycle"]
+
+[[test.corpus.coverage]]
+semantic = "{semantic}"
+artifact_roles = ["install_request"]
+"#
+        ))
+        .unwrap()
+    }
+
     fn base_assertion() -> Assertion {
         Assertion::default()
     }
@@ -481,6 +545,44 @@ mod validation_tests {
         a.exit_code = Some(0);
         a.stdout_contains = Some("ok".into());
         assert!(a.validate("T01", 0).is_ok());
+    }
+
+    #[test]
+    fn corpus_cases_require_exact_suite_coverage_authority() {
+        let missing_suite = corpus_manifest("", "identity_exact_version");
+        assert!(missing_suite.validate().is_err());
+
+        let mismatched = corpus_manifest(
+            "[suite.corpus]\nrequired = [\"payload_files\"]",
+            "identity_exact_version",
+        );
+        let error = mismatched.validate().unwrap_err().to_string();
+        assert!(error.contains("coverage and case claims disagree"));
+
+        let exact = corpus_manifest(
+            "[suite.corpus]\nrequired = [\"identity_exact_version\"]",
+            "identity_exact_version",
+        );
+        assert!(exact.validate().is_ok());
+    }
+
+    #[test]
+    fn unknown_free_form_semantic_is_not_deserializable() {
+        let source = r#"
+[suite]
+name = "corpus"
+phase = 4
+
+[suite.corpus]
+required = ["package_seems_complex"]
+
+[[test]]
+id = "TC01"
+name = "corpus"
+description = "typed corpus"
+timeout = 30
+"#;
+        assert!(toml::from_str::<TestManifest>(source).is_err());
     }
 
     #[test]

--- a/apps/conary-test/src/config/mod.rs
+++ b/apps/conary-test/src/config/mod.rs
@@ -60,4 +60,6 @@ pub fn validate_unique_test_ids(manifests: &[(PathBuf, TestManifest)]) -> Result
 
 #[cfg(test)]
 mod tests;
-pub use corpus::{CorpusCaseDef, CorpusSourceFormat, CorpusTargetDef};
+pub use corpus::{
+    CorpusCaseDef, CorpusCoverageClaimDef, CorpusSourceFormat, CorpusSuiteDef, CorpusTargetDef,
+};

--- a/apps/conary-test/src/config/tests.rs
+++ b/apps/conary-test/src/config/tests.rs
@@ -40,6 +40,7 @@ fn minimal_manifest_with_id(id: &str) -> TestManifest {
             setup: Vec::new(),
             mock_server: None,
             timeout: None,
+            corpus: None,
         },
         test: vec![manifest::TestDef {
             id: id.to_string(),
@@ -777,6 +778,20 @@ fn focused_native_cross_source_manifest_runs_the_shared_lifecycle_contract() {
     let manifest = load_manifest(&path).expect("load focused native lifecycle manifest");
     assert_eq!(manifest.suite.phase, 4);
     assert_eq!(manifest.test.len(), 4);
+    assert_eq!(
+        manifest
+            .suite
+            .corpus
+            .as_ref()
+            .expect("suite coverage authority")
+            .required,
+        [
+            conary_core::corpus::CorpusSemantic::IdentityExactVersion,
+            conary_core::corpus::CorpusSemantic::IdentityNativeArchitecture,
+            conary_core::corpus::CorpusSemantic::PayloadFiles,
+            conary_core::corpus::CorpusSemantic::LifecycleShell,
+        ]
+    );
     for (test, expected_id, expected_profile, expected_format) in [
         (&manifest.test[0], "TNPMX01R", "fedora-44", "rpm"),
         (&manifest.test[1], "TNPMX01D", "ubuntu-26.04", "deb"),
@@ -795,6 +810,12 @@ fn focused_native_cross_source_manifest_runs_the_shared_lifecycle_contract() {
             conary_core::corpus::SourceArtifactDigestSource::FixtureBuildManifest
         );
         assert_eq!(corpus.stages.len(), 4);
+        assert_eq!(corpus.coverage.len(), 4);
+        assert!(corpus.coverage.iter().all(|claim| claim.artifact_roles
+            == [
+                conary_core::corpus::SourceArtifactRole::InstallRequest,
+                conary_core::corpus::SourceArtifactRole::UpdateRequest,
+            ]));
 
         let rendered = format!("{test:?}");
         assert!(

--- a/apps/conary-test/src/engine/corpus.rs
+++ b/apps/conary-test/src/engine/corpus.rs
@@ -7,8 +7,8 @@ use crate::container::backend::{ContainerBackend, ContainerId};
 use crate::engine::suite::TestStatus;
 use anyhow::{Result, bail};
 use conary_core::corpus::{
-    ConversionFailure, ConversionStage, CorpusCaseResult, CorpusOutcome, SourceArtifactIdentity,
-    SourceProfileIdentity, StageResult, TargetCapabilitySnapshot,
+    ConversionFailure, ConversionStage, CorpusCaseResult, CorpusCoverageClaim, CorpusOutcome,
+    SourceArtifactIdentity, SourceProfileIdentity, StageResult, TargetCapabilitySnapshot,
 };
 use serde::Deserialize;
 use std::collections::HashSet;
@@ -108,6 +108,7 @@ pub async fn capture_case(
         source_profile(definition),
         evidence.source_artifacts,
         target_snapshot(definition, target_profile),
+        coverage_claims(definition),
         stages,
     )
 }
@@ -172,6 +173,23 @@ fn validate_evidence(
             bail!("runtime artifact digest source contradicts the corpus declaration");
         }
     }
+    for claim in &definition.coverage {
+        for role in &claim.artifact_roles {
+            if evidence
+                .source_artifacts
+                .iter()
+                .filter(|artifact| artifact.role == *role)
+                .count()
+                != 1
+            {
+                bail!(
+                    "corpus coverage {:?} does not resolve role {:?} to one exact source artifact",
+                    claim.semantic,
+                    role
+                );
+            }
+        }
+    }
     if definition.stages.contains(&ConversionStage::Installation)
         && !request_roles.contains(&conary_core::corpus::SourceArtifactRole::InstallRequest)
     {
@@ -230,6 +248,7 @@ fn evidence_failure_case(
         source_profile(definition),
         source_artifacts,
         target_snapshot(definition, target_profile),
+        Vec::new(),
         stages,
     )
 }
@@ -245,6 +264,7 @@ fn skipped_case(
         source_profile(definition),
         Vec::new(),
         target_snapshot(definition, target_profile),
+        Vec::new(),
         definition
             .stages
             .iter()
@@ -283,11 +303,24 @@ fn target_snapshot(definition: &CorpusCaseDef, target_profile: &str) -> TargetCa
     }
 }
 
+fn coverage_claims(definition: &CorpusCaseDef) -> Vec<CorpusCoverageClaim> {
+    definition
+        .coverage
+        .iter()
+        .map(|claim| CorpusCoverageClaim {
+            semantic: claim.semantic,
+            artifact_roles: claim.artifact_roles.clone(),
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::corpus::{CorpusSourceFormat, CorpusTargetDef};
-    use conary_core::corpus::{FailureKind, SourceArtifactDigestSource, SourceArtifactRole};
+    use crate::config::corpus::{CorpusCoverageClaimDef, CorpusSourceFormat, CorpusTargetDef};
+    use conary_core::corpus::{
+        CorpusSemantic, FailureKind, SourceArtifactDigestSource, SourceArtifactRole,
+    };
 
     fn definition() -> CorpusCaseDef {
         CorpusCaseDef {
@@ -300,6 +333,13 @@ mod tests {
                 init_system: "systemd".into(),
                 capabilities: vec!["native_lifecycle".into()],
             },
+            coverage: vec![CorpusCoverageClaimDef {
+                semantic: CorpusSemantic::LifecycleShell,
+                artifact_roles: vec![
+                    SourceArtifactRole::InstallRequest,
+                    SourceArtifactRole::UpdateRequest,
+                ],
+            }],
             stages: vec![
                 ConversionStage::Installation,
                 ConversionStage::Update,
@@ -395,6 +435,25 @@ mod tests {
             active_stage: None,
         };
         assert!(validate_evidence(&definition(), TestStatus::Passed, &evidence).is_err());
+    }
+
+    #[test]
+    fn semantic_claims_require_one_exact_runtime_artifact_per_role() {
+        let mut definition = definition();
+        definition.coverage[0].artifact_roles = vec![SourceArtifactRole::InstallDependency];
+        let evidence = CorpusRuntimeEvidence {
+            schema_version: EVIDENCE_SCHEMA_VERSION,
+            source_profile: "fedora-44".into(),
+            source_format: "rpm".into(),
+            source_artifacts: artifacts(),
+            completed_stages: definition.stages.clone(),
+            active_stage: None,
+        };
+
+        let error = validate_evidence(&definition, TestStatus::Passed, &evidence)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("does not resolve role"));
     }
 
     #[test]

--- a/apps/conary-test/src/engine/runner.rs
+++ b/apps/conary-test/src/engine/runner.rs
@@ -189,6 +189,13 @@ impl TestRunner {
                 .filter(|test| test.corpus.is_some())
                 .count(),
         );
+        suite.expect_corpus_coverage(
+            manifest
+                .suite
+                .corpus
+                .iter()
+                .flat_map(|corpus| corpus.required.iter().copied()),
+        );
         suite.status = crate::engine::suite::RunStatus::Running;
 
         // Emit suite-started event.

--- a/apps/conary-test/src/engine/runner/tests.rs
+++ b/apps/conary-test/src/engine/runner/tests.rs
@@ -105,6 +105,7 @@ fn make_manifest(tests: Vec<TestDef>) -> TestManifest {
             setup: Vec::new(),
             mock_server: None,
             timeout: None,
+            corpus: None,
         },
         test: tests,
         distro_overrides: HashMap::new(),
@@ -178,6 +179,7 @@ async fn suite_setup_executes_before_tests() {
             )],
             mock_server: None,
             timeout: None,
+            corpus: None,
         },
         test: vec![TestDef {
             id: "TSETUP".to_string(),
@@ -588,6 +590,7 @@ async fn test_resource_scoped_flaky_retries_use_fresh_container() {
             setup: Vec::new(),
             mock_server: None,
             timeout: None,
+            corpus: None,
         },
         test: vec![TestDef {
             id: "T-resource-flaky".to_string(),

--- a/apps/conary-test/src/engine/runner/tests/controls.rs
+++ b/apps/conary-test/src/engine/runner/tests/controls.rs
@@ -317,6 +317,7 @@ async fn test_suite_timeout_cancels_remaining() {
             setup: Vec::new(),
             mock_server: None,
             timeout: Some(0), // Already expired.
+            corpus: None,
         },
         test: vec![
             TestDef {

--- a/apps/conary-test/src/engine/suite.rs
+++ b/apps/conary-test/src/engine/suite.rs
@@ -75,6 +75,8 @@ pub struct TestSuite {
     pub target_release: Option<crate::config::release_root::TargetReleaseEvidence>,
     #[serde(skip)]
     corpus_expected: usize,
+    #[serde(skip)]
+    corpus_required: Vec<conary_core::corpus::CorpusSemantic>,
     pub started_at: DateTime<Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub finished_at: Option<DateTime<Utc>>,
@@ -92,6 +94,7 @@ impl TestSuite {
             corpus_cases: Vec::new(),
             target_release: None,
             corpus_expected: 0,
+            corpus_required: Vec::new(),
             started_at: Utc::now(),
             finished_at: None,
             unsuccessful_ids: HashSet::new(),
@@ -115,6 +118,19 @@ impl TestSuite {
 
     pub fn corpus_expected(&self) -> usize {
         self.corpus_expected
+    }
+
+    pub fn expect_corpus_coverage(
+        &mut self,
+        required: impl IntoIterator<Item = conary_core::corpus::CorpusSemantic>,
+    ) {
+        self.corpus_required.extend(required);
+        self.corpus_required.sort();
+        self.corpus_required.dedup();
+    }
+
+    pub fn corpus_required(&self) -> &[conary_core::corpus::CorpusSemantic] {
+        &self.corpus_required
     }
 
     pub fn has_failed(&self, id: &str) -> bool {
@@ -163,6 +179,8 @@ impl TestSuite {
     pub fn corpus_all_completed(&self) -> bool {
         self.corpus_cases.len() == self.corpus_expected
             && conary_core::corpus::aggregate_cases(&self.corpus_cases).all_completed()
+            && conary_core::corpus::aggregate_coverage(&self.corpus_required, &self.corpus_cases)
+                .all_covered()
     }
 
     /// Whether anything in this suite blocks calling the run a success.

--- a/apps/conary-test/src/engine/variables.rs
+++ b/apps/conary-test/src/engine/variables.rs
@@ -140,6 +140,7 @@ pub fn expand_corpus_case(
                 .map(|value| expand_variables(value, vars))
                 .collect(),
         },
+        coverage: definition.coverage.clone(),
         stages: definition.stages.clone(),
     }
 }
@@ -430,6 +431,7 @@ mod tests {
                 setup: Vec::new(),
                 mock_server: None,
                 timeout: None,
+                corpus: None,
             },
             test: Vec::new(),
             distro_overrides: HashMap::new(),
@@ -596,6 +598,10 @@ source_profile = "arch"
 source_format = "alpm"
 digest_source = "fixture_build_manifest"
 stages = ["installation"]
+
+[[coverage]]
+semantic = "identity_exact_version"
+artifact_roles = ["install_request"]
 
 [target]
 architecture = "x86_64"

--- a/apps/conary-test/src/report/corpus.rs
+++ b/apps/conary-test/src/report/corpus.rs
@@ -2,25 +2,34 @@
 
 //! Fail-closed JSON envelope for attributable just-works corpus evidence.
 
-use conary_core::corpus::{CorpusAggregate, CorpusCaseResult, aggregate_cases};
+use conary_core::corpus::{
+    CorpusAggregate, CorpusCaseResult, CorpusCoverageAggregate, CorpusSemantic, aggregate_cases,
+    aggregate_coverage,
+};
 use serde::Serialize;
 
-pub const CORPUS_REPORT_SCHEMA_VERSION: u32 = 1;
+pub const CORPUS_REPORT_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Serialize)]
 pub struct CorpusReport<'a> {
     pub schema_version: u32,
     pub expected_cases: usize,
     pub aggregate: CorpusAggregate,
+    pub coverage: CorpusCoverageAggregate,
     pub cases: &'a [CorpusCaseResult],
 }
 
 impl<'a> CorpusReport<'a> {
-    pub fn from_cases(cases: &'a [CorpusCaseResult], expected_cases: usize) -> Option<Self> {
-        (expected_cases > 0 || !cases.is_empty()).then(|| Self {
+    pub fn from_cases(
+        cases: &'a [CorpusCaseResult],
+        expected_cases: usize,
+        required: &[CorpusSemantic],
+    ) -> Option<Self> {
+        (expected_cases > 0 || !cases.is_empty() || !required.is_empty()).then(|| Self {
             schema_version: CORPUS_REPORT_SCHEMA_VERSION,
             expected_cases,
             aggregate: aggregate_cases(cases),
+            coverage: aggregate_coverage(required, cases),
             cases,
         })
     }

--- a/apps/conary-test/src/report/json.rs
+++ b/apps/conary-test/src/report/json.rs
@@ -51,6 +51,7 @@ pub fn to_json_value(suite: &TestSuite) -> Result<serde_json::Value> {
         corpus: crate::report::corpus::CorpusReport::from_cases(
             &suite.corpus_cases,
             suite.corpus_expected(),
+            suite.corpus_required(),
         ),
         target_release: suite.target_release.as_ref(),
     };
@@ -73,8 +74,9 @@ mod tests {
     };
     use crate::engine::suite::{TestResult, TestStatus, TestSuite};
     use conary_core::corpus::{
-        ConversionStage, CorpusCaseResult, SourceArtifactDigestSource, SourceArtifactIdentity,
-        SourceArtifactRole, SourceProfileIdentity, StageResult, TargetCapabilitySnapshot,
+        ConversionStage, CorpusCaseResult, CorpusCoverageClaim, CorpusSemantic,
+        SourceArtifactDigestSource, SourceArtifactIdentity, SourceArtifactRole,
+        SourceProfileIdentity, StageResult, TargetCapabilitySnapshot,
     };
 
     #[test]
@@ -166,6 +168,7 @@ mod tests {
     fn corpus_report_is_attributable_and_fail_closed() {
         let mut suite = TestSuite::new("corpus", 4);
         suite.expect_corpus_cases(1);
+        suite.expect_corpus_coverage([CorpusSemantic::IdentityExactVersion]);
         suite.record_corpus(CorpusCaseResult::from_stages(
             "TC-RPM-FEDORA",
             SourceProfileIdentity {
@@ -186,15 +189,27 @@ mod tests {
                 init_system: "systemd".into(),
                 capabilities: vec!["native_lifecycle".into()],
             },
+            vec![CorpusCoverageClaim {
+                semantic: CorpusSemantic::IdentityExactVersion,
+                artifact_roles: vec![SourceArtifactRole::InstallRequest],
+            }],
             vec![StageResult::passed(ConversionStage::Installation)],
         ));
 
         let parsed: serde_json::Value =
             serde_json::from_str(&to_json_report(&suite).unwrap()).unwrap();
-        assert_eq!(parsed["corpus"]["schema_version"], 1);
+        assert_eq!(parsed["corpus"]["schema_version"], 2);
         assert_eq!(parsed["corpus"]["expected_cases"], 1);
         assert_eq!(parsed["corpus"]["aggregate"]["cases"], 1);
         assert_eq!(parsed["corpus"]["aggregate"]["completed"], 1);
+        assert_eq!(
+            parsed["corpus"]["coverage"]["covered"][0],
+            "identity_exact_version"
+        );
+        assert_eq!(
+            parsed["corpus"]["coverage"]["missing"],
+            serde_json::json!([])
+        );
         assert_eq!(parsed["corpus"]["cases"][0]["case_id"], "TC-RPM-FEDORA");
         assert_eq!(
             parsed["corpus"]["cases"][0]["source_artifacts"][0]["role"],
@@ -207,11 +222,16 @@ mod tests {
     fn missing_declared_corpus_case_is_published_and_blocks_success() {
         let mut suite = TestSuite::new("corpus", 4);
         suite.expect_corpus_cases(1);
+        suite.expect_corpus_coverage([CorpusSemantic::IdentityExactVersion]);
 
         let parsed: serde_json::Value =
             serde_json::from_str(&to_json_report(&suite).unwrap()).unwrap();
         assert_eq!(parsed["corpus"]["expected_cases"], 1);
         assert_eq!(parsed["corpus"]["aggregate"]["cases"], 0);
+        assert_eq!(
+            parsed["corpus"]["coverage"]["missing"][0],
+            "identity_exact_version"
+        );
         assert!(!suite.corpus_all_completed());
     }
 }

--- a/apps/conary/tests/integration/remi/manifests/native-cross-source-lifecycle.toml
+++ b/apps/conary/tests/integration/remi/manifests/native-cross-source-lifecycle.toml
@@ -7,6 +7,14 @@ name = "Native Cross-Source Lifecycle"
 phase = 4
 timeout = 3600
 
+[suite.corpus]
+required = [
+    "identity_exact_version",
+    "identity_native_architecture",
+    "payload_files",
+    "lifecycle_shell",
+]
+
 [distro_overrides.fedora44]
 native_lifecycle_oracle_format = "rpm"
 target_init_system = "systemd"
@@ -59,6 +67,22 @@ architecture = "x86_64"
 init_system = "${target_init_system}"
 capabilities = ["native_lifecycle", "selected_root_generation"]
 
+[[test.corpus.coverage]]
+semantic = "identity_exact_version"
+artifact_roles = ["install_request", "update_request"]
+
+[[test.corpus.coverage]]
+semantic = "identity_native_architecture"
+artifact_roles = ["install_request", "update_request"]
+
+[[test.corpus.coverage]]
+semantic = "payload_files"
+artifact_roles = ["install_request", "update_request"]
+
+[[test.corpus.coverage]]
+semantic = "lifecycle_shell"
+artifact_roles = ["install_request", "update_request"]
+
 [[test.step]]
 run = "CONARY_CORPUS_EVIDENCE_PATH=/tmp/conary-corpus-rpm.json CONARY_BIN=${CONARY_BIN} /opt/remi-tests/fixtures/native/run-cross-source-lifecycle-matrix.sh ${native_lifecycle_oracle_format} rpm"
 
@@ -85,6 +109,22 @@ architecture = "x86_64"
 init_system = "${target_init_system}"
 capabilities = ["native_lifecycle", "selected_root_generation"]
 
+[[test.corpus.coverage]]
+semantic = "identity_exact_version"
+artifact_roles = ["install_request", "update_request"]
+
+[[test.corpus.coverage]]
+semantic = "identity_native_architecture"
+artifact_roles = ["install_request", "update_request"]
+
+[[test.corpus.coverage]]
+semantic = "payload_files"
+artifact_roles = ["install_request", "update_request"]
+
+[[test.corpus.coverage]]
+semantic = "lifecycle_shell"
+artifact_roles = ["install_request", "update_request"]
+
 [[test.step]]
 run = "CONARY_CORPUS_EVIDENCE_PATH=/tmp/conary-corpus-deb.json CONARY_BIN=${CONARY_BIN} /opt/remi-tests/fixtures/native/run-cross-source-lifecycle-matrix.sh ${native_lifecycle_oracle_format} deb"
 
@@ -110,6 +150,22 @@ stages = ["installation", "update", "rollback", "removal"]
 architecture = "x86_64"
 init_system = "${target_init_system}"
 capabilities = ["native_lifecycle", "selected_root_generation"]
+
+[[test.corpus.coverage]]
+semantic = "identity_exact_version"
+artifact_roles = ["install_request", "update_request"]
+
+[[test.corpus.coverage]]
+semantic = "identity_native_architecture"
+artifact_roles = ["install_request", "update_request"]
+
+[[test.corpus.coverage]]
+semantic = "payload_files"
+artifact_roles = ["install_request", "update_request"]
+
+[[test.corpus.coverage]]
+semantic = "lifecycle_shell"
+artifact_roles = ["install_request", "update_request"]
 
 [[test.step]]
 run = "CONARY_CORPUS_EVIDENCE_PATH=/tmp/conary-corpus-arch.json CONARY_BIN=${CONARY_BIN} /opt/remi-tests/fixtures/native/run-cross-source-lifecycle-matrix.sh ${native_lifecycle_oracle_format} arch"

--- a/crates/conary-core/src/corpus/aggregate.rs
+++ b/crates/conary-core/src/corpus/aggregate.rs
@@ -164,6 +164,7 @@ mod tests {
                 init_system: "systemd".into(),
                 capabilities: Vec::new(),
             },
+            Vec::new(),
             vec![StageResult::failed(stage, failure)],
         )
     }
@@ -189,6 +190,7 @@ mod tests {
                 init_system: "systemd".into(),
                 capabilities: Vec::new(),
             },
+            Vec::new(),
             vec![StageResult::passed(ConversionStage::Installation)],
         )
     }

--- a/crates/conary-core/src/corpus/coverage.rs
+++ b/crates/conary-core/src/corpus/coverage.rs
@@ -1,0 +1,300 @@
+// conary-core/src/corpus/coverage.rs
+
+//! Typed semantic coverage for the just-works corpus gate.
+
+use super::{CorpusCaseResult, SourceArtifactRole};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeSet, HashSet};
+
+/// One exact semantic property required by the W7 just-works corpus.
+///
+/// The serialized spellings are release-gate authority. Coverage must never be
+/// inferred from fixture names, test identifiers, or diagnostic wording.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CorpusSemantic {
+    IdentityExactVersion,
+    IdentityEpochRelease,
+    IdentityArchitectureIndependent,
+    IdentityNativeArchitecture,
+    PayloadFiles,
+    PayloadDirectories,
+    PayloadSymlinks,
+    PayloadHardlinks,
+    PayloadSparseFiles,
+    PayloadLargeFiles,
+    MetadataXattrs,
+    MetadataCapabilities,
+    MetadataOwnership,
+    MetadataTimestamps,
+    RelationsVersionedDependency,
+    RelationsVirtualProvide,
+    RelationsSameNameCompatibilityProvide,
+    RelationsConflict,
+    RelationsReplacement,
+    ConfigurationMatchedConfig,
+    ConfigurationUnmatchedDeclaration,
+    ConfigurationLocalModification,
+    ConfigurationDeletion,
+    ConfigurationUpgrade,
+    ConfigurationRemoval,
+    LifecycleNone,
+    LifecycleShell,
+    LifecycleNonShellInterpreter,
+    LifecycleTrigger,
+    LifecycleTransactionHook,
+    TrustMultipleValidSigningKeys,
+    TrustSigningSubkeys,
+    TrustExpiredKey,
+    TrustRevokedKey,
+    TrustUnknownKey,
+    RuntimeServiceActivation,
+    RuntimeTargetHelper,
+    RuntimeDeferredGenerationWork,
+    FailureInterruptedDownload,
+    FailureConversion,
+    FailurePayloadMutation,
+    FailureLifecycle,
+    FailurePublication,
+    FailureActivation,
+}
+
+impl CorpusSemantic {
+    /// Complete W7 semantic-property vocabulary in stable report order.
+    pub const ALL: [Self; 44] = [
+        Self::IdentityExactVersion,
+        Self::IdentityEpochRelease,
+        Self::IdentityArchitectureIndependent,
+        Self::IdentityNativeArchitecture,
+        Self::PayloadFiles,
+        Self::PayloadDirectories,
+        Self::PayloadSymlinks,
+        Self::PayloadHardlinks,
+        Self::PayloadSparseFiles,
+        Self::PayloadLargeFiles,
+        Self::MetadataXattrs,
+        Self::MetadataCapabilities,
+        Self::MetadataOwnership,
+        Self::MetadataTimestamps,
+        Self::RelationsVersionedDependency,
+        Self::RelationsVirtualProvide,
+        Self::RelationsSameNameCompatibilityProvide,
+        Self::RelationsConflict,
+        Self::RelationsReplacement,
+        Self::ConfigurationMatchedConfig,
+        Self::ConfigurationUnmatchedDeclaration,
+        Self::ConfigurationLocalModification,
+        Self::ConfigurationDeletion,
+        Self::ConfigurationUpgrade,
+        Self::ConfigurationRemoval,
+        Self::LifecycleNone,
+        Self::LifecycleShell,
+        Self::LifecycleNonShellInterpreter,
+        Self::LifecycleTrigger,
+        Self::LifecycleTransactionHook,
+        Self::TrustMultipleValidSigningKeys,
+        Self::TrustSigningSubkeys,
+        Self::TrustExpiredKey,
+        Self::TrustRevokedKey,
+        Self::TrustUnknownKey,
+        Self::RuntimeServiceActivation,
+        Self::RuntimeTargetHelper,
+        Self::RuntimeDeferredGenerationWork,
+        Self::FailureInterruptedDownload,
+        Self::FailureConversion,
+        Self::FailurePayloadMutation,
+        Self::FailureLifecycle,
+        Self::FailurePublication,
+        Self::FailureActivation,
+    ];
+}
+
+/// A semantic claim and the exact source-artifact roles that must support it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CorpusCoverageClaim {
+    pub semantic: CorpusSemantic,
+    pub artifact_roles: Vec<SourceArtifactRole>,
+}
+
+/// Coverage projected from completed, digest-attributable corpus cases.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorpusCoverageAggregate {
+    pub required: Vec<CorpusSemantic>,
+    pub covered: Vec<CorpusSemantic>,
+    pub missing: Vec<CorpusSemantic>,
+    /// Claims that did not resolve every declared role to one exact artifact.
+    pub unattributed_claims: usize,
+}
+
+impl CorpusCoverageAggregate {
+    pub fn all_covered(&self) -> bool {
+        self.missing.is_empty() && self.covered == self.required && self.unattributed_claims == 0
+    }
+}
+
+/// Aggregate coverage without consulting free-form diagnostics.
+pub fn aggregate_coverage(
+    required: &[CorpusSemantic],
+    cases: &[CorpusCaseResult],
+) -> CorpusCoverageAggregate {
+    let required = required.iter().copied().collect::<BTreeSet<_>>();
+    let mut covered = BTreeSet::new();
+    let mut unattributed_claims = 0;
+
+    for case in cases.iter().filter(|case| case.completed()) {
+        let mut seen = HashSet::new();
+        for claim in &case.coverage_claims {
+            if !seen.insert(claim.semantic) || !claim_is_attributable(case, claim) {
+                unattributed_claims += 1;
+                continue;
+            }
+            covered.insert(claim.semantic);
+        }
+    }
+
+    let missing = required.difference(&covered).copied().collect();
+    CorpusCoverageAggregate {
+        required: required.into_iter().collect(),
+        covered: covered.into_iter().collect(),
+        missing,
+        unattributed_claims,
+    }
+}
+
+fn claim_is_attributable(case: &CorpusCaseResult, claim: &CorpusCoverageClaim) -> bool {
+    if claim.artifact_roles.is_empty()
+        || !claim
+            .artifact_roles
+            .windows(2)
+            .all(|roles| roles[0] < roles[1])
+    {
+        return false;
+    }
+
+    claim.artifact_roles.iter().all(|role| {
+        let matching = case
+            .source_artifacts
+            .iter()
+            .filter(|artifact| artifact.role == *role)
+            .collect::<Vec<_>>();
+        matching.len() == 1
+            && !matching[0].name.trim().is_empty()
+            && !matching[0].version.trim().is_empty()
+            && matching[0].digest.len() == 64
+            && matching[0]
+                .digest
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::corpus::{
+        ConversionStage, SourceArtifactDigestSource, SourceArtifactIdentity, SourceProfileIdentity,
+        StageResult, TargetCapabilitySnapshot,
+    };
+
+    fn case(completed: bool, digest: &str) -> CorpusCaseResult {
+        CorpusCaseResult::from_stages(
+            "rpm-fedora",
+            SourceProfileIdentity {
+                profile: "fedora-44".into(),
+                format: "rpm".into(),
+            },
+            vec![SourceArtifactIdentity {
+                role: SourceArtifactRole::InstallRequest,
+                digest_source: SourceArtifactDigestSource::FixtureBuildManifest,
+                name: "fixture".into(),
+                version: "1-1".into(),
+                architecture: Some("x86_64".into()),
+                digest: digest.into(),
+            }],
+            TargetCapabilitySnapshot {
+                profile: "fedora44".into(),
+                architecture: "x86_64".into(),
+                init_system: "systemd".into(),
+                capabilities: vec!["native_lifecycle".into()],
+            },
+            vec![CorpusCoverageClaim {
+                semantic: CorpusSemantic::IdentityExactVersion,
+                artifact_roles: vec![SourceArtifactRole::InstallRequest],
+            }],
+            if completed {
+                vec![StageResult::passed(ConversionStage::Installation)]
+            } else {
+                vec![StageResult::not_reached(ConversionStage::Installation)]
+            },
+        )
+    }
+
+    #[test]
+    fn only_completed_attributable_cases_cover_requirements() {
+        let required = [
+            CorpusSemantic::IdentityExactVersion,
+            CorpusSemantic::PayloadHardlinks,
+        ];
+        let digest = "a".repeat(64);
+        let aggregate = aggregate_coverage(&required, &[case(true, &digest)]);
+
+        assert_eq!(
+            aggregate.covered,
+            vec![CorpusSemantic::IdentityExactVersion]
+        );
+        assert_eq!(aggregate.missing, vec![CorpusSemantic::PayloadHardlinks]);
+        assert_eq!(aggregate.unattributed_claims, 0);
+        assert!(!aggregate.all_covered());
+
+        let incomplete = aggregate_coverage(&required[..1], &[case(false, &digest)]);
+        assert!(incomplete.covered.is_empty());
+        assert_eq!(
+            incomplete.missing,
+            vec![CorpusSemantic::IdentityExactVersion]
+        );
+    }
+
+    #[test]
+    fn malformed_or_unbound_artifacts_do_not_satisfy_coverage() {
+        let required = [CorpusSemantic::IdentityExactVersion];
+        let aggregate = aggregate_coverage(&required, &[case(true, "short")]);
+        assert_eq!(aggregate.unattributed_claims, 1);
+        assert_eq!(aggregate.missing, required);
+
+        let mut wrong_role = case(true, &"b".repeat(64));
+        wrong_role.coverage_claims[0].artifact_roles = vec![SourceArtifactRole::UpdateRequest];
+        let aggregate = aggregate_coverage(&required, &[wrong_role]);
+        assert_eq!(aggregate.unattributed_claims, 1);
+        assert_eq!(aggregate.missing, required);
+    }
+
+    #[test]
+    fn undeclared_extra_coverage_cannot_pass_the_gate() {
+        let required = [CorpusSemantic::IdentityExactVersion];
+        let mut case = case(true, &"c".repeat(64));
+        case.coverage_claims.push(CorpusCoverageClaim {
+            semantic: CorpusSemantic::PayloadFiles,
+            artifact_roles: vec![SourceArtifactRole::InstallRequest],
+        });
+
+        let aggregate = aggregate_coverage(&required, &[case]);
+        assert!(aggregate.missing.is_empty());
+        assert_eq!(aggregate.covered.len(), 2);
+        assert!(!aggregate.all_covered());
+    }
+
+    #[test]
+    fn vocabulary_round_trips_all_stable_spellings() {
+        let mut spellings = Vec::new();
+        for semantic in CorpusSemantic::ALL {
+            let json = serde_json::to_string(&semantic).unwrap();
+            let restored: CorpusSemantic = serde_json::from_str(&json).unwrap();
+            assert_eq!(restored, semantic);
+            spellings.push(json);
+        }
+        spellings.sort();
+        spellings.dedup();
+        assert_eq!(spellings.len(), 44);
+    }
+}

--- a/crates/conary-core/src/corpus/mod.rs
+++ b/crates/conary-core/src/corpus/mod.rs
@@ -16,9 +16,13 @@
 //! and the `conary-test` runner. See [`failure`] for the classification rule.
 
 mod aggregate;
+mod coverage;
 mod failure;
 
 pub use aggregate::{CorpusAggregate, FailureTally, StageTally, aggregate_cases};
+pub use coverage::{
+    CorpusCoverageAggregate, CorpusCoverageClaim, CorpusSemantic, aggregate_coverage,
+};
 pub use failure::{ConversionFailure, FailureKind};
 
 use serde::{Deserialize, Serialize};
@@ -114,7 +118,7 @@ pub struct SourceArtifactIdentity {
 /// A case may consume more than one artifact: an install followed by an update
 /// must identify both inputs rather than attributing the complete journey to
 /// the first package digest.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SourceArtifactRole {
     InstallRequest,
@@ -225,6 +229,7 @@ pub struct CorpusCaseResult {
     pub source_profile: SourceProfileIdentity,
     pub source_artifacts: Vec<SourceArtifactIdentity>,
     pub target_profile: TargetCapabilitySnapshot,
+    pub coverage_claims: Vec<CorpusCoverageClaim>,
     pub stage_results: Vec<StageResult>,
     pub final_outcome: CorpusOutcome,
 }
@@ -240,6 +245,7 @@ impl CorpusCaseResult {
         source_profile: SourceProfileIdentity,
         source_artifacts: Vec<SourceArtifactIdentity>,
         target_profile: TargetCapabilitySnapshot,
+        coverage_claims: Vec<CorpusCoverageClaim>,
         stage_results: Vec<StageResult>,
     ) -> Self {
         let first_failure = stage_results.iter().find_map(|result| {
@@ -266,6 +272,7 @@ impl CorpusCaseResult {
             source_profile,
             source_artifacts,
             target_profile,
+            coverage_claims,
             stage_results,
             final_outcome,
         }
@@ -328,6 +335,7 @@ mod tests {
             profile(),
             vec![artifact()],
             target(),
+            Vec::new(),
             stages,
         );
 
@@ -342,6 +350,7 @@ mod tests {
             profile(),
             vec![artifact()],
             target(),
+            Vec::new(),
             vec![StageResult::not_reached(ConversionStage::Installation)],
         );
 
@@ -369,6 +378,7 @@ mod tests {
             profile(),
             vec![artifact()],
             target(),
+            Vec::new(),
             stages,
         );
 
@@ -401,6 +411,7 @@ mod tests {
             profile(),
             vec![artifact()],
             target(),
+            Vec::new(),
             stages,
         );
 
@@ -442,6 +453,7 @@ mod tests {
             profile(),
             vec![artifact()],
             target(),
+            Vec::new(),
             vec![StageResult::failed(
                 ConversionStage::NativeParse,
                 ConversionFailure::SourceMetadata {

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-08-13
-revision: 49
-summary: Document authenticated derivative targets, transport normalization, typed release evidence, and native lifecycle gates
+last_updated: 2026-08-15
+revision: 50
+summary: Document typed semantic corpus coverage, authenticated derivative targets, release evidence, and native lifecycle gates
 ---
 
 # Integration Testing
@@ -557,9 +557,16 @@ envelope carrying both install and update artifact digests, the typed fixture
 build-manifest authority that produced them, and stage checkpoints. It is
 projected by `conary-test` into a typed
 `CorpusCaseResult`. The suite JSON carries the typed aggregate beside the
-ordinary test results and records the manifest-declared case count; a missing,
-malformed, skipped, failed, or unclassified corpus case makes the command fail
-even if generic command output happened to look successful.
+ordinary test results and records the manifest-declared case count. The suite
+also declares an exact typed semantic requirement set, while each case binds
+its claims to install or update artifact roles. The report publishes required,
+covered, and missing properties; a claim counts only after its role resolves to
+one runtime artifact with fixture-build SHA-256 authority and the case
+completes. The current focused lifecycle suite claims exact version, native
+architecture, regular-file payload, and shell-lifecycle coverage only. It does
+not stand in for the remaining W7 dimension corpus. A missing, malformed,
+skipped, failed, unclassified, or semantically incomplete corpus case makes the
+command fail even if generic command output happened to look successful.
 
 The adopted-artifact bridge has a separate hermetic command test:
 

--- a/docs/modules/feature-ownership.md
+++ b/docs/modules/feature-ownership.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-08-14
-revision: 75
-summary: Route feature ownership through set-based package transaction persistence, typed database rebuilds, generation snapshots and recovery deltas, exact native source identity and adopted-artifact conversion, native declaration and trust-import planning, exact Remi signing, streaming package payloads, serialized selected-root mutation, typed rollback lineage, exact lifecycle, canonical-map authority, carrier security, generation GC, exact release authority, and current canonical docs
+last_updated: 2026-08-15
+revision: 76
+summary: Route feature ownership through typed corpus coverage, package transactions, database rebuilds, generation recovery, source identity, Remi, lifecycle, release, and canonical docs
 ---
 
 # Feature Ownership And Interaction Gates
@@ -1432,7 +1432,11 @@ artifact first. Corpus cases
 must carry versioned runtime evidence with exact role-tagged artifact digests,
 typed digest authority, target capabilities, and canonically ordered stage
 checkpoints; report aggregation uses typed stage/failure discriminants and
-never diagnostic text. The declared and emitted case counts must agree.
+never diagnostic text. Corpus suites declare one exact semantic requirement
+set, and each case binds its claims to source-artifact roles that must resolve
+to unique runtime SHA-256 identities. Only completed cases contribute coverage;
+the declared and emitted case counts and required/covered semantic sets must
+agree.
 
 ## Agent/MCP Operation Surfaces
 

--- a/docs/modules/test-fixtures.md
+++ b/docs/modules/test-fixtures.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-08-14
-revision: 32
-summary: Map fixture ownership, including set-based package transaction scaling, authenticated Debian-derivative roots, and cross-source lifecycle proof
+last_updated: 2026-08-15
+revision: 33
+summary: Map fixture ownership, including typed semantic coverage, authenticated derivative roots, and cross-source lifecycle proof
 ---
 
 # Test Fixtures And Proof Maps
@@ -404,9 +404,12 @@ Each fixture family should record:
   `apps/conary-test/src/suite_inventory.rs`.
 - **Purpose:** Declarative Remi and package-manager integration suites. Corpus
   tests declare exact source/target/stage and artifact-digest authority,
-  consume a versioned runtime evidence file, and emit `CorpusCaseResult` plus
-  typed aggregation with an exact declared-case count; generic stdout and
-  error messages remain diagnostics only.
+  suite-level semantic requirements, and per-case claims bound to exact source
+  artifact roles. They consume a versioned runtime evidence file and emit
+  `CorpusCaseResult` plus typed result and semantic-coverage aggregation with
+  an exact declared-case count; generic stdout and error messages remain
+  diagnostics only. A property counts as covered only when every claimed role
+  resolves to one SHA-256-attributed runtime artifact and the case completes.
 - **Fixture sources:** `apps/conary/tests/integration/remi/manifests/`;
   `apps/conary/tests/integration/remi/containers/`;
   `apps/conary/tests/fixtures/conary-test-fixture/`;

--- a/docs/roadmaps/development-roadmap.md
+++ b/docs/roadmaps/development-roadmap.md
@@ -1,11 +1,11 @@
 ---
-last_updated: 2026-08-13
-revision: 20
-summary: Track Conary's cross-distro package milestone, authenticated derivative execution, and the issue-decomposed W10 takeover horizon
+last_updated: 2026-08-15
+revision: 21
+summary: Track Conary's active W7 just-works corpus gate, typed semantic coverage, external tester milestone, and later workstreams
 proof_baseline: "immutable synchronized v0.15.0 suite at 642750878d5a59a9aa27976347cafc6f9dd86cfd; exact tagged Remi deployed; external tester result remains 0/10 behind #110"
 current_milestone: first external tester loop
-active_workstream: W6 Authority Audit Closure
-next_workstream: W7 Just-Works Corpus Gate
+active_workstream: W7 Just-Works Corpus Gate
+next_workstream: W8 External Tester Outreach
 ---
 
 # Codebase Development Roadmap
@@ -207,10 +207,9 @@ the stated scope, not whether a workstream happens to be active.
 - **Outcome:** ordinary Fedora and Arch repository packages stop failing
   conversion on Conary-invented invariants, and hosted Remi health becomes
   evidence bearing.
-- **Execution status:** implementation issues complete; aggregate gate
-  closeout remains active. The owned #98, #99, #102, #103, and #107 slices are
-  closed, while #110 still owns the typed corpus vocabulary required to report
-  the aggregate prewarm gate without message-text authority.
+- **Execution status:** complete. The owned #98, #99, #102, #103, and #107
+  slices are closed. W7's landed typed corpus vocabulary reports their
+  aggregate evidence without message-text authority.
 - **Issues:** #102 (P0), #103 (P0), #98 (P0), #99 (P0, split into three
   slices), plus #107 for the Remi readiness probe.
 - **Ordering:** #102, #103, and #107 run in parallel with #98
@@ -314,8 +313,11 @@ the stated scope, not whether a workstream happens to be active.
 - **Outcome:** a clean machine on each supported host completes the ordinary
   user journey end to end, and failures are reported as typed stages rather
   than message text.
-- **Execution status:** blocked on W4 through W6.
-- **Issues:** #110 as the corpus umbrella, plus #39 for bootstrap.
+- **Execution status:** active after W4 through W6 completion. Typed per-case
+  reporting is landed; #456 owns the next bounded semantic-coverage authority
+  before the remaining fixture and hosted-execution slices.
+- **Issues:** #110 as the corpus umbrella, #456 for attributable semantic
+  coverage, plus #39 for bootstrap.
 - **User journey:** install the signed release through one documented bootstrap
   entry point; `conary system init` with no hand-edited state; sync and
   authenticate repositories; request a package by ordinary name; resolve the

--- a/scripts/check-conary-corpus-result-gate.sh
+++ b/scripts/check-conary-corpus-result-gate.sh
@@ -21,21 +21,45 @@ import sys
 path = pathlib.Path(sys.argv[1])
 data = json.loads(path.read_text())
 corpus = data.get("corpus") if isinstance(data, dict) else None
-if not isinstance(corpus, dict) or corpus.get("schema_version") != 1:
-    print(f"{path}: corpus gate failed: missing schema version 1 corpus object", file=sys.stderr)
+if not isinstance(corpus, dict) or corpus.get("schema_version") != 2:
+    print(f"{path}: corpus gate failed: missing schema version 2 corpus object", file=sys.stderr)
     sys.exit(1)
 
 aggregate = corpus.get("aggregate")
 cases = corpus.get("cases")
 expected_cases = corpus.get("expected_cases")
+coverage = corpus.get("coverage")
 if (
     not isinstance(expected_cases, int)
     or expected_cases <= 0
     or not isinstance(aggregate, dict)
     or not isinstance(cases, list)
     or not cases
+    or not isinstance(coverage, dict)
 ):
-    print(f"{path}: corpus gate failed: expected count, aggregate, and non-empty cases are required", file=sys.stderr)
+    print(f"{path}: corpus gate failed: expected count, aggregate, coverage, and non-empty cases are required", file=sys.stderr)
+    sys.exit(1)
+
+required = coverage.get("required")
+covered = coverage.get("covered")
+missing = coverage.get("missing")
+unattributed = coverage.get("unattributed_claims")
+if (
+    not isinstance(required, list)
+    or not required
+    or not isinstance(covered, list)
+    or not isinstance(missing, list)
+    or not isinstance(unattributed, int)
+    or unattributed != 0
+    or any(not isinstance(item, str) or not item for item in required + covered + missing)
+    or len(set(required)) != len(required)
+    or len(set(covered)) != len(covered)
+    or len(set(missing)) != len(missing)
+):
+    print(f"{path}: corpus gate failed: typed coverage aggregate is malformed", file=sys.stderr)
+    sys.exit(1)
+if missing or set(required) != set(covered):
+    print(f"{path}: corpus gate failed: required semantic coverage is incomplete", file=sys.stderr)
     sys.exit(1)
 
 required_counts = ["cases", "completed", "failed", "skipped", "unclassified"]
@@ -64,6 +88,7 @@ if (
 
 digest_pattern = re.compile(r"^[0-9a-f]{64}$")
 case_ids = set()
+claimed_semantics = set()
 for case in cases:
     if not isinstance(case, dict):
         print(f"{path}: corpus gate failed: case must be an object", file=sys.stderr)
@@ -78,6 +103,7 @@ for case in cases:
     target = case.get("target_profile")
     artifacts = case.get("source_artifacts")
     stages = case.get("stage_results")
+    claims = case.get("coverage_claims")
     if (
         not isinstance(source, dict)
         or not source.get("profile")
@@ -92,6 +118,8 @@ for case in cases:
         or not artifacts
         or not isinstance(stages, list)
         or not stages
+        or not isinstance(claims, list)
+        or not claims
     ):
         print(f"{path}: corpus gate failed: {case_id} lacks attributable authority", file=sys.stderr)
         sys.exit(1)
@@ -139,6 +167,36 @@ for case in cases:
         print(f"{path}: corpus gate failed: {case_id} lacks its update request", file=sys.stderr)
         sys.exit(1)
 
+    claim_keys = set()
+    case_semantics = set()
+    for claim in claims:
+        semantic = claim.get("semantic") if isinstance(claim, dict) else None
+        roles = claim.get("artifact_roles") if isinstance(claim, dict) else None
+        if (
+            not isinstance(semantic, str)
+            or not semantic
+            or not isinstance(roles, list)
+            or not roles
+            or len(set(roles)) != len(roles)
+            or any(not isinstance(role, str) or not role for role in roles)
+        ):
+            print(f"{path}: corpus gate failed: {case_id} has malformed semantic coverage", file=sys.stderr)
+            sys.exit(1)
+        claim_key = (semantic, tuple(roles))
+        if claim_key in claim_keys:
+            print(f"{path}: corpus gate failed: {case_id} repeats a semantic coverage claim", file=sys.stderr)
+            sys.exit(1)
+        claim_keys.add(claim_key)
+        if semantic in case_semantics:
+            print(f"{path}: corpus gate failed: {case_id} repeats a semantic property", file=sys.stderr)
+            sys.exit(1)
+        case_semantics.add(semantic)
+        for role in roles:
+            if sum(1 for artifact in artifacts if artifact.get("role") == role) != 1:
+                print(f"{path}: corpus gate failed: {case_id} has an unbound semantic coverage claim", file=sys.stderr)
+                sys.exit(1)
+        claimed_semantics.add(semantic)
+
     if any(stage.get("outcome") != "passed" for stage in stages if isinstance(stage, dict)) \
        or any(not isinstance(stage, dict) for stage in stages):
         print(f"{path}: corpus gate failed: {case_id} has a non-passing stage", file=sys.stderr)
@@ -146,6 +204,10 @@ for case in cases:
     if case.get("final_outcome") != {"outcome": "completed"}:
         print(f"{path}: corpus gate failed: {case_id} did not complete", file=sys.stderr)
         sys.exit(1)
+
+if claimed_semantics != set(required):
+    print(f"{path}: corpus gate failed: case claims contradict the coverage aggregate", file=sys.stderr)
+    sys.exit(1)
 
 print(f"{path}: corpus ok ({len(cases)} cases)")
 PY

--- a/scripts/test-conary-corpus-result-gate.sh
+++ b/scripts/test-conary-corpus-result-gate.sh
@@ -15,7 +15,7 @@ write_result() {
   local completed="$3"
   local failed="$4"
   local outcome="$5"
-  printf '%s\n' "{\"corpus\":{\"schema_version\":1,\"expected_cases\":1,\"aggregate\":{\"cases\":1,\"completed\":${completed},\"failed\":${failed},\"skipped\":0,\"stages\":[],\"unclassified\":0},\"cases\":[{\"case_id\":\"rpm-fedora\",\"source_profile\":{\"profile\":\"fedora-44\",\"format\":\"rpm\"},\"source_artifacts\":[{\"role\":\"install_request\",\"digest_source\":\"fixture_build_manifest\",\"name\":\"fixture\",\"version\":\"1-1\",\"architecture\":\"x86_64\",\"digest\":\"${digest}\"}],\"target_profile\":{\"profile\":\"fedora44\",\"architecture\":\"x86_64\",\"init_system\":\"systemd\",\"capabilities\":[\"native_lifecycle\"]},\"stage_results\":[{\"stage\":\"installation\",\"outcome\":\"${outcome}\"}],\"final_outcome\":{\"outcome\":\"completed\"}}]}}" > "${path}"
+  printf '%s\n' "{\"corpus\":{\"schema_version\":2,\"expected_cases\":1,\"aggregate\":{\"cases\":1,\"completed\":${completed},\"failed\":${failed},\"skipped\":0,\"stages\":[],\"unclassified\":0},\"coverage\":{\"required\":[\"identity_exact_version\"],\"covered\":[\"identity_exact_version\"],\"missing\":[],\"unattributed_claims\":0},\"cases\":[{\"case_id\":\"rpm-fedora\",\"source_profile\":{\"profile\":\"fedora-44\",\"format\":\"rpm\"},\"source_artifacts\":[{\"role\":\"install_request\",\"digest_source\":\"fixture_build_manifest\",\"name\":\"fixture\",\"version\":\"1-1\",\"architecture\":\"x86_64\",\"digest\":\"${digest}\"}],\"target_profile\":{\"profile\":\"fedora44\",\"architecture\":\"x86_64\",\"init_system\":\"systemd\",\"capabilities\":[\"native_lifecycle\"]},\"coverage_claims\":[{\"semantic\":\"identity_exact_version\",\"artifact_roles\":[\"install_request\"]}],\"stage_results\":[{\"stage\":\"installation\",\"outcome\":\"${outcome}\"}],\"final_outcome\":{\"outcome\":\"completed\"}}]}}" > "${path}"
 }
 
 write_result "${root}/passing.json" "$(printf 'a%.0s' {1..64})" 1 0 passed
@@ -37,6 +37,27 @@ sed 's/"expected_cases":1/"expected_cases":2/' \
   "${root}/passing.json" > "${root}/missing-case.json"
 if "${gate}" "${root}/missing-case.json" >/dev/null 2>&1; then
   echo "missing emitted case unexpectedly passed corpus gate" >&2
+  exit 1
+fi
+
+sed 's/"missing":\[\]/"missing":["identity_exact_version"]/' \
+  "${root}/passing.json" > "${root}/missing-coverage.json"
+if "${gate}" "${root}/missing-coverage.json" >/dev/null 2>&1; then
+  echo "missing semantic coverage unexpectedly passed corpus gate" >&2
+  exit 1
+fi
+
+sed 's/"artifact_roles":\["install_request"\]/"artifact_roles":["update_request"]/' \
+  "${root}/passing.json" > "${root}/unbound-coverage.json"
+if "${gate}" "${root}/unbound-coverage.json" >/dev/null 2>&1; then
+  echo "unbound semantic coverage unexpectedly passed corpus gate" >&2
+  exit 1
+fi
+
+sed 's/"covered":\["identity_exact_version"\]/"covered":["payload_files"]/' \
+  "${root}/passing.json" > "${root}/contradictory-coverage.json"
+if "${gate}" "${root}/contradictory-coverage.json" >/dev/null 2>&1; then
+  echo "contradictory semantic coverage unexpectedly passed corpus gate" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Problem

W7 had digest-attributable per-case results, but no typed authority connecting exact fixtures to the semantic properties required by #110. Coverage remained prose: manifests could not declare the required set, reports could not distinguish covered from missing properties, and a passing case could not prove which runtime artifact supported a claim.

## Change

- add the closed 44-property W7 semantic vocabulary in `conary_core::corpus`
- require corpus suites to declare one canonical requirement set and cases to declare canonical claims bound to source-artifact roles
- resolve every claimed role to one runtime artifact with typed SHA-256 authority before emitting coverage
- aggregate required, covered, missing, and unattributed claims from completed cases only
- hard-cut the corpus JSON report to schema version 2 and make the standalone gate reject missing, unbound, duplicate, or contradictory coverage
- declare only the four properties already proved by the focused native lifecycle fixture: exact version, native architecture, regular-file payload, and shell lifecycle
- advance canonical roadmap and ownership truth from completed W4-W6 into active W7 without claiming the remaining corpus complete

## Verification

- `cargo run -p conary-test -- list`
- `cargo test -p conary-core corpus:: -- --nocapture` (33 passed)
- `cargo test -p conary-test` (310 library passed, 1 ignored; 14 CLI passed)
- `cargo test -p conary-test corpus -- --nocapture` (19 passed)
- `bash scripts/test-conary-corpus-result-gate.sh`
- `bash scripts/agent-context.sh --feature conary-test --run focused` (5 commands passed)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `bash scripts/check-doc-truth.sh`
- `bash scripts/test-agent-context.sh`
- `git diff --check`

Closes #456
Refs #110
Blocks #48
