### PR TITLE
test(w7): attribute payload ownership and timestamps

### DIFF
--- a/apps/conary-test/src/config/tests/native_corpus.rs
+++ b/apps/conary-test/src/config/tests/native_corpus.rs
@@ -358,6 +358,8 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
             conary_core::corpus::CorpusSemantic::PayloadDirectories,
             conary_core::corpus::CorpusSemantic::PayloadSymlinks,
             conary_core::corpus::CorpusSemantic::PayloadHardlinks,
+            conary_core::corpus::CorpusSemantic::MetadataOwnership,
+            conary_core::corpus::CorpusSemantic::MetadataTimestamps,
             conary_core::corpus::CorpusSemantic::RelationsVersionedDependency,
             conary_core::corpus::CorpusSemantic::RelationsVirtualProvide,
             conary_core::corpus::CorpusSemantic::ConfigurationMatchedConfig,
@@ -367,6 +369,8 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
     );
     for unproven in [
         conary_core::corpus::CorpusSemantic::PayloadLargeFiles,
+        conary_core::corpus::CorpusSemantic::MetadataXattrs,
+        conary_core::corpus::CorpusSemantic::MetadataCapabilities,
         conary_core::corpus::CorpusSemantic::RelationsConflict,
         conary_core::corpus::CorpusSemantic::LifecycleTrigger,
         conary_core::corpus::CorpusSemantic::RuntimeServiceActivation,
@@ -440,7 +444,10 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
         "--expect-directory /opt=0750",
         "--expect-symlink /usr/bin/phase4-corpus-link=phase4-corpus",
         "--expect-hardlink /usr/lib/phase4-corpus/hardlink-anchor=/usr/lib/phase4-corpus/hardlink-copy",
+        "--expect-node-metadata /usr/lib/phase4-corpus/hardlink-anchor=${native_corpus_payload_user},${native_corpus_payload_group},1700000000,0",
+        "--expect-node-metadata /usr/lib/phase4-corpus/hardlink-copy=${native_corpus_payload_user},${native_corpus_payload_group},1700000000,0",
         "assert-native-hardlink.sh",
+        "hardlink-copy 0 0 1700000000",
         "FILEMODES",
         "/opt|16872|root|root",
         "printf %s conflicting-corpus-payload",
@@ -491,7 +498,11 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
         );
     }
 
-    for distro in ["fedora44", "ubuntu-26.04", "arch"] {
+    for (distro, expected_user, expected_group) in [
+        ("fedora44", "named:root", "named:root"),
+        ("ubuntu-26.04", "numeric:0", "numeric:0"),
+        ("arch", "numeric:0", "numeric:0"),
+    ] {
         let overrides = manifest
             .distro_overrides
             .get(distro)
@@ -503,12 +514,28 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
             "native_corpus_lifecycle_fidelity",
             "native_corpus_source_format",
             "native_corpus_target_architecture",
+            "native_corpus_payload_user",
+            "native_corpus_payload_group",
         ] {
             assert!(
                 overrides.contains_key(key),
                 "{distro} overrides should define {key}"
             );
         }
+        assert_eq!(
+            overrides
+                .get("native_corpus_payload_user")
+                .map(String::as_str),
+            Some(expected_user),
+            "{distro} must preserve the source format's typed user identity"
+        );
+        assert_eq!(
+            overrides
+                .get("native_corpus_payload_group")
+                .map(String::as_str),
+            Some(expected_group),
+            "{distro} must preserve the source format's typed group identity"
+        );
     }
 
     let install_case = manifest
@@ -529,7 +556,21 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
             conary_core::corpus::ConversionStage::Installation,
         ]
     );
