### PR TITLE
test(corpus): prove native configuration upgrades

### DIFF
--- a/apps/conary-test/src/config/tests/native_corpus.rs
+++ b/apps/conary-test/src/config/tests/native_corpus.rs
@@ -2,6 +2,8 @@
 
 use super::{conary_fixture_path, load_manifest, remi_manifest_path};
 
+mod evidence;
+
 #[test]
 fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contract() {
     let path = remi_manifest_path("phase4-native-pm-parity.toml");
@@ -363,6 +365,7 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
             conary_core::corpus::CorpusSemantic::RelationsVersionedDependency,
             conary_core::corpus::CorpusSemantic::RelationsVirtualProvide,
             conary_core::corpus::CorpusSemantic::ConfigurationMatchedConfig,
+            conary_core::corpus::CorpusSemantic::ConfigurationUpgrade,
             conary_core::corpus::CorpusSemantic::ConfigurationRemoval,
             conary_core::corpus::CorpusSemantic::LifecycleShell,
         ]
@@ -372,6 +375,9 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
         conary_core::corpus::CorpusSemantic::MetadataXattrs,
         conary_core::corpus::CorpusSemantic::MetadataCapabilities,
         conary_core::corpus::CorpusSemantic::RelationsConflict,
+        conary_core::corpus::CorpusSemantic::ConfigurationUnmatchedDeclaration,
+        conary_core::corpus::CorpusSemantic::ConfigurationLocalModification,
+        conary_core::corpus::CorpusSemantic::ConfigurationDeletion,
         conary_core::corpus::CorpusSemantic::LifecycleTrigger,
         conary_core::corpus::CorpusSemantic::RuntimeServiceActivation,
         conary_core::corpus::CorpusSemantic::RuntimeTargetHelper,
