### PR TITLE
test(w7): prove versioned dependency resolution

### DIFF
--- a/apps/conary-test/src/config/tests/native_corpus.rs
+++ b/apps/conary-test/src/config/tests/native_corpus.rs
@@ -268,6 +268,8 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
         "\"download_url\": f\"{repository_url}/{artifact.name}\"",
         "\"requirements\": []",
         "\"relations\": []",
+        "pinned-binary-fixture-manifest.json",
+        "\"schema_version\": 1",
         "os.replace(temporary_path, path)",
     ] {
         assert!(
@@ -355,6 +357,7 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
             conary_core::corpus::CorpusSemantic::PayloadDirectories,
             conary_core::corpus::CorpusSemantic::PayloadSymlinks,
             conary_core::corpus::CorpusSemantic::PayloadHardlinks,
+            conary_core::corpus::CorpusSemantic::RelationsVersionedDependency,
             conary_core::corpus::CorpusSemantic::RelationsVirtualProvide,
             conary_core::corpus::CorpusSemantic::ConfigurationMatchedConfig,
             conary_core::corpus::CorpusSemantic::ConfigurationRemoval,
@@ -420,6 +423,9 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
         "phase4-corpus-user",
         "phase4-corpus-group",
         "${native_corpus_dependency_probe}",
+        "phase4-repository-fixture|= 1.0.0-1",
+        "|repository|dependency",
+        "/usr/share/phase4-repository-fixture/probe.txt",
         "/var/lib/phase4-corpus/scriptlet.marker",
         "/var/lib/phase4-corpus/remove.marker",
         "phase4-corpus-conflict",
@@ -443,10 +449,44 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
         "--from ${native_profile}",
         "query whatprovides 'virtual(phase4-corpus-tool)'",
         "0 config rows",
+        "--dependency-fixture-manifest",
+        "resolution",
     ] {
         assert!(
             rendered.contains(required),
             "daily-driver corpus should cover {required}"
+        );
+    }
+    let daily_driver_setup = format!("{:?}", manifest.suite.setup);
+    for required in [
+        "build-pinned-binary-fixture.sh ${native_target}",
+        "http://127.0.0.1:18084",
+        "--default-strategy binary",
+        "--ccs-package-key ${FIXTURE_CCS_PUBLIC_KEY}",
+        "repo sync ${REPO_NAME} --force",
+    ] {
+        assert!(
+            daily_driver_setup.contains(required),
+            "daily-driver dependency setup must enforce {required}"
+        );
+    }
+    assert!(
+        !daily_driver_setup.contains("${REMI_ENDPOINT}"),
+        "daily-driver dependency proof must not consume the live Remi endpoint"
+    );
+    let mock_server = manifest
+        .suite
+        .mock_server
+        .as_ref()
+        .expect("daily-driver dependency proof needs a pinned loopback repository");
+    assert_eq!(mock_server.port, 18084);
+    for required in ["/metadata.json", "/phase4-repository-fixture-1.0.0-1.ccs"] {
+        assert!(
+            mock_server
+                .routes
+                .iter()
+                .any(|route| route.path == required),
+            "daily-driver dependency proof must serve {required}"
         );
     }
 
@@ -483,13 +523,33 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
     );
     assert_eq!(
         install_case.stages,
-        [conary_core::corpus::ConversionStage::Installation]
+        [
+            conary_core::corpus::ConversionStage::Resolution,
+            conary_core::corpus::ConversionStage::Installation,
+        ]
     );
-    assert_eq!(install_case.coverage.len(), 9);
+    assert_eq!(install_case.coverage.len(), 10);
+    let dependency_claim = install_case
+        .coverage
+        .iter()
+        .find(|claim| {
+            claim.semantic == conary_core::corpus::CorpusSemantic::RelationsVersionedDependency
+        })
+        .expect("versioned dependency coverage claim");
+    assert_eq!(
+        dependency_claim.artifact_roles,
+        [
+            conary_core::corpus::SourceArtifactRole::InstallRequest,
+            conary_core::corpus::SourceArtifactRole::InstallDependency,
+        ]
+    );
     assert!(
         install_case
             .coverage
             .iter()
+            .filter(|claim| {
+                claim.semantic != conary_core::corpus::CorpusSemantic::RelationsVersionedDependency
+            })
             .all(|claim| claim.artifact_roles
                 == [conary_core::corpus::SourceArtifactRole::InstallRequest])
     );
