### PR TITLE
test(conary-test): make TNPM04 providers source exact

### DIFF
--- a/apps/conary-test/src/config/tests/native_corpus.rs
+++ b/apps/conary-test/src/config/tests/native_corpus.rs
@@ -3,7 +3,7 @@
 use super::{conary_fixture_path, load_manifest, remi_manifest_path};
 
 #[test]
-fn phase4_native_manifests_separate_parity_from_daily_driver_authority() {
+fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contract() {
     let path = remi_manifest_path("phase4-native-pm-parity.toml");
     if !path.exists() {
         return;
@@ -105,6 +105,51 @@ fn phase4_native_manifests_separate_parity_from_daily_driver_authority() {
                 "{trace_path} must contain only normalized lifecycle records"
             );
         }
+    }
+
+    let provider_contract = [
+        (
+            "fedora44",
+            "4",
+            "3",
+            "/etc/phase4-runtime-fixture/app.conf,/usr/bin/phase4-runtime-fixture,/usr/include/phase4-runtime-fixture/api.h",
+        ),
+        ("ubuntu-26.04", "1", "0", "no file provides"),
+        ("arch", "1", "0", "no file provides"),
+    ];
+    for (distro, provider_count, file_provider_count, file_provider_set) in provider_contract {
+        let overrides = parity_manifest
+            .distro_overrides
+            .get(distro)
+            .unwrap_or_else(|| panic!("missing {distro} overrides"));
+        for (key, expected) in [
+            ("native_provider_count", provider_count),
+            ("native_file_provider_count", file_provider_count),
+            ("native_file_provider_set", file_provider_set),
+        ] {
+            assert_eq!(
+                overrides.get(key).map(String::as_str),
+                Some(expected),
+                "{distro} must declare its exact {key}"
+            );
+        }
+    }
+    let metadata_test = parity_manifest
+        .test
+        .iter()
+        .find(|test| test.id == "TNPM04")
+        .expect("Phase 4 native PM parity must include TNPM04");
+    let metadata_rendered = format!("{metadata_test:?}");
+    for required in [
+        "${native_provider_count} provides",
+        "${native_file_provider_count} file provides",
+        "phase4-runtime-fixture|${native_fixture_version}|package",
+        "${native_file_provider_set}",
+    ] {
+        assert!(
+            metadata_rendered.contains(required),
+            "TNPM04 must enforce the source-format-owned provider contract {required}"
+        );
     }
 
     let daily_driver_path = remi_manifest_path("phase4-native-daily-driver-corpus.toml");

--- a/apps/conary/tests/integration/remi/manifests/phase4-native-pm-parity.toml
+++ b/apps/conary/tests/integration/remi/manifests/phase4-native-pm-parity.toml
@@ -42,6 +42,9 @@ native_dependency_probe = "no-deps"
 native_config_count = "1"
 native_config_source = "rpm"
 native_lifecycle_fidelity = "native-free"
+native_provider_count = "4"
+native_file_provider_count = "3"
+native_file_provider_set = "/etc/phase4-runtime-fixture/app.conf,/usr/bin/phase4-runtime-fixture,/usr/include/phase4-runtime-fixture/api.h"
 repo_install_pkg = "tree"
 repo_install_path = "/usr/bin/tree"
 repo_seed_security_version = "9999.0-1"
@@ -59,6 +62,9 @@ native_dependency_probe = "no-deps"
 native_config_count = "1"
 native_config_source = "deb"
 native_lifecycle_fidelity = "native-free"
+native_provider_count = "1"
+native_file_provider_count = "0"
+native_file_provider_set = "no file provides"
 repo_install_pkg = "nano"
 repo_install_path = "/usr/bin/nano"
 repo_seed_security_version = "9999.0"
@@ -76,6 +82,9 @@ native_dependency_probe = "no-deps"
 native_config_count = "1"
 native_config_source = "arch"
 native_lifecycle_fidelity = "native-free"
+native_provider_count = "1"
+native_file_provider_count = "0"
+native_file_provider_set = "no file provides"
 repo_install_pkg = "tree"
 repo_install_path = "/usr/bin/tree"
 repo_seed_security_version = "9999.0-1"
@@ -194,11 +203,11 @@ exit_code = 0
 stdout_contains_all = ["3 regular files", "/etc/phase4-runtime-fixture/app.conf|1da0b50cb027387347265437a11956c1433788d045e4c63b379a1e0740882e7c|61|regular|33188", "/usr/bin/phase4-runtime-fixture|517631de24336343a6aaf1a8f704d326299c14c619fe8c8d75d17824d074bd7f|44|regular|33188", "/usr/include/phase4-runtime-fixture/api.h|88904c275ae0f26a566c03f488ae82869c47ac921fb6f0cf7979d5845f199c88|130|regular|33188"]
 
 [[test.step]]
-run = "sqlite3 ${DB_PATH} \"SELECT COUNT(*) || ' provides' FROM provides WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-runtime-fixture'); SELECT capability || '|' || COALESCE(version, '') || '|' || COALESCE(kind, '') FROM provides WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-runtime-fixture') ORDER BY capability\""
+run = "sqlite3 ${DB_PATH} \"SELECT COUNT(*) || ' provides' FROM provides WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-runtime-fixture'); SELECT COUNT(*) || ' file provides' FROM provides WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-runtime-fixture') AND kind = 'file'; SELECT capability || '|' || COALESCE(version, '') || '|' || COALESCE(kind, '') FROM provides WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-runtime-fixture') AND kind = 'package'; SELECT COALESCE((SELECT group_concat(capability, ',') FROM (SELECT capability FROM provides WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-runtime-fixture') AND kind = 'file' ORDER BY capability)), 'no file provides')\""
 
 [test.step.assert]
 exit_code = 0
-stdout_contains_all = ["4 provides", "/etc/phase4-runtime-fixture/app.conf||file", "/usr/bin/phase4-runtime-fixture||file", "/usr/include/phase4-runtime-fixture/api.h||file", "phase4-runtime-fixture|${native_fixture_version}|package"]
+stdout_contains_all = ["${native_provider_count} provides", "${native_file_provider_count} file provides", "phase4-runtime-fixture|${native_fixture_version}|package", "${native_file_provider_set}"]
 
 [[test.step]]
 run = "sqlite3 ${DB_PATH} \"SELECT COUNT(*) || ' requirement groups' FROM package_requirement_groups WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-runtime-fixture')\""

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -524,7 +524,10 @@ payload snapshot, not mislabeled as a native package-manager downgrade.
 update, query, security-refusal, and autoremove parity proof. Repository update
 selection uses a signed CCS package synchronized through typed JSON metadata;
 the unknown-security case also enters through normal typed repository sync,
-not a synthetic package row. The focused
+not a synthetic package row. `TNPM04` binds its provider assertions to the
+source format: RPM requires the exact package provide plus its three native
+file provides, while DEB and Arch require only the exact versioned package
+provide and reject invented file-provide rows. The focused
 `phase4-native-daily-driver-corpus` manifest owns `TNPM13` through `TNPM18`
 without inheriting the live repository or prior parity state. That corpus
 builds a package in the host-native format and then proves:

--- a/docs/modules/test-fixtures.md
+++ b/docs/modules/test-fixtures.md
@@ -428,6 +428,7 @@ Each fixture family should record:
   suite runner, local QEMU validation scripts.
 - **Fast proof:** `cargo run -p conary-test -- list`;
   `cargo test -p conary-test suite_inventory`;
+  `cargo test -p conary-test phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contract`;
   `cargo test -p conary-test focused_native_cross_source_manifest_runs_the_shared_lifecycle_contract`;
   `cargo test -p conary-test native_cross_source_`.
 - **Medium proof:**


### PR DESCRIPTION
## Problem

TNPM04 currently applies RPM's four-provider expectation to DEB and Arch conversions. Hosted evidence shows that RPM owns three native file provides in addition to the package provide, while DEB and Arch own only the exact versioned package provide.

## Change

- declare the exact provider count, file-provider count, and ordered file-provider set per source format
- assert the exact versioned package provide independently on every format
- lock all three distro contracts and TNPM04's consumed placeholders in the manifest regression test
- document the source-format boundary in the owning integration-test docs

## Verification

- `cargo test -p conary-test phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contract` (1 passed)
- `bash scripts/agent-context.sh --feature conary-test --run focused` (5/5 commands passed)
- `cargo run -p conary-test -- list`
- `cargo fmt --check`
- `git diff --check`
- `bash scripts/check-doc-truth.sh`

Hosted PR-gate results are pending on this exact head. The full Fedora 44, Ubuntu 26.04, and Arch `phase4-native-pm-parity` acceptance remains explicitly dependent on fixing TNPM01 under #461; this PR does not claim that terminal proof.

Refs #460