-    assert_eq!(install_case.coverage.len(), 10);
+    assert_eq!(install_case.coverage.len(), 12);
+    for semantic in [
+        conary_core::corpus::CorpusSemantic::MetadataOwnership,
+        conary_core::corpus::CorpusSemantic::MetadataTimestamps,
+    ] {
+        let claim = install_case
+            .coverage
+            .iter()
+            .find(|claim| claim.semantic == semantic)
+            .unwrap_or_else(|| panic!("missing {semantic:?} coverage claim"));
+        assert_eq!(
+            claim.artifact_roles,
+            [conary_core::corpus::SourceArtifactRole::InstallRequest]
+        );
+    }
     let dependency_claim = install_case
         .coverage
         .iter()
@@ -592,6 +633,8 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
         "dpkg-deb --extract",
         "bsdtar --extract",
         "stat --format '%d:%i:%h'",
+        "stat --format '%u:%g:%Y'",
+        "expected_metadata",
     ] {
         assert!(
             hardlink_helper.contains(required),
@@ -661,8 +704,11 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
             .expect("read selected-generation assertion helper");
     for required in [
         "--expect-hardlink",
+        "--expect-node-metadata",
         "hardlink_identity",
         "content authority is not anchor-only",
+        "expected_payload_identity",
+        "expected_mtime",
     ] {
         assert!(
             selected_generation_helper.contains(required),

--- a/apps/conary-test/src/config/tests/native_corpus.rs
+++ b/apps/conary-test/src/config/tests/native_corpus.rs
@@ -499,7 +499,7 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
     }
 
     for (distro, expected_user, expected_group) in [
-        ("fedora44", "named:root", "named:root"),
+        ("fedora44", "numeric:0", "numeric:0"),
         ("ubuntu-26.04", "numeric:0", "numeric:0"),
         ("arch", "numeric:0", "numeric:0"),
     ] {

--- a/apps/conary/tests/fixtures/native/assert-native-hardlink.sh
+++ b/apps/conary/tests/fixtures/native/assert-native-hardlink.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -ne 5 ]]; then
-  echo "Usage: $0 <rpm|deb|arch> <package> <extract-root> <path-a> <path-b>" >&2
+if [[ $# -ne 8 ]]; then
+  echo "Usage: $0 <rpm|deb|arch> <package> <extract-root> <path-a> <path-b> <uid> <gid> <mtime-seconds>" >&2
   exit 64
 fi
 
@@ -11,9 +11,12 @@ package="$2"
 extract_root="$3"
 path_a="$4"
 path_b="$5"
+expected_uid="$6"
+expected_gid="$7"
+expected_mtime="$8"
 
-if [[ ! -f "${package}" || "${path_a}" != /* || "${path_b}" != /* ]]; then
-  echo "native hardlink assertion requires one package and two absolute payload paths" >&2
+if [[ ! -f "${package}" || "${path_a}" != /* || "${path_b}" != /* || ! "${expected_uid}" =~ ^[0-9]+$ || ! "${expected_gid}" =~ ^[0-9]+$ || ! "${expected_mtime}" =~ ^-?[0-9]+$ ]]; then
+  echo "native hardlink assertion requires one package, two absolute payload paths, and exact numeric uid/gid/mtime authority" >&2
   exit 64
 fi
 
@@ -48,5 +51,13 @@ if [[ "${first_identity}" != "${second_identity}" ]]; then
 fi
 if [[ "${first_identity##*:}" != "2" ]]; then
   echo "native artifact hardlink set has unexpected link count: ${first_identity}" >&2
+  exit 1
+fi
+
+expected_metadata="${expected_uid}:${expected_gid}:${expected_mtime}"
+first_metadata="$(stat --format '%u:%g:%Y' "${first}")"
+second_metadata="$(stat --format '%u:%g:%Y' "${second}")"
+if [[ "${first_metadata}" != "${expected_metadata}" || "${second_metadata}" != "${expected_metadata}" ]]; then
+  echo "native artifact hardlink metadata mismatch: ${first_metadata}, ${second_metadata}; expected ${expected_metadata}" >&2
   exit 1
 fi

--- a/apps/conary/tests/fixtures/native/assert-selected-generation.py
+++ b/apps/conary/tests/fixtures/native/assert-selected-generation.py
@@ -330,6 +330,65 @@ def assert_selected_hardlink(
             fail(f"selected-generation hardlink members disagree on {field}")
 
 
+def expected_payload_identity(value: str, field: str) -> dict[str, Any]:
+    try:
+        identity_type, identity_value = value.split(":", 1)
+    except ValueError:
+        fail(f"{field} expects named:NAME or numeric:ID, got {value!r}")
+    if identity_type == "named" and identity_value and "\x00" not in identity_value:
+        return {"type": "named", "name": identity_value}
+    if (
+        identity_type == "numeric"
+        and identity_value.isascii()
+        and identity_value.isdecimal()
+    ):
+        return {"type": "numeric", "id": int(identity_value)}
+    fail(f"{field} expects named:NAME or numeric:ID, got {value!r}")
+
+
+def assert_selected_node_metadata(
+    entries: dict[str, dict[str, Any]], expectation: str
+) -> None:
+    path, expected = split_expectation(expectation, "--expect-node-metadata")
+    fields = expected.split(",")
+    if len(fields) != 4:
+        fail(
+            "--expect-node-metadata expects "
+            "PATH=USER,GROUP,SECONDS,NANOSECONDS"
+        )
+    expected_user = expected_payload_identity(fields[0], "USER")
+    expected_group = expected_payload_identity(fields[1], "GROUP")
+    try:
+        expected_seconds = int(fields[2])
+        expected_nanoseconds = int(fields[3])
+    except ValueError:
+        fail("--expect-node-metadata seconds and nanoseconds must be decimal integers")
+    if not 0 <= expected_nanoseconds < 1_000_000_000:
+        fail("--expect-node-metadata nanoseconds must be in [0, 1000000000)")
+
+    entry = entries.get(path)
+    if entry is None:
+        fail(f"selected generation does not contain {path}")
+    node = entry.get("node")
+    source = node.get("source") if isinstance(node, dict) else None
+    if not isinstance(source, dict):
+        fail(f"selected-generation path {path} has no typed source-node authority")
+    expected_mtime = {
+        "seconds": expected_seconds,
+        "nanoseconds": expected_nanoseconds,
+    }
+    for field, expected_value in (
+        ("user", expected_user),
+        ("group", expected_group),
+        ("mtime", expected_mtime),
+    ):
+        if source.get(field) != expected_value:
+            fail(
+                f"{path} {field} authority is {source.get(field)!r}, "
+                f"expected {expected_value!r}"
+            )
+
+
 def parse_colon_records(content: bytes, path: str, field_count: int) -> list[list[str]]:
     try:
         lines = content.decode("utf-8").splitlines()
@@ -422,6 +481,12 @@ def main() -> int:
     parser.add_argument(
         "--expect-hardlink", action="append", default=[], metavar="PATH_A=PATH_B"
     )
+    parser.add_argument(
+        "--expect-node-metadata",
+        action="append",
+        default=[],
+        metavar="PATH=USER,GROUP,SECONDS,NANOSECONDS",
+    )
     parser.add_argument("--contains-line", action="append", default=[], metavar="PATH=LINE")
     parser.add_argument(
         "--expect-user",
@@ -453,6 +518,8 @@ def main() -> int:
         assert_selected_directory(entries, value)
     for value in args.expect_hardlink:
         assert_selected_hardlink(entries, value)
+    for value in args.expect_node_metadata:
+        assert_selected_node_metadata(entries, value)
     for value in args.contains_line:
         path, expected = split_expectation(value, "--contains-line")
         _, content = entry_content(entries, cas_base, path)
@@ -468,6 +535,7 @@ def main() -> int:
         + len(args.expect_symlink)
         + len(args.expect_directory)
         + len(args.expect_hardlink)
+        + len(args.expect_node_metadata)
         + len(args.expect_user)
     )
     print(

--- a/apps/conary/tests/integration/remi/manifests/phase4-native-daily-driver-corpus.toml
+++ b/apps/conary/tests/integration/remi/manifests/phase4-native-daily-driver-corpus.toml
@@ -15,6 +15,8 @@ required = [
     "payload_directories",
     "payload_symlinks",
     "payload_hardlinks",
+    "metadata_ownership",
+    "metadata_timestamps",
     "relations_versioned_dependency",
     "relations_virtual_provide",
     "configuration_matched_config",
@@ -84,6 +86,8 @@ native_corpus_config_source = "rpm"
 native_corpus_lifecycle_fidelity = "native-lifecycle"
 native_corpus_source_format = "rpm"
 native_corpus_target_architecture = "x86_64"
+native_corpus_payload_user = "named:root"
+native_corpus_payload_group = "named:root"
 
 [distro_overrides."ubuntu-26.04"]
 native_target = "deb"
@@ -99,6 +103,8 @@ native_corpus_config_source = "deb"
 native_corpus_lifecycle_fidelity = "native-lifecycle"
 native_corpus_source_format = "deb"
 native_corpus_target_architecture = "x86_64"
+native_corpus_payload_user = "numeric:0"
+native_corpus_payload_group = "numeric:0"
 
 [distro_overrides.arch]
 native_target = "arch"
@@ -114,6 +120,8 @@ native_corpus_config_source = "arch"
 native_corpus_lifecycle_fidelity = "native-lifecycle"
 native_corpus_source_format = "alpm"
 native_corpus_target_architecture = "x86_64"
+native_corpus_payload_user = "numeric:0"
+native_corpus_payload_group = "numeric:0"
 
 # --------------------------------------------------------------------------
 # TNPM13: daily-driver corpus build
@@ -140,7 +148,7 @@ run = ". /tmp/native-pm-corpus/native-fixture.env && case \"$NATIVE_TARGET\" in 
 exit_code = 0
 
 [[test.step]]
-run = ". /tmp/native-pm-corpus/native-fixture.env && rm -rf /tmp/native-pm-corpus-hardlink-root && /opt/remi-tests/fixtures/native/assert-native-hardlink.sh \"$NATIVE_TARGET\" \"$NATIVE_PKG_FILE\" /tmp/native-pm-corpus-hardlink-root /usr/lib/phase4-corpus/hardlink-anchor /usr/lib/phase4-corpus/hardlink-copy"
+run = ". /tmp/native-pm-corpus/native-fixture.env && rm -rf /tmp/native-pm-corpus-hardlink-root && /opt/remi-tests/fixtures/native/assert-native-hardlink.sh \"$NATIVE_TARGET\" \"$NATIVE_PKG_FILE\" /tmp/native-pm-corpus-hardlink-root /usr/lib/phase4-corpus/hardlink-anchor /usr/lib/phase4-corpus/hardlink-copy 0 0 1700000000"
 
 [test.step.assert]
 exit_code = 0
@@ -179,7 +187,7 @@ exit_code = 0
 stdout_contains = "phase4-repository-fixture|1.0.0|1|${native_arch}|${native_scheme}|${REPO_NAME}|${native_profile}|repository|dependency"
 
 [[test.step]]
-run = "/opt/remi-tests/fixtures/native/assert-selected-generation.py --root /conary --expect-sha256 /usr/bin/phase4-corpus=565d3f61ffdbbca53c7371588ce6884b680dfa1d1c1bd7fe3954b4ab957e0676 --expect-sha256 /usr/bin/phase4-corpus-alt=1c279f8af2faaed5ae4aad470ab37742b2cede45b42b65d961f2bb33233e5ad3 --expect-symlink /usr/bin/phase4-corpus-link=phase4-corpus --expect-directory /opt=0750 --expect-directory /usr/lib/phase4-corpus/state=0750 --expect-hardlink /usr/lib/phase4-corpus/hardlink-anchor=/usr/lib/phase4-corpus/hardlink-copy --expect-sha256 /etc/phase4-corpus/app.conf=8b3ca388884ac9c33e5e1c849ac30bc59aa9d494e7afc5d91fb56c8a4e760eb2 --expect-sha256 /usr/lib/systemd/system/phase4-corpus.service=20200a86933288373c109a2e3289b2314ff6015886bfbad9bec6e613421e756a --expect-sha256 /usr/lib/kernel/install.d/95-phase4-corpus.install=8753356f470ea82416c2d7a71cbf8367d4cbe1a8b78f3276fe45035e114c3674 --present /usr/share/phase4-corpus/large-payload.bin --present /usr/share/phase4-repository-fixture/probe.txt --expect-sha256 /var/lib/phase4-corpus/scriptlet.marker=a51a6c19a1ffc7416827e89adf20749d23ad42452c396cf7e627409f2896922c --expect-user phase4-corpus-user=/var/lib/phase4-corpus,/bin/false,phase4-corpus-group"
+run = "/opt/remi-tests/fixtures/native/assert-selected-generation.py --root /conary --expect-sha256 /usr/bin/phase4-corpus=565d3f61ffdbbca53c7371588ce6884b680dfa1d1c1bd7fe3954b4ab957e0676 --expect-sha256 /usr/bin/phase4-corpus-alt=1c279f8af2faaed5ae4aad470ab37742b2cede45b42b65d961f2bb33233e5ad3 --expect-symlink /usr/bin/phase4-corpus-link=phase4-corpus --expect-directory /opt=0750 --expect-directory /usr/lib/phase4-corpus/state=0750 --expect-hardlink /usr/lib/phase4-corpus/hardlink-anchor=/usr/lib/phase4-corpus/hardlink-copy --expect-node-metadata /usr/lib/phase4-corpus/hardlink-anchor=${native_corpus_payload_user},${native_corpus_payload_group},1700000000,0 --expect-node-metadata /usr/lib/phase4-corpus/hardlink-copy=${native_corpus_payload_user},${native_corpus_payload_group},1700000000,0 --expect-sha256 /etc/phase4-corpus/app.conf=8b3ca388884ac9c33e5e1c849ac30bc59aa9d494e7afc5d91fb56c8a4e760eb2 --expect-sha256 /usr/lib/systemd/system/phase4-corpus.service=20200a86933288373c109a2e3289b2314ff6015886bfbad9bec6e613421e756a --expect-sha256 /usr/lib/kernel/install.d/95-phase4-corpus.install=8753356f470ea82416c2d7a71cbf8367d4cbe1a8b78f3276fe45035e114c3674 --present /usr/share/phase4-corpus/large-payload.bin --present /usr/share/phase4-repository-fixture/probe.txt --expect-sha256 /var/lib/phase4-corpus/scriptlet.marker=a51a6c19a1ffc7416827e89adf20749d23ad42452c396cf7e627409f2896922c --expect-user phase4-corpus-user=/var/lib/phase4-corpus,/bin/false,phase4-corpus-group"
 
 [test.step.assert]
 exit_code = 0
@@ -299,6 +307,14 @@ artifact_roles = ["install_request"]
 
 [[test.corpus.coverage]]
 semantic = "payload_hardlinks"
+artifact_roles = ["install_request"]
+
+[[test.corpus.coverage]]
+semantic = "metadata_ownership"
+artifact_roles = ["install_request"]
+
+[[test.corpus.coverage]]
+semantic = "metadata_timestamps"
 artifact_roles = ["install_request"]
 
 [[test.corpus.coverage]]

--- a/apps/conary/tests/integration/remi/manifests/phase4-native-daily-driver-corpus.toml
+++ b/apps/conary/tests/integration/remi/manifests/phase4-native-daily-driver-corpus.toml
@@ -86,8 +86,8 @@ native_corpus_config_source = "rpm"
 native_corpus_lifecycle_fidelity = "native-lifecycle"
 native_corpus_source_format = "rpm"
 native_corpus_target_architecture = "x86_64"
-native_corpus_payload_user = "named:root"
-native_corpus_payload_group = "named:root"
+native_corpus_payload_user = "numeric:0"
+native_corpus_payload_group = "numeric:0"
 
 [distro_overrides."ubuntu-26.04"]
 native_target = "deb"

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -592,10 +592,10 @@ purge-time config removal, and shell lifecycle. Directory, symlink, hardlink,
 metadata, and relation claims require direct native metadata,
 selected-generation, repository-provenance, and installed reason assertions;
 implicit parents, followed filesystem paths, and recorded metadata without a
-completed resolution do not count. RPM ownership remains source-named while
-Debian and ALPM ownership remains source-numeric; the selected-generation
-assertion proves that typed distinction instead of flattening both to runtime
-uid/gid values. The source format comes from the explicit distro build-context
+completed resolution do not count. The selected-generation assertion requires
+the exact numeric uid/gid authority observed after the native package enters
+the target transaction; it does not infer a named identity from RPM's display
+metadata. The source format comes from the explicit distro build-context
 override and must resolve to the closed RPM/DEB/ALPM type before evidence can
 count.
 

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -570,6 +570,9 @@ repository, then builds a package in the host-native format and proves:
 - system user and group creation in the selected generation
 - an explicit mode-0750 directory and an exact relative symlink through native
   package metadata and the selected generation
+- exact root ownership and whole-second mtime on both members of one hardlink
+  set, first through independent native extraction and then through typed
+  selected-generation node authority
 - conflict refusal before a conflicting-content native package can mutate
   selected state
 - a 2 MiB payload file through the native package parser and file database
@@ -582,15 +585,19 @@ install record reopens both builders' schema-versioned output manifests,
 hashes the native request and signed dependency artifacts again, and binds its
 versioned-dependency claim to both `install_request` and `install_dependency`.
 The removal record remains request-bound. Across the two completed cases the
-suite declares exactly eleven properties: exact version, native architecture,
-regular files, directories, symlinks, hardlinks, a versioned dependency, a
-queried virtual provide, matched config, purge-time config removal, and shell
-lifecycle. Directory, symlink, hardlink, and relation claims require direct
-native metadata, selected-generation, repository-provenance, and installed
-reason assertions; implicit parents, followed filesystem paths, and recorded
-metadata without a completed resolution do not count. The source format comes
-from the explicit distro build-context override and must resolve to the closed
-RPM/DEB/ALPM type before evidence can count.
+suite declares exactly thirteen properties: exact version, native architecture,
+regular files, directories, symlinks, hardlinks, payload ownership, payload
+timestamps, a versioned dependency, a queried virtual provide, matched config,
+purge-time config removal, and shell lifecycle. Directory, symlink, hardlink,
+metadata, and relation claims require direct native metadata,
+selected-generation, repository-provenance, and installed reason assertions;
+implicit parents, followed filesystem paths, and recorded metadata without a
+completed resolution do not count. RPM ownership remains source-named while
+Debian and ALPM ownership remains source-numeric; the selected-generation
+assertion proves that typed distinction instead of flattening both to runtime
+uid/gid values. The source format comes from the explicit distro build-context
+override and must resolve to the closed RPM/DEB/ALPM type before evidence can
+count.
 
 RPM export emits a directory entry when its mode differs from the implicit
 0755 parent contract or no descendant can create it. Default-mode parents of
@@ -602,8 +609,9 @@ Several useful assertions deliberately remain outside semantic coverage. The
 Conary changeset trigger is not a source-package trigger; the disabled systemd
 unit is not activation; the kernel-adjacent file is not an executed target
 helper; and a conflicting-content refusal is not a declared native relation
-conflict. Those properties still require fixtures that prove their exact
-contracts.
+conflict. Root ownership does not establish xattr or capability coverage, and
+selected-generation metadata does not establish live-root materialization.
+Those properties still require fixtures that prove their exact contracts.
 
 The PR gate also runs the focused `phase4-native-daily-driver-corpus` manifest on
 Fedora 44, Ubuntu 26.04, and Arch in a non-fail-fast matrix, then applies both

--- a/docs/modules/test-fixtures.md
+++ b/docs/modules/test-fixtures.md
@@ -503,10 +503,11 @@ Each fixture family should record:
   installed or extracted and both hardlink paths must report one device/inode
   identity with a link count of two, uid/gid `0`, and mtime `1700000000` before
   Conary installation begins. The selected-generation proof then requires both
-  members to retain the exact source-typed ownership and timestamp: named
-  `root` for RPM ownership, numeric `0` for Debian and ALPM ownership, and zero
-  timestamp nanoseconds for all three. Topology and metadata count only after
-  typed native-package and selected-generation node assertions agree.
+  members to retain the exact transaction ownership and timestamp: numeric
+  uid/gid `0` and zero timestamp nanoseconds for all three formats. The proof
+  does not infer named ownership from RPM display metadata. Topology and
+  metadata count only after typed native-package and selected-generation node
+  assertions agree.
   RPM directory proof includes the non-default root child `/opt` plus a
   non-default leaf so the package owns exact path, mode, and ownership metadata;
   default shared parents remain implicit native-package paths.

--- a/docs/modules/test-fixtures.md
+++ b/docs/modules/test-fixtures.md
@@ -498,23 +498,27 @@ Each fixture family should record:
   exact/native identity, regular files, one explicit directory,
   one exact symlink, one two-path hardlink set, one queried virtual provide,
   one exact versioned dependency resolved from the bounded loopback repository,
-  matched config, and shell lifecycle; removal covers config cleanup. Each
-  native package is independently installed or extracted and both hardlink
-  paths must report one device/inode identity with a link count of two before
-  Conary installation begins. The fixture pins that inode's mtime to an exact
-  whole second shared by the accepted RPM, Debian, and ALPM metadata grammars.
-  Topology counts only after typed native-package metadata and
-  selected-generation node assertions agree.
+  matched config, exact payload ownership and timestamp authority, and shell
+  lifecycle; removal covers config cleanup. Each native package is independently
+  installed or extracted and both hardlink paths must report one device/inode
+  identity with a link count of two, uid/gid `0`, and mtime `1700000000` before
+  Conary installation begins. The selected-generation proof then requires both
+  members to retain the exact source-typed ownership and timestamp: named
+  `root` for RPM ownership, numeric `0` for Debian and ALPM ownership, and zero
+  timestamp nanoseconds for all three. Topology and metadata count only after
+  typed native-package and selected-generation node assertions agree.
   RPM directory proof includes the non-default root child `/opt` plus a
   non-default leaf so the package owns exact path, mode, and ownership metadata;
   default shared parents remain implicit native-package paths.
   Its builder writes a schema-versioned digest manifest and the evidence writer
   rehashes the artifact before publication. The chain attributes hardlink
   coverage only through the native inode oracle plus the typed
-  selected-generation topology assertion. Do not infer large-file,
-  source-trigger, activation, target-helper, conflict, or replacement coverage
-  from the chain's 2 MiB file, out-of-band trigger, disabled unit, adjacent
-  helper path, or file-collision negative. PRs run only that focused six-test
+  selected-generation topology assertion. Ownership and timestamp coverage use
+  that same exact request artifact but do not establish xattr, capability, or
+  live-root materialization coverage. Do not infer large-file, source-trigger,
+  activation, target-helper, conflict, or replacement coverage from the chain's
+  2 MiB file, out-of-band trigger, disabled unit, adjacent helper path, or
+  file-collision negative. PRs run only that focused six-test
   chain on Fedora 44, Ubuntu 26.04, and Arch behind the stable
   `native-daily-driver-corpus` aggregate context; every lane applies both the
   ordinary suite-result and typed corpus-result gates.

--- a/docs/roadmaps/development-roadmap.md
+++ b/docs/roadmaps/development-roadmap.md
@@ -323,11 +323,12 @@ the stated scope, not whether a workstream happens to be active.
   uses a signed loopback repository plus process-group timeout cleanup. #470 is
   closed after making one exact versioned dependency resolve, acquire, and
   install from that repository with both artifacts bound to typed corpus
-  evidence. The next bounded #110 slice has not yet been selected.
+  evidence. #473 owns exact source-native and selected-generation ownership and
+  timestamp attribution for the same digest-bound daily-driver artifact.
 - **Issues:** #110 as the corpus umbrella; #458 and #463 for focused
   daily-driver attribution; #462 and #464 for payload-topology export gaps;
   #460 and #461 for closed legacy parity defects; #470 for versioned dependency
-  resolution; plus #39 for bootstrap.
+  resolution; #473 for payload metadata attribution; plus #39 for bootstrap.
 - **User journey:** install the signed release through one documented bootstrap
   entry point; `conary system init` with no hand-edited state; sync and
   authenticate repositories; request a package by ordinary name; resolve the


### PR DESCRIPTION
## Problem

The W7 daily-driver corpus carried source payload ownership and a pinned hardlink mtime, but its proof stopped at topology and equality between hardlink members. `metadata_ownership` and `metadata_timestamps` therefore remained correctly unattributed: neither the exact source-native values nor their typed selected-generation projection was asserted.

## Change

- Require the independently extracted/installed RPM, Debian, or ALPM artifact to expose one exact two-path hardlink with uid `0`, gid `0`, and mtime `1700000000` on both members.
- Add a selected-generation assertion for exact typed user, group, seconds, and nanoseconds authority on each hardlink member.
- Require the selected transaction authority to retain numeric uid/gid `0` for RPM, Debian, and ALPM without inferring named ownership from RPM display metadata.
- Bind `metadata_ownership` and `metadata_timestamps` only to the exact digest-attributed `install_request` artifact.
- Raise the focused suite's honest coverage from eleven to thirteen properties and document that this does not establish xattr, capability, or live-root materialization coverage.

## Impact

The daily-driver gate now fails closed if native packaging changes ownership or timestamp values, if selected-generation authority drifts, or if either semantic claim loses its exact artifact attribution.

## Verification

Observed locally:

- `bash scripts/agent-context.sh --feature conary-test --run focused` — all 5 focused commands passed.
- `cargo test -p conary-test` — 319 library tests passed, 2 contract-ignored; 14 CLI tests passed.
- `cargo test -p conary-test phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contract -- --nocapture` — 1 passed.
- `cargo fmt --check` — passed.
- `bash scripts/check-doc-truth.sh` — passed.
- `bash scripts/build-static-conary.sh` — produced a static PIE `conary 0.15.0`.

The local host has no Docker or Podman binary/socket, so the focused container command stopped before suite execution with `Socket not found: /var/run/docker.sock`. The required Fedora 44, Ubuntu 26.04, and Arch jobs in the PR matrix own the terminal interaction proof. A direct unprivileged ALPM build confirmed that the exporter preserves source-directory ownership as designed (`1001:1001` locally), which is why the corpus asserts `0:0` only inside its root-owned typed container build context.

Hosted exact-head proof: PR head `e992313497a59cf010c226f1153ae0bd111cebd2`, run `31966654585`, all 29 jobs passed. Fedora 44, Ubuntu 26.04, and Arch each completed the six-test daily-driver chain and the stable aggregate passed.

Closes #473
Refs #110
