### PR TITLE
test(corpus): attribute payload topology

### DIFF
--- a/apps/conary-test/src/config/tests/native_corpus.rs
+++ b/apps/conary-test/src/config/tests/native_corpus.rs
@@ -121,6 +121,8 @@ fn phase4_native_manifests_separate_parity_from_daily_driver_authority() {
             conary_core::corpus::CorpusSemantic::IdentityExactVersion,
             conary_core::corpus::CorpusSemantic::IdentityNativeArchitecture,
             conary_core::corpus::CorpusSemantic::PayloadFiles,
+            conary_core::corpus::CorpusSemantic::PayloadDirectories,
+            conary_core::corpus::CorpusSemantic::PayloadSymlinks,
             conary_core::corpus::CorpusSemantic::RelationsVirtualProvide,
             conary_core::corpus::CorpusSemantic::ConfigurationMatchedConfig,
             conary_core::corpus::CorpusSemantic::ConfigurationRemoval,
@@ -189,6 +191,10 @@ fn phase4_native_manifests_separate_parity_from_daily_driver_authority() {
         "/var/lib/phase4-corpus/scriptlet.marker",
         "/var/lib/phase4-corpus/remove.marker",
         "phase4-corpus-conflict",
+        "/usr/lib/phase4-corpus/state|directory|0750",
+        "/usr/bin/phase4-corpus-link|symlink|phase4-corpus",
+        "--expect-directory /usr/lib/phase4-corpus/state=0750",
+        "--expect-symlink /usr/bin/phase4-corpus-link=phase4-corpus",
         "printf %s conflicting-corpus-payload",
         "is incompatible with package phase4-daily-driver-corpus",
         "large-payload.bin",
@@ -238,7 +244,7 @@ fn phase4_native_manifests_separate_parity_from_daily_driver_authority() {
         install_case.stages,
         [conary_core::corpus::ConversionStage::Installation]
     );
-    assert_eq!(install_case.coverage.len(), 6);
+    assert_eq!(install_case.coverage.len(), 8);
     assert!(
         install_case
             .coverage

--- a/apps/conary/tests/fixtures/native/assert-selected-generation.py
+++ b/apps/conary/tests/fixtures/native/assert-selected-generation.py
@@ -267,6 +267,33 @@ def assert_selected_symlink(
         fail(f"{path} symlink target is {actual!r}, expected {expected!r}")
 
 
+def assert_selected_directory(
+    entries: dict[str, dict[str, Any]], expectation: str
+) -> None:
+    path, expected = split_expectation(expectation, "--expect-directory")
+    if any(character not in "01234567" for character in expected):
+        fail(f"--expect-directory mode is not octal: {expected!r}")
+    expected_mode = int(expected, 8)
+    if expected_mode > 0o7777:
+        fail(f"--expect-directory mode exceeds permission bits: {expected!r}")
+    entry = entries.get(path)
+    if entry is None:
+        fail(f"selected generation does not contain {path}")
+    node = entry.get("node")
+    source = node.get("source") if isinstance(node, dict) else None
+    kind = source.get("kind") if isinstance(source, dict) else None
+    if not isinstance(kind, dict) or kind.get("type") != "directory":
+        fail(f"selected-generation path {path} is not a directory")
+    actual_mode = source.get("mode")
+    if isinstance(actual_mode, bool) or not isinstance(actual_mode, int):
+        fail(f"selected-generation directory {path} has no numeric mode")
+    if actual_mode & 0o7777 != expected_mode:
+        fail(
+            f"{path} directory mode is {actual_mode & 0o7777:04o}, "
+            f"expected {expected_mode:04o}"
+        )
+
+
 def parse_colon_records(content: bytes, path: str, field_count: int) -> list[list[str]]:
     try:
         lines = content.decode("utf-8").splitlines()
@@ -353,6 +380,9 @@ def main() -> int:
     parser.add_argument(
         "--expect-symlink", action="append", default=[], metavar="PATH=TARGET"
     )
+    parser.add_argument(
+        "--expect-directory", action="append", default=[], metavar="PATH=MODE"
+    )
     parser.add_argument("--contains-line", action="append", default=[], metavar="PATH=LINE")
     parser.add_argument(
         "--expect-user",
@@ -380,6 +410,8 @@ def main() -> int:
             fail(f"{path} bytes do not match expected digest {expected}")
     for value in args.expect_symlink:
         assert_selected_symlink(entries, value)
+    for value in args.expect_directory:
+        assert_selected_directory(entries, value)
     for value in args.contains_line:
         path, expected = split_expectation(value, "--contains-line")
         _, content = entry_content(entries, cas_base, path)
@@ -393,6 +425,7 @@ def main() -> int:
         len(args.present)
         + len(args.expect_sha256)
         + len(args.expect_symlink)
+        + len(args.expect_directory)
         + len(args.expect_user)
     )
     print(

--- a/apps/conary/tests/integration/remi/manifests/phase4-native-daily-driver-corpus.toml
+++ b/apps/conary/tests/integration/remi/manifests/phase4-native-daily-driver-corpus.toml
@@ -12,6 +12,8 @@ required = [
     "identity_exact_version",
     "identity_native_architecture",
     "payload_files",
+    "payload_directories",
+    "payload_symlinks",
     "relations_virtual_provide",
     "configuration_matched_config",
     "configuration_removal",
@@ -88,7 +90,7 @@ timeout = 240
 fatal = true
 
 [[test.step]]
-run = "rm -rf /tmp/native-pm-corpus /tmp/native-pm-corpus-src /tmp/native-pm-corpus-conflict /tmp/native-pm-corpus-conflict-src && cp -a /opt/remi-tests/fixtures/phase4-daily-driver-corpus /tmp/native-pm-corpus-src && mkdir -p /tmp/native-pm-corpus-src/stage/usr/share/phase4-corpus && dd if=/dev/zero of=/tmp/native-pm-corpus-src/stage/usr/share/phase4-corpus/large-payload.bin bs=1048576 count=2 && mkdir -p /tmp/native-pm-corpus && CONARY_BIN=${CONARY_BIN} /opt/remi-tests/fixtures/native/build-native-fixtures.sh ${native_target} /tmp/native-pm-corpus /tmp/native-pm-corpus-src && . /tmp/native-pm-corpus/native-fixture.env && test -f \"$NATIVE_PKG_FILE\" && test \"$NATIVE_TARGET\" = \"${native_target}\" && test ${#NATIVE_PKG_SHA256} -eq 64 && case \"$NATIVE_PKG_FILE\" in /tmp/native-pm-corpus/${native_glob}) true ;; *) echo \"unexpected native corpus package path: $NATIVE_PKG_FILE\"; exit 1 ;; esac"
+run = "rm -rf /tmp/native-pm-corpus /tmp/native-pm-corpus-src /tmp/native-pm-corpus-conflict /tmp/native-pm-corpus-conflict-src && cp -a /opt/remi-tests/fixtures/phase4-daily-driver-corpus /tmp/native-pm-corpus-src && mkdir -p /tmp/native-pm-corpus-src/stage/usr/share/phase4-corpus /tmp/native-pm-corpus-src/stage/usr/lib/phase4-corpus/state && chmod 0750 /tmp/native-pm-corpus-src/stage/usr/lib/phase4-corpus/state && ln -s phase4-corpus /tmp/native-pm-corpus-src/stage/usr/bin/phase4-corpus-link && dd if=/dev/zero of=/tmp/native-pm-corpus-src/stage/usr/share/phase4-corpus/large-payload.bin bs=1048576 count=2 && mkdir -p /tmp/native-pm-corpus && CONARY_BIN=${CONARY_BIN} /opt/remi-tests/fixtures/native/build-native-fixtures.sh ${native_target} /tmp/native-pm-corpus /tmp/native-pm-corpus-src && . /tmp/native-pm-corpus/native-fixture.env && test -f \"$NATIVE_PKG_FILE\" && test \"$NATIVE_TARGET\" = \"${native_target}\" && test ${#NATIVE_PKG_SHA256} -eq 64 && case \"$NATIVE_PKG_FILE\" in /tmp/native-pm-corpus/${native_glob}) true ;; *) echo \"unexpected native corpus package path: $NATIVE_PKG_FILE\"; exit 1 ;; esac"
 
 [test.step.assert]
 exit_code = 0
@@ -120,7 +122,7 @@ exit_code = 0
 stdout_contains_any = ["Successfully installed", "Installed", "phase4-daily-driver-corpus"]
 
 [[test.step]]
-run = "/opt/remi-tests/fixtures/native/assert-selected-generation.py --root /conary --expect-sha256 /usr/bin/phase4-corpus=565d3f61ffdbbca53c7371588ce6884b680dfa1d1c1bd7fe3954b4ab957e0676 --expect-sha256 /usr/bin/phase4-corpus-alt=1c279f8af2faaed5ae4aad470ab37742b2cede45b42b65d961f2bb33233e5ad3 --expect-sha256 /etc/phase4-corpus/app.conf=8b3ca388884ac9c33e5e1c849ac30bc59aa9d494e7afc5d91fb56c8a4e760eb2 --expect-sha256 /usr/lib/systemd/system/phase4-corpus.service=20200a86933288373c109a2e3289b2314ff6015886bfbad9bec6e613421e756a --expect-sha256 /usr/lib/kernel/install.d/95-phase4-corpus.install=8753356f470ea82416c2d7a71cbf8367d4cbe1a8b78f3276fe45035e114c3674 --present /usr/share/phase4-corpus/large-payload.bin --expect-sha256 /var/lib/phase4-corpus/scriptlet.marker=a51a6c19a1ffc7416827e89adf20749d23ad42452c396cf7e627409f2896922c --expect-user phase4-corpus-user=/var/lib/phase4-corpus,/bin/false,phase4-corpus-group"
+run = "/opt/remi-tests/fixtures/native/assert-selected-generation.py --root /conary --expect-sha256 /usr/bin/phase4-corpus=565d3f61ffdbbca53c7371588ce6884b680dfa1d1c1bd7fe3954b4ab957e0676 --expect-sha256 /usr/bin/phase4-corpus-alt=1c279f8af2faaed5ae4aad470ab37742b2cede45b42b65d961f2bb33233e5ad3 --expect-symlink /usr/bin/phase4-corpus-link=phase4-corpus --expect-directory /usr/lib/phase4-corpus/state=0750 --expect-sha256 /etc/phase4-corpus/app.conf=8b3ca388884ac9c33e5e1c849ac30bc59aa9d494e7afc5d91fb56c8a4e760eb2 --expect-sha256 /usr/lib/systemd/system/phase4-corpus.service=20200a86933288373c109a2e3289b2314ff6015886bfbad9bec6e613421e756a --expect-sha256 /usr/lib/kernel/install.d/95-phase4-corpus.install=8753356f470ea82416c2d7a71cbf8367d4cbe1a8b78f3276fe45035e114c3674 --present /usr/share/phase4-corpus/large-payload.bin --expect-sha256 /var/lib/phase4-corpus/scriptlet.marker=a51a6c19a1ffc7416827e89adf20749d23ad42452c396cf7e627409f2896922c --expect-user phase4-corpus-user=/var/lib/phase4-corpus,/bin/false,phase4-corpus-group"
 
 [test.step.assert]
 exit_code = 0
@@ -151,6 +153,13 @@ run = "sqlite3 ${DB_PATH} \"SELECT COUNT(*) || ' regular files' FROM files WHERE
 [test.step.assert]
 exit_code = 0
 stdout_contains_all = ["6 regular files", "/etc/phase4-corpus/app.conf", "/usr/bin/phase4-corpus-alt", "/usr/lib/kernel/install.d/95-phase4-corpus.install", "/usr/lib/systemd/system/phase4-corpus.service", "/usr/share/phase4-corpus/large-payload.bin|2097152|regular"]
+
+[[test.step]]
+run = "sqlite3 ${DB_PATH} \"SELECT path || '|' || json_extract(payload_node_json, '$.source.kind.type') || '|' || printf('%04o', json_extract(payload_node_json, '$.source.mode') & 4095) FROM files WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-daily-driver-corpus') AND path = '/usr/lib/phase4-corpus/state'; SELECT path || '|' || json_extract(payload_node_json, '$.source.kind.type') || '|' || json_extract(payload_node_json, '$.source.kind.target') FROM files WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-daily-driver-corpus') AND path = '/usr/bin/phase4-corpus-link'\""
+
+[test.step.assert]
+exit_code = 0
+stdout_contains_all = ["/usr/lib/phase4-corpus/state|directory|0750", "/usr/bin/phase4-corpus-link|symlink|phase4-corpus"]
 
 [[test.step]]
 run = "sqlite3 ${DB_PATH} \"SELECT COUNT(*) || ' requirement groups' FROM package_requirement_groups WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-daily-driver-corpus'); SELECT COALESCE((SELECT group_concat(kind || '|' || version_scheme || '|' || requirement_json, char(10)) FROM package_requirement_groups WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-daily-driver-corpus') ORDER BY id), 'no-deps')\""
@@ -217,6 +226,14 @@ semantic = "payload_files"
 artifact_roles = ["install_request"]
 
 [[test.corpus.coverage]]
+semantic = "payload_directories"
+artifact_roles = ["install_request"]
+
+[[test.corpus.coverage]]
+semantic = "payload_symlinks"
+artifact_roles = ["install_request"]
+
+[[test.corpus.coverage]]
 semantic = "relations_virtual_provide"
 artifact_roles = ["install_request"]
 
@@ -240,7 +257,7 @@ conary = "list phase4-daily-driver-corpus --files"
 
 [test.step.assert]
 exit_code = 0
-stdout_contains_all = ["/usr/bin/phase4-corpus", "/usr/bin/phase4-corpus-alt", "/etc/phase4-corpus/app.conf", "/usr/lib/systemd/system/phase4-corpus.service", "/usr/share/phase4-corpus/large-payload.bin", "/usr/lib/kernel/install.d/95-phase4-corpus.install"]
+stdout_contains_all = ["/usr/bin/phase4-corpus", "/usr/bin/phase4-corpus-alt", "/usr/bin/phase4-corpus-link", "/usr/lib/phase4-corpus/state", "/etc/phase4-corpus/app.conf", "/usr/lib/systemd/system/phase4-corpus.service", "/usr/share/phase4-corpus/large-payload.bin", "/usr/lib/kernel/install.d/95-phase4-corpus.install"]
 
 [[test.step]]
 conary = "list --path /usr/bin/phase4-corpus-alt"
@@ -352,7 +369,7 @@ exit_code = 0
 stdout_contains = "Removed package: phase4-daily-driver-corpus version ${native_corpus_fixture_version}"
 
 [[test.step]]
-run = "/opt/remi-tests/fixtures/native/assert-selected-generation.py --root /conary --expect-sha256 /var/lib/phase4-corpus/remove.marker=e1f79758cc42e6fe6037941205d1fbc37f5780f13aa077d0ba8287fd93cecd52 --absent /usr/bin/phase4-corpus --absent /usr/bin/phase4-corpus-alt --absent /etc/phase4-corpus/app.conf --absent /usr/lib/systemd/system/phase4-corpus.service --absent /usr/lib/kernel/install.d/95-phase4-corpus.install --absent /usr/share/phase4-corpus/large-payload.bin"
+run = "/opt/remi-tests/fixtures/native/assert-selected-generation.py --root /conary --expect-sha256 /var/lib/phase4-corpus/remove.marker=e1f79758cc42e6fe6037941205d1fbc37f5780f13aa077d0ba8287fd93cecd52 --absent /usr/bin/phase4-corpus --absent /usr/bin/phase4-corpus-alt --absent /usr/bin/phase4-corpus-link --absent /usr/lib/phase4-corpus/state --absent /etc/phase4-corpus/app.conf --absent /usr/lib/systemd/system/phase4-corpus.service --absent /usr/lib/kernel/install.d/95-phase4-corpus.install --absent /usr/share/phase4-corpus/large-payload.bin"
 
 [test.step.assert]
 exit_code = 0

--- a/crates/conary-core/src/ccs/native_export/arch.rs
+++ b/crates/conary-core/src/ccs/native_export/arch.rs
@@ -347,6 +347,7 @@ fn create_arch_package(pkg_root: &Path, output_path: &Path) -> Result<()> {
     {
         let file = File::create(&tar_path)?;
         let mut archive = TarBuilder::new(file);
+        archive.follow_symlinks(false);
 
         // Add .PKGINFO first (required)
         let pkginfo_path = pkg_root.join(".PKGINFO");

--- a/crates/conary-core/src/ccs/native_export/deb.rs
+++ b/crates/conary-core/src/ccs/native_export/deb.rs
@@ -304,6 +304,7 @@ fn create_tarball(source_dir: &Path, output_path: &Path) -> Result<()> {
     let file = File::create(output_path)?;
     let encoder = GzEncoder::new(file, Compression::default());
     let mut archive = TarBuilder::new(encoder);
+    archive.follow_symlinks(false);
 
     // Add files from directory
     for entry in fs::read_dir(source_dir)? {

--- a/crates/conary-core/src/ccs/native_export/mod.rs
+++ b/crates/conary-core/src/ccs/native_export/mod.rs
@@ -258,6 +258,9 @@ pub fn arch_for_format(arch: Option<&str>, format: &str) -> anyhow::Result<Strin
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::packages::PackageFormat;
+    use crate::payload::PayloadNodeKind;
+    use std::os::unix::fs::PermissionsExt;
 
     #[test]
     fn source_backed_copy_preserves_bytes_and_computes_debian_md5() {
@@ -311,6 +314,72 @@ mod tests {
         assert!(arch_for_format(Some("noarch"), "deb").is_err());
         assert!(arch_for_format(None, "arch").is_err());
         assert!(arch_for_format(Some("riscv64"), "arch").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn native_exporters_round_trip_explicit_directory_and_symlink_topology() {
+        let source = tempfile::tempdir().unwrap();
+        let state_dir = source.path().join("usr/lib/topology/state");
+        let bin_dir = source.path().join("usr/bin");
+        std::fs::create_dir_all(&state_dir).unwrap();
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o750)).unwrap();
+        std::fs::write(bin_dir.join("topology-tool"), b"topology\n").unwrap();
+        std::os::unix::fs::symlink("topology-tool", bin_dir.join("topology-link")).unwrap();
+
+        let mut manifest = crate::ccs::manifest::CcsManifest::new_minimal("topology", "1.0.0");
+        manifest.package.license = Some("MIT".to_string());
+        manifest.package.homepage = Some("https://example.invalid/topology".to_string());
+        manifest.package.authors = Some(crate::ccs::manifest::Authors {
+            maintainers: vec!["Topology Test <topology@example.invalid>".to_string()],
+            upstream: None,
+        });
+        manifest.package.platform = Some(crate::ccs::manifest::Platform {
+            arch: Some("x86_64".to_string()),
+            ..Default::default()
+        });
+        let result = crate::ccs::builder::CcsBuilder::new(manifest, source.path())
+            .unwrap()
+            .build()
+            .unwrap();
+        let output = tempfile::tempdir().unwrap();
+
+        let rpm_path = output.path().join("topology.rpm");
+        rpm::generate(&result, &rpm_path).unwrap();
+        let rpm = crate::packages::rpm::RpmPackage::parse(rpm_path.to_str().unwrap()).unwrap();
+        assert_topology("rpm", &rpm);
+
+        let deb_path = output.path().join("topology.deb");
+        deb::generate(&result, &deb_path).unwrap();
+        let deb = crate::packages::deb::DebPackage::parse(deb_path.to_str().unwrap()).unwrap();
+        assert_topology("deb", &deb);
+
+        let arch_path = output.path().join("topology.pkg.tar.zst");
+        arch::generate(&result, &arch_path).unwrap();
+        let arch = crate::packages::arch::ArchPackage::parse(arch_path.to_str().unwrap()).unwrap();
+        assert_topology("arch", &arch);
+    }
+
+    fn assert_topology(format: &str, package: &impl PackageFormat) {
+        let payload = package.package_payload().unwrap();
+        let directory = payload
+            .files()
+            .iter()
+            .find(|file| file.path == "/usr/lib/topology/state")
+            .expect("explicit topology directory");
+        assert!(matches!(directory.node.kind, PayloadNodeKind::Directory));
+        assert_eq!(directory.node.mode & 0o7777, 0o750);
+
+        let symlink = payload
+            .files()
+            .iter()
+            .find(|file| file.path == "/usr/bin/topology-link")
+            .expect("topology symlink");
+        let PayloadNodeKind::Symlink { target } = &symlink.node.kind else {
+            panic!("{format} topology link is {:?}", symlink.node.kind);
+        };
+        assert_eq!(target, "topology-tool", "{format} symlink target");
     }
 
     #[test]

--- a/crates/conary-core/src/ccs/native_export/mod.rs
+++ b/crates/conary-core/src/ccs/native_export/mod.rs
@@ -371,6 +371,20 @@ mod tests {
         assert!(matches!(directory.node.kind, PayloadNodeKind::Directory));
         assert_eq!(directory.node.mode & 0o7777, 0o750);
 
+        if format == "rpm" {
+            assert!(
+                payload.files().iter().all(|file| file.path != "/usr/bin"),
+                "rpm must not claim the target filesystem package's default parent directory"
+            );
+            assert!(
+                payload
+                    .files()
+                    .iter()
+                    .all(|file| file.path != "/usr/lib/topology"),
+                "rpm must leave default parent directories implicit"
+            );
+        }
+
         let symlink = payload
             .files()
             .iter()

--- a/crates/conary-core/src/ccs/native_export/rpm.rs
+++ b/crates/conary-core/src/ccs/native_export/rpm.rs
@@ -140,12 +140,19 @@ pub fn generate(result: &BuildResult, output_path: &Path) -> Result<GenerationRe
         );
     }
 
-    // Write files to temp dir and add to RPM
+    // Write files to temp dir and add to RPM.
+    let mut omitted_top_level_directory = false;
     for file in &result.files {
-        if matches!(&file.node.kind, PayloadNodeKind::Directory) {
+        if matches!(&file.node.kind, PayloadNodeKind::Directory)
+            && Path::new(&file.path).parent() == Some(Path::new("/"))
+        {
+            // rpm-rs 0.27 currently encodes a root-child directory such as
+            // /usr with dirname "//", which is not canonical RPM authority.
+            // Parent directories are implicit for descendant entries; retain
+            // an explicit loss record instead of publishing malformed bytes.
+            omitted_top_level_directory = true;
             continue;
         }
-
         match &file.node.kind {
             PayloadNodeKind::Regular { .. } => {
                 // Write to temp location
@@ -213,13 +220,24 @@ pub fn generate(result: &BuildResult, output_path: &Path) -> Result<GenerationRe
                     .with_symlink(options)
                     .context(format!("Failed to add symlink: {}", file.path))?;
             }
-            PayloadNodeKind::Directory => unreachable!("directories filtered above"),
+            PayloadNodeKind::Directory => {
+                let options =
+                    rpm::FileOptions::dir(&file.path).permissions((file.node.mode & 0o7777) as u16);
+                builder
+                    .with_dir_entry(options)
+                    .with_context(|| format!("Failed to add directory: {}", file.path))?;
+            }
             other => anyhow::bail!(
                 "RPM generator does not yet encode {} node {}",
                 payload_kind_name(other),
                 file.path
             ),
         }
+    }
+    if omitted_top_level_directory {
+        loss_report.add_unsupported(
+            "Explicit top-level directory metadata (RPM descendant paths create parents implicitly)",
+        );
     }
 
     for config in manifest.config.files.iter().filter(|config| config.ghost()) {

--- a/crates/conary-core/src/ccs/native_export/rpm.rs
+++ b/crates/conary-core/src/ccs/native_export/rpm.rs
@@ -10,8 +10,9 @@ use crate::ccs::manifest::Hooks;
 use crate::payload::PayloadNodeKind;
 use anyhow::{Context, Result};
 use rpm::PackageBuilder;
+use std::collections::HashSet;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// RPM-specific hook converter
 struct RpmHookConverter;
@@ -140,18 +141,35 @@ pub fn generate(result: &BuildResult, output_path: &Path) -> Result<GenerationRe
         );
     }
 
+    let mut implicit_parent_dirs = HashSet::<PathBuf>::new();
+    for file in &result.files {
+        let mut parent = Path::new(&file.path).parent();
+        while let Some(path) = parent {
+            implicit_parent_dirs.insert(path.to_path_buf());
+            parent = path.parent();
+        }
+    }
+
     // Write files to temp dir and add to RPM.
     let mut omitted_top_level_directory = false;
     for file in &result.files {
-        if matches!(&file.node.kind, PayloadNodeKind::Directory)
-            && Path::new(&file.path).parent() == Some(Path::new("/"))
-        {
-            // rpm-rs 0.27 currently encodes a root-child directory such as
-            // /usr with dirname "//", which is not canonical RPM authority.
-            // Parent directories are implicit for descendant entries; retain
-            // an explicit loss record instead of publishing malformed bytes.
-            omitted_top_level_directory = true;
-            continue;
+        if matches!(&file.node.kind, PayloadNodeKind::Directory) {
+            let has_descendant = implicit_parent_dirs.contains(Path::new(&file.path));
+            let has_default_parent_metadata = file.node.mode & 0o7777 == 0o755;
+            if has_descendant && has_default_parent_metadata {
+                // RPM creates default-mode parent directories for descendant
+                // entries. Do not claim shared paths such as /usr/bin, which
+                // belong to the target's filesystem package.
+                continue;
+            }
+            if Path::new(&file.path).parent() == Some(Path::new("/")) {
+                // rpm-rs 0.27 currently encodes a root-child directory such as
+                // /usr with dirname "//", which is not canonical RPM authority.
+                // Retain an explicit loss record instead of publishing malformed
+                // bytes when its metadata cannot be represented implicitly.
+                omitted_top_level_directory = true;
+                continue;
+            }
         }
         match &file.node.kind {
             PayloadNodeKind::Regular { .. } => {

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-08-15
-revision: 52
-summary: Document the focused attributable daily-driver manifest, typed corpus coverage, authenticated derivative targets, release evidence, and native lifecycle gates
+last_updated: 2026-08-16
+revision: 53
+summary: Document attributable daily-driver payload topology, typed corpus coverage, authenticated derivative targets, release evidence, and native lifecycle gates
 ---
 
 # Integration Testing
@@ -534,6 +534,8 @@ builds a package in the host-native format and then proves:
 - native dependency metadata for a real package dependency
 - an exact installed native-lifecycle bundle plus install/remove hook effects
 - system user and group creation in the selected generation
+- an explicit mode-0750 directory and an exact relative symlink through native
+  package metadata and the selected generation
 - conflict refusal before a conflicting-content native package can mutate
   selected state
 - a 2 MiB payload file through the native package parser and file database
@@ -544,11 +546,14 @@ builds a package in the host-native format and then proves:
 `TNPM16` and `TNPM18` make the chain visible to the typed W7 aggregator. Each
 record reopens the builder's schema-versioned output manifest, hashes the exact
 native artifact again, and binds its claims to the install-request role.
-Across the two completed cases the suite declares exactly seven properties:
-exact version, native architecture, regular files, a queried virtual provide,
-matched config, purge-time config removal, and shell lifecycle. The source
-format comes from the explicit distro build-context override and must resolve
-to the closed RPM/DEB/ALPM type before evidence can count.
+Across the two completed cases the suite declares exactly nine properties:
+exact version, native architecture, regular files, directories, symlinks, a
+queried virtual provide, matched config, purge-time config removal, and shell
+lifecycle. Directory and symlink claims require exact typed node/mode/target
+queries plus selected-generation assertions; implicit parents and followed
+filesystem paths do not count. The source format comes from the explicit
+distro build-context override and must resolve to the closed RPM/DEB/ALPM type
+before evidence can count.
 
 Several useful assertions deliberately remain outside semantic coverage. The
 2 MiB zero-filled file is not W7 large-file/resource-boundary proof; the

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -555,6 +555,11 @@ filesystem paths do not count. The source format comes from the explicit
 distro build-context override and must resolve to the closed RPM/DEB/ALPM type
 before evidence can count.
 
+RPM export emits a directory entry when its mode differs from the implicit
+0755 parent contract or no descendant can create it. Default-mode parents of
+payload entries remain implicit so generated packages do not claim shared
+target paths such as `/usr/bin` from the native filesystem package.
+
 Several useful assertions deliberately remain outside semantic coverage. The
 2 MiB zero-filled file is not W7 large-file/resource-boundary proof; the
 Conary changeset trigger is not a source-package trigger; the disabled systemd

--- a/docs/modules/test-fixtures.md
+++ b/docs/modules/test-fixtures.md
@@ -488,6 +488,8 @@ Each fixture family should record:
   one exact symlink, one queried virtual provide, matched config, and shell
   lifecycle; removal covers config cleanup. Topology counts only after typed
   native-package metadata and selected-generation node assertions agree.
+  RPM directory proof uses a non-default leaf so the package owns its metadata;
+  default shared parents remain implicit native-package paths.
   Its builder writes a schema-versioned digest manifest and the evidence writer
   rehashes the artifact before publication. Do not infer hardlink, large-file,
   source-trigger, activation, target-helper, or declared-relation coverage from

--- a/docs/modules/test-fixtures.md
+++ b/docs/modules/test-fixtures.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-08-15
-revision: 35
-summary: Map fixture ownership, including the focused attributable daily-driver manifest, authenticated derivative roots, and cross-source lifecycle proof
+last_updated: 2026-08-16
+revision: 36
+summary: Map fixture ownership, including attributable daily-driver payload topology, authenticated derivative roots, and cross-source lifecycle proof
 ---
 
 # Test Fixtures And Proof Maps
@@ -484,10 +484,12 @@ Each fixture family should record:
   all-lane aggregator context; do not weaken either in workflow-only edits.
   The focused `phase4-native-daily-driver-corpus` chain emits two exact-artifact records
   for its host-native RPM, DEB, or ALPM build: the completed install/query
-  chain covers exact/native identity, regular files, one queried virtual
-  provide, matched config, and shell lifecycle; removal covers config cleanup.
+  chain covers exact/native identity, regular files, one explicit directory,
+  one exact symlink, one queried virtual provide, matched config, and shell
+  lifecycle; removal covers config cleanup. Topology counts only after typed
+  native-package metadata and selected-generation node assertions agree.
   Its builder writes a schema-versioned digest manifest and the evidence writer
-  rehashes the artifact before publication. Do not infer large-file,
+  rehashes the artifact before publication. Do not infer hardlink, large-file,
   source-trigger, activation, target-helper, or declared-relation coverage from
   the chain's 2 MiB file, out-of-band trigger, disabled unit, adjacent helper
   path, or file-collision negative.

--- a/docs/roadmaps/development-roadmap.md
+++ b/docs/roadmaps/development-roadmap.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-08-15
-revision: 23
-summary: Track Conary's active W7 just-works corpus gate, typed semantic coverage, external tester milestone, and later workstreams
+last_updated: 2026-08-16
+revision: 24
+summary: Track Conary's active W7 payload-topology corpus slice, typed semantic coverage, external tester milestone, and later workstreams
 proof_baseline: "immutable synchronized v0.15.0 suite at 642750878d5a59a9aa27976347cafc6f9dd86cfd; exact tagged Remi deployed; external tester result remains 0/10 behind #110"
 current_milestone: first external tester loop
 active_workstream: W7 Just-Works Corpus Gate
@@ -316,13 +316,14 @@ the stated scope, not whether a workstream happens to be active.
 - **Execution status:** active after W4 through W6 completion. Typed per-case
   reporting and the closed 44-property authority landed through #456; #458
   makes the daily-driver native fixture attributable in one focused local
-  manifest before the remaining fixture and hosted-execution slices. Its
-  discovery run filed the legacy provider-set defect as #460 and live
-  repository-sync nondeterminism as #461 rather than folding them into the
-  focused W7 fixture gate.
-- **Issues:** #110 as the corpus umbrella, #458 for daily-driver fixture
-  attribution, #460 and #461 for exact legacy parity defects found by its
-  discovery run, plus #39 for bootstrap.
+  manifest. #463 adds exact directory and symlink topology to that same
+  digest-bound chain. Hardlink export remains an explicit #462 gap, and
+  root-child RPM directory authoring remains #464. The #458 discovery run
+  filed the legacy provider-set defect as #460 and live repository-sync
+  nondeterminism as #461 rather than folding them into the focused W7 gate.
+- **Issues:** #110 as the corpus umbrella; #458 and #463 for focused
+  daily-driver attribution; #462 and #464 for payload-topology export gaps;
+  #460 and #461 for exact legacy parity defects; plus #39 for bootstrap.
 - **User journey:** install the signed release through one documented bootstrap
   entry point; `conary system init` with no hand-edited state; sync and
   authenticate repositories; request a package by ordinary name; resolve the


### PR DESCRIPTION
## Problem

The focused W7 daily-driver corpus proved regular files but did not attribute explicit directory or symlink topology to the exact native artifact. RPM export discarded explicit directories, while DEB and ALPM tar construction followed staged symlinks.

## Changes

- preserve non-default or otherwise non-implied directory entries in RPM export with exact permission bits
- leave default-mode parent directories implicit so generated RPMs do not claim shared filesystem-package paths such as `/usr/bin`
- preserve symlink nodes in DEB and ALPM archives
- round-trip one mode-0750 directory and one relative symlink through RPM, DEB, and ALPM parsers
- assert exact typed directory mode and symlink target in package metadata and selected-generation state
- attribute only `payload_directories` and `payload_symlinks` to the digest-bound install artifact
- record the independent root-child RPM limitation in #464 and retain it as an explicit loss

## Hosted finding resolved

PR run `31922660277` proved all three focused topology lanes, but its Fedora and openSUSE lifecycle jobs failed because the first head made generated RPMs claim `/usr/bin` and `/usr/share`, conflicting with each target's `filesystem` package. Head `2573c98c` fixes the exporter ownership rule and locks both the preserved non-default leaf and omitted default parents in the cross-format regression.

## Verification

- `cargo test -p conary-core native_export` — 23 passed
- `cargo test -p conary-core` — 3,625 passed, 5 declared ignored; integration and doc tests passed
- `cargo test -p conary-test` — 327 passed, 1 declared ignored
- exact focused corpus regression — 1 passed
- `cargo run -p conary-test -- list` — manifest inventory parsed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `bash scripts/check-doc-truth.sh`
- Python fixture syntax compile
- `git diff --check`
- replacement-head PR run `31923221610` — all 25 jobs passed, including three focused topology lanes, stable aggregate, and the Fedora/openSUSE lifecycle regressions

Closes #463
Refs #110
Refs #458
Refs #462
Refs #464