@@ -389,8 +395,8 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
         .collect();
 
     assert!(
-        corpus_tests.len() == 6,
-        "focused daily-driver manifest should own exactly TNPM13 through TNPM18"
+        corpus_tests.len() == 7,
+        "focused daily-driver manifest should own exactly TNPM13 through TNPM19"
     );
     assert!(
         corpus_tests.iter().all(|test| test.skip.is_none()),
@@ -458,6 +464,14 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
         "query whatprovides 'virtual(phase4-corpus-tool)'",
         "0 config rows",
         "--dependency-fixture-manifest",
+        "build-daily-driver-update-fixture.sh",
+        "prepare-native-update-repository.sh",
+        "--update-fixture-manifest",
+        "daily_driver_corpus_configuration_upgrade",
+        "installation",
+        "update",
+        "source_checksum",
+        "w7-native-update",
         "resolution",
     ] {
         assert!(
@@ -509,6 +523,7 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
             .unwrap_or_else(|| panic!("missing {distro} overrides"));
         for key in [
             "native_corpus_fixture_version",
+            "native_corpus_update_version",
             "native_corpus_dependency_count",
             "native_corpus_dependency_probe",
             "native_corpus_lifecycle_fidelity",
@@ -596,15 +611,41 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
                 == [conary_core::corpus::SourceArtifactRole::InstallRequest])
     );
 
-    let removal_test = manifest
+    let update_case = manifest
         .test
         .iter()
         .find(|test| test.id == "TNPM18")
-        .expect("TNPM18 removal test");
+        .and_then(|test| test.corpus.as_ref())
+        .expect("TNPM18 typed configuration-upgrade evidence");
+    assert_eq!(
+        update_case.stages,
+        [
+            conary_core::corpus::ConversionStage::Installation,
+            conary_core::corpus::ConversionStage::Update,
+        ]
+    );
+    assert_eq!(update_case.coverage.len(), 1);
+    assert_eq!(
+        update_case.coverage[0].semantic,
+        conary_core::corpus::CorpusSemantic::ConfigurationUpgrade
+    );
+    assert_eq!(
+        update_case.coverage[0].artifact_roles,
+        [
+            conary_core::corpus::SourceArtifactRole::InstallRequest,
+            conary_core::corpus::SourceArtifactRole::UpdateRequest,
+        ]
+    );
+
+    let removal_test = manifest
+        .test
+        .iter()
+        .find(|test| test.id == "TNPM19")
+        .expect("TNPM19 removal test");
     let removal_case = removal_test
         .corpus
         .as_ref()
-        .expect("TNPM18 typed removal evidence");
+        .expect("TNPM19 typed removal evidence");
     assert_eq!(
         removal_case.stages,
         [conary_core::corpus::ConversionStage::Removal]
@@ -613,6 +654,10 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
     assert_eq!(
         removal_case.coverage[0].semantic,
         conary_core::corpus::CorpusSemantic::ConfigurationRemoval
+    );
+    assert_eq!(
+        removal_case.coverage[0].artifact_roles,
+        [conary_core::corpus::SourceArtifactRole::UpdateRequest]
     );
     assert!(
         format!("{removal_test:?}").contains("--purge"),
@@ -725,7 +770,9 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
         "sha256(artifact_path)",
         "fixture_build_manifest",
         "install_dependency",
+        "update_request",
         "dependency artifact identity requires all dependency arguments",
+        "update artifact identity requires all update arguments",
         "os.replace",
     ] {
         assert!(
@@ -733,113 +780,41 @@ fn phase4_native_pm_parity_manifest_carries_cross_source_and_daily_driver_contra
             "native corpus evidence writer should enforce {required}"
         );
     }
-}
 
-#[test]
-fn corpus_evidence_writer_binds_request_and_dependency_to_exact_digests() {
-    let directory = tempfile::tempdir().expect("create evidence test directory");
-    let request_artifact = directory.path().join("request.rpm");
-    let dependency_artifact = directory.path().join("dependency.ccs");
-    std::fs::write(&request_artifact, b"exact native request").unwrap();
-    std::fs::write(&dependency_artifact, b"exact signed dependency").unwrap();
-
-    let request_manifest = directory.path().join("request-manifest.json");
-    let dependency_manifest = directory.path().join("dependency-manifest.json");
-    for (manifest, artifact, target) in [
-        (&request_manifest, &request_artifact, "rpm"),
-        (&dependency_manifest, &dependency_artifact, "rpm"),
+    let update_builder = std::fs::read_to_string(conary_fixture_path(
+        "native/build-daily-driver-update-fixture.sh",
+    ))
+    .expect("read daily-driver update builder");
+    for required in [
+        "version = \"1.0.1\"",
+        "revision = \"v2\"",
+        "build-native-fixtures.sh",
+        "native-fixture-manifest.json",
     ] {
-        std::fs::write(
-            manifest,
-            serde_json::to_vec(&serde_json::json!({
-                "schema_version": 1,
-                "artifact_path": artifact,
-                "builder_target": target,
-                "sha256": conary_core::hash::sha256(&std::fs::read(artifact).unwrap()),
-            }))
-            .unwrap(),
-        )
-        .unwrap();
+        assert!(
+            update_builder.contains(required),
+            "daily-driver update builder should enforce {required}"
+        );
     }
 
-    let evidence_path = directory.path().join("evidence.json");
-    let script = conary_fixture_path("native/write-corpus-evidence.py");
-    let output = std::process::Command::new("python3")
-        .arg(&script)
-        .args([
-            request_manifest.as_os_str(),
-            evidence_path.as_os_str(),
-            "fedora-44".as_ref(),
-            "rpm".as_ref(),
-            "phase4-daily-driver-corpus".as_ref(),
-            "1.0.0-1".as_ref(),
-            "x86_64".as_ref(),
-            "resolution".as_ref(),
-            "installation".as_ref(),
-            "--dependency-fixture-manifest".as_ref(),
-            dependency_manifest.as_os_str(),
-            "--dependency-name".as_ref(),
-            "phase4-repository-fixture".as_ref(),
-            "--dependency-version".as_ref(),
-            "1.0.0-1".as_ref(),
-            "--dependency-architecture".as_ref(),
-            "x86_64".as_ref(),
-        ])
-        .output()
-        .expect("run evidence writer");
-    assert!(
-        output.status.success(),
-        "evidence writer failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    let evidence: serde_json::Value =
-        serde_json::from_slice(&std::fs::read(&evidence_path).unwrap()).unwrap();
-    assert_eq!(
-        evidence["completed_stages"],
-        serde_json::json!(["resolution", "installation"])
-    );
-    let artifacts = evidence["source_artifacts"].as_array().unwrap();
-    assert_eq!(artifacts.len(), 2);
-    assert_eq!(artifacts[0]["role"], "install_request");
-    assert_eq!(artifacts[1]["role"], "install_dependency");
-    assert_eq!(
-        artifacts[0]["digest"],
-        conary_core::hash::sha256(&std::fs::read(&request_artifact).unwrap())
-    );
-    assert_eq!(
-        artifacts[1]["digest"],
-        conary_core::hash::sha256(&std::fs::read(&dependency_artifact).unwrap())
-    );
-
-    std::fs::write(&dependency_artifact, b"mutated dependency").unwrap();
-    let contradiction = std::process::Command::new("python3")
-        .arg(script)
-        .args([
-            request_manifest.as_os_str(),
-            evidence_path.as_os_str(),
-            "fedora-44".as_ref(),
-            "rpm".as_ref(),
-            "request".as_ref(),
-            "1".as_ref(),
-            "x86_64".as_ref(),
-            "installation".as_ref(),
-            "--dependency-fixture-manifest".as_ref(),
-            dependency_manifest.as_os_str(),
-            "--dependency-name".as_ref(),
-            "dependency".as_ref(),
-            "--dependency-version".as_ref(),
-            "1".as_ref(),
-            "--dependency-architecture".as_ref(),
-            "x86_64".as_ref(),
-        ])
-        .output()
-        .expect("run contradictory evidence writer");
-    assert!(!contradiction.status.success());
-    assert!(
-        String::from_utf8_lossy(&contradiction.stderr)
-            .contains("artifact digest contradicts its build manifest")
-    );
+    let update_repository = std::fs::read_to_string(conary_fixture_path(
+        "native/prepare-native-update-repository.sh",
+    ))
+    .expect("read native update repository helper");
+    for required in [
+        "native update artifact digest contradicts its build manifest",
+        "cook \"${native_artifact}\"",
+        "ccs verify",
+        "repository-fixture-manifest.json",
+        "--default-strategy binary",
+        "--ccs-package-key",
+        "repo sync",
+    ] {
+        assert!(
+            update_repository.contains(required),
+            "native update repository should enforce {required}"
+        );
+    }
 }
 
 #[test]

--- a/apps/conary-test/src/config/tests/native_corpus/evidence.rs
+++ b/apps/conary-test/src/config/tests/native_corpus/evidence.rs
@@ -1,0 +1,128 @@
+// conary-test/src/config/tests/native_corpus/evidence.rs
+
+use super::conary_fixture_path;
+
+#[test]
+fn corpus_evidence_writer_binds_request_update_and_dependency_to_exact_digests() {
+    let directory = tempfile::tempdir().expect("create evidence test directory");
+    let request_artifact = directory.path().join("request.rpm");
+    let update_artifact = directory.path().join("update.rpm");
+    let dependency_artifact = directory.path().join("dependency.ccs");
+    std::fs::write(&request_artifact, b"exact native request").unwrap();
+    std::fs::write(&update_artifact, b"exact native update").unwrap();
+    std::fs::write(&dependency_artifact, b"exact signed dependency").unwrap();
+
+    let request_manifest = directory.path().join("request-manifest.json");
+    let update_manifest = directory.path().join("update-manifest.json");
+    let dependency_manifest = directory.path().join("dependency-manifest.json");
+    for (manifest, artifact, target) in [
+        (&request_manifest, &request_artifact, "rpm"),
+        (&update_manifest, &update_artifact, "rpm"),
+        (&dependency_manifest, &dependency_artifact, "rpm"),
+    ] {
+        std::fs::write(
+            manifest,
+            serde_json::to_vec(&serde_json::json!({
+                "schema_version": 1,
+                "artifact_path": artifact,
+                "builder_target": target,
+                "sha256": conary_core::hash::sha256(&std::fs::read(artifact).unwrap()),
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+    }
+
+    let evidence_path = directory.path().join("evidence.json");
+    let script = conary_fixture_path("native/write-corpus-evidence.py");
+    let output = std::process::Command::new("python3")
+        .arg(&script)
+        .args([
+            request_manifest.as_os_str(),
+            evidence_path.as_os_str(),
+            "fedora-44".as_ref(),
+            "rpm".as_ref(),
+            "phase4-daily-driver-corpus".as_ref(),
+            "1.0.0-1".as_ref(),
+            "x86_64".as_ref(),
+            "resolution".as_ref(),
+            "installation".as_ref(),
+            "update".as_ref(),
+            "--update-fixture-manifest".as_ref(),
+            update_manifest.as_os_str(),
+            "--update-name".as_ref(),
+            "phase4-daily-driver-corpus".as_ref(),
+            "--update-version".as_ref(),
+            "1.0.1-1".as_ref(),
+            "--update-architecture".as_ref(),
+            "x86_64".as_ref(),
+            "--dependency-fixture-manifest".as_ref(),
+            dependency_manifest.as_os_str(),
+            "--dependency-name".as_ref(),
+            "phase4-repository-fixture".as_ref(),
+            "--dependency-version".as_ref(),
+            "1.0.0-1".as_ref(),
+            "--dependency-architecture".as_ref(),
+            "x86_64".as_ref(),
+        ])
+        .output()
+        .expect("run evidence writer");
+    assert!(
+        output.status.success(),
+        "evidence writer failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let evidence: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&evidence_path).unwrap()).unwrap();
+    assert_eq!(
+        evidence["completed_stages"],
+        serde_json::json!(["resolution", "installation", "update"])
+    );
+    let artifacts = evidence["source_artifacts"].as_array().unwrap();
+    assert_eq!(artifacts.len(), 3);
+    assert_eq!(artifacts[0]["role"], "install_request");
+    assert_eq!(artifacts[1]["role"], "update_request");
+    assert_eq!(artifacts[2]["role"], "install_dependency");
+    assert_eq!(
+        artifacts[0]["digest"],
+        conary_core::hash::sha256(&std::fs::read(&request_artifact).unwrap())
+    );
+    assert_eq!(
+        artifacts[1]["digest"],
+        conary_core::hash::sha256(&std::fs::read(&update_artifact).unwrap())
+    );
+    assert_eq!(
+        artifacts[2]["digest"],
+        conary_core::hash::sha256(&std::fs::read(&dependency_artifact).unwrap())
+    );
+
+    std::fs::write(&dependency_artifact, b"mutated dependency").unwrap();
+    let contradiction = std::process::Command::new("python3")
+        .arg(script)
+        .args([
+            request_manifest.as_os_str(),
+            evidence_path.as_os_str(),
+            "fedora-44".as_ref(),
+            "rpm".as_ref(),
+            "request".as_ref(),
+            "1".as_ref(),
+            "x86_64".as_ref(),
+            "installation".as_ref(),
+            "--dependency-fixture-manifest".as_ref(),
+            dependency_manifest.as_os_str(),
+            "--dependency-name".as_ref(),
+            "dependency".as_ref(),
+            "--dependency-version".as_ref(),
+            "1".as_ref(),
+            "--dependency-architecture".as_ref(),
+            "x86_64".as_ref(),
+        ])
+        .output()
+        .expect("run contradictory evidence writer");
+    assert!(!contradiction.status.success());
+    assert!(
+        String::from_utf8_lossy(&contradiction.stderr)
+            .contains("artifact digest contradicts its build manifest")
+    );
+}

--- a/apps/conary/tests/fixtures/native/build-daily-driver-update-fixture.sh
+++ b/apps/conary/tests/fixtures/native/build-daily-driver-update-fixture.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+  echo "Usage: $0 <rpm|deb|arch> <v1-source-dir> <v2-source-dir> <output-dir>" >&2
+  exit 64
+fi
+
+target="$1"
+v1_source_dir="$2"
+v2_source_dir="$3"
+output_dir="$4"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+case "${target}" in
+  rpm|deb|arch) ;;
+  *)
+    echo "Unsupported daily-driver update target: ${target}" >&2
+    exit 64
+    ;;
+esac
+if [[ "${v1_source_dir}" != "/tmp/native-pm-corpus-src" \
+  || "${v2_source_dir}" != "/tmp/native-pm-corpus-v2-src" \
+  || "${output_dir}" != "/tmp/native-pm-corpus-v2" ]]; then
+  echo "Daily-driver update paths must match the focused suite scratch contract" >&2
+  exit 64
+fi
+if [[ ! -f "${v1_source_dir}/ccs.toml" || ! -d "${v1_source_dir}/stage" ]]; then
+  echo "Daily-driver v1 source is incomplete: ${v1_source_dir}" >&2
+  exit 64
+fi
+
+rm -rf "${v2_source_dir}" "${output_dir}"
+cp -a "${v1_source_dir}" "${v2_source_dir}"
+mkdir -p "${output_dir}"
+
+python3 - "${v2_source_dir}" <<'PY'
+from pathlib import Path
+import sys
+
+source = Path(sys.argv[1])
+manifest_path = source / "ccs.toml"
+manifest = manifest_path.read_text(encoding="utf-8")
+old_version = 'version = "1.0.0"'
+if manifest.count(old_version) != 1:
+    raise SystemExit("daily-driver manifest must contain one exact v1 package version")
+manifest_path.write_text(
+    manifest.replace(old_version, 'version = "1.0.1"'), encoding="utf-8"
+)
+
+(source / "stage/etc/phase4-corpus/app.conf").write_text(
+    'mode = "daily-driver"\n'
+    'service = "phase4-corpus"\n'
+    'revision = "v2"\n',
+    encoding="utf-8",
+)
+(source / "stage/usr/bin/phase4-corpus").write_text(
+    "#!/bin/sh\nprintf 'phase4-daily-driver-corpus-v2\\n'\n",
+    encoding="utf-8",
+)
+PY
+
+"${script_dir}/build-native-fixtures.sh" \
+  "${target}" \
+  "${output_dir}" \
+  "${v2_source_dir}"
+test -s "${output_dir}/native-fixture-manifest.json"

--- a/apps/conary/tests/fixtures/native/prepare-native-update-repository.sh
+++ b/apps/conary/tests/fixtures/native/prepare-native-update-repository.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 8 ]]; then
+  echo "Usage: $0 <native-fixture-manifest> <source-format> <source-profile> <db-path> <package-name> <version> <version-scheme> <architecture>" >&2
+  exit 64
+fi
+
+fixture_manifest="$1"
+source_format="$2"
+source_profile="$3"
+db_path="$4"
+package_name="$5"
+package_version="$6"
+version_scheme="$7"
+architecture="$8"
+conary_bin="${CONARY_BIN:-conary}"
+work="/tmp/native-update-repository"
+package_output="${work}/packages"
+repo_name="w7-native-update"
+repo_url="http://127.0.0.1:18087"
+
+case "${source_format}:${version_scheme}" in
+  rpm:rpm|deb:debian|arch:arch) ;;
+  *)
+    echo "Native update source format and version scheme disagree: ${source_format}:${version_scheme}" >&2
+    exit 64
+    ;;
+esac
+case "${db_path}" in
+  /*) ;;
+  *)
+    echo "Database path must be absolute: ${db_path}" >&2
+    exit 64
+    ;;
+esac
+if [[ ! -f "${fixture_manifest}" || ! -f "${db_path}" ]]; then
+  echo "Native fixture manifest or Conary database is absent" >&2
+  exit 64
+fi
+
+if [[ -f "${work}/http.pid" ]]; then
+  old_pid="$(<"${work}/http.pid")"
+  case "${old_pid}" in
+    ''|*[!0-9]*) ;;
+    *) kill "${old_pid}" 2>/dev/null || true ;;
+  esac
+fi
+rm -rf "${work}"
+mkdir -p "${package_output}" "${work}/home"
+
+mapfile -t native_identity < <(python3 - "${fixture_manifest}" "${source_format}" <<'PY'
+import hashlib
+import json
+from pathlib import Path
+import sys
+
+manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if manifest.get("schema_version") != 1:
+    raise SystemExit("unsupported native fixture manifest schema")
+if manifest.get("builder_target") != sys.argv[2]:
+    raise SystemExit("native fixture target contradicts the update source format")
+artifact = Path(manifest["artifact_path"])
+digest = hashlib.sha256(artifact.read_bytes()).hexdigest()
+if digest != manifest.get("sha256"):
+    raise SystemExit("native update artifact digest contradicts its build manifest")
+print(artifact)
+print(digest)
+PY
+)
+if [[ "${#native_identity[@]}" -ne 2 ]]; then
+  echo "Native update fixture did not resolve to one exact artifact identity" >&2
+  exit 1
+fi
+native_artifact="${native_identity[0]}"
+native_digest="${native_identity[1]}"
+
+XDG_DATA_HOME="${work}/xdg-data" HOME="${work}/home" \
+  "${conary_bin}" cook "${native_artifact}" --output "${package_output}"
+
+mapfile -t packages < <(
+  find "${package_output}" -maxdepth 1 -type f -name '*.ccs' -print | sort
+)
+if [[ "${#packages[@]}" -ne 1 ]]; then
+  echo "Expected one converted native update package, found ${#packages[@]}" >&2
+  exit 1
+fi
+package_path="${packages[0]}"
+public_key="${work}/xdg-data/conary/ccs/local-dev/local-dev-key.public.toml"
+test -s "${public_key}"
+
+"${conary_bin}" ccs inspect "${package_path}" --format json > "${work}/inspection.json"
+python3 - \
+  "${work}/inspection.json" \
+  "${work}/metadata.json" \
+  "${work}/repository-fixture-manifest.json" \
+  "${work}/trust-policy.toml" \
+  "${public_key}" \
+  "${package_path}" \
+  "${native_artifact}" \
+  "${native_digest}" \
+  "${package_name}" \
+  "${package_version}" \
+  "${version_scheme}" \
+  "${architecture}" \
+  "${repo_url}" <<'PY'
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+import tomllib
+
+(
+    inspection_path,
+    metadata_path,
+    repository_manifest_path,
+    policy_path,
+    public_key_path,
+    package_path,
+    native_artifact_path,
+    native_digest,
+    package_name,
+    package_version,
+    version_scheme,
+    architecture,
+    repo_url,
+) = sys.argv[1:]
+
+inspection = json.loads(Path(inspection_path).read_text(encoding="utf-8"))
+if inspection.get("name") != package_name or inspection.get("version") != package_version:
+    raise SystemExit("converted update identity contradicts the native fixture declaration")
+
+package = Path(package_path)
+package_bytes = package.read_bytes()
+package_digest = hashlib.sha256(package_bytes).hexdigest()
+metadata = {
+    "name": "w7-native-update",
+    "version": "1",
+    "security_advisory_source": None,
+    "packages": [
+        {
+            "name": package_name,
+            "version": package_version,
+            "version_scheme": version_scheme,
+            "architecture": architecture,
+            "description": "W7 native-derived configuration update fixture",
+            "checksum": package_digest,
+            "size": len(package_bytes),
+            "download_url": f"{repo_url}/packages/{package.name}",
+            "requirements": [],
+            "relations": [],
+            "delta_from": None,
+            "security_advisory": None,
+        }
+    ],
+}
+repository_manifest = {
+    "schema_version": 1,
+    "source_artifact": {
+        "artifact_path": native_artifact_path,
+        "sha256": native_digest,
+    },
+    "repository_artifact": {
+        "artifact_path": str(package),
+        "sha256": package_digest,
+    },
+}
+with Path(public_key_path).open("rb") as stream:
+    public_key = tomllib.load(stream)
+
+for path, document in [
+    (Path(metadata_path), metadata),
+    (Path(repository_manifest_path), repository_manifest),
+]:
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(document, separators=(",", ":")) + "\n", encoding="utf-8"
+    )
+    os.replace(temporary, path)
+Path(policy_path).write_text(
+    f'trusted_keys = ["{public_key["key"]}"]\nrequire_timestamp = false\n',
+    encoding="utf-8",
+)
+PY
+
+"${conary_bin}" ccs verify "${package_path}" --policy "${work}/trust-policy.toml"
+
+python3 -m http.server 18087 \
+  --bind 127.0.0.1 \
+  --directory "${work}" \
+  >"${work}/http.log" 2>&1 &
+echo "$!" > "${work}/http.pid"
+
+server_ready=false
+for _attempt in $(seq 1 50); do
+  if python3 - "${repo_url}/metadata.json" <<'PY' >/dev/null 2>&1
+import sys
+import urllib.request
+
+with urllib.request.urlopen(sys.argv[1], timeout=1) as response:
+    if response.status != 200:
+        raise SystemExit(1)
+PY
+  then
+    server_ready=true
+    break
+  fi
+  sleep 0.1
+done
+if [[ "${server_ready}" != true ]]; then
+  echo "Native update repository did not become ready" >&2
+  exit 1
+fi
+
+"${conary_bin}" repo remove "${repo_name}" \
+  --db-path "${db_path}" >/dev/null 2>&1 || true
+"${conary_bin}" repo add "${repo_name}" "${repo_url}" \
+  --package-format json \
+  --default-strategy binary \
+  --ccs-package-key "${public_key}" \
+  --source-profile "${source_profile}" \
+  --db-path "${db_path}"
+"${conary_bin}" repo sync "${repo_name}" \
+  --db-path "${db_path}" \
+  --force
+
+repository_digest="$(sha256sum "${package_path}" | awk '{print $1}')"
+printf 'NATIVE_UPDATE_SOURCE_ARTIFACT=%q\n' "${native_artifact}" > "${work}/native-update-repository.env"
+printf 'NATIVE_UPDATE_SOURCE_SHA256=%q\n' "${native_digest}" >> "${work}/native-update-repository.env"
+printf 'NATIVE_UPDATE_CCS_ARTIFACT=%q\n' "${package_path}" >> "${work}/native-update-repository.env"
+printf 'NATIVE_UPDATE_CCS_SHA256=%q\n' "${repository_digest}" >> "${work}/native-update-repository.env"
+printf 'NATIVE_UPDATE_REPOSITORY=%q\n' "${repo_name}" >> "${work}/native-update-repository.env"

--- a/apps/conary/tests/fixtures/native/write-corpus-evidence.py
+++ b/apps/conary/tests/fixtures/native/write-corpus-evidence.py
@@ -54,6 +54,10 @@ def main() -> None:
     parser.add_argument("--dependency-name")
     parser.add_argument("--dependency-version")
     parser.add_argument("--dependency-architecture")
+    parser.add_argument("--update-fixture-manifest", type=Path)
+    parser.add_argument("--update-name")
+    parser.add_argument("--update-version")
+    parser.add_argument("--update-architecture")
     args = parser.parse_args()
 
     dependency_values = [
@@ -66,6 +70,16 @@ def main() -> None:
         value is not None for value in dependency_values
     ):
         parser.error("dependency artifact identity requires all dependency arguments")
+    update_values = [
+        args.update_fixture_manifest,
+        args.update_name,
+        args.update_version,
+        args.update_architecture,
+    ]
+    if any(value is not None for value in update_values) and not all(
+        value is not None for value in update_values
+    ):
+        parser.error("update artifact identity requires all update arguments")
 
     source_artifacts = [
         artifact_identity(
@@ -76,6 +90,16 @@ def main() -> None:
             args.architecture,
         )
     ]
+    if args.update_fixture_manifest is not None:
+        source_artifacts.append(
+            artifact_identity(
+                args.update_fixture_manifest,
+                "update_request",
+                args.update_name,
+                args.update_version,
+                args.update_architecture,
+            )
+        )
     if args.dependency_fixture_manifest is not None:
         source_artifacts.append(
             artifact_identity(

--- a/apps/conary/tests/integration/remi/manifests/phase4-native-daily-driver-corpus.toml
+++ b/apps/conary/tests/integration/remi/manifests/phase4-native-daily-driver-corpus.toml
@@ -5,7 +5,7 @@
 [suite]
 name = "Phase 4: Native Daily-Driver Corpus"
 phase = 4
-timeout = 1200
+timeout = 1500
 
 [suite.corpus]
 required = [
@@ -20,6 +20,7 @@ required = [
     "relations_versioned_dependency",
     "relations_virtual_provide",
     "configuration_matched_config",
+    "configuration_upgrade",
     "configuration_removal",
     "lifecycle_shell",
 ]
@@ -79,6 +80,7 @@ native_arch = "x86_64"
 native_scheme = "rpm"
 native_profile = "fedora-44"
 native_corpus_fixture_version = "1.0.0-1"
+native_corpus_update_version = "1.0.1-1"
 native_corpus_dependency_count = "4"
 native_corpus_dependency_probe = "phase4-repository-fixture"
 native_corpus_config_count = "1"
@@ -96,6 +98,7 @@ native_arch = "amd64"
 native_scheme = "debian"
 native_profile = "ubuntu-26.04"
 native_corpus_fixture_version = "1.0.0-1"
+native_corpus_update_version = "1.0.1-1"
 native_corpus_dependency_count = "1"
 native_corpus_dependency_probe = "phase4-repository-fixture"
 native_corpus_config_count = "1"
@@ -113,6 +116,7 @@ native_arch = "x86_64"
 native_scheme = "arch"
 native_profile = "arch"
 native_corpus_fixture_version = "1.0.0-1"
+native_corpus_update_version = "1.0.1-1"
 native_corpus_dependency_count = "1"
 native_corpus_dependency_probe = "phase4-repository-fixture"
 native_corpus_config_count = "1"
@@ -130,7 +134,7 @@ native_corpus_payload_group = "numeric:0"
 [[test]]
 id = "TNPM13"
 name = "daily_driver_corpus_build"
-description = "Build a curated native package corpus with hardlinks, service, config, dependency, scriptlet, alternative target, large payload, and kernel-adjacent files"
+description = "Build exact v1 and v2 native corpus packages with hardlinks, service, versioned config, dependency, scriptlet, alternative target, large payload, and kernel-adjacent files"
 group = "daily-driver-corpus"
 timeout = 240
 fatal = true
@@ -149,6 +153,18 @@ exit_code = 0
 
 [[test.step]]
 run = ". /tmp/native-pm-corpus/native-fixture.env && rm -rf /tmp/native-pm-corpus-hardlink-root && /opt/remi-tests/fixtures/native/assert-native-hardlink.sh \"$NATIVE_TARGET\" \"$NATIVE_PKG_FILE\" /tmp/native-pm-corpus-hardlink-root /usr/lib/phase4-corpus/hardlink-anchor /usr/lib/phase4-corpus/hardlink-copy 0 0 1700000000"
+
+[test.step.assert]
+exit_code = 0
+
+[[test.step]]
+run = "CONARY_BIN=${CONARY_BIN} /opt/remi-tests/fixtures/native/build-daily-driver-update-fixture.sh ${native_target} /tmp/native-pm-corpus-src /tmp/native-pm-corpus-v2-src /tmp/native-pm-corpus-v2"
+
+[test.step.assert]
+exit_code = 0
+
+[[test.step]]
+run = ". /tmp/native-pm-corpus-v2/native-fixture.env && rm -rf /tmp/native-pm-corpus-v2-root && /opt/remi-tests/fixtures/native/assert-native-hardlink.sh \"$NATIVE_TARGET\" \"$NATIVE_PKG_FILE\" /tmp/native-pm-corpus-v2-root /usr/lib/phase4-corpus/hardlink-anchor /usr/lib/phase4-corpus/hardlink-copy 0 0 1700000000 && test \"$(sha256sum /tmp/native-pm-corpus-v2-root/etc/phase4-corpus/app.conf | awk '{print $1}')\" = 97d836d4bf6c4c49fa763836c117d738fef15b7d995bc2cf82e2a02704364d27 && case \"$NATIVE_TARGET\" in rpm) test \"$(rpm -qp --qf '%{VERSION}-%{RELEASE}' \"$NATIVE_PKG_FILE\")\" = \"${native_corpus_update_version}\" ;; deb) test \"$(dpkg-deb --field \"$NATIVE_PKG_FILE\" Version)\" = \"${native_corpus_update_version}\" ;; arch) bsdtar -xOf \"$NATIVE_PKG_FILE\" .PKGINFO | grep -Fx \"pkgver = ${native_corpus_update_version}\" ;; esac"
 
 [test.step.assert]
 exit_code = 0
@@ -421,17 +437,90 @@ exit_code = 0
 stdout_contains_all = ["1 installed", "0 conflicts"]
 
 # --------------------------------------------------------------------------
-# TNPM18: daily-driver corpus removal hook and cleanup
+# TNPM18: daily-driver corpus configuration upgrade
 # --------------------------------------------------------------------------
 
 [[test]]
 id = "TNPM18"
+name = "daily_driver_corpus_configuration_upgrade"
+description = "Update through a bounded signed repository and prove the v2 native config artifact, persisted config authority, and selected generation agree"
+group = "daily-driver-corpus"
+timeout = 300
+fatal = true
+depends_on = ["TNPM17"]
+
+[test.corpus]
+evidence_path = "/tmp/conary-corpus-daily-driver-update.json"
+source_profile = "${native_profile}"
+source_format = "${native_corpus_source_format}"
+digest_source = "fixture_build_manifest"
+stages = ["installation", "update"]
+
+[test.corpus.target]
+architecture = "${native_corpus_target_architecture}"
+init_system = "systemd"
+capabilities = ["native_lifecycle", "selected_root_generation"]
+
+[[test.corpus.coverage]]
+semantic = "configuration_upgrade"
+artifact_roles = ["install_request", "update_request"]
+
+[[test.step]]
+run = "CONARY_BIN=${CONARY_BIN} /opt/remi-tests/fixtures/native/prepare-native-update-repository.sh /tmp/native-pm-corpus-v2/native-fixture-manifest.json ${native_target} ${native_profile} ${DB_PATH} phase4-daily-driver-corpus ${native_corpus_update_version} ${native_scheme} ${native_arch}"
+
+[test.step.assert]
+exit_code = 0
+
+[[test.step]]
+run = ". /tmp/native-update-repository/native-update-repository.env && sqlite3 ${DB_PATH} \"SELECT r.name || '|' || r.default_strategy || '|' || r.source_profile || '|' || rp.name || '|' || rp.version || '|' || rp.version_scheme || '|' || rp.architecture || '|' || rp.checksum || '|' || k.status FROM repositories r JOIN repository_packages rp ON rp.repository_id = r.id JOIN repository_package_keys k ON k.repository_id = r.id WHERE r.name = '$NATIVE_UPDATE_REPOSITORY'\" | grep -Fx \"$NATIVE_UPDATE_REPOSITORY|binary|${native_profile}|phase4-daily-driver-corpus|${native_corpus_update_version}|${native_scheme}|${native_arch}|$NATIVE_UPDATE_CCS_SHA256|active\""
+
+[test.step.assert]
+exit_code = 0
+
+[[test.step]]
+run = "CONARY_TEST_SKIP_GENERATION_MOUNT=1 ${CONARY_BIN} update phase4-daily-driver-corpus --db-path ${DB_PATH} --root /conary --yes --sandbox always"
+
+[test.step.assert]
+exit_code = 0
+stdout_contains = "phase4-daily-driver-corpus"
+
+[[test.step]]
+run = "/opt/remi-tests/fixtures/native/assert-selected-generation.py --root /conary --expect-sha256 /usr/bin/phase4-corpus=f8dced754a927950dfaaeab8b1b61d0c119e2fdb68ced61381748dc406f752a5 --expect-sha256 /etc/phase4-corpus/app.conf=97d836d4bf6c4c49fa763836c117d738fef15b7d995bc2cf82e2a02704364d27 --expect-hardlink /usr/lib/phase4-corpus/hardlink-anchor=/usr/lib/phase4-corpus/hardlink-copy"
+
+[test.step.assert]
+exit_code = 0
+
+[[test.step]]
+run = "sqlite3 ${DB_PATH} \"SELECT t.name || '|' || t.version || '|' || COALESCE(t.architecture, '') || '|' || t.version_scheme || '|' || COALESCE(t.source_profile, '') || '|' || COALESCE(r.name, '') || '|' || t.install_source || '|' || t.install_reason FROM troves t LEFT JOIN repositories r ON r.id = t.installed_from_repository_id WHERE t.name = 'phase4-daily-driver-corpus'; SELECT path || '|' || original_hash || '|' || COALESCE(current_hash, '') || '|' || noreplace || '|' || status || '|' || source FROM config_files WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-daily-driver-corpus')\""
+
+[test.step.assert]
+exit_code = 0
+stdout_contains_all = ["phase4-daily-driver-corpus|${native_corpus_update_version}|${native_arch}|${native_scheme}|${native_profile}|w7-native-update|repository|explicit", "/etc/phase4-corpus/app.conf|97d836d4bf6c4c49fa763836c117d738fef15b7d995bc2cf82e2a02704364d27|97d836d4bf6c4c49fa763836c117d738fef15b7d995bc2cf82e2a02704364d27|1|pristine|${native_corpus_config_source}"]
+
+[[test.step]]
+run = ". /tmp/native-update-repository/native-update-repository.env && test \"$(sqlite3 ${DB_PATH} \"SELECT source_format || '|' || source_package || '|' || source_version || '|' || lifecycle_state FROM installed_native_lifecycle_bundles WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-daily-driver-corpus')\")\" = \"${native_target}|phase4-daily-driver-corpus|${native_corpus_update_version}|installed\" && sqlite3 ${DB_PATH} \"SELECT bundle_toml FROM installed_native_lifecycle_bundles WHERE trove_id = (SELECT id FROM troves WHERE name = 'phase4-daily-driver-corpus')\" | grep -F \"source_checksum = \\\"sha256:$NATIVE_UPDATE_SOURCE_SHA256\\\"\""
+
+[test.step.assert]
+exit_code = 0
+
+[[test.step]]
+run = "/opt/remi-tests/fixtures/native/write-corpus-evidence.py /tmp/native-pm-corpus/native-fixture-manifest.json /tmp/conary-corpus-daily-driver-update.json ${native_profile} ${native_corpus_source_format} phase4-daily-driver-corpus ${native_corpus_fixture_version} ${native_arch} installation update --update-fixture-manifest /tmp/native-pm-corpus-v2/native-fixture-manifest.json --update-name phase4-daily-driver-corpus --update-version ${native_corpus_update_version} --update-architecture ${native_arch}"
+
+[test.step.assert]
+exit_code = 0
+
+# --------------------------------------------------------------------------
+# TNPM19: daily-driver corpus removal hook and cleanup
+# --------------------------------------------------------------------------
+
+[[test]]
+id = "TNPM19"
 name = "daily_driver_corpus_remove_hooks_and_cleanup"
 description = "Purging the corpus package runs its pre-remove hook and deletes the tracked files and config"
 group = "daily-driver-corpus"
 timeout = 120
 fatal = true
-depends_on = ["TNPM17"]
+depends_on = ["TNPM18"]
 
 [test.corpus]
 evidence_path = "/tmp/conary-corpus-daily-driver-removal.json"
@@ -447,14 +536,14 @@ capabilities = ["native_lifecycle", "selected_root_generation"]
 
 [[test.corpus.coverage]]
 semantic = "configuration_removal"
-artifact_roles = ["install_request"]
+artifact_roles = ["update_request"]
 
 [[test.step]]
 run = "CONARY_TEST_SKIP_GENERATION_MOUNT=1 ${CONARY_BIN} remove phase4-daily-driver-corpus --db-path ${DB_PATH} --root /conary --sandbox always --purge --yes"
 
 [test.step.assert]
 exit_code = 0
-stdout_contains = "Removed package: phase4-daily-driver-corpus version ${native_corpus_fixture_version}"
+stdout_contains = "Removed package: phase4-daily-driver-corpus version ${native_corpus_update_version}"
 
 [[test.step]]
 run = "/opt/remi-tests/fixtures/native/assert-selected-generation.py --root /conary --expect-sha256 /var/lib/phase4-corpus/remove.marker=e1f79758cc42e6fe6037941205d1fbc37f5780f13aa077d0ba8287fd93cecd52 --absent /opt --absent /usr/bin/phase4-corpus --absent /usr/bin/phase4-corpus-alt --absent /usr/bin/phase4-corpus-link --absent /usr/lib/phase4-corpus/state --absent /usr/lib/phase4-corpus/hardlink-anchor --absent /usr/lib/phase4-corpus/hardlink-copy --absent /etc/phase4-corpus/app.conf --absent /usr/lib/systemd/system/phase4-corpus.service --absent /usr/lib/kernel/install.d/95-phase4-corpus.install --absent /usr/share/phase4-corpus/large-payload.bin"
@@ -470,7 +559,7 @@ exit_code = 0
 stdout_contains_all = ["0 installed", "0 config rows"]
 
 [[test.step]]
-run = "/opt/remi-tests/fixtures/native/write-corpus-evidence.py /tmp/native-pm-corpus/native-fixture-manifest.json /tmp/conary-corpus-daily-driver-removal.json ${native_profile} ${native_corpus_source_format} phase4-daily-driver-corpus ${native_corpus_fixture_version} ${native_arch} removal"
+run = "/opt/remi-tests/fixtures/native/write-corpus-evidence.py /tmp/native-pm-corpus/native-fixture-manifest.json /tmp/conary-corpus-daily-driver-removal.json ${native_profile} ${native_corpus_source_format} phase4-daily-driver-corpus ${native_corpus_fixture_version} ${native_arch} removal --update-fixture-manifest /tmp/native-pm-corpus-v2/native-fixture-manifest.json --update-name phase4-daily-driver-corpus --update-version ${native_corpus_update_version} --update-architecture ${native_arch}"
 
 [test.step.assert]
 exit_code = 0

--- a/docs/INTEGRATION-TESTING.md
+++ b/docs/INTEGRATION-TESTING.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-16
-revision: 53
-summary: Document attributable daily-driver payload topology, typed corpus coverage, authenticated derivative targets, release evidence, and native lifecycle gates
+revision: 54
+summary: Document attributable daily-driver configuration upgrade, payload topology, typed corpus coverage, authenticated derivative targets, release evidence, and native lifecycle gates
 ---
 
 # Integration Testing
@@ -557,12 +557,14 @@ can select only the matching enrolled repository. The signed update
 fixture enrolls its binary JSON repository, exact source profile, and CCS
 package key through `conary repo add`; it does not mutate protected SQLite
 authority out of band. The focused
-`phase4-native-daily-driver-corpus` manifest owns `TNPM13` through `TNPM18`
+`phase4-native-daily-driver-corpus` manifest owns `TNPM13` through `TNPM19`
 without inheriting prior parity state. It builds a bounded signed loopback CCS
 repository, then builds a package in the host-native format and proves:
 
 - systemd unit file deployment and trigger matching
 - tracked `/etc` config file metadata
+- pristine `/etc` config upgrade from an exact v1 native artifact to an exact
+  v2 native artifact through a bounded signed loopback repository
 - one exact native versioned dependency resolved by SAT, acquired from the
   synchronized repository, signature-verified, and installed with dependency
   reason and source provenance
@@ -580,15 +582,21 @@ repository, then builds a package in the host-native format and proves:
 - an alternative target binary (`/usr/bin/phase4-corpus-alt`) as packaged file
   coverage
 
-`TNPM16` and `TNPM18` make the chain visible to the typed W7 aggregator. The
+`TNPM16`, `TNPM18`, and `TNPM19` make the chain visible to the typed W7 aggregator. The
 install record reopens both builders' schema-versioned output manifests,
 hashes the native request and signed dependency artifacts again, and binds its
 versioned-dependency claim to both `install_request` and `install_dependency`.
-The removal record remains request-bound. Across the two completed cases the
-suite declares exactly thirteen properties: exact version, native architecture,
+The update record rehashes independently built v1 and v2 native artifacts and
+binds pristine config-upgrade coverage to `install_request` plus
+`update_request`. Conary converts the exact v2 artifact, serves the signed CCS
+from a bounded repository, and must preserve the native checksum in the
+installed lifecycle bundle while its repository checksum, selected-generation
+config bytes, and persisted pristine config hashes agree. The removal record
+binds to the installed v2 update request. Across the three completed cases the
+suite declares exactly fourteen properties: exact version, native architecture,
 regular files, directories, symlinks, hardlinks, payload ownership, payload
 timestamps, a versioned dependency, a queried virtual provide, matched config,
-purge-time config removal, and shell lifecycle. Directory, symlink, hardlink,
+pristine config upgrade, purge-time config removal, and shell lifecycle. Directory, symlink, hardlink,
 metadata, and relation claims require direct native metadata,
 selected-generation, repository-provenance, and installed reason assertions;
 implicit parents, followed filesystem paths, and recorded metadata without a
@@ -922,7 +930,7 @@ Adversarial and stress tests.
 
 ### Phase 4: Feature Validation
 
-Phase 4 currently contains 155 tests across nine manifests. It validates the
+Phase 4 currently contains 153 tests across nine manifests. It validates the
 active, user-facing command surface and checks that claimed features still match
 the current binary. Where a flow is intentionally preview-only or not yet
 implemented, the manifest asserts that it fails cleanly with an explicit
@@ -930,14 +938,14 @@ message rather than pretending it is production-ready.
 
 | Suite | IDs | Count | Category |
 |-------|-----|-------|----------|
-| A | T160-T176 | 17 | Config, distro, canonical, groups, registry |
+| A | T160-T176 | 15 | Config, distro, canonical, groups, registry |
 | B | T177-T195 plus suffix IDs | 20 | Label, model, collection, derive |
 | C | T196-T220 plus suffix IDs | 27 | CCS ops, query, repo management |
 | D | T221-T255 plus suffix IDs | 38 | Provenance, capability, trust, system ops, federation, automation |
 | E | T256-T273 and T276-T277 plus suffix IDs | 22 | Cross-source compatibility overlay: native package parity, source identity, model convergence, and takeover |
 | Native package-manager parity | TNPM01-TNPM12 plus TNPM02X | 13 | Cross-distro repository and native package-manager parity |
-| Native daily-driver corpus | TNPM13-TNPM18 | 6 | Focused attributable host-native daily-driver semantics |
-| Native cross-source lifecycle | TNPMX01R, TNPMX01D, TNPMX01A | 3 | Attributable native-oracle install/update/rollback/remove corpus evidence on every target image |
+| Native daily-driver corpus | TNPM13-TNPM19 | 7 | Focused attributable host-native daily-driver semantics |
+| Native cross-source lifecycle | TNPMX01R, TNPMX01D, TNPMX01A, TNPMX02O | 4 | Attributable native-oracle install/update/rollback/remove corpus evidence plus OpenRC activation proof on every target image |
 | Security advisory pipeline | TSEC01-TSEC07 | 7 | Trusted advisory ingestion and security update proof |
 
 Phase 4 is intentionally mixed:

--- a/docs/modules/test-fixtures.md
+++ b/docs/modules/test-fixtures.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-16
-revision: 36
-summary: Map fixture ownership, including attributable daily-driver payload topology, authenticated derivative roots, and cross-source lifecycle proof
+revision: 37
+summary: Map fixture ownership, including attributable daily-driver configuration upgrade, payload topology, authenticated derivative roots, and cross-source lifecycle proof
 ---
 
 # Test Fixtures And Proof Maps
@@ -490,16 +490,22 @@ Each fixture family should record:
   authority from distro-name matching. The typed workflow test owns the three
   source-format cases across all six required target lanes and the stable
   all-lane aggregator context; do not weaken either in workflow-only edits.
-  The focused `phase4-native-daily-driver-corpus` chain emits two case records
+  The focused `phase4-native-daily-driver-corpus` chain emits three case records
   for its host-native RPM, DEB, or ALPM build. The completed install/query
   record binds both the native request and its SAT-selected signed CCS
-  dependency to exact build-manifest SHA-256 identities; the removal record
-  remains bound to the request artifact. The completed chain covers
+  dependency to exact build-manifest SHA-256 identities. The update record
+  binds the installed v1 request and an independently built and extracted v2
+  native request, converts that exact v2 artifact through Conary's native
+  parser, and acquires the resulting signed CCS from a bounded loopback
+  repository. Selected-generation v2 bytes, pristine config hashes and source
+  format, repository checksum and provenance, and the installed lifecycle
+  bundle's native source checksum must all agree. The removal record binds to
+  the installed v2 update request. The completed chain covers
   exact/native identity, regular files, one explicit directory,
   one exact symlink, one two-path hardlink set, one queried virtual provide,
   one exact versioned dependency resolved from the bounded loopback repository,
-  matched config, exact payload ownership and timestamp authority, and shell
-  lifecycle; removal covers config cleanup. Each native package is independently
+  matched config, pristine config upgrade, exact payload ownership and timestamp
+  authority, and shell lifecycle; removal covers config cleanup. Each native package is independently
   installed or extracted and both hardlink paths must report one device/inode
   identity with a link count of two, uid/gid `0`, and mtime `1700000000` before
   Conary installation begins. The selected-generation proof then requires both
@@ -519,7 +525,7 @@ Each fixture family should record:
   live-root materialization coverage. Do not infer large-file, source-trigger,
   activation, target-helper, conflict, or replacement coverage from the chain's
   2 MiB file, out-of-band trigger, disabled unit, adjacent helper path, or
-  file-collision negative. PRs run only that focused six-test
+  file-collision negative. PRs run only that focused seven-test
   chain on Fedora 44, Ubuntu 26.04, and Arch behind the stable
   `native-daily-driver-corpus` aggregate context; every lane applies both the
   ordinary suite-result and typed corpus-result gates.

--- a/docs/roadmaps/development-roadmap.md
+++ b/docs/roadmaps/development-roadmap.md
@@ -1,6 +1,6 @@
 ---
 last_updated: 2026-08-16
-revision: 26
+revision: 27
 summary: Track Conary's active W7 corpus gate, typed semantic coverage, external tester milestone, and later workstreams
 proof_baseline: "immutable synchronized v0.15.0 suite at 642750878d5a59a9aa27976347cafc6f9dd86cfd; exact tagged Remi deployed; external tester result remains 0/10 behind #110"
 current_milestone: first external tester loop
@@ -324,11 +324,14 @@ the stated scope, not whether a workstream happens to be active.
   closed after making one exact versioned dependency resolve, acquire, and
   install from that repository with both artifacts bound to typed corpus
   evidence. #473 owns exact source-native and selected-generation ownership and
-  timestamp attribution for the same digest-bound daily-driver artifact.
+  timestamp attribution for the same digest-bound daily-driver artifact. #475
+  is the active bounded slice for digest-attributable pristine configuration
+  upgrade through the same focused daily-driver authority.
 - **Issues:** #110 as the corpus umbrella; #458 and #463 for focused
   daily-driver attribution; #462 and #464 for payload-topology export gaps;
   #460 and #461 for closed legacy parity defects; #470 for versioned dependency
-  resolution; #473 for payload metadata attribution; plus #39 for bootstrap.
+  resolution; #473 for payload metadata attribution; #475 for configuration
+  upgrade attribution; plus #39 for bootstrap.
 - **User journey:** install the signed release through one documented bootstrap
   entry point; `conary system init` with no hand-edited state; sync and
   authenticate repositories; request a package by ordinary name; resolve the
@@ -408,7 +411,7 @@ acceptance criteria, and proof.
 | W4 Source Fidelity Hard Cut | #102, #103, #98, #99 (slices 99a-99c), #107 | P0 |
 | W5 Source Authority Model | #108 specification, #104, #105 | P0 |
 | W6 Authority Audit Closure | #67 epic, #109, plus narrow ledger slices | P1 |
-| W7 Just-Works Corpus Gate | #110 umbrella, #39 | P0 |
+| W7 Just-Works Corpus Gate | #110 umbrella, #475 active slice, #39 | P0 |
 | W8 External Tester Outreach | #48 | gated |
 | W9 Common Package Capability Classes | #74, #50, #46, #67 P2 remainder | P1 |
 | W10 Distro-Agnostic Takeover | #62 epic decomposed, #68 | P2 |


### PR DESCRIPTION
## Problem

The focused W7 daily-driver corpus proved matched configuration at installation and purge-time removal, but it had no digest-attributable update case. Existing update tests did not bind the installed v1 request, the v2 native source artifact, repository acquisition, persisted config authority, and selected-generation bytes into one typed corpus result.

## What changed

- derive a deterministic v2 from the existing daily-driver fixture source and build it independently as RPM, DEB, or ALPM
- independently extract the v2 native artifact to verify its version, config bytes, and preserved hardlink topology
- convert that exact artifact through Conary's native parser, verify the resulting signed CCS, and serve it from a bounded loopback repository
- update through conary update and require repository checksum/provenance, selected-generation v2 bytes, pristine config hashes/source, and installed native source checksum to agree
- emit configuration_upgrade evidence bound to exactly one install_request and one update_request
- bind the later removal case to the actually installed v2 request
- extend canonical integration, fixture, and roadmap truth from thirteen to fourteen declared properties

Local modification, deletion, unmatched declarations, and live-root materialization remain explicit non-claims.

## Verification

Passed locally:

- cargo run -p conary-test -- list
- cargo test -p conary-test
  - 319 library tests passed; 2 explicitly ignored
  - 14 CLI tests passed
- feature-card focused suite_inventory, typed build-context, and native-cross-source tests
- cargo clippy -p conary-test --all-targets -- -D warnings
- cargo fmt --check
- bash scripts/check-doc-truth.sh
- git diff --check
- bash syntax checks for both new fixture helpers
- bash scripts/build-static-conary.sh

Attempted but unavailable on this host:

- cargo run -p conary-test -- run --suite phase4-native-daily-driver-corpus --distro fedora44 --phase 4
- The command stopped before suite setup because /var/run/docker.sock is absent and no Podman socket is active. The required Fedora, Ubuntu, and Arch hosted PR matrix is therefore the interaction proof for this head.

Closes #475.
Refs #110.