@@ -566,10 +626,11 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
             .expect("read primary daily-driver fixture");
     for required in [
         "[native_export.rpm]",
-        "requires = [\"bash\"]",
+        "requires = [{ name = \"phase4-repository-fixture\", relation = \"equal\", version = \"1.0.0-1\" }]",
         "[native_export.deb]",
+        "depends = [\"phase4-repository-fixture (= 1.0.0-1)\"]",
         "[native_export.arch]",
-        "depends = [\"bash\"]",
+        "depends = [\"phase4-repository-fixture=1.0.0-1\"]",
         "provides = [\"phase4-corpus-tool\"]",
     ] {
         assert!(
@@ -616,6 +677,8 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
         "schema_version",
         "sha256(artifact_path)",
         "fixture_build_manifest",
+        "install_dependency",
+        "dependency artifact identity requires all dependency arguments",
         "os.replace",
     ] {
         assert!(
@@ -623,6 +686,113 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
             "native corpus evidence writer should enforce {required}"
         );
     }
+}
+
+#[test]
+fn corpus_evidence_writer_binds_request_and_dependency_to_exact_digests() {
+    let directory = tempfile::tempdir().expect("create evidence test directory");
+    let request_artifact = directory.path().join("request.rpm");
+    let dependency_artifact = directory.path().join("dependency.ccs");
+    std::fs::write(&request_artifact, b"exact native request").unwrap();
+    std::fs::write(&dependency_artifact, b"exact signed dependency").unwrap();
+
+    let request_manifest = directory.path().join("request-manifest.json");
+    let dependency_manifest = directory.path().join("dependency-manifest.json");
+    for (manifest, artifact, target) in [
+        (&request_manifest, &request_artifact, "rpm"),
+        (&dependency_manifest, &dependency_artifact, "rpm"),
+    ] {
+        std::fs::write(
+            manifest,
+            serde_json::to_vec(&serde_json::json!({
+                "schema_version": 1,
+                "artifact_path": artifact,
+                "builder_target": target,
+                "sha256": conary_core::hash::sha256(&std::fs::read(artifact).unwrap()),
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+    }
+
+    let evidence_path = directory.path().join("evidence.json");
+    let script = conary_fixture_path("native/write-corpus-evidence.py");
+    let output = std::process::Command::new("python3")
+        .arg(&script)
+        .args([
+            request_manifest.as_os_str(),
+            evidence_path.as_os_str(),
+            "fedora-44".as_ref(),
+            "rpm".as_ref(),
+            "phase4-daily-driver-corpus".as_ref(),
+            "1.0.0-1".as_ref(),
+            "x86_64".as_ref(),
+            "resolution".as_ref(),
+            "installation".as_ref(),
+            "--dependency-fixture-manifest".as_ref(),
+            dependency_manifest.as_os_str(),
+            "--dependency-name".as_ref(),
+            "phase4-repository-fixture".as_ref(),
+            "--dependency-version".as_ref(),
+            "1.0.0-1".as_ref(),
+            "--dependency-architecture".as_ref(),
+            "x86_64".as_ref(),
+        ])
+        .output()
+        .expect("run evidence writer");
+    assert!(
+        output.status.success(),
+        "evidence writer failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let evidence: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&evidence_path).unwrap()).unwrap();
+    assert_eq!(
+        evidence["completed_stages"],
+        serde_json::json!(["resolution", "installation"])
+    );
+    let artifacts = evidence["source_artifacts"].as_array().unwrap();
+    assert_eq!(artifacts.len(), 2);
+    assert_eq!(artifacts[0]["role"], "install_request");
+    assert_eq!(artifacts[1]["role"], "install_dependency");
+    assert_eq!(
+        artifacts[0]["digest"],
+        conary_core::hash::sha256(&std::fs::read(&request_artifact).unwrap())
+    );
+    assert_eq!(
+        artifacts[1]["digest"],
+        conary_core::hash::sha256(&std::fs::read(&dependency_artifact).unwrap())
+    );
+
+    std::fs::write(&dependency_artifact, b"mutated dependency").unwrap();
+    let contradiction = std::process::Command::new("python3")
+        .arg(script)
+        .args([
+            request_manifest.as_os_str(),
+            evidence_path.as_os_str(),
+            "fedora-44".as_ref(),
+            "rpm".as_ref(),
+            "request".as_ref(),
+            "1".as_ref(),
+            "x86_64".as_ref(),
+            "installation".as_ref(),
+            "--dependency-fixture-manifest".as_ref(),
+            dependency_manifest.as_os_str(),
+            "--dependency-name".as_ref(),
+            "dependency".as_ref(),
+            "--dependency-version".as_ref(),
+            "1".as_ref(),
+            "--dependency-architecture".as_ref(),
+            "x86_64".as_ref(),
+        ])
+        .output()
+        .expect("run contradictory evidence writer");
+    assert!(!contradiction.status.success());
+    assert!(
+        String::from_utf8_lossy(&contradiction.stderr)
+            .contains("artifact digest contradicts its build manifest")
+    );
 }
 
 #[test]

--- a/apps/conary-test/src/config/tests/native_corpus.rs
+++ b/apps/conary-test/src/config/tests/native_corpus.rs
@@ -266,6 +266,7 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
         "hashlib.sha256(artifact_bytes).hexdigest()",
         "\"security_advisory_source\": None",
         "\"download_url\": f\"{repository_url}/{artifact.name}\"",
+        "\"release\": release",
         "\"requirements\": []",
         "\"relations\": []",
         "pinned-binary-fixture-manifest.json",
@@ -423,7 +424,7 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
         "phase4-corpus-user",
         "phase4-corpus-group",
         "${native_corpus_dependency_probe}",
-        "phase4-repository-fixture|= 1.0.0-1",
+        "phase4-repository-fixture|= 1.0.0",
         "|repository|dependency",
         "/usr/share/phase4-repository-fixture/probe.txt",
         "/var/lib/phase4-corpus/scriptlet.marker",
@@ -626,11 +627,11 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
             .expect("read primary daily-driver fixture");
     for required in [
         "[native_export.rpm]",
-        "requires = [{ name = \"phase4-repository-fixture\", relation = \"equal\", version = \"1.0.0-1\" }]",
+        "requires = [{ name = \"phase4-repository-fixture\", relation = \"equal\", version = \"1.0.0\" }]",
         "[native_export.deb]",
-        "depends = [\"phase4-repository-fixture (= 1.0.0-1)\"]",
+        "depends = [\"phase4-repository-fixture (= 1.0.0)\"]",
         "[native_export.arch]",
-        "depends = [\"phase4-repository-fixture=1.0.0-1\"]",
+        "depends = [\"phase4-repository-fixture=1.0.0\"]",
         "provides = [\"phase4-corpus-tool\"]",
     ] {
         assert!(

--- a/apps/conary/src/commands/ccs/install/command.rs
+++ b/apps/conary/src/commands/ccs/install/command.rs
@@ -179,10 +179,9 @@ pub async fn cmd_ccs_install(
             &conn,
             conary_core::repository::resolution_policy::RequestScope::Any,
         )?;
-        let resolution = conary_core::resolver::solve_requirement_groups_with_policy(
+        let resolution = conary_core::resolver::solve_package_requirements_with_policy(
             &conn,
-            ccs_pkg.requirements(),
-            ccs_pkg.version_scheme(),
+            &ccs_pkg,
             &effective_policy.resolution,
         )?;
         if let Some(conflict) = resolution.conflict_message {

--- a/apps/conary/src/commands/install/conversion.rs
+++ b/apps/conary/src/commands/install/conversion.rs
@@ -572,10 +572,9 @@ pub async fn install_ccs_artifact(opts: CcsArtifactInstallOptions<'_>) -> Result
     let mut selected_dependencies = Vec::new();
     if !no_deps && !ccs_pkg.requirements().is_empty() {
         let conn = open_db(db_path)?;
-        let sat_result = conary_core::resolver::solve_requirement_groups_with_policy(
+        let sat_result = conary_core::resolver::solve_package_requirements_with_policy(
             &conn,
-            ccs_pkg.requirements(),
-            ccs_pkg.version_scheme(),
+            &ccs_pkg,
             &resolution_policy,
         )
         .with_context(|| {

--- a/apps/conary/src/commands/install/dependencies.rs
+++ b/apps/conary/src/commands/install/dependencies.rs
@@ -16,7 +16,7 @@ use conary_core::db::paths::keyring_dir;
 use conary_core::packages::PackageFormat;
 use conary_core::repository;
 use conary_core::repository::dependency_model::RepositoryRequirementKind;
-use conary_core::resolver::{PackageIdentity, SatResolution, SatSource};
+use conary_core::resolver::{SatResolution, SatSource};
 use conary_core::scriptlet::SandboxMode;
 use std::collections::HashMap;
 use tempfile::TempDir;
@@ -70,40 +70,8 @@ pub(super) async fn handle_dependencies(ctx: &DepAnalysisContext<'_>) -> Result<
     );
     println!("Checking dependencies for {}...", ctx.pkg.name());
 
-    let incoming_package = PackageIdentity {
-        repo_package_id: None,
-        name: ctx.pkg.name().to_string(),
-        version: ctx.pkg.version().to_string(),
-        package_release: ctx.pkg.package_release().map(str::to_string),
-        architecture: ctx.pkg.architecture().map(str::to_string),
-        debian_multi_arch: ctx.pkg.debian_multi_arch(),
-        version_scheme: ctx.pkg.version_scheme(),
-        repository_id: None,
-        repository_name: String::new(),
-        repository_profile: None,
-        repository_priority: 0,
-        canonical_id: None,
-        canonical_name: None,
-        installed_trove_id: None,
-        installed_pinned: false,
-        provided_capabilities: ctx.pkg.resolution_capabilities()?,
-    };
-    let mut external_requirements = Vec::new();
-    for requirement in ctx.pkg.requirements() {
-        if !conary_core::resolver::positive_requirement_group_satisfied_by_package(
-            requirement,
-            ctx.pkg.version_scheme(),
-            &incoming_package,
-        )? {
-            external_requirements.push(requirement.clone());
-        }
-    }
-
-    let sat_result = conary_core::resolver::solve_requirement_groups_with_policy(
-        ctx.conn,
-        &external_requirements,
-        ctx.pkg.version_scheme(),
-        ctx.policy,
+    let sat_result = conary_core::resolver::solve_package_requirements_with_policy(
+        ctx.conn, ctx.pkg, ctx.policy,
     )
     .with_context(|| format!("Failed to resolve dependencies for '{}'", ctx.pkg.name()))?;
 

--- a/apps/conary/src/commands/install/dependencies.rs
+++ b/apps/conary/src/commands/install/dependencies.rs
@@ -16,7 +16,7 @@ use conary_core::db::paths::keyring_dir;
 use conary_core::packages::PackageFormat;
 use conary_core::repository;
 use conary_core::repository::dependency_model::RepositoryRequirementKind;
-use conary_core::resolver::{SatResolution, SatSource};
+use conary_core::resolver::{PackageIdentity, SatResolution, SatSource};
 use conary_core::scriptlet::SandboxMode;
 use std::collections::HashMap;
 use tempfile::TempDir;
@@ -70,9 +70,38 @@ pub(super) async fn handle_dependencies(ctx: &DepAnalysisContext<'_>) -> Result<
     );
     println!("Checking dependencies for {}...", ctx.pkg.name());
 
+    let incoming_package = PackageIdentity {
+        repo_package_id: None,
+        name: ctx.pkg.name().to_string(),
+        version: ctx.pkg.version().to_string(),
+        package_release: ctx.pkg.package_release().map(str::to_string),
+        architecture: ctx.pkg.architecture().map(str::to_string),
+        debian_multi_arch: ctx.pkg.debian_multi_arch(),
+        version_scheme: ctx.pkg.version_scheme(),
+        repository_id: None,
+        repository_name: String::new(),
+        repository_profile: None,
+        repository_priority: 0,
+        canonical_id: None,
+        canonical_name: None,
+        installed_trove_id: None,
+        installed_pinned: false,
+        provided_capabilities: ctx.pkg.resolution_capabilities()?,
+    };
+    let mut external_requirements = Vec::new();
+    for requirement in ctx.pkg.requirements() {
+        if !conary_core::resolver::positive_requirement_group_satisfied_by_package(
+            requirement,
+            ctx.pkg.version_scheme(),
+            &incoming_package,
+        )? {
+            external_requirements.push(requirement.clone());
+        }
+    }
+
     let sat_result = conary_core::resolver::solve_requirement_groups_with_policy(
         ctx.conn,
-        ctx.pkg.requirements(),
+        &external_requirements,
         ctx.pkg.version_scheme(),
         ctx.policy,
     )

--- a/apps/conary/tests/fixtures/native/build-pinned-binary-fixture.sh
+++ b/apps/conary/tests/fixtures/native/build-pinned-binary-fixture.sh
@@ -53,7 +53,8 @@ python3 - \
   "${output_dir}/pinned-binary-fixture-manifest.json" \
   "$version_scheme" \
   "$package_name" \
-  "${version}-${release}" \
+  "$version" \
+  "$release" \
   "$architecture" \
   "$artifact" \
   "$repository_url" <<'PY'
@@ -69,6 +70,7 @@ from pathlib import Path
     version_scheme,
     package_name,
     version,
+    release,
     architecture,
     artifact_path,
     repository_url,
@@ -83,6 +85,7 @@ document = {
         {
             "name": package_name,
             "version": version,
+            "release": release,
             "version_scheme": version_scheme,
             "architecture": architecture,
             "description": "Pinned signed CCS repository fixture",

--- a/apps/conary/tests/fixtures/native/build-pinned-binary-fixture.sh
+++ b/apps/conary/tests/fixtures/native/build-pinned-binary-fixture.sh
@@ -2,13 +2,14 @@
 # tests/fixtures/native/build-pinned-binary-fixture.sh
 set -euo pipefail
 
-if [[ $# -ne 2 ]]; then
-  echo "Usage: $0 <rpm|deb|arch> <output-dir>" >&2
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  echo "Usage: $0 <rpm|deb|arch> <output-dir> [repository-url]" >&2
   exit 64
 fi
 
 target="$1"
 output_dir="$2"
+repository_url="${3:-http://127.0.0.1:18083}"
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 fixture_root="${script_dir}/../phase4-pinned-repository"
 authority_root="${script_dir}/../ccs-test-authority"
@@ -49,12 +50,13 @@ test -s "$artifact"
 
 python3 - \
   "${output_dir}/metadata.json" \
+  "${output_dir}/pinned-binary-fixture-manifest.json" \
   "$version_scheme" \
   "$package_name" \
   "${version}-${release}" \
   "$architecture" \
   "$artifact" \
-  "http://127.0.0.1:18083" <<'PY'
+  "$repository_url" <<'PY'
 import hashlib
 import json
 import os
@@ -63,6 +65,7 @@ from pathlib import Path
 
 (
     metadata_path,
+    fixture_manifest_path,
     version_scheme,
     package_name,
     version,
@@ -99,7 +102,21 @@ temporary_path.write_text(
     json.dumps(document, separators=(",", ":")) + "\n", encoding="utf-8"
 )
 os.replace(temporary_path, path)
+
+fixture_manifest = {
+    "schema_version": 1,
+    "artifact_path": str(artifact),
+    "builder_target": version_scheme,
+    "sha256": hashlib.sha256(artifact_bytes).hexdigest(),
+}
+manifest_path = Path(fixture_manifest_path)
+temporary_manifest_path = manifest_path.with_suffix(manifest_path.suffix + ".tmp")
+temporary_manifest_path.write_text(
+    json.dumps(fixture_manifest, separators=(",", ":")) + "\n", encoding="utf-8"
+)
+os.replace(temporary_manifest_path, manifest_path)
 PY
 
 printf 'PINNED_BINARY_ARTIFACT=%q\n' "$artifact" > "${output_dir}/pinned-binary-fixture.env"
 printf 'PINNED_REPOSITORY_METADATA=%q\n' "${output_dir}/metadata.json" >> "${output_dir}/pinned-binary-fixture.env"
+printf 'PINNED_BINARY_FIXTURE_MANIFEST=%q\n' "${output_dir}/pinned-binary-fixture-manifest.json" >> "${output_dir}/pinned-binary-fixture.env"

--- a/apps/conary/tests/fixtures/native/write-corpus-evidence.py
+++ b/apps/conary/tests/fixtures/native/write-corpus-evidence.py
@@ -16,6 +16,30 @@ def sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def artifact_identity(
+    fixture_manifest: Path,
+    role: str,
+    package_name: str,
+    package_version: str,
+    architecture: str,
+) -> dict[str, str]:
+    fixture = json.loads(fixture_manifest.read_text(encoding="utf-8"))
+    if fixture.get("schema_version") != 1:
+        raise ValueError("unsupported native fixture manifest schema")
+    artifact_path = Path(fixture["artifact_path"])
+    observed_digest = sha256(artifact_path)
+    if observed_digest != fixture["sha256"]:
+        raise ValueError("native fixture artifact digest contradicts its build manifest")
+    return {
+        "role": role,
+        "digest_source": "fixture_build_manifest",
+        "name": package_name,
+        "version": package_version,
+        "architecture": architecture,
+        "digest": observed_digest,
+    }
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("fixture_manifest", type=Path)
@@ -25,31 +49,50 @@ def main() -> None:
     parser.add_argument("package_name")
     parser.add_argument("package_version")
     parser.add_argument("architecture")
-    parser.add_argument("completed_stage")
+    parser.add_argument("completed_stages", nargs="+")
+    parser.add_argument("--dependency-fixture-manifest", type=Path)
+    parser.add_argument("--dependency-name")
+    parser.add_argument("--dependency-version")
+    parser.add_argument("--dependency-architecture")
     args = parser.parse_args()
 
-    fixture = json.loads(args.fixture_manifest.read_text(encoding="utf-8"))
-    if fixture.get("schema_version") != 1:
-        raise ValueError("unsupported native fixture manifest schema")
-    artifact_path = Path(fixture["artifact_path"])
-    observed_digest = sha256(artifact_path)
-    if observed_digest != fixture["sha256"]:
-        raise ValueError("native fixture artifact digest contradicts its build manifest")
+    dependency_values = [
+        args.dependency_fixture_manifest,
+        args.dependency_name,
+        args.dependency_version,
+        args.dependency_architecture,
+    ]
+    if any(value is not None for value in dependency_values) and not all(
+        value is not None for value in dependency_values
+    ):
+        parser.error("dependency artifact identity requires all dependency arguments")
+
+    source_artifacts = [
+        artifact_identity(
+            args.fixture_manifest,
+            "install_request",
+            args.package_name,
+            args.package_version,
+            args.architecture,
+        )
+    ]
+    if args.dependency_fixture_manifest is not None:
+        source_artifacts.append(
+            artifact_identity(
+                args.dependency_fixture_manifest,
+                "install_dependency",
+                args.dependency_name,
+                args.dependency_version,
+                args.dependency_architecture,
+            )
+        )
+
     evidence = {
         "schema_version": 1,
         "source_profile": args.source_profile,
         "source_format": args.source_format,
-        "source_artifacts": [
-            {
-                "role": "install_request",
-                "digest_source": "fixture_build_manifest",
-                "name": args.package_name,
-                "version": args.package_version,
-                "architecture": args.architecture,
-                "digest": observed_digest,
-            }
-        ],
-        "completed_stages": [args.completed_stage],
+        "source_artifacts": source_artifacts,
+        "completed_stages": args.completed_stages,
         "active_stage": None,
     }
 

--- a/apps/conary/tests/fixtures/phase4-daily-driver-corpus/ccs.toml
+++ b/apps/conary/tests/fixtures/phase4-daily-driver-corpus/ccs.toml
@@ -1,5 +1,5 @@
 requirements = [
-    { kind = "Depends", behavior = "Hard", expression = { operator = "atom", operands = { name = "phase4-repository-fixture", capability_kind = "PackageName", version_constraint = "=1.0.0-1", native_text = "phase4-repository-fixture =1.0.0-1" } }, alternatives = [{ name = "phase4-repository-fixture", capability_kind = "PackageName", version_constraint = "=1.0.0-1", native_text = "phase4-repository-fixture =1.0.0-1" }], native_text = "phase4-repository-fixture =1.0.0-1" },
+    { kind = "Depends", behavior = "Hard", expression = { operator = "atom", operands = { name = "phase4-repository-fixture", capability_kind = "PackageName", version_constraint = "=1.0.0", native_text = "phase4-repository-fixture =1.0.0" } }, alternatives = [{ name = "phase4-repository-fixture", capability_kind = "PackageName", version_constraint = "=1.0.0", native_text = "phase4-repository-fixture =1.0.0" }], native_text = "phase4-repository-fixture =1.0.0" },
 ]
 
 [package]
@@ -21,15 +21,15 @@ libc = "gnu"
 maintainers = ["Conary Fixture Maintainers <fixtures@conary.io>"]
 
 [native_export.rpm]
-requires = [{ name = "phase4-repository-fixture", relation = "equal", version = "1.0.0-1" }]
+requires = [{ name = "phase4-repository-fixture", relation = "equal", version = "1.0.0" }]
 provides = ["phase4-corpus-tool"]
 
 [native_export.deb]
-depends = ["phase4-repository-fixture (= 1.0.0-1)"]
+depends = ["phase4-repository-fixture (= 1.0.0)"]
 provides = ["phase4-corpus-tool"]
 
 [native_export.arch]
-depends = ["phase4-repository-fixture=1.0.0-1"]
+depends = ["phase4-repository-fixture=1.0.0"]
 provides = ["phase4-corpus-tool"]
 
 [provides]

--- a/apps/conary/tests/fixtures/phase4-daily-driver-corpus/ccs.toml
+++ b/apps/conary/tests/fixtures/phase4-daily-driver-corpus/ccs.toml
@@ -1,5 +1,5 @@
 requirements = [
-    { kind = "Depends", behavior = "Hard", expression = { operator = "atom", operands = { name = "bash", capability_kind = "PackageName", native_text = "bash" } }, alternatives = [{ name = "bash", capability_kind = "PackageName", native_text = "bash" }], native_text = "bash" },
+    { kind = "Depends", behavior = "Hard", expression = { operator = "atom", operands = { name = "phase4-repository-fixture", capability_kind = "PackageName", version_constraint = "=1.0.0-1", native_text = "phase4-repository-fixture =1.0.0-1" } }, alternatives = [{ name = "phase4-repository-fixture", capability_kind = "PackageName", version_constraint = "=1.0.0-1", native_text = "phase4-repository-fixture =1.0.0-1" }], native_text = "phase4-repository-fixture =1.0.0-1" },
 ]
 
 [package]
@@ -21,15 +21,15 @@ libc = "gnu"
 maintainers = ["Conary Fixture Maintainers <fixtures@conary.io>"]
 
 [native_export.rpm]
-requires = ["bash"]
+requires = [{ name = "phase4-repository-fixture", relation = "equal", version = "1.0.0-1" }]
 provides = ["phase4-corpus-tool"]
 
 [native_export.deb]
-depends = ["bash"]
+depends = ["phase4-repository-fixture (= 1.0.0-1)"]
 provides = ["phase4-corpus-tool"]
 
 [native_export.arch]
-depends = ["bash"]
+depends = ["phase4-repository-fixture=1.0.0-1"]
 provides = ["phase4-corpus-tool"]
 
 [provides]

--- a/apps/conary/tests/integration/remi/manifests/phase4-native-daily-driver-corpus.toml
+++ b/apps/conary/tests/integration/remi/manifests/phase4-native-daily-driver-corpus.toml
@@ -230,7 +230,7 @@ run = "sqlite3 ${DB_PATH} \"SELECT COUNT(*) || ' requirement groups' FROM packag
 
 [test.step.assert]
 exit_code = 0
-stdout_contains_all = ["${native_corpus_dependency_count} requirement groups", "${native_corpus_dependency_probe}", "phase4-repository-fixture|= 1.0.0-1"]
+stdout_contains_all = ["${native_corpus_dependency_count} requirement groups", "${native_corpus_dependency_probe}", "phase4-repository-fixture|= 1.0.0"]
 
 [[test.step]]
 run = "sqlite3 ${DB_PATH} \"SELECT COUNT(*) || ' config rows' FROM config_files WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-daily-driver-corpus'); SELECT path || '|' || noreplace || '|' || status || '|' || source FROM config_files WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-daily-driver-corpus') ORDER BY path\""

--- a/apps/conary/tests/integration/remi/manifests/phase4-native-daily-driver-corpus.toml
+++ b/apps/conary/tests/integration/remi/manifests/phase4-native-daily-driver-corpus.toml
@@ -15,14 +15,51 @@ required = [
     "payload_directories",
     "payload_symlinks",
     "payload_hardlinks",
+    "relations_versioned_dependency",
     "relations_virtual_provide",
     "configuration_matched_config",
     "configuration_removal",
     "lifecycle_shell",
 ]
 
+[suite.mock_server]
+port = 18084
+
+[[suite.mock_server.routes]]
+path = "/metadata.json"
+status = 200
+body_file = "/tmp/native-pm-corpus-repo/metadata.json"
+headers = { "Content-Type" = "application/json" }
+
+[[suite.mock_server.routes]]
+path = "/phase4-repository-fixture-1.0.0-1.ccs"
+status = 200
+body_file = "/tmp/native-pm-corpus-repo/phase4-repository-fixture-1.0.0-1.ccs"
+headers = { "Content-Type" = "application/octet-stream" }
+
 [[suite.setup]]
 conary = "system init"
+
+[suite.setup.assert]
+exit_code = 0
+
+[[suite.setup]]
+run = "${CONARY_BIN} repo remove ${REPO_NAME} --db-path ${DB_PATH} >/dev/null 2>&1 || true"
+
+[[suite.setup]]
+run = "rm -rf /tmp/native-pm-corpus-repo && CONARY_BIN=${CONARY_BIN} /opt/remi-tests/fixtures/native/build-pinned-binary-fixture.sh ${native_target} /tmp/native-pm-corpus-repo http://127.0.0.1:18084"
+
+[suite.setup.assert]
+exit_code = 0
+
+[[suite.setup]]
+conary = "repo add ${REPO_NAME} http://127.0.0.1:18084 --package-format json --default-strategy binary --ccs-package-key ${FIXTURE_CCS_PUBLIC_KEY} --source-profile ${native_profile}"
+
+[suite.setup.assert]
+exit_code = 0
+
+[[suite.setup]]
+conary = "repo sync ${REPO_NAME} --force"
 
 [suite.setup.assert]
 exit_code = 0
@@ -41,7 +78,7 @@ native_scheme = "rpm"
 native_profile = "fedora-44"
 native_corpus_fixture_version = "1.0.0-1"
 native_corpus_dependency_count = "4"
-native_corpus_dependency_probe = "bash"
+native_corpus_dependency_probe = "phase4-repository-fixture"
 native_corpus_config_count = "1"
 native_corpus_config_source = "rpm"
 native_corpus_lifecycle_fidelity = "native-lifecycle"
@@ -56,7 +93,7 @@ native_scheme = "debian"
 native_profile = "ubuntu-26.04"
 native_corpus_fixture_version = "1.0.0-1"
 native_corpus_dependency_count = "1"
-native_corpus_dependency_probe = "bash"
+native_corpus_dependency_probe = "phase4-repository-fixture"
 native_corpus_config_count = "1"
 native_corpus_config_source = "deb"
 native_corpus_lifecycle_fidelity = "native-lifecycle"
@@ -71,7 +108,7 @@ native_scheme = "arch"
 native_profile = "arch"
 native_corpus_fixture_version = "1.0.0-1"
 native_corpus_dependency_count = "1"
-native_corpus_dependency_probe = "bash"
+native_corpus_dependency_probe = "phase4-repository-fixture"
 native_corpus_config_count = "1"
 native_corpus_config_source = "arch"
 native_corpus_lifecycle_fidelity = "native-lifecycle"
@@ -128,14 +165,21 @@ exit_code = 0
 stdout_contains = "Created trigger: phase4-corpus-trigger"
 
 [[test.step]]
-run = ". /tmp/native-pm-corpus/native-fixture.env && CONARY_TEST_SKIP_GENERATION_MOUNT=1 ${CONARY_BIN} install \"$NATIVE_PKG_FILE\" --convert-to-ccs --from ${native_profile} --db-path ${DB_PATH} --root /conary --no-deps --yes --sandbox always"
+run = ". /tmp/native-pm-corpus/native-fixture.env && CONARY_TEST_SKIP_GENERATION_MOUNT=1 ${CONARY_BIN} install \"$NATIVE_PKG_FILE\" --convert-to-ccs --from ${native_profile} --db-path ${DB_PATH} --root /conary --yes --sandbox always"
 
 [test.step.assert]
 exit_code = 0
 stdout_contains_any = ["Successfully installed", "Installed", "phase4-daily-driver-corpus"]
 
 [[test.step]]
-run = "/opt/remi-tests/fixtures/native/assert-selected-generation.py --root /conary --expect-sha256 /usr/bin/phase4-corpus=565d3f61ffdbbca53c7371588ce6884b680dfa1d1c1bd7fe3954b4ab957e0676 --expect-sha256 /usr/bin/phase4-corpus-alt=1c279f8af2faaed5ae4aad470ab37742b2cede45b42b65d961f2bb33233e5ad3 --expect-symlink /usr/bin/phase4-corpus-link=phase4-corpus --expect-directory /opt=0750 --expect-directory /usr/lib/phase4-corpus/state=0750 --expect-hardlink /usr/lib/phase4-corpus/hardlink-anchor=/usr/lib/phase4-corpus/hardlink-copy --expect-sha256 /etc/phase4-corpus/app.conf=8b3ca388884ac9c33e5e1c849ac30bc59aa9d494e7afc5d91fb56c8a4e760eb2 --expect-sha256 /usr/lib/systemd/system/phase4-corpus.service=20200a86933288373c109a2e3289b2314ff6015886bfbad9bec6e613421e756a --expect-sha256 /usr/lib/kernel/install.d/95-phase4-corpus.install=8753356f470ea82416c2d7a71cbf8367d4cbe1a8b78f3276fe45035e114c3674 --present /usr/share/phase4-corpus/large-payload.bin --expect-sha256 /var/lib/phase4-corpus/scriptlet.marker=a51a6c19a1ffc7416827e89adf20749d23ad42452c396cf7e627409f2896922c --expect-user phase4-corpus-user=/var/lib/phase4-corpus,/bin/false,phase4-corpus-group"
+run = "sqlite3 ${DB_PATH} \"SELECT t.name || '|' || t.version || '|' || COALESCE(t.package_release, '') || '|' || COALESCE(t.architecture, '') || '|' || COALESCE(t.version_scheme, '') || '|' || COALESCE(r.name, '') || '|' || COALESCE(t.source_profile, '') || '|' || COALESCE(t.install_source, '') || '|' || COALESCE(t.install_reason, '') FROM troves t LEFT JOIN repositories r ON r.id = t.installed_from_repository_id WHERE t.name = 'phase4-repository-fixture'\""
+
+[test.step.assert]
+exit_code = 0
+stdout_contains = "phase4-repository-fixture|1.0.0|1|${native_arch}|${native_scheme}|${REPO_NAME}|${native_profile}|repository|dependency"
+
+[[test.step]]
+run = "/opt/remi-tests/fixtures/native/assert-selected-generation.py --root /conary --expect-sha256 /usr/bin/phase4-corpus=565d3f61ffdbbca53c7371588ce6884b680dfa1d1c1bd7fe3954b4ab957e0676 --expect-sha256 /usr/bin/phase4-corpus-alt=1c279f8af2faaed5ae4aad470ab37742b2cede45b42b65d961f2bb33233e5ad3 --expect-symlink /usr/bin/phase4-corpus-link=phase4-corpus --expect-directory /opt=0750 --expect-directory /usr/lib/phase4-corpus/state=0750 --expect-hardlink /usr/lib/phase4-corpus/hardlink-anchor=/usr/lib/phase4-corpus/hardlink-copy --expect-sha256 /etc/phase4-corpus/app.conf=8b3ca388884ac9c33e5e1c849ac30bc59aa9d494e7afc5d91fb56c8a4e760eb2 --expect-sha256 /usr/lib/systemd/system/phase4-corpus.service=20200a86933288373c109a2e3289b2314ff6015886bfbad9bec6e613421e756a --expect-sha256 /usr/lib/kernel/install.d/95-phase4-corpus.install=8753356f470ea82416c2d7a71cbf8367d4cbe1a8b78f3276fe45035e114c3674 --present /usr/share/phase4-corpus/large-payload.bin --present /usr/share/phase4-repository-fixture/probe.txt --expect-sha256 /var/lib/phase4-corpus/scriptlet.marker=a51a6c19a1ffc7416827e89adf20749d23ad42452c396cf7e627409f2896922c --expect-user phase4-corpus-user=/var/lib/phase4-corpus,/bin/false,phase4-corpus-group"
 
 [test.step.assert]
 exit_code = 0
@@ -182,11 +226,11 @@ exit_code = 0
 stdout_contains_all = ["1 hardlinks", "/usr/lib/phase4-corpus/hardlink-anchor|", "/usr/lib/phase4-corpus/hardlink-copy|"]
 
 [[test.step]]
-run = "sqlite3 ${DB_PATH} \"SELECT COUNT(*) || ' requirement groups' FROM package_requirement_groups WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-daily-driver-corpus'); SELECT COALESCE((SELECT group_concat(kind || '|' || version_scheme || '|' || requirement_json, char(10)) FROM package_requirement_groups WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-daily-driver-corpus') ORDER BY id), 'no-deps')\""
+run = "sqlite3 ${DB_PATH} \"SELECT COUNT(*) || ' requirement groups' FROM package_requirement_groups WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-daily-driver-corpus'); SELECT COALESCE((SELECT group_concat(kind || '|' || version_scheme || '|' || requirement_json, char(10)) FROM package_requirement_groups WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-daily-driver-corpus') ORDER BY id), 'no-deps'); SELECT json_extract(requirement_json, '$.expression.operands.name') || '|' || json_extract(requirement_json, '$.expression.operands.version_constraint') FROM package_requirement_groups WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-daily-driver-corpus') AND json_extract(requirement_json, '$.expression.operands.name') = 'phase4-repository-fixture'\""
 
 [test.step.assert]
 exit_code = 0
-stdout_contains_all = ["${native_corpus_dependency_count} requirement groups", "${native_corpus_dependency_probe}"]
+stdout_contains_all = ["${native_corpus_dependency_count} requirement groups", "${native_corpus_dependency_probe}", "phase4-repository-fixture|= 1.0.0-1"]
 
 [[test.step]]
 run = "sqlite3 ${DB_PATH} \"SELECT COUNT(*) || ' config rows' FROM config_files WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-daily-driver-corpus'); SELECT path || '|' || noreplace || '|' || status || '|' || source FROM config_files WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-daily-driver-corpus') ORDER BY path\""
@@ -226,7 +270,7 @@ evidence_path = "/tmp/conary-corpus-daily-driver-install.json"
 source_profile = "${native_profile}"
 source_format = "${native_corpus_source_format}"
 digest_source = "fixture_build_manifest"
-stages = ["installation"]
+stages = ["resolution", "installation"]
 
 [test.corpus.target]
 architecture = "${native_corpus_target_architecture}"
@@ -256,6 +300,10 @@ artifact_roles = ["install_request"]
 [[test.corpus.coverage]]
 semantic = "payload_hardlinks"
 artifact_roles = ["install_request"]
+
+[[test.corpus.coverage]]
+semantic = "relations_versioned_dependency"
+artifact_roles = ["install_request", "install_dependency"]
 
 [[test.corpus.coverage]]
 semantic = "relations_virtual_provide"
@@ -312,7 +360,7 @@ exit_code = 0
 stdout_contains_all = ["Capability 'virtual(phase4-corpus-tool)' is provided by:", "phase4-daily-driver-corpus ${native_corpus_fixture_version}"]
 
 [[test.step]]
-run = "/opt/remi-tests/fixtures/native/write-corpus-evidence.py /tmp/native-pm-corpus/native-fixture-manifest.json /tmp/conary-corpus-daily-driver-install.json ${native_profile} ${native_corpus_source_format} phase4-daily-driver-corpus ${native_corpus_fixture_version} ${native_arch} installation"
+run = "/opt/remi-tests/fixtures/native/write-corpus-evidence.py /tmp/native-pm-corpus/native-fixture-manifest.json /tmp/conary-corpus-daily-driver-install.json ${native_profile} ${native_corpus_source_format} phase4-daily-driver-corpus ${native_corpus_fixture_version} ${native_arch} resolution installation --dependency-fixture-manifest /tmp/native-pm-corpus-repo/pinned-binary-fixture-manifest.json --dependency-name phase4-repository-fixture --dependency-version 1.0.0-1 --dependency-architecture ${native_arch}"
 
 [test.step.assert]
 exit_code = 0

--- a/crates/conary-core/src/ccs/manifest.rs
+++ b/crates/conary-core/src/ccs/manifest.rs
@@ -575,10 +575,38 @@ pub struct RpmExport {
     pub group: Option<String>,
 
     #[serde(default)]
-    pub requires: Vec<String>,
+    pub requires: Vec<RpmDependency>,
 
     #[serde(default)]
     pub provides: Vec<String>,
+}
+
+/// One exact RPM dependency header declaration.
+///
+/// Keep the operator typed: passing an RPM-spec expression to
+/// `rpm::Dependency::any` encodes the entire expression as an unversioned
+/// dependency name rather than as a version constraint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RpmDependency {
+    pub name: String,
+
+    pub relation: RpmDependencyRelation,
+
+    #[serde(default)]
+    pub version: Option<String>,
+}
+
+/// RPM comparison flags. Every relation except `any` requires a version.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RpmDependencyRelation {
+    Any,
+    Equal,
+    Less,
+    LessOrEqual,
+    Greater,
+    GreaterOrEqual,
 }
 
 /// Debian-specific export overrides.

--- a/crates/conary-core/src/ccs/native_export/arch.rs
+++ b/crates/conary-core/src/ccs/native_export/arch.rs
@@ -429,7 +429,7 @@ mod tests {
         let mut result = create_test_build_result();
         result.manifest.native_export = Some(NativeExport {
             arch: Some(ArchExport {
-                depends: vec!["bash".to_string()],
+                depends: vec!["phase4-repository-fixture=1.0.0-1".to_string()],
                 provides: vec!["virtual-test-tool".to_string()],
                 ..ArchExport::default()
             }),
@@ -442,7 +442,21 @@ mod tests {
         let package = crate::packages::arch::ArchPackage::parse(output_path.to_str().unwrap())
             .expect("parse generated Arch package");
 
-        assert_eq!(package.requirements().len(), 1);
+        let requirement = package
+            .requirements()
+            .iter()
+            .find(|group| {
+                group
+                    .alternatives
+                    .iter()
+                    .any(|clause| clause.name == "phase4-repository-fixture")
+            })
+            .expect("versioned Arch dependency");
+        assert_eq!(requirement.alternatives.len(), 1);
+        assert_eq!(
+            requirement.alternatives[0].version_constraint.as_deref(),
+            Some("= 1.0.0-1")
+        );
         assert!(
             package
                 .resolution_capabilities()

--- a/crates/conary-core/src/ccs/native_export/deb.rs
+++ b/crates/conary-core/src/ccs/native_export/deb.rs
@@ -436,7 +436,7 @@ mod tests {
         let mut result = create_test_build_result();
         result.manifest.native_export = Some(NativeExport {
             deb: Some(DebExport {
-                depends: vec!["bash".to_string()],
+                depends: vec!["phase4-repository-fixture (= 1.0.0-1)".to_string()],
                 provides: vec!["virtual-test-tool".to_string()],
                 ..DebExport::default()
             }),
@@ -449,7 +449,21 @@ mod tests {
         let package = crate::packages::deb::DebPackage::parse(output_path.to_str().unwrap())
             .expect("parse generated Debian package");
 
-        assert_eq!(package.requirements().len(), 1);
+        let requirement = package
+            .requirements()
+            .iter()
+            .find(|group| {
+                group
+                    .alternatives
+                    .iter()
+                    .any(|clause| clause.name == "phase4-repository-fixture")
+            })
+            .expect("versioned Debian dependency");
+        assert_eq!(requirement.alternatives.len(), 1);
+        assert_eq!(
+            requirement.alternatives[0].version_constraint.as_deref(),
+            Some("= 1.0.0-1")
+        );
         assert!(
             package
                 .resolution_capabilities()

--- a/crates/conary-core/src/ccs/native_export/rpm.rs
+++ b/crates/conary-core/src/ccs/native_export/rpm.rs
@@ -6,7 +6,7 @@
 
 use super::{CommonHookGenerator, GenerationResult, HookConverter, LossReport, arch_for_format};
 use crate::ccs::builder::BuildResult;
-use crate::ccs::manifest::Hooks;
+use crate::ccs::manifest::{Hooks, RpmDependency, RpmDependencyRelation};
 use crate::payload::PayloadNodeKind;
 use anyhow::{Context, Result};
 use rpm::PackageBuilder;
@@ -127,8 +127,8 @@ pub fn generate(result: &BuildResult, output_path: &Path) -> Result<GenerationRe
         }
 
         // Add explicit requires
-        for req in &rpm_export.requires {
-            builder.requires(rpm::Dependency::any(req));
+        for requirement in &rpm_export.requires {
+            builder.requires(rpm_dependency(requirement)?);
         }
 
         // Add explicit provides
@@ -369,6 +369,44 @@ pub fn generate(result: &BuildResult, output_path: &Path) -> Result<GenerationRe
     Ok(GenerationResult { size, loss_report })
 }
 
+fn rpm_dependency(requirement: &RpmDependency) -> Result<rpm::Dependency> {
+    let name = requirement.name.trim();
+    if name.is_empty() {
+        anyhow::bail!("RPM export dependency name must not be empty");
+    }
+
+    let version = || {
+        requirement
+            .version
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("RPM export dependency '{name}' requires a version"))
+            .and_then(|value| rpm_dependency_version(name, value))
+    };
+    Ok(match requirement.relation {
+        RpmDependencyRelation::Any => {
+            if requirement.version.is_some() {
+                anyhow::bail!(
+                    "RPM export unversioned dependency '{name}' must not declare a version"
+                );
+            }
+            rpm::Dependency::any(name)
+        }
+        RpmDependencyRelation::Equal => rpm::Dependency::eq(name, version()?),
+        RpmDependencyRelation::Less => rpm::Dependency::less(name, version()?),
+        RpmDependencyRelation::LessOrEqual => rpm::Dependency::less_eq(name, version()?),
+        RpmDependencyRelation::Greater => rpm::Dependency::greater(name, version()?),
+        RpmDependencyRelation::GreaterOrEqual => rpm::Dependency::greater_eq(name, version()?),
+    })
+}
+
+fn rpm_dependency_version<'a>(name: &str, value: &'a str) -> Result<&'a str> {
+    let value = value.trim();
+    if value.is_empty() {
+        anyhow::bail!("RPM export dependency '{name}' has an empty version");
+    }
+    Ok(value)
+}
+
 fn hardlink_file_options(
     options: rpm::FileOptionsBuilder,
     node: &crate::payload::PayloadNode,
@@ -431,7 +469,7 @@ fn payload_kind_name(kind: &PayloadNodeKind) -> &'static str {
 mod tests {
     use super::*;
     use crate::ccs::builder::FileEntry;
-    use crate::ccs::manifest::CcsManifest;
+    use crate::ccs::manifest::{CcsManifest, NativeExport, RpmExport};
     use crate::packages::PackageFormat;
     use crate::payload::{PayloadIdentity, PayloadNode, PayloadTimestamp};
     use std::collections::HashMap;
@@ -481,6 +519,73 @@ mod tests {
         let gen_result = generate(&result, &output_path).unwrap();
         assert!(output_path.exists());
         assert!(gen_result.size > 0);
+    }
+
+    #[test]
+    fn rpm_versioned_dependency_round_trips_as_typed_header_authority() {
+        let mut result = create_test_build_result();
+        result.manifest.native_export = Some(NativeExport {
+            rpm: Some(RpmExport {
+                requires: vec![RpmDependency {
+                    name: "phase4-repository-fixture".to_string(),
+                    relation: RpmDependencyRelation::Equal,
+                    version: Some("1.0.0-1".to_string()),
+                }],
+                ..RpmExport::default()
+            }),
+            ..NativeExport::default()
+        });
+        let temp_dir = TempDir::new().unwrap();
+        let output_path = temp_dir.path().join("versioned-dependency.rpm");
+
+        generate(&result, &output_path).unwrap();
+        let package = crate::packages::rpm::RpmPackage::parse(output_path.to_str().unwrap())
+            .expect("parse generated RPM");
+        let requirement = package
+            .requirements()
+            .iter()
+            .find(|group| {
+                group
+                    .alternatives
+                    .iter()
+                    .any(|clause| clause.name == "phase4-repository-fixture")
+            })
+            .expect("versioned RPM dependency");
+        assert_eq!(requirement.alternatives.len(), 1);
+        assert_eq!(
+            requirement.alternatives[0].version_constraint.as_deref(),
+            Some("= 1.0.0-1")
+        );
+    }
+
+    #[test]
+    fn rpm_versioned_dependency_rejects_empty_authority() {
+        for requirement in [
+            RpmDependency {
+                name: " ".to_string(),
+                relation: RpmDependencyRelation::Any,
+                version: None,
+            },
+            RpmDependency {
+                name: "phase4-repository-fixture".to_string(),
+                relation: RpmDependencyRelation::Equal,
+                version: Some(" ".to_string()),
+            },
+        ] {
+            let mut result = create_test_build_result();
+            result.manifest.native_export = Some(NativeExport {
+                rpm: Some(RpmExport {
+                    requires: vec![requirement],
+                    ..RpmExport::default()
+                }),
+                ..NativeExport::default()
+            });
+            let temp_dir = TempDir::new().unwrap();
+            let output_path = temp_dir.path().join("invalid-dependency.rpm");
+
+            assert!(generate(&result, &output_path).is_err());
+            assert!(!output_path.exists());
+        }
     }
 
     #[test]

--- a/crates/conary-core/src/repository/metadata.rs
+++ b/crates/conary-core/src/repository/metadata.rs
@@ -43,6 +43,10 @@ pub struct DeltaInfo {
 pub struct PackageMetadata {
     pub name: String,
     pub version: String,
+    /// Monotonic signed CCS build release, when the indexed artifact is a CCS
+    /// package. This stays separate from the source-native version authority.
+    #[serde(default)]
+    pub release: Option<String>,
     /// Exact native version ordering contract for this package.
     pub version_scheme: VersionScheme,
     pub architecture: Option<String>,

--- a/crates/conary-core/src/repository/registry.rs
+++ b/crates/conary-core/src/repository/registry.rs
@@ -51,6 +51,21 @@ pub fn arch_to_debian(arch: &str) -> String {
     }
 }
 
+/// Return the current machine architecture in one source ecosystem's exact
+/// package token grammar.
+pub fn native_architecture_for_scheme(
+    scheme: crate::repository::versioning::VersionScheme,
+) -> String {
+    let architecture = detect_system_arch();
+    match scheme {
+        crate::repository::versioning::VersionScheme::Debian => arch_to_debian(&architecture),
+        crate::repository::versioning::VersionScheme::Rpm
+        | crate::repository::versioning::VersionScheme::Arch
+        | crate::repository::versioning::VersionScheme::Eopkg
+        | crate::repository::versioning::VersionScheme::Conary => architecture,
+    }
+}
+
 /// Explicit package-metadata format for a repository.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RepositoryFormat {
@@ -273,6 +288,10 @@ mod tests {
         assert_eq!(arch_to_debian("riscv64"), "riscv64");
         // Unknown arches pass through unchanged
         assert_eq!(arch_to_debian("unknown"), "unknown");
+        assert_eq!(
+            native_architecture_for_scheme(crate::repository::versioning::VersionScheme::Debian),
+            arch_to_debian(&detect_system_arch())
+        );
     }
 
     #[test]

--- a/crates/conary-core/src/repository/sync.rs
+++ b/crates/conary-core/src/repository/sync.rs
@@ -468,6 +468,14 @@ fn json_repository_sync_snapshot(
         );
 
         let version_scheme = pkg_meta.version_scheme;
+        if let Some(release) = pkg_meta.release.as_deref() {
+            crate::repository::versioning::validate_package_release(release).map_err(|error| {
+                Error::ParseError(format!(
+                    "repository package '{}' has invalid CCS release '{}': {error}",
+                    pkg_meta.name, release
+                ))
+            })?;
+        }
         let mut repo_pkg = RepositoryPackage::new(
             repo_id,
             pkg_meta.name.clone(),
@@ -477,6 +485,7 @@ fn json_repository_sync_snapshot(
             pkg_meta.size,
             download_url,
         );
+        repo_pkg.package_release = pkg_meta.release.unwrap_or_default();
         repo_pkg.architecture = pkg_meta.architecture;
         repo_pkg.debian_multi_arch = if version_scheme == VersionScheme::Debian {
             Some(pkg_meta.debian_multi_arch.unwrap_or_default())

--- a/crates/conary-core/src/repository/sync/tests/native.rs
+++ b/crates/conary-core/src/repository/sync/tests/native.rs
@@ -639,6 +639,45 @@ fn test_json_contract_persists_trusted_advisory_metadata() {
 }
 
 #[test]
+fn json_contract_keeps_source_version_and_ccs_release_separate() {
+    let conn = Connection::open_in_memory().unwrap();
+    ensure_current(&conn).unwrap();
+    let mut repo = Repository::new(
+        "signed-static".to_string(),
+        "https://example.test/static".to_string(),
+    );
+    repo.insert(&conn).unwrap();
+    let repo_id = repo.id.unwrap();
+    let metadata: JsonRepositoryMetadata = serde_json::from_value(json!({
+        "name": "signed-static",
+        "version": "1",
+        "security_advisory_source": null,
+        "packages": [{
+            "name": "fixture",
+            "version": "1.0.0",
+            "release": "1",
+            "version_scheme": "rpm",
+            "architecture": "x86_64",
+            "description": "signed fixture",
+            "checksum": "fixture-checksum",
+            "size": 42,
+            "download_url": "https://example.test/static/fixture-1.0.0-1.ccs",
+            "requirements": [],
+            "relations": [],
+            "delta_from": null,
+            "security_advisory": null
+        }]
+    }))
+    .unwrap();
+
+    let snapshot = json_repository_sync_snapshot(&repo, metadata).unwrap();
+    persist_repository_sync_snapshot(&conn, &mut repo, snapshot).unwrap();
+    let stored = RepositoryPackage::find_by_repository(&conn, repo_id).unwrap();
+    assert_eq!(stored[0].version, "1.0.0");
+    assert_eq!(stored[0].package_release, "1");
+}
+
+#[test]
 fn test_json_contract_supported_repo_requires_trusted_advisory_source() {
     let mut repo = Repository::new(
         "fedora-security".to_string(),

--- a/crates/conary-core/src/repository/sync/tests/native.rs
+++ b/crates/conary-core/src/repository/sync/tests/native.rs
@@ -646,6 +646,7 @@ fn json_contract_keeps_source_version_and_ccs_release_separate() {
         "signed-static".to_string(),
         "https://example.test/static".to_string(),
     );
+    repo.source_profile = Some("ubuntu-26.04".to_string());
     repo.insert(&conn).unwrap();
     let repo_id = repo.id.unwrap();
     let metadata: JsonRepositoryMetadata = serde_json::from_value(json!({
@@ -656,8 +657,8 @@ fn json_contract_keeps_source_version_and_ccs_release_separate() {
             "name": "fixture",
             "version": "1.0.0",
             "release": "1",
-            "version_scheme": "rpm",
-            "architecture": "x86_64",
+            "version_scheme": "debian",
+            "architecture": "amd64",
             "description": "signed fixture",
             "checksum": "fixture-checksum",
             "size": 42,
@@ -675,6 +676,23 @@ fn json_contract_keeps_source_version_and_ccs_release_separate() {
     let stored = RepositoryPackage::find_by_repository(&conn, repo_id).unwrap();
     assert_eq!(stored[0].version, "1.0.0");
     assert_eq!(stored[0].package_release, "1");
+
+    let requirement = crate::repository::requirement::parse_native_requirement(
+        crate::repository::dependency_model::RepositoryRequirementKind::Depends,
+        VersionScheme::Debian,
+        "fixture (= 1.0.0)",
+    )
+    .unwrap();
+    let resolution = crate::resolver::solve_requirement_groups_with_policy(
+        &conn,
+        &[requirement],
+        VersionScheme::Debian,
+        &crate::repository::resolution_policy::ResolutionPolicy::new()
+            .with_primary_source_identity("ubuntu-26.04"),
+    )
+    .unwrap();
+    assert!(resolution.conflict_message.is_none(), "{resolution:?}");
+    assert_eq!(resolution.install_order.len(), 1);
 }
 
 #[test]

--- a/crates/conary-core/src/resolver/mod.rs
+++ b/crates/conary-core/src/resolver/mod.rs
@@ -26,6 +26,6 @@ pub use provides_index::ProvidesIndex;
 pub use requirements::{load_installed_package_identities, requirement_expression_satisfied};
 pub use sat::{
     SatPackage, SatResolution, SatSource, positive_requirement_group_satisfied_by_package,
-    solve_install_with_policy, solve_removal, solve_removal_troves,
-    solve_requirement_groups_with_policy,
+    solve_install_with_policy, solve_package_requirements_with_policy, solve_removal,
+    solve_removal_troves, solve_requirement_groups_with_policy,
 };

--- a/crates/conary-core/src/resolver/mod.rs
+++ b/crates/conary-core/src/resolver/mod.rs
@@ -25,6 +25,7 @@ pub use plan::{MissingDependency, ResolutionPlan};
 pub use provides_index::ProvidesIndex;
 pub use requirements::{load_installed_package_identities, requirement_expression_satisfied};
 pub use sat::{
-    SatPackage, SatResolution, SatSource, solve_install_with_policy, solve_removal,
-    solve_removal_troves, solve_requirement_groups_with_policy,
+    SatPackage, SatResolution, SatSource, positive_requirement_group_satisfied_by_package,
+    solve_install_with_policy, solve_removal, solve_removal_troves,
+    solve_requirement_groups_with_policy,
 };

--- a/crates/conary-core/src/resolver/provider/loading.rs
+++ b/crates/conary-core/src/resolver/provider/loading.rs
@@ -103,11 +103,11 @@ pub(crate) fn repository_expression_to_solver(
     expression: &RepositoryRequirementExpression,
     scheme: VersionScheme,
 ) -> Result<SolverExpression> {
-    let native_architecture = crate::repository::registry::detect_system_arch();
+    let native_architecture = crate::repository::registry::native_architecture_for_scheme(scheme);
     repository_expression_to_solver_for_architecture(expression, scheme, &native_architecture)
 }
 
-fn repository_expression_to_solver_for_architecture(
+pub(crate) fn repository_expression_to_solver_for_architecture(
     expression: &RepositoryRequirementExpression,
     scheme: VersionScheme,
     depending_architecture: &str,

--- a/crates/conary-core/src/resolver/provider/matching.rs
+++ b/crates/conary-core/src/resolver/provider/matching.rs
@@ -449,6 +449,74 @@ pub(crate) fn provider_expression_matches_package(
     }
 }
 
+/// Evaluate one solver constraint against a package using exact identity,
+/// capability, architecture, and native-version authority. Callers decide
+/// whether the requested name is an admitted identity (exact for incoming
+/// packages; exact or canonical for persisted SAT candidates).
+pub(crate) fn constraint_matches_candidate(
+    requested_name: &str,
+    constraint: &ConaryConstraint,
+    package: &PackageIdentity,
+    native_architecture: &str,
+    identity_name_matches: bool,
+) -> VersionResult<bool> {
+    let requested_kind = match constraint {
+        ConaryConstraint::Repository {
+            capability_kind, ..
+        } => *capability_kind,
+        ConaryConstraint::Requested(_)
+        | ConaryConstraint::RpmRuntime(_)
+        | ConaryConstraint::ProviderExpression { .. } => None,
+    };
+
+    match constraint {
+        ConaryConstraint::RpmRuntime(_) => Ok(false),
+        ConaryConstraint::ProviderExpression { expression } => Ok(
+            constraint_architecture_matches_package(constraint, package, native_architecture)
+                && provider_expression_matches_package(expression, package)?,
+        ),
+        constraint
+            if matches!(
+                requested_kind,
+                None | Some(
+                    crate::repository::dependency_model::RepositoryCapabilityKind::PackageName
+                )
+            ) && identity_name_matches =>
+        {
+            Ok(
+                constraint_architecture_matches_package(constraint, package, native_architecture)
+                    && constraint_matches_package(
+                        constraint,
+                        &package.version,
+                        package.version_scheme,
+                    )?,
+            )
+        }
+        constraint => {
+            for capability in package.provided_capabilities.iter().filter(|capability| {
+                capability.name == requested_name
+                    && requested_kind.is_none_or(|kind| capability.kind == kind)
+            }) {
+                if constraint_architecture_matches_provide(
+                    constraint,
+                    package,
+                    &capability.architecture_qualifier,
+                    capability.version_scheme,
+                    native_architecture,
+                ) && constraint_matches_provide(
+                    constraint,
+                    capability.version.as_deref(),
+                    capability.version_relation,
+                    capability.version_scheme,
+                )? {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        }
+    }
+}
+
 fn requested_constraint_matches(
     constraint: &VersionConstraint,
     version: &str,

--- a/crates/conary-core/src/resolver/provider/mod.rs
+++ b/crates/conary-core/src/resolver/provider/mod.rs
@@ -28,7 +28,7 @@ use resolvo::{
     VersionSetUnionId,
 };
 
-pub(crate) use loading::repository_expression_to_solver;
+pub(crate) use loading::repository_expression_to_solver_for_architecture;
 use loading::{
     find_repo_package_by_id, load_installed_dependency_requests, load_installed_relations,
     load_repo_dependency_requests, load_repo_provided_capabilities, load_repo_relations,

--- a/crates/conary-core/src/resolver/provider/traits.rs
+++ b/crates/conary-core/src/resolver/provider/traits.rs
@@ -15,10 +15,7 @@ use resolvo::{
 };
 
 use super::ConaryProvider;
-use super::matching::{
-    constraint_architecture_matches_package, constraint_architecture_matches_provide,
-    constraint_matches_package, constraint_matches_provide, provider_expression_matches_package,
-};
+use super::matching::constraint_matches_candidate;
 use super::types::ConaryConstraint;
 
 // --- Display helpers ---
@@ -116,77 +113,24 @@ impl DependencyProvider for ConaryProvider<'_> {
     ) -> Vec<SolvableId> {
         let (name_id, ref constraint) = self.version_sets[version_set.to_index()];
         let requested_name = &self.names[name_id.to_index()];
-        let requested_kind = match constraint {
-            ConaryConstraint::Repository {
-                capability_kind, ..
-            } => *capability_kind,
-            ConaryConstraint::Requested(_)
-            | ConaryConstraint::RpmRuntime(_)
-            | ConaryConstraint::ProviderExpression { .. } => None,
-        };
         candidates
             .iter()
             .copied()
             .filter(|&sid| {
                 let pkg = &self.solvables[sid.to_index()];
-                let matches = match constraint {
-                    ConaryConstraint::RpmRuntime(_) => false,
-                    ConaryConstraint::ProviderExpression { expression } => {
-                        constraint_architecture_matches_package(
-                            constraint,
-                            pkg,
-                            &self.native_architecture,
-                        ) && provider_expression_matches_package(expression, pkg)
-                            .expect("resolver package versions are validated before SAT filtering")
-                    }
-                    _ if matches!(
-                        requested_kind,
-                        None
-                            | Some(
-                                crate::repository::dependency_model::RepositoryCapabilityKind::PackageName
-                            )
-                    ) && (pkg.name == *requested_name
-                        || self
-                            .canonical_equivalents(requested_name)
-                            .iter()
-                            .any(|equivalent| equivalent == &pkg.name)) =>
-                    {
-                        constraint_architecture_matches_package(
-                            constraint,
-                            pkg,
-                            &self.native_architecture,
-                        ) && constraint_matches_package(
-                            constraint,
-                            &pkg.version,
-                            pkg.version_scheme,
-                        )
-                        .expect("resolver package versions are validated before SAT filtering")
-                    }
-                    _ => pkg
-                        .provided_capabilities
+                let identity_name_matches = pkg.name == *requested_name
+                    || self
+                        .canonical_equivalents(requested_name)
                         .iter()
-                        .filter(|capability| {
-                            capability.name == *requested_name
-                                && requested_kind.is_none_or(|kind| capability.kind == kind)
-                        })
-                        .any(|capability| {
-                            constraint_architecture_matches_provide(
-                                constraint,
-                                pkg,
-                                &capability.architecture_qualifier,
-                                capability.version_scheme,
-                                &self.native_architecture,
-                            ) && constraint_matches_provide(
-                                constraint,
-                                capability.version.as_deref(),
-                                capability.version_relation,
-                                capability.version_scheme,
-                            )
-                            .expect(
-                                "resolver capability versions are validated before SAT filtering",
-                            )
-                        }),
-                };
+                        .any(|equivalent| equivalent == &pkg.name);
+                let matches = constraint_matches_candidate(
+                    requested_name,
+                    constraint,
+                    pkg,
+                    &self.native_architecture,
+                    identity_name_matches,
+                )
+                .expect("resolver package versions are validated before SAT filtering");
                 if inverse { !matches } else { matches }
             })
             .collect()

--- a/crates/conary-core/src/resolver/sat.rs
+++ b/crates/conary-core/src/resolver/sat.rs
@@ -14,6 +14,7 @@ use rusqlite::Connection;
 use std::time::Duration;
 
 use crate::error::{Error, Result};
+use crate::packages::PackageFormat;
 use crate::repository::dependency_model::{RepositoryRequirementGroup, RepositoryRequirementKind};
 use crate::repository::resolution_policy::ResolutionPolicy;
 use crate::repository::versioning::VersionScheme;
@@ -148,16 +149,37 @@ pub fn solve_requirement_groups_with_policy(
     version_scheme: VersionScheme,
     policy: &ResolutionPolicy,
 ) -> Result<SatResolution> {
+    let depending_architecture =
+        crate::repository::registry::native_architecture_for_scheme(version_scheme);
+    solve_requirement_groups_for_architecture_with_policy(
+        conn,
+        groups,
+        version_scheme,
+        &depending_architecture,
+        policy,
+    )
+}
+
+fn solve_requirement_groups_for_architecture_with_policy(
+    conn: &Connection,
+    groups: &[RepositoryRequirementGroup],
+    version_scheme: VersionScheme,
+    depending_architecture: &str,
+    policy: &ResolutionPolicy,
+) -> Result<SatResolution> {
     let mut expressions = Vec::new();
     for group in groups {
         crate::repository::requirement::validate_requirement_group(group, version_scheme)
             .map_err(Error::ConfigError)?;
         match group.kind {
             RepositoryRequirementKind::Depends | RepositoryRequirementKind::PreDepends => {
-                expressions.push(crate::resolver::provider::repository_expression_to_solver(
-                    &group.expression,
-                    version_scheme,
-                )?);
+                expressions.push(
+                    crate::resolver::provider::repository_expression_to_solver_for_architecture(
+                        &group.expression,
+                        version_scheme,
+                        depending_architecture,
+                    )?,
+                );
             }
             RepositoryRequirementKind::Optional | RepositoryRequirementKind::Build => {}
             RepositoryRequirementKind::Conflict
@@ -238,15 +260,18 @@ pub fn positive_requirement_group_satisfied_by_package(
         expression: &crate::repository::dependency_model::RepositoryRequirementExpression,
         version_scheme: VersionScheme,
         package: &PackageIdentity,
+        depending_architecture: &str,
         native_architecture: &str,
     ) -> Result<bool> {
         use crate::repository::dependency_model::RepositoryRequirementExpression as Expression;
         match expression {
             Expression::Atom(_) => {
-                let solver_expression = crate::resolver::provider::repository_expression_to_solver(
-                    expression,
-                    version_scheme,
-                )?;
+                let solver_expression =
+                    crate::resolver::provider::repository_expression_to_solver_for_architecture(
+                        expression,
+                        version_scheme,
+                        depending_architecture,
+                    )?;
                 let crate::resolver::provider::SolverExpression::Atom(atom) = solver_expression
                 else {
                     return Ok(false);
@@ -266,6 +291,7 @@ pub fn positive_requirement_group_satisfied_by_package(
                         operand,
                         version_scheme,
                         package,
+                        depending_architecture,
                         native_architecture,
                     )? {
                         return Ok(false);
@@ -279,6 +305,7 @@ pub fn positive_requirement_group_satisfied_by_package(
                         operand,
                         version_scheme,
                         package,
+                        depending_architecture,
                         native_architecture,
                     )? {
                         return Ok(true);
@@ -293,11 +320,70 @@ pub fn positive_requirement_group_satisfied_by_package(
         }
     }
 
+    let native_architecture = crate::repository::registry::detect_system_arch();
+    let depending_architecture = package
+        .architecture
+        .as_deref()
+        .unwrap_or(native_architecture.as_str());
     matches_positive_expression(
         &group.expression,
         version_scheme,
         package,
-        &crate::repository::registry::detect_system_arch(),
+        depending_architecture,
+        &native_architecture,
+    )
+}
+
+/// Solve one parsed package's external requirements after discharging exact
+/// positive requirements that the incoming package itself provides.
+///
+/// All install entrypoints use this boundary so a converted CCS archive and
+/// its source-native package receive identical dependency semantics.
+pub fn solve_package_requirements_with_policy(
+    conn: &Connection,
+    package: &dyn PackageFormat,
+    policy: &ResolutionPolicy,
+) -> Result<SatResolution> {
+    let incoming = PackageIdentity {
+        repo_package_id: None,
+        name: package.name().to_string(),
+        version: package.version().to_string(),
+        package_release: package.package_release().map(str::to_string),
+        architecture: package.architecture().map(str::to_string),
+        debian_multi_arch: package.debian_multi_arch(),
+        version_scheme: package.version_scheme(),
+        repository_id: None,
+        repository_name: String::new(),
+        repository_profile: None,
+        repository_priority: 0,
+        canonical_id: None,
+        canonical_name: None,
+        installed_trove_id: None,
+        installed_pinned: false,
+        provided_capabilities: package.resolution_capabilities()?,
+    };
+    let mut external_requirements = Vec::new();
+    for requirement in package.requirements() {
+        if !positive_requirement_group_satisfied_by_package(
+            requirement,
+            package.version_scheme(),
+            &incoming,
+        )? {
+            external_requirements.push(requirement.clone());
+        }
+    }
+    let depending_architecture = package
+        .architecture()
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            crate::repository::registry::native_architecture_for_scheme(package.version_scheme())
+        });
+    solve_requirement_groups_for_architecture_with_policy(
+        conn,
+        &external_requirements,
+        package.version_scheme(),
+        &depending_architecture,
+        policy,
     )
 }
 

--- a/crates/conary-core/src/resolver/sat.rs
+++ b/crates/conary-core/src/resolver/sat.rs
@@ -17,6 +17,7 @@ use crate::error::{Error, Result};
 use crate::repository::dependency_model::{RepositoryRequirementGroup, RepositoryRequirementKind};
 use crate::repository::resolution_policy::ResolutionPolicy;
 use crate::repository::versioning::VersionScheme;
+use crate::resolver::identity::PackageIdentity;
 use crate::version::VersionConstraint;
 
 const MAX_LOADED_NAMES: usize = 50_000;
@@ -210,6 +211,94 @@ pub fn solve_requirement_groups_with_policy(
             "Dependency resolution was cancelled".to_string(),
         )),
     }
+}
+
+/// Return whether an incoming package already satisfies one positive
+/// requirement group from its exact identity and declared provides.
+///
+/// Conditional and negated forms remain SAT-owned because their truth can
+/// depend on other packages selected into the transaction. Positive atoms,
+/// conjunctions, and disjunctions are safe to discharge against the incoming
+/// package alone.
+pub fn positive_requirement_group_satisfied_by_package(
+    group: &RepositoryRequirementGroup,
+    version_scheme: VersionScheme,
+    package: &PackageIdentity,
+) -> Result<bool> {
+    crate::repository::requirement::validate_requirement_group(group, version_scheme)
+        .map_err(Error::ConfigError)?;
+    if !matches!(
+        group.kind,
+        RepositoryRequirementKind::Depends | RepositoryRequirementKind::PreDepends
+    ) {
+        return Ok(false);
+    }
+
+    fn matches_positive_expression(
+        expression: &crate::repository::dependency_model::RepositoryRequirementExpression,
+        version_scheme: VersionScheme,
+        package: &PackageIdentity,
+        native_architecture: &str,
+    ) -> Result<bool> {
+        use crate::repository::dependency_model::RepositoryRequirementExpression as Expression;
+        match expression {
+            Expression::Atom(_) => {
+                let solver_expression = crate::resolver::provider::repository_expression_to_solver(
+                    expression,
+                    version_scheme,
+                )?;
+                let crate::resolver::provider::SolverExpression::Atom(atom) = solver_expression
+                else {
+                    return Ok(false);
+                };
+                crate::resolver::provider::matching::constraint_matches_candidate(
+                    &atom.name,
+                    &atom.constraint,
+                    package,
+                    native_architecture,
+                    package.name == atom.name,
+                )
+                .map_err(Error::from)
+            }
+            Expression::And(operands) => {
+                for operand in operands {
+                    if !matches_positive_expression(
+                        operand,
+                        version_scheme,
+                        package,
+                        native_architecture,
+                    )? {
+                        return Ok(false);
+                    }
+                }
+                Ok(true)
+            }
+            Expression::Or(operands) => {
+                for operand in operands {
+                    if matches_positive_expression(
+                        operand,
+                        version_scheme,
+                        package,
+                        native_architecture,
+                    )? {
+                        return Ok(true);
+                    }
+                }
+                Ok(false)
+            }
+            Expression::If { .. }
+            | Expression::Unless { .. }
+            | Expression::With { .. }
+            | Expression::Without { .. } => Ok(false),
+        }
+    }
+
+    matches_positive_expression(
+        &group.expression,
+        version_scheme,
+        package,
+        &crate::repository::registry::detect_system_arch(),
+    )
 }
 
 /// Check what packages would break if the given packages are removed.

--- a/crates/conary-core/src/resolver/sat/tests/root_requirements.rs
+++ b/crates/conary-core/src/resolver/sat/tests/root_requirements.rs
@@ -3,11 +3,64 @@
 use super::formal_dependencies::insert_repo_pkg_with_reqs;
 use super::*;
 use crate::db::models::RepositoryProvide;
+use crate::packages::traits::PackageFile;
+use crate::packages::{PackageFormat, PackagePayload};
 use crate::repository::dependency_model::{
     CapabilityProvenance, ProvideArchitectureQualifier, ProvideVersionRelation, ProvidedCapability,
     RepositoryCapabilityKind, RepositoryRequirementKind, SourcePackageFormat,
 };
 use crate::repository::requirement::parse_native_requirement;
+
+struct IncomingPackage {
+    requirements: Vec<crate::repository::dependency_model::RepositoryRequirementGroup>,
+    capabilities: Vec<ProvidedCapability>,
+}
+
+impl PackageFormat for IncomingPackage {
+    fn parse(_path: &str) -> crate::Result<Self> {
+        unreachable!("test package is constructed directly")
+    }
+
+    fn name(&self) -> &str {
+        "phase4-corpus"
+    }
+
+    fn version(&self) -> &str {
+        "1.0.0-1"
+    }
+
+    fn version_scheme(&self) -> VersionScheme {
+        VersionScheme::Rpm
+    }
+
+    fn architecture(&self) -> Option<&str> {
+        Some("x86_64")
+    }
+
+    fn description(&self) -> Option<&str> {
+        None
+    }
+
+    fn files(&self) -> &[PackageFile] {
+        &[]
+    }
+
+    fn requirements(&self) -> &[crate::repository::dependency_model::RepositoryRequirementGroup] {
+        &self.requirements
+    }
+
+    fn resolution_capabilities(&self) -> crate::Result<Vec<ProvidedCapability>> {
+        Ok(self.capabilities.clone())
+    }
+
+    fn package_payload(&self) -> crate::Result<PackagePayload> {
+        unreachable!("dependency solving does not read payload")
+    }
+
+    fn to_trove(&self) -> crate::db::models::Trove {
+        unreachable!("dependency solving does not construct a trove")
+    }
+}
 
 fn repository(conn: &Connection) -> i64 {
     let mut repository = Repository::new(
@@ -135,6 +188,60 @@ fn incoming_exact_provide_satisfies_only_its_matching_positive_requirement() {
         )
         .unwrap()
     );
+}
+
+#[test]
+fn package_solver_discharge_self_provide_but_selects_external_dependency() {
+    let (_temp, conn) = setup_test_db();
+    let repository_id = repository(&conn);
+    insert_repo_pkg_with_reqs(
+        &conn,
+        repository_id,
+        "phase4-repository-fixture",
+        "1.0.0",
+        "https://rich-root.invalid/phase4-repository-fixture.rpm",
+        "rpm",
+        &[],
+    );
+    let requirements = [
+        "config(phase4-corpus) = 1.0.0-1",
+        "phase4-repository-fixture = 1.0.0",
+    ]
+    .into_iter()
+    .map(|native| {
+        parse_native_requirement(
+            RepositoryRequirementKind::Depends,
+            VersionScheme::Rpm,
+            native,
+        )
+        .unwrap()
+    })
+    .collect();
+    let package = IncomingPackage {
+        requirements,
+        capabilities: vec![ProvidedCapability {
+            kind: RepositoryCapabilityKind::Generic,
+            name: "config(phase4-corpus)".to_string(),
+            version: Some("1.0.0-1".to_string()),
+            version_relation: Some(ProvideVersionRelation::Equal),
+            version_scheme: VersionScheme::Rpm,
+            architecture_qualifier: ProvideArchitectureQualifier::Implicit,
+            provenance: CapabilityProvenance::SourceDeclared {
+                format: SourcePackageFormat::Rpm,
+                record_index: 0,
+            },
+        }],
+    };
+
+    let result = solve_package_requirements_with_policy(
+        &conn,
+        &package,
+        &ResolutionPolicy::new()
+            .with_mixing(crate::repository::resolution_policy::DependencyMixingPolicy::Permissive),
+    )
+    .unwrap();
+    assert!(result.conflict_message.is_none(), "{result:?}");
+    assert_eq!(selected_names(&result), ["phase4-repository-fixture"]);
 }
 
 #[test]

--- a/crates/conary-core/src/resolver/sat/tests/root_requirements.rs
+++ b/crates/conary-core/src/resolver/sat/tests/root_requirements.rs
@@ -3,7 +3,10 @@
 use super::formal_dependencies::insert_repo_pkg_with_reqs;
 use super::*;
 use crate::db::models::RepositoryProvide;
-use crate::repository::dependency_model::RepositoryRequirementKind;
+use crate::repository::dependency_model::{
+    CapabilityProvenance, ProvideArchitectureQualifier, ProvideVersionRelation, ProvidedCapability,
+    RepositoryCapabilityKind, RepositoryRequirementKind, SourcePackageFormat,
+};
 use crate::repository::requirement::parse_native_requirement;
 
 fn repository(conn: &Connection) -> i64 {
@@ -70,6 +73,68 @@ fn selected_names(result: &SatResolution) -> Vec<&str> {
         .iter()
         .map(|package| package.name.as_str())
         .collect()
+}
+
+#[test]
+fn incoming_exact_provide_satisfies_only_its_matching_positive_requirement() {
+    let self_requirement = parse_native_requirement(
+        RepositoryRequirementKind::Depends,
+        VersionScheme::Rpm,
+        "config(phase4-corpus) = 1.0.0-1",
+    )
+    .unwrap();
+    let external_requirement = parse_native_requirement(
+        RepositoryRequirementKind::Depends,
+        VersionScheme::Rpm,
+        "phase4-repository-fixture = 1.0.0",
+    )
+    .unwrap();
+    let incoming = PackageIdentity {
+        repo_package_id: None,
+        name: "phase4-corpus".to_string(),
+        version: "1.0.0-1".to_string(),
+        package_release: None,
+        architecture: Some("x86_64".to_string()),
+        debian_multi_arch: None,
+        version_scheme: VersionScheme::Rpm,
+        repository_id: None,
+        repository_name: String::new(),
+        repository_profile: None,
+        repository_priority: 0,
+        canonical_id: None,
+        canonical_name: None,
+        installed_trove_id: None,
+        installed_pinned: false,
+        provided_capabilities: vec![ProvidedCapability {
+            kind: RepositoryCapabilityKind::Generic,
+            name: "config(phase4-corpus)".to_string(),
+            version: Some("1.0.0-1".to_string()),
+            version_relation: Some(ProvideVersionRelation::Equal),
+            version_scheme: VersionScheme::Rpm,
+            architecture_qualifier: ProvideArchitectureQualifier::Implicit,
+            provenance: CapabilityProvenance::SourceDeclared {
+                format: SourcePackageFormat::Rpm,
+                record_index: 0,
+            },
+        }],
+    };
+
+    assert!(
+        positive_requirement_group_satisfied_by_package(
+            &self_requirement,
+            VersionScheme::Rpm,
+            &incoming,
+        )
+        .unwrap()
+    );
+    assert!(
+        !positive_requirement_group_satisfied_by_package(
+            &external_requirement,
+            VersionScheme::Rpm,
+            &incoming,
+        )
+        .unwrap()
+    );
 }
 
 #[test]

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -558,12 +558,14 @@ fixture enrolls its binary JSON repository, exact source profile, and CCS
 package key through `conary repo add`; it does not mutate protected SQLite
 authority out of band. The focused
 `phase4-native-daily-driver-corpus` manifest owns `TNPM13` through `TNPM18`
-without inheriting the live repository or prior parity state. That corpus
-builds a package in the host-native format and then proves:
+without inheriting prior parity state. It builds a bounded signed loopback CCS
+repository, then builds a package in the host-native format and proves:
 
 - systemd unit file deployment and trigger matching
 - tracked `/etc` config file metadata
-- native dependency metadata for a real package dependency
+- one exact native versioned dependency resolved by SAT, acquired from the
+  synchronized repository, signature-verified, and installed with dependency
+  reason and source provenance
 - an exact installed native-lifecycle bundle plus install/remove hook effects
 - system user and group creation in the selected generation
 - an explicit mode-0750 directory and an exact relative symlink through native
@@ -575,17 +577,20 @@ builds a package in the host-native format and then proves:
 - an alternative target binary (`/usr/bin/phase4-corpus-alt`) as packaged file
   coverage
 
-`TNPM16` and `TNPM18` make the chain visible to the typed W7 aggregator. Each
-record reopens the builder's schema-versioned output manifest, hashes the exact
-native artifact again, and binds its claims to the install-request role.
-Across the two completed cases the suite declares exactly nine properties:
-exact version, native architecture, regular files, directories, symlinks, a
+`TNPM16` and `TNPM18` make the chain visible to the typed W7 aggregator. The
+install record reopens both builders' schema-versioned output manifests,
+hashes the native request and signed dependency artifacts again, and binds its
+versioned-dependency claim to both `install_request` and `install_dependency`.
+The removal record remains request-bound. Across the two completed cases the
+suite declares exactly eleven properties: exact version, native architecture,
+regular files, directories, symlinks, hardlinks, a versioned dependency, a
 queried virtual provide, matched config, purge-time config removal, and shell
-lifecycle. Directory and symlink claims require exact typed node/mode/target
-queries plus selected-generation assertions; implicit parents and followed
-filesystem paths do not count. The source format comes from the explicit
-distro build-context override and must resolve to the closed RPM/DEB/ALPM type
-before evidence can count.
+lifecycle. Directory, symlink, hardlink, and relation claims require direct
+native metadata, selected-generation, repository-provenance, and installed
+reason assertions; implicit parents, followed filesystem paths, and recorded
+metadata without a completed resolution do not count. The source format comes
+from the explicit distro build-context override and must resolve to the closed
+RPM/DEB/ALPM type before evidence can count.
 
 RPM export emits a directory entry when its mode differs from the implicit
 0755 parent contract or no descendant can create it. Default-mode parents of
@@ -605,8 +610,8 @@ Fedora 44, Ubuntu 26.04, and Arch in a non-fail-fast matrix, then applies both
 the generic suite-result checker and the typed corpus-coverage checker to every
 lane. The stable `native-daily-driver-corpus` aggregate context fails unless
 all three source-format/target pairs complete. The full deterministic repository
-and package-manager matrix remains owned by `phase4-native-pm-parity`; it is not
-a prerequisite for this focused digest-attributed fixture chain.
+and package-manager matrix remains owned by `phase4-native-pm-parity`; the
+focused chain consumes only its deterministic signed-repository fixture.
 
 Corpus coverage boundaries (not product support exemptions):
 

--- a/docs/modules/test-fixtures.md
+++ b/docs/modules/test-fixtures.md
@@ -490,10 +490,14 @@ Each fixture family should record:
   authority from distro-name matching. The typed workflow test owns the three
   source-format cases across all six required target lanes and the stable
   all-lane aggregator context; do not weaken either in workflow-only edits.
-  The focused `phase4-native-daily-driver-corpus` chain emits two exact-artifact records
-  for its host-native RPM, DEB, or ALPM build: the completed install/query
-  chain covers exact/native identity, regular files, one explicit directory,
+  The focused `phase4-native-daily-driver-corpus` chain emits two case records
+  for its host-native RPM, DEB, or ALPM build. The completed install/query
+  record binds both the native request and its SAT-selected signed CCS
+  dependency to exact build-manifest SHA-256 identities; the removal record
+  remains bound to the request artifact. The completed chain covers
+  exact/native identity, regular files, one explicit directory,
   one exact symlink, one two-path hardlink set, one queried virtual provide,
+  one exact versioned dependency resolved from the bounded loopback repository,
   matched config, and shell lifecycle; removal covers config cleanup. Each
   native package is independently installed or extracted and both hardlink
   paths must report one device/inode identity with a link count of two before
@@ -508,10 +512,10 @@ Each fixture family should record:
   rehashes the artifact before publication. The chain attributes hardlink
   coverage only through the native inode oracle plus the typed
   selected-generation topology assertion. Do not infer large-file,
-  source-trigger, activation, target-helper, or declared-relation coverage from
-  the chain's 2 MiB file, out-of-band trigger, disabled unit, adjacent helper
-  path, or file-collision negative.
-  PRs run only that focused six-test chain on Fedora 44, Ubuntu 26.04, and Arch behind the stable
+  source-trigger, activation, target-helper, conflict, or replacement coverage
+  from the chain's 2 MiB file, out-of-band trigger, disabled unit, adjacent
+  helper path, or file-collision negative. PRs run only that focused six-test
+  chain on Fedora 44, Ubuntu 26.04, and Arch behind the stable
   `native-daily-driver-corpus` aggregate context; every lane applies both the
   ordinary suite-result and typed corpus-result gates.
   Derivative roots are assembled from digest-pinned transport images, exact

--- a/docs/roadmaps/development-roadmap.md
+++ b/docs/roadmaps/development-roadmap.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-16
 revision: 25
-summary: Track Conary's active W7 deterministic native-parity slice, typed semantic coverage, external tester milestone, and later workstreams
+summary: Track Conary's active W7 versioned-dependency corpus slice, typed semantic coverage, external tester milestone, and later workstreams
 proof_baseline: "immutable synchronized v0.15.0 suite at 642750878d5a59a9aa27976347cafc6f9dd86cfd; exact tagged Remi deployed; external tester result remains 0/10 behind #110"
 current_milestone: first external tester loop
 active_workstream: W7 Just-Works Corpus Gate
@@ -318,14 +318,16 @@ the stated scope, not whether a workstream happens to be active.
   makes the daily-driver native fixture attributable in one focused local
   manifest. #463 adds exact directory and symlink topology to that same
   digest-bound chain. #462 and #464 add exact hardlink and root-directory export
-  with hosted inode and RPM parser proof. #460 now pins the legacy provider-set
-  contract per source format but remains open for the full matrix. #461 is the
-  active slice removing live repository-sync nondeterminism and host-PID timeout
-  cleanup from that terminal parity proof. The #458 discovery run filed both
-  defects rather than folding them into the focused W7 gate.
+  with hosted inode and RPM parser proof. #460 and #461 are closed: the legacy
+  provider contract is exact per source format and the full parity matrix now
+  uses a signed loopback repository plus process-group timeout cleanup. #470 is
+  the active slice making one exact versioned dependency resolve, acquire, and
+  install from that repository with both artifacts bound to typed corpus
+  evidence.
 - **Issues:** #110 as the corpus umbrella; #458 and #463 for focused
   daily-driver attribution; #462 and #464 for payload-topology export gaps;
-  #460 and #461 for exact legacy parity defects; plus #39 for bootstrap.
+  #460 and #461 for closed legacy parity defects; #470 for versioned dependency
+  resolution; plus #39 for bootstrap.
 - **User journey:** install the signed release through one documented bootstrap
   entry point; `conary system init` with no hand-edited state; sync and
   authenticate repositories; request a package by ordinary name; resolve the


### PR DESCRIPTION
## Problem

The attributable native daily-driver fixture recorded dependency metadata but installed every package with `--no-deps`, so W7 had no proof for the ordinary versioned dependency-resolution path. RPM export also encoded configured requirements only as unversioned header names, which could not represent an exact constraint.

Hosted interaction exposed three shared authority defects rather than flaky lanes: RPM's exact paired `config(NAME)` provide/require was sent to the external resolver; JSON repository metadata collapsed source version with signed CCS build release; and unpersisted Debian requirements used the Rust host token `x86_64` as though it were the Debian token `amd64`.

## Change

- make RPM native-export dependency declarations typed by name, relation, and version, with fail-closed validation and parser round-trip proof
- give the RPM, Debian, and ALPM daily-driver artifacts the same exact `phase4-repository-fixture = 1.0.0` source-version dependency
- reuse the deterministic signed loopback binary repository and install the native request through SAT and repository acquisition without `--no-deps`
- route all package install entrypoints through one shared solver boundary that discharges only positive requirements satisfied by the incoming package; conditional expressions remain SAT-owned
- bind unpersisted dependency expressions to the incoming package's exact source-native architecture
- keep JSON repository source version (`1.0.0`) and signed package release (`1`) as separate typed authorities
- prove the dependency's exact CCS identity, install reason, repository/source-profile provenance, and selected-generation payload
- extend corpus evidence to rehash both request and dependency build manifests and emit the `install_request` and `install_dependency` roles
- claim only `relations_versioned_dependency`, only after resolution and installation complete, and bind it to both artifact identities
- update fixture and W7 roadmap truth, including the closed #460/#461 state

## Verification

- `cargo test -p conary-core ccs::native_export --no-fail-fast` — 28 passed
- `cargo test -p conary-core resolver::sat::tests::root_requirements --no-fail-fast` — 6 passed
- `cargo test -p conary-core resolver::provider::tests --no-fail-fast` — 25 passed
- `cargo test -p conary-core repository::sync::tests --no-fail-fast` — 30 passed, including strict Debian JSON repository resolution
- `cargo test -p conary commands::install --no-fail-fast` — 233 passed, 1 intentional network conformance test ignored
- `cargo test -p conary commands::ccs::install --no-fail-fast` — 30 passed
- `cargo test -p conary-test config::tests::native_corpus::phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contract -- --exact` — 1 passed
- `cargo test -p conary-test corpus_evidence_writer_binds_request_and_dependency_to_exact_digests --no-fail-fast` — 1 passed; mutated dependency digest rejected
- `cargo run -p conary-test -- list` — 34 suites loaded, including the six-test focused corpus
- built the exact daily-driver native artifact and signed dependency CCS fixture locally for RPM, Debian, and ALPM — six artifacts produced
- locally generated all three JSON indexes with `version=1.0.0`, `release=1`, and the exact ecosystem architecture
- `cargo clippy -p conary-core -p conary -p conary-test --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `bash scripts/check-doc-truth.sh` — passed
- `git diff --check` — passed

Hosted Fedora 44, Ubuntu 26.04, and Arch focused lanes plus the stable corpus aggregate passed on exact head `bb36702e`; all 29 PR jobs are terminal green.

Closes #470
Refs #